### PR TITLE
fix(compiler): nest generated function object types

### DIFF
--- a/src/Compiler/Services/TwoPhaseCompilation/GeneratedFunctionObjectEmitter.cs
+++ b/src/Compiler/Services/TwoPhaseCompilation/GeneratedFunctionObjectEmitter.cs
@@ -137,13 +137,14 @@ internal sealed class GeneratedFunctionObjectEmitter
             }
 
             var canonicalBody = (MethodDefinitionHandle)bodyToken;
-            var ownerType = ResolveCanonicalOwnerType(plan);
-            _nestedTypeRegistry.Add(typeHandle, ownerType);
+            var canonicalOwnerType = ResolveCanonicalOwnerType(plan);
+            var nestingOwnerType = ResolveNestingOwnerType(plan, canonicalOwnerType);
+            _nestedTypeRegistry.Add(typeHandle, nestingOwnerType);
             _functionObjectRegistry.SetMetadata(new GeneratedFunctionObjectMetadata
             {
                 Plan = plan,
                 TypeHandle = typeHandle,
-                CanonicalOwnerTypeHandle = ownerType,
+                CanonicalOwnerTypeHandle = canonicalOwnerType,
                 ConstructorHandle = constructor,
                 IsConstructorGetterHandle = isConstructorGetter,
                 RequiresInvocationContextGetterHandle = requiresContextGetter,
@@ -912,6 +913,21 @@ internal sealed class GeneratedFunctionObjectEmitter
 
         throw new InvalidOperationException(
             $"Could not resolve canonical owner type for '{callable.DisplayName}'.");
+    }
+
+    private TypeDefinitionHandle ResolveNestingOwnerType(
+        GeneratedFunctionObjectPlan plan,
+        TypeDefinitionHandle canonicalOwnerType)
+    {
+        if (!string.IsNullOrWhiteSpace(plan.CanonicalOwnerScopeName)
+            && _scopeMetadata.TryGetScopeTypeHandle(
+                plan.CanonicalOwnerScopeName,
+                out var scopeOwner))
+        {
+            return scopeOwner;
+        }
+
+        return canonicalOwnerType;
     }
 
     private BlobHandle CreateFieldSignature(EntityHandle typeHandle)

--- a/src/Compiler/Services/TwoPhaseCompilation/GeneratedFunctionObjectMetadata.cs
+++ b/src/Compiler/Services/TwoPhaseCompilation/GeneratedFunctionObjectMetadata.cs
@@ -50,6 +50,8 @@ public sealed record GeneratedFunctionObjectPlan
 
     public required string CanonicalOwnerTypeName { get; init; }
 
+    public string? CanonicalOwnerScopeName { get; init; }
+
     public IReadOnlyList<GeneratedFunctionCapturePlan> Captures { get; init; } =
         Array.Empty<GeneratedFunctionCapturePlan>();
 

--- a/src/Compiler/Services/TwoPhaseCompilation/GeneratedFunctionObjectPlanner.cs
+++ b/src/Compiler/Services/TwoPhaseCompilation/GeneratedFunctionObjectPlanner.cs
@@ -1,6 +1,7 @@
 using Acornima.Ast;
 using Jroc.Services.ScopesAbi;
 using Jroc.SymbolTables;
+using Jroc.Utilities;
 
 namespace Jroc.Services.TwoPhaseCompilation;
 
@@ -22,15 +23,16 @@ internal static class GeneratedFunctionObjectPlanner
             Signature = signature,
             Namespace = string.Empty,
             ModuleName = symbolTable.Root.Name,
-            TypeName = callable.Kind is CallableKind.Arrow
-                or CallableKind.FunctionDeclaration
-                or CallableKind.FunctionExpression
-                ? GeneratedFunctionObjectNaming.WrapperTypeName
-                : BuildTypeName(callable),
+            TypeName = GeneratedFunctionObjectNaming.WrapperTypeName,
             CanonicalOwnerTypeName = ResolveCanonicalOwnerTypeName(
                 callable,
                 callableScope,
                 classScope),
+            CanonicalOwnerScopeName = IsClassCallable(callable)
+                ? callableScope is null
+                    ? null
+                    : ScopeNaming.GetRegistryScopeName(callableScope)
+                : null,
             Captures = captures,
             StateFields = BuildStatePlan(
                 callable,
@@ -294,13 +296,14 @@ internal static class GeneratedFunctionObjectPlanner
                     : GeneratedFunctionReturnKind.Value;
     }
 
-    private static string BuildTypeName(CallableId callable)
-    {
-        var identity = callable.Name
-            ?? callable.Location?.ToString()
-            ?? "anonymous";
-        return $"FunctionObject_{callable.Kind}_{StableSuffix(callable.UniqueKey)}_{Sanitize(identity)}";
-    }
+    private static bool IsClassCallable(CallableId callable)
+        => callable.Kind is CallableKind.ClassConstructor
+            or CallableKind.ClassMethod
+            or CallableKind.ClassGetter
+            or CallableKind.ClassSetter
+            or CallableKind.ClassStaticMethod
+            or CallableKind.ClassStaticGetter
+            or CallableKind.ClassStaticSetter;
 
     private static string ResolveCanonicalOwnerTypeName(
         CallableId callable,
@@ -348,15 +351,4 @@ internal static class GeneratedFunctionObjectPlanner
         return new string(chars);
     }
 
-    private static string StableSuffix(string value)
-    {
-        uint hash = 2166136261;
-        foreach (var character in value)
-        {
-            hash ^= character;
-            hash *= 16777619;
-        }
-
-        return hash.ToString("X8", System.Globalization.CultureInfo.InvariantCulture);
-    }
 }

--- a/src/Compiler/Services/TypeGenerator.cs
+++ b/src/Compiler/Services/TypeGenerator.cs
@@ -259,6 +259,13 @@ namespace Jroc.Services
             return scope.Name;
         }
 
+        private static string GetChildScopeDeduplicationName(Scope scope)
+            => scope.Parent?.Kind == ScopeKind.Class
+                && scope.Kind == ScopeKind.Function
+                && !string.IsNullOrWhiteSpace(scope.DotNetTypeName)
+                ? scope.DotNetTypeName
+                : scope.Name;
+
         private void CreateTypeFields(Scope scope, TypeBuilder typeBuilder)
         {
             var scopeKey = GetRegistryScopeName(scope);
@@ -423,7 +430,7 @@ namespace Jroc.Services
             var seenChildNames = new HashSet<string>();
             foreach (var childScope in scope.Children)
             {
-                if (!seenChildNames.Add(childScope.Name))
+                if (!seenChildNames.Add(GetChildScopeDeduplicationName(childScope)))
                 {
                     // Duplicate child scope name under the same parent (e.g., repeated traversal). Skip.
                     continue;
@@ -510,7 +517,7 @@ namespace Jroc.Services
             var seenChildNames = new HashSet<string>(StringComparer.Ordinal);
             foreach (var child in root.Children)
             {
-                if (seenChildNames.Add(child.Name))
+                if (seenChildNames.Add(GetChildScopeDeduplicationName(child)))
                 {
                     count += CountScopeTypeDefinitions(child);
                 }
@@ -893,7 +900,7 @@ namespace Jroc.Services
             var seenChildNames = new HashSet<string>();
             foreach (var childScope in scope.Children)
             {
-                if (!seenChildNames.Add(childScope.Name))
+                if (!seenChildNames.Add(GetChildScopeDeduplicationName(childScope)))
                 {
                     continue;
                 }

--- a/src/Compiler/Utilities/ScopeNaming.cs
+++ b/src/Compiler/Utilities/ScopeNaming.cs
@@ -25,8 +25,15 @@ internal static class ScopeNaming
             return scope.Name;
         }
 
+        var qualifiedName = scope.GetQualifiedName();
+        if (scope.Parent?.Kind == ScopeKind.Class
+            && !string.IsNullOrWhiteSpace(scope.DotNetTypeName))
+        {
+            qualifiedName = $"{scope.Parent.GetQualifiedName()}/{scope.DotNetTypeName}";
+        }
+
         var moduleName = GetModuleName(scope);
-        return $"{moduleName}/{scope.GetQualifiedName()}";
+        return $"{moduleName}/{qualifiedName}";
     }
 
     public static string GetRegistryClassName(Scope classScope)

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_JsObject_NamedProperties.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_JsObject_NamedProperties.verified.txt
@@ -33,6 +33,90 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0,
+						class [System.Runtime]System.Object capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Array_JsObject_NamedProperties/DerivedArray/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class [System.Runtime]System.Object Modules.Array_JsObject_NamedProperties/DerivedArray/Scope_ctor/FunctionObject::_homeObject
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Array_JsObject_NamedProperties/DerivedArray/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_001b: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.Array_JsObject_NamedProperties/DerivedArray/Scope_ctor/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Array_JsObject_NamedProperties/DerivedArray/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,88 +132,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_B384E33B_DerivedArray
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0,
-					class [System.Runtime]System.Object capture1,
-					object[] capture2
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 28 (0x1c)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Array_JsObject_NamedProperties/DerivedArray/FunctionObject_ClassConstructor_B384E33B_DerivedArray::_transitionalScopes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.Array_JsObject_NamedProperties/DerivedArray/FunctionObject_ClassConstructor_B384E33B_DerivedArray::_homeObject
-				IL_0014: ldarg.0
-				IL_0015: ldarg.3
-				IL_0016: stfld object[] Modules.Array_JsObject_NamedProperties/DerivedArray/FunctionObject_ClassConstructor_B384E33B_DerivedArray::_lexicalSuperScopes
-				IL_001b: ret
-			} // end of method FunctionObject_ClassConstructor_B384E33B_DerivedArray::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_B384E33B_DerivedArray::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_B384E33B_DerivedArray::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.Array_JsObject_NamedProperties/DerivedArray/FunctionObject_ClassConstructor_B384E33B_DerivedArray::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_B384E33B_DerivedArray::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Array_JsObject_NamedProperties/DerivedArray/FunctionObject_ClassConstructor_B384E33B_DerivedArray::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_B384E33B_DerivedArray::GetLexicalSuperScopesCore
-
-		} // end of class FunctionObject_ClassConstructor_B384E33B_DerivedArray
 
 
 		// Methods
@@ -259,7 +261,7 @@
 			[21] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[22] object[],
 			[23] class [System.Runtime]System.Type,
-			[24] class Modules.Array_JsObject_NamedProperties/DerivedArray/FunctionObject_ClassConstructor_B384E33B_DerivedArray
+			[24] class Modules.Array_JsObject_NamedProperties/DerivedArray/Scope_ctor/FunctionObject
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -678,14 +680,14 @@
 		IL_051c: ldc.i4.0
 		IL_051d: ldloc.0
 		IL_051e: stelem.ref
-		IL_051f: newobj instance void Modules.Array_JsObject_NamedProperties/DerivedArray/FunctionObject_ClassConstructor_B384E33B_DerivedArray::.ctor(object[], class [System.Runtime]System.Object, object[])
+		IL_051f: newobj instance void Modules.Array_JsObject_NamedProperties/DerivedArray/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object, object[])
 		IL_0524: ldloc.s 23
 		IL_0526: ldloc.s 22
 		IL_0528: ldc.i4.0
 		IL_0529: conv.r8
 		IL_052a: ldc.i4.0
 		IL_052b: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0530: castclass Modules.Array_JsObject_NamedProperties/DerivedArray/FunctionObject_ClassConstructor_B384E33B_DerivedArray
+		IL_0530: castclass Modules.Array_JsObject_NamedProperties/DerivedArray/Scope_ctor/FunctionObject
 		IL_0535: stloc.s 24
 		IL_0537: ldstr "Array"
 		IL_053c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalSuper_MethodAndConstructor.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalSuper_MethodAndConstructor.verified.txt
@@ -11,25 +11,6 @@
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
 		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
@@ -172,25 +153,6 @@
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
 		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
@@ -355,6 +317,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -374,6 +386,71 @@
 		.class nested public auto ansi beforefieldinit Scope_read
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base
+					IL_001d: call instance object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base::read()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -389,117 +466,6 @@
 			} // end of method Scope_read::.ctor
 
 		} // end of class Scope_read
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_3C0F3AD3_Base
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassConstructor_3C0F3AD3_Base::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_3C0F3AD3_Base::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_3C0F3AD3_Base::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_3C0F3AD3_Base::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_3C0F3AD3_Base
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_CB6C7DBA_Base_read
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_CB6C7DBA_Base_read::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_CB6C7DBA_Base_read::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_CB6C7DBA_Base_read::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base
-				IL_001d: call instance object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base::read()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_CB6C7DBA_Base_read::CallCore
-
-		} // end of class FunctionObject_ClassMethod_CB6C7DBA_Base_read
 
 
 		// Fields
@@ -569,6 +535,109 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0,
+						class [System.Runtime]System.Object capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class [System.Runtime]System.Object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/Scope_ctor/FunctionObject::_homeObject
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_001b: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/Scope_ctor/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -588,6 +657,98 @@
 		.class nested public auto ansi beforefieldinit Scope_makeReader
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/Scope_makeReader/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/Scope_makeReader/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
+					IL_001d: call instance object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived::makeReader()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -603,159 +764,6 @@
 			} // end of method Scope_makeReader::.ctor
 
 		} // end of class Scope_makeReader
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_FE3E82D3_Derived
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0,
-					class [System.Runtime]System.Object capture1,
-					object[] capture2
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 28 (0x1c)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassConstructor_FE3E82D3_Derived::_transitionalScopes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassConstructor_FE3E82D3_Derived::_homeObject
-				IL_0014: ldarg.0
-				IL_0015: ldarg.3
-				IL_0016: stfld object[] Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassConstructor_FE3E82D3_Derived::_lexicalSuperScopes
-				IL_001b: ret
-			} // end of method FunctionObject_ClassConstructor_FE3E82D3_Derived::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_FE3E82D3_Derived::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_FE3E82D3_Derived::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassConstructor_FE3E82D3_Derived::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_FE3E82D3_Derived::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassConstructor_FE3E82D3_Derived::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_FE3E82D3_Derived::GetLexicalSuperScopesCore
-
-		} // end of class FunctionObject_ClassConstructor_FE3E82D3_Derived
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_66614F7D_Derived_makeReader
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_66614F7D_Derived_makeReader::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_66614F7D_Derived_makeReader::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_66614F7D_Derived_makeReader::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-				IL_001d: call instance object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived::makeReader()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_66614F7D_Derived_makeReader::CallCore
-
-		} // end of class FunctionObject_ClassMethod_66614F7D_Derived_makeReader
 
 
 		// Fields
@@ -930,8 +938,8 @@
 			[5] class [System.Runtime]System.Type,
 			[6] object,
 			[7] object[],
-			[8] class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassConstructor_3C0F3AD3_Base,
-			[9] class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassConstructor_FE3E82D3_Derived,
+			[8] class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/Scope_ctor/FunctionObject,
+			[9] class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/Scope_ctor/FunctionObject,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[11] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
@@ -952,14 +960,14 @@
 		IL_0030: stloc.s 7
 		IL_0032: ldloc.s 6
 		IL_0034: ldstr "read"
-		IL_0039: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read::.ctor()
+		IL_0039: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/Scope_read/FunctionObject::.ctor()
 		IL_003e: ldc.i4.0
 		IL_003f: conv.r8
 		IL_0040: ldstr "read"
 		IL_0045: ldc.i4.1
 		IL_0046: ldc.i4.1
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read>(!!0, float64, string, bool, bool)
-		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassMethod_CB6C7DBA_Base_read>(!!0)
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/Scope_read/FunctionObject>(!!0)
 		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0056: pop
 		IL_0057: ldc.i4.1
@@ -970,14 +978,14 @@
 		IL_0060: stelem.ref
 		IL_0061: stloc.s 7
 		IL_0063: ldloc.s 7
-		IL_0065: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassConstructor_3C0F3AD3_Base::.ctor(object[])
+		IL_0065: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_006a: ldloc.s 5
 		IL_006c: ldloc.s 7
 		IL_006e: ldc.i4.1
 		IL_006f: conv.r8
 		IL_0070: ldc.i4.0
 		IL_0071: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0076: castclass Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassConstructor_3C0F3AD3_Base
+		IL_0076: castclass Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/Scope_ctor/FunctionObject
 		IL_007b: stloc.s 8
 		IL_007d: ldloc.0
 		IL_007e: ldloc.s 8
@@ -996,14 +1004,14 @@
 		IL_00b0: ldloc.s 6
 		IL_00b2: ldstr "makeReader"
 		IL_00b7: ldloc.s 7
-		IL_00b9: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader::.ctor(object[])
+		IL_00b9: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/Scope_makeReader/FunctionObject::.ctor(object[])
 		IL_00be: ldc.i4.0
 		IL_00bf: conv.r8
 		IL_00c0: ldstr "makeReader"
 		IL_00c5: ldc.i4.0
 		IL_00c6: ldc.i4.1
-		IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader>(!!0, float64, string, bool, bool)
-		IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassMethod_66614F7D_Derived_makeReader>(!!0)
+		IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/Scope_makeReader/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/Scope_makeReader/FunctionObject>(!!0)
 		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_00d6: pop
 		IL_00d7: ldc.i4.1
@@ -1021,14 +1029,14 @@
 		IL_00f1: ldc.i4.0
 		IL_00f2: ldloc.0
 		IL_00f3: stelem.ref
-		IL_00f4: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassConstructor_FE3E82D3_Derived::.ctor(object[], class [System.Runtime]System.Object, object[])
+		IL_00f4: newobj instance void Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object, object[])
 		IL_00f9: ldloc.s 5
 		IL_00fb: ldloc.s 7
 		IL_00fd: ldc.i4.1
 		IL_00fe: conv.r8
 		IL_00ff: ldc.i4.0
 		IL_0100: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0105: castclass Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassConstructor_FE3E82D3_Derived
+		IL_0105: castclass Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/Scope_ctor/FunctionObject
 		IL_010a: stloc.s 9
 		IL_010c: ldloc.s 9
 		IL_010e: ldloc.s 8

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ConstructorAssigned.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ConstructorAssigned.verified.txt
@@ -11,25 +11,6 @@
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
 		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
@@ -156,6 +137,75 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -171,54 +221,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_74E2BB29_Counter
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter/FunctionObject_ClassConstructor_74E2BB29_Counter::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_74E2BB29_Counter::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_74E2BB29_Counter::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_74E2BB29_Counter::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_74E2BB29_Counter
 
 
 		// Fields
@@ -324,7 +326,7 @@
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object[],
 			[5] class [System.Runtime]System.Type,
-			[6] class Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter/FunctionObject_ClassConstructor_74E2BB29_Counter,
+			[6] class Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter/Scope_ctor/FunctionObject,
 			[7] object,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[9] class Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter
@@ -346,14 +348,14 @@
 		IL_0022: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0027: stloc.s 5
 		IL_0029: ldloc.s 4
-		IL_002b: newobj instance void Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter/FunctionObject_ClassConstructor_74E2BB29_Counter::.ctor(object[])
+		IL_002b: newobj instance void Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_0030: ldloc.s 5
 		IL_0032: ldloc.s 4
 		IL_0034: ldc.i4.1
 		IL_0035: conv.r8
 		IL_0036: ldc.i4.0
 		IL_0037: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_003c: castclass Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter/FunctionObject_ClassConstructor_74E2BB29_Counter
+		IL_003c: castclass Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter/Scope_ctor/FunctionObject
 		IL_0041: stloc.s 6
 		IL_0043: ldloc.s 6
 		IL_0045: stloc.1

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_CreatedInMethod.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_CreatedInMethod.verified.txt
@@ -11,25 +11,6 @@
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
 		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
@@ -156,6 +137,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -175,6 +206,98 @@
 		.class nested public auto ansi beforefieldinit Scope_makeGetter
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter/Scope_makeGetter/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter/Scope_makeGetter/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter
+					IL_001d: call instance object Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter::makeGetter()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -190,125 +313,6 @@
 			} // end of method Scope_makeGetter::.ctor
 
 		} // end of class Scope_makeGetter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_AB3D4F93_Counter
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter/FunctionObject_ClassConstructor_AB3D4F93_Counter::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_AB3D4F93_Counter::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_AB3D4F93_Counter::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_AB3D4F93_Counter::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_AB3D4F93_Counter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter/FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter/FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter
-				IL_001d: call instance object Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter::makeGetter()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter::CallCore
-
-		} // end of class FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter
 
 
 		// Fields

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ObjectLiteralProperty.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ObjectLiteralProperty.verified.txt
@@ -11,25 +11,6 @@
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
 		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
@@ -156,6 +137,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -175,6 +206,98 @@
 		.class nested public auto ansi beforefieldinit Scope_make
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C/Scope_make/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C/Scope_make/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C
+					IL_001d: call instance object Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C::make()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -190,125 +313,6 @@
 			} // end of method Scope_make::.ctor
 
 		} // end of class Scope_make
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_85FC1835_C
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C/FunctionObject_ClassConstructor_85FC1835_C::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_85FC1835_C::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_85FC1835_C::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_85FC1835_C::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_85FC1835_C
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_79440680_C_make
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C/FunctionObject_ClassMethod_79440680_C_make::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_79440680_C_make::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_79440680_C_make::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_79440680_C_make::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C/FunctionObject_ClassMethod_79440680_C_make::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C
-				IL_001d: call instance object Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C::make()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_79440680_C_make::CallCore
-
-		} // end of class FunctionObject_ClassMethod_79440680_C_make
 
 
 		// Fields

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_LexicalThis.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_LexicalThis.verified.txt
@@ -130,32 +130,6 @@
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [JavaScriptRuntime]JavaScriptRuntime.AsyncScope
-		{
-			.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
-				01 00 1b 53 63 6f 70 65 20 5f 61 77 61 69 74 65
-				64 31 3d 7b 5f 61 77 61 69 74 65 64 31 7d 00 00
-			)
-			// Fields
-			.field public object _awaited1
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
 		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
@@ -256,7 +230,7 @@
 			// Code size: 345 (0x159)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.Async_ArrowFunction_LexicalThis/ArrowFunction_L9C16/Scope,
+				[0] class Modules.Async_ArrowFunction_LexicalThis/Counter/Scope_makeGetter/Scope,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 				[2] object
 			)
@@ -264,12 +238,12 @@
 			IL_0000: ldarg.0
 			IL_0001: ldc.i4.0
 			IL_0002: ldelem.ref
-			IL_0003: isinst Modules.Async_ArrowFunction_LexicalThis/ArrowFunction_L9C16/Scope
+			IL_0003: isinst Modules.Async_ArrowFunction_LexicalThis/Counter/Scope_makeGetter/Scope
 			IL_0008: dup
 			IL_0009: brtrue IL_0050
 
 			IL_000e: pop
-			IL_000f: newobj instance void Modules.Async_ArrowFunction_LexicalThis/ArrowFunction_L9C16/Scope::.ctor()
+			IL_000f: newobj instance void Modules.Async_ArrowFunction_LexicalThis/Counter/Scope_makeGetter/Scope::.ctor()
 			IL_0014: stloc.0
 			IL_0015: ldloc.0
 			IL_0016: ldarg.0
@@ -359,7 +333,7 @@
 			IL_00e9: ret
 
 			IL_00ea: ldloc.0
-			IL_00eb: ldfld object Modules.Async_ArrowFunction_LexicalThis/ArrowFunction_L9C16/Scope::_awaited1
+			IL_00eb: ldfld object Modules.Async_ArrowFunction_LexicalThis/Counter/Scope_makeGetter/Scope::_awaited1
 			IL_00f0: pop
 			IL_00f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_00f6: stloc.1
@@ -423,6 +397,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Async_ArrowFunction_LexicalThis/Counter/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -442,6 +466,105 @@
 		.class nested public auto ansi beforefieldinit Scope_makeGetter
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [JavaScriptRuntime]JavaScriptRuntime.AsyncScope
+			{
+				.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+					01 00 1b 53 63 6f 70 65 20 5f 61 77 61 69 74 65
+					64 31 3d 7b 5f 61 77 61 69 74 65 64 31 7d 00 00
+				)
+				// Fields
+				.field public object _awaited1
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Async_ArrowFunction_LexicalThis/Counter/Scope_makeGetter/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Async_ArrowFunction_LexicalThis/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Async_ArrowFunction_LexicalThis/Counter/Scope_makeGetter/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Async_ArrowFunction_LexicalThis/Counter
+					IL_001d: call instance object Modules.Async_ArrowFunction_LexicalThis/Counter::makeGetter()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -457,125 +580,6 @@
 			} // end of method Scope_makeGetter::.ctor
 
 		} // end of class Scope_makeGetter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_48958275_Counter
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_ArrowFunction_LexicalThis/Counter/FunctionObject_ClassConstructor_48958275_Counter::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_48958275_Counter::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_48958275_Counter::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_48958275_Counter::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_48958275_Counter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_020123DD_Counter_makeGetter
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_ArrowFunction_LexicalThis/Counter/FunctionObject_ClassMethod_020123DD_Counter_makeGetter::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_020123DD_Counter_makeGetter::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_020123DD_Counter_makeGetter::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_020123DD_Counter_makeGetter::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Async_ArrowFunction_LexicalThis/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Async_ArrowFunction_LexicalThis/Counter/FunctionObject_ClassMethod_020123DD_Counter_makeGetter::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Async_ArrowFunction_LexicalThis/Counter
-				IL_001d: call instance object Modules.Async_ArrowFunction_LexicalThis/Counter::makeGetter()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_020123DD_Counter_makeGetter::CallCore
-
-		} // end of class FunctionObject_ClassMethod_020123DD_Counter_makeGetter
 
 
 		// Fields

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_CallsOtherAsync.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_CallsOtherAsync.verified.txt
@@ -157,6 +157,83 @@
 				74 61 20 5f 61 77 61 69 74 65 64 31 3d 7b 5f 61
 				77 61 69 74 65 64 31 7d 00 00
 			)
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Async_ClassMethod_CallsOtherAsync/Service/Scope_fetchData/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 47 (0x2f)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Async_ClassMethod_CallsOtherAsync/Service
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Async_ClassMethod_CallsOtherAsync/Service/Scope_fetchData/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Async_ClassMethod_CallsOtherAsync/Service
+					IL_001d: ldarg.0
+					IL_001e: ldfld object[] Modules.Async_ClassMethod_CallsOtherAsync/Service/Scope_fetchData/FunctionObject::_transitionalScopes
+					IL_0023: ldnull
+					IL_0024: call instance object Modules.Async_ClassMethod_CallsOtherAsync/Service::fetchData(object[], object)
+					IL_0029: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
+					IL_002e: ret
+				} // end of method FunctionObject::CallCoreAsync
+
+			} // end of class FunctionObject
+
+
 			// Fields
 			.field public object _awaited1
 
@@ -184,6 +261,83 @@
 				44 61 74 61 20 5f 61 77 61 69 74 65 64 31 3d 7b
 				5f 61 77 61 69 74 65 64 31 7d 00 00
 			)
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Async_ClassMethod_CallsOtherAsync/Service/Scope_processData/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 47 (0x2f)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Async_ClassMethod_CallsOtherAsync/Service
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Async_ClassMethod_CallsOtherAsync/Service/Scope_processData/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Async_ClassMethod_CallsOtherAsync/Service
+					IL_001d: ldarg.0
+					IL_001e: ldfld object[] Modules.Async_ClassMethod_CallsOtherAsync/Service/Scope_processData/FunctionObject::_transitionalScopes
+					IL_0023: ldnull
+					IL_0024: call instance object Modules.Async_ClassMethod_CallsOtherAsync/Service::processData(object[], object)
+					IL_0029: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
+					IL_002e: ret
+				} // end of method FunctionObject::CallCoreAsync
+
+			} // end of class FunctionObject
+
+
 			// Fields
 			.field public object _awaited1
 
@@ -203,7 +357,7 @@
 
 		} // end of class Scope_processData
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_C5820907_Service
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -223,9 +377,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject_ClassConstructor_C5820907_Service::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_C5820907_Service::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -236,7 +390,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_C5820907_Service::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -247,159 +401,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_C5820907_Service::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_C5820907_Service
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_94242E88_Service_fetchData
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject_ClassMethod_94242E88_Service_fetchData::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_94242E88_Service_fetchData::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_94242E88_Service_fetchData::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_94242E88_Service_fetchData::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 47 (0x2f)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Async_ClassMethod_CallsOtherAsync/Service
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject_ClassMethod_94242E88_Service_fetchData::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Async_ClassMethod_CallsOtherAsync/Service
-				IL_001d: ldarg.0
-				IL_001e: ldfld object[] Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject_ClassMethod_94242E88_Service_fetchData::_transitionalScopes
-				IL_0023: ldnull
-				IL_0024: call instance object Modules.Async_ClassMethod_CallsOtherAsync/Service::fetchData(object[], object)
-				IL_0029: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
-				IL_002e: ret
-			} // end of method FunctionObject_ClassMethod_94242E88_Service_fetchData::CallCoreAsync
-
-		} // end of class FunctionObject_ClassMethod_94242E88_Service_fetchData
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_D1758AD5_Service_processData
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject_ClassMethod_D1758AD5_Service_processData::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_D1758AD5_Service_processData::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_D1758AD5_Service_processData::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_D1758AD5_Service_processData::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 47 (0x2f)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Async_ClassMethod_CallsOtherAsync/Service
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject_ClassMethod_D1758AD5_Service_processData::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Async_ClassMethod_CallsOtherAsync/Service
-				IL_001d: ldarg.0
-				IL_001e: ldfld object[] Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject_ClassMethod_D1758AD5_Service_processData::_transitionalScopes
-				IL_0023: ldnull
-				IL_0024: call instance object Modules.Async_ClassMethod_CallsOtherAsync/Service::processData(object[], object)
-				IL_0029: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
-				IL_002e: ret
-			} // end of method FunctionObject_ClassMethod_D1758AD5_Service_processData::CallCoreAsync
-
-		} // end of class FunctionObject_ClassMethod_D1758AD5_Service_processData
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -454,7 +458,7 @@
 			IL_0020: ldftn instance object Modules.Async_ClassMethod_CallsOtherAsync/Service::fetchData(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.1
-			IL_002c: ldtoken Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject_ClassMethod_94242E88_Service_fetchData
+			IL_002c: ldtoken Modules.Async_ClassMethod_CallsOtherAsync/Service/Scope_fetchData/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -580,7 +584,7 @@
 			IL_0020: ldftn instance object Modules.Async_ClassMethod_CallsOtherAsync/Service::processData(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.1
-			IL_002c: ldtoken Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject_ClassMethod_D1758AD5_Service_processData
+			IL_002c: ldtoken Modules.Async_ClassMethod_CallsOtherAsync/Service/Scope_processData/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -743,7 +747,7 @@
 			[2] class Modules.Async_ClassMethod_CallsOtherAsync/Service,
 			[3] class [System.Runtime]System.Type,
 			[4] object[],
-			[5] class Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject_ClassConstructor_C5820907_Service,
+			[5] class Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject,
 			[6] class Modules.Async_ClassMethod_CallsOtherAsync/Service,
 			[7] object,
 			[8] class Modules.Async_ClassMethod_CallsOtherAsync/ArrowFunction_L15C28/FunctionObject
@@ -874,14 +878,14 @@
 		IL_0105: stelem.ref
 		IL_0106: stloc.s 4
 		IL_0108: ldloc.s 4
-		IL_010a: newobj instance void Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject_ClassConstructor_C5820907_Service::.ctor(object[])
+		IL_010a: newobj instance void Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject::.ctor(object[])
 		IL_010f: ldloc.3
 		IL_0110: ldloc.s 4
 		IL_0112: ldc.i4.0
 		IL_0113: conv.r8
 		IL_0114: ldc.i4.0
 		IL_0115: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_011a: castclass Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject_ClassConstructor_C5820907_Service
+		IL_011a: castclass Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject
 		IL_011f: stloc.s 5
 		IL_0121: ldloc.s 5
 		IL_0123: stloc.1

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_MultipleAwaits.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_MultipleAwaits.verified.txt
@@ -158,6 +158,86 @@
 				69 74 65 64 31 7d 2c 20 5f 61 77 61 69 74 65 64
 				32 3d 7b 5f 61 77 61 69 74 65 64 32 7d 00 00
 			)
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Async_ClassMethod_MultipleAwaits/Processor/Scope_process/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 54 (0x36)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Async_ClassMethod_MultipleAwaits/Processor
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Async_ClassMethod_MultipleAwaits/Processor/Scope_process/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Async_ClassMethod_MultipleAwaits/Processor
+					IL_001d: ldarg.0
+					IL_001e: ldfld object[] Modules.Async_ClassMethod_MultipleAwaits/Processor/Scope_process/FunctionObject::_transitionalScopes
+					IL_0023: ldnull
+					IL_0024: ldarg.2
+					IL_0025: ldc.i4.0
+					IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_002b: call instance object Modules.Async_ClassMethod_MultipleAwaits/Processor::process(object[], object, object)
+					IL_0030: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
+					IL_0035: ret
+				} // end of method FunctionObject::CallCoreAsync
+
+			} // end of class FunctionObject
+
+
 			// Fields
 			.field public object _awaited1
 			.field public object _awaited2
@@ -178,7 +258,7 @@
 
 		} // end of class Scope_process
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_23495614_Processor
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -198,9 +278,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_ClassMethod_MultipleAwaits/Processor/FunctionObject_ClassConstructor_23495614_Processor::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_ClassMethod_MultipleAwaits/Processor/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_23495614_Processor::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -211,7 +291,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_23495614_Processor::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -222,87 +302,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_23495614_Processor::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_23495614_Processor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_A33ABC2A_Processor_process
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_ClassMethod_MultipleAwaits/Processor/FunctionObject_ClassMethod_A33ABC2A_Processor_process::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_A33ABC2A_Processor_process::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_A33ABC2A_Processor_process::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_A33ABC2A_Processor_process::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 54 (0x36)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Async_ClassMethod_MultipleAwaits/Processor
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Async_ClassMethod_MultipleAwaits/Processor/FunctionObject_ClassMethod_A33ABC2A_Processor_process::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Async_ClassMethod_MultipleAwaits/Processor
-				IL_001d: ldarg.0
-				IL_001e: ldfld object[] Modules.Async_ClassMethod_MultipleAwaits/Processor/FunctionObject_ClassMethod_A33ABC2A_Processor_process::_transitionalScopes
-				IL_0023: ldnull
-				IL_0024: ldarg.2
-				IL_0025: ldc.i4.0
-				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_002b: call instance object Modules.Async_ClassMethod_MultipleAwaits/Processor::process(object[], object, object)
-				IL_0030: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
-				IL_0035: ret
-			} // end of method FunctionObject_ClassMethod_A33ABC2A_Processor_process::CallCoreAsync
-
-		} // end of class FunctionObject_ClassMethod_A33ABC2A_Processor_process
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -361,7 +363,7 @@
 			IL_0020: ldftn instance object Modules.Async_ClassMethod_MultipleAwaits/Processor::process(object[], object, object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002b: ldarg.1
-			IL_002c: ldtoken Modules.Async_ClassMethod_MultipleAwaits/Processor/FunctionObject_ClassMethod_A33ABC2A_Processor_process
+			IL_002c: ldtoken Modules.Async_ClassMethod_MultipleAwaits/Processor/Scope_process/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.1
 			IL_0037: newarr [System.Runtime]System.Object
@@ -568,7 +570,7 @@
 			[2] class Modules.Async_ClassMethod_MultipleAwaits/Processor,
 			[3] class [System.Runtime]System.Type,
 			[4] object[],
-			[5] class Modules.Async_ClassMethod_MultipleAwaits/Processor/FunctionObject_ClassConstructor_23495614_Processor,
+			[5] class Modules.Async_ClassMethod_MultipleAwaits/Processor/FunctionObject,
 			[6] class Modules.Async_ClassMethod_MultipleAwaits/Processor,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[8] object,
@@ -651,14 +653,14 @@
 		IL_00a1: stelem.ref
 		IL_00a2: stloc.s 4
 		IL_00a4: ldloc.s 4
-		IL_00a6: newobj instance void Modules.Async_ClassMethod_MultipleAwaits/Processor/FunctionObject_ClassConstructor_23495614_Processor::.ctor(object[])
+		IL_00a6: newobj instance void Modules.Async_ClassMethod_MultipleAwaits/Processor/FunctionObject::.ctor(object[])
 		IL_00ab: ldloc.3
 		IL_00ac: ldloc.s 4
 		IL_00ae: ldc.i4.0
 		IL_00af: conv.r8
 		IL_00b0: ldc.i4.0
 		IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_00b6: castclass Modules.Async_ClassMethod_MultipleAwaits/Processor/FunctionObject_ClassConstructor_23495614_Processor
+		IL_00b6: castclass Modules.Async_ClassMethod_MultipleAwaits/Processor/FunctionObject
 		IL_00bb: stloc.s 5
 		IL_00bd: ldloc.s 5
 		IL_00bf: stloc.1

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_SimpleAwait.verified.txt
@@ -157,6 +157,89 @@
 				61 69 74 65 64 31 3d 7b 5f 61 77 61 69 74 65 64
 				31 7d 00 00
 			)
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Async_ClassMethod_SimpleAwait/Calculator/Scope_add/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 61 (0x3d)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Async_ClassMethod_SimpleAwait/Calculator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Async_ClassMethod_SimpleAwait/Calculator/Scope_add/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Async_ClassMethod_SimpleAwait/Calculator
+					IL_001d: ldarg.0
+					IL_001e: ldfld object[] Modules.Async_ClassMethod_SimpleAwait/Calculator/Scope_add/FunctionObject::_transitionalScopes
+					IL_0023: ldnull
+					IL_0024: ldarg.2
+					IL_0025: ldc.i4.0
+					IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_002b: ldarg.2
+					IL_002c: ldc.i4.1
+					IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0032: call instance object Modules.Async_ClassMethod_SimpleAwait/Calculator::'add'(object[], object, object, object)
+					IL_0037: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
+					IL_003c: ret
+				} // end of method FunctionObject::CallCoreAsync
+
+			} // end of class FunctionObject
+
+
 			// Fields
 			.field public object _awaited1
 
@@ -176,7 +259,7 @@
 
 		} // end of class Scope_add
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_83149DA3_Calculator
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -196,9 +279,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_ClassMethod_SimpleAwait/Calculator/FunctionObject_ClassConstructor_83149DA3_Calculator::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_ClassMethod_SimpleAwait/Calculator/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_83149DA3_Calculator::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -209,7 +292,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_83149DA3_Calculator::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -220,90 +303,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_83149DA3_Calculator::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_83149DA3_Calculator
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_4CA51A8F_Calculator_add
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_ClassMethod_SimpleAwait/Calculator/FunctionObject_ClassMethod_4CA51A8F_Calculator_add::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_4CA51A8F_Calculator_add::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_4CA51A8F_Calculator_add::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_4CA51A8F_Calculator_add::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 61 (0x3d)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Async_ClassMethod_SimpleAwait/Calculator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Async_ClassMethod_SimpleAwait/Calculator/FunctionObject_ClassMethod_4CA51A8F_Calculator_add::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Async_ClassMethod_SimpleAwait/Calculator
-				IL_001d: ldarg.0
-				IL_001e: ldfld object[] Modules.Async_ClassMethod_SimpleAwait/Calculator/FunctionObject_ClassMethod_4CA51A8F_Calculator_add::_transitionalScopes
-				IL_0023: ldnull
-				IL_0024: ldarg.2
-				IL_0025: ldc.i4.0
-				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_002b: ldarg.2
-				IL_002c: ldc.i4.1
-				IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0032: call instance object Modules.Async_ClassMethod_SimpleAwait/Calculator::'add'(object[], object, object, object)
-				IL_0037: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
-				IL_003c: ret
-			} // end of method FunctionObject_ClassMethod_4CA51A8F_Calculator_add::CallCoreAsync
-
-		} // end of class FunctionObject_ClassMethod_4CA51A8F_Calculator_add
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -361,7 +363,7 @@
 			IL_0020: ldftn instance object Modules.Async_ClassMethod_SimpleAwait/Calculator::'add'(object[], object, object, object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
 			IL_002b: ldarg.1
-			IL_002c: ldtoken Modules.Async_ClassMethod_SimpleAwait/Calculator/FunctionObject_ClassMethod_4CA51A8F_Calculator_add
+			IL_002c: ldtoken Modules.Async_ClassMethod_SimpleAwait/Calculator/Scope_add/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.2
 			IL_0037: newarr [System.Runtime]System.Object
@@ -508,7 +510,7 @@
 			[2] class Modules.Async_ClassMethod_SimpleAwait/Calculator,
 			[3] class [System.Runtime]System.Type,
 			[4] object[],
-			[5] class Modules.Async_ClassMethod_SimpleAwait/Calculator/FunctionObject_ClassConstructor_83149DA3_Calculator,
+			[5] class Modules.Async_ClassMethod_SimpleAwait/Calculator/FunctionObject,
 			[6] class Modules.Async_ClassMethod_SimpleAwait/Calculator,
 			[7] object,
 			[8] class Modules.Async_ClassMethod_SimpleAwait/ArrowFunction_L10C21/FunctionObject
@@ -590,14 +592,14 @@
 		IL_00a1: stelem.ref
 		IL_00a2: stloc.s 4
 		IL_00a4: ldloc.s 4
-		IL_00a6: newobj instance void Modules.Async_ClassMethod_SimpleAwait/Calculator/FunctionObject_ClassConstructor_83149DA3_Calculator::.ctor(object[])
+		IL_00a6: newobj instance void Modules.Async_ClassMethod_SimpleAwait/Calculator/FunctionObject::.ctor(object[])
 		IL_00ab: ldloc.3
 		IL_00ac: ldloc.s 4
 		IL_00ae: ldc.i4.0
 		IL_00af: conv.r8
 		IL_00b0: ldc.i4.0
 		IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_00b6: castclass Modules.Async_ClassMethod_SimpleAwait/Calculator/FunctionObject_ClassConstructor_83149DA3_Calculator
+		IL_00b6: castclass Modules.Async_ClassMethod_SimpleAwait/Calculator/FunctionObject
 		IL_00bb: stloc.s 5
 		IL_00bd: ldloc.s 5
 		IL_00bf: stloc.1

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_WithThis.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_WithThis.verified.txt
@@ -152,6 +152,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Async_ClassMethod_WithThis/Counter/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -176,6 +226,83 @@
 				74 20 5f 61 77 61 69 74 65 64 31 3d 7b 5f 61 77
 				61 69 74 65 64 31 7d 00 00
 			)
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Async_ClassMethod_WithThis/Counter/Scope_getCount/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 47 (0x2f)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Async_ClassMethod_WithThis/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Async_ClassMethod_WithThis/Counter/Scope_getCount/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Async_ClassMethod_WithThis/Counter
+					IL_001d: ldarg.0
+					IL_001e: ldfld object[] Modules.Async_ClassMethod_WithThis/Counter/Scope_getCount/FunctionObject::_transitionalScopes
+					IL_0023: ldnull
+					IL_0024: call instance object Modules.Async_ClassMethod_WithThis/Counter::getCount(object[], object)
+					IL_0029: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
+					IL_002e: ret
+				} // end of method FunctionObject::CallCoreAsync
+
+			} // end of class FunctionObject
+
+
 			// Fields
 			.field public object _awaited1
 
@@ -194,129 +321,6 @@
 			} // end of method Scope_getCount::.ctor
 
 		} // end of class Scope_getCount
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_9194BF49_Counter
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_ClassMethod_WithThis/Counter/FunctionObject_ClassConstructor_9194BF49_Counter::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_9194BF49_Counter::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_9194BF49_Counter::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_9194BF49_Counter::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_9194BF49_Counter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_00DEF71B_Counter_getCount
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_ClassMethod_WithThis/Counter/FunctionObject_ClassMethod_00DEF71B_Counter_getCount::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_00DEF71B_Counter_getCount::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_00DEF71B_Counter_getCount::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_00DEF71B_Counter_getCount::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 47 (0x2f)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Async_ClassMethod_WithThis/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Async_ClassMethod_WithThis/Counter/FunctionObject_ClassMethod_00DEF71B_Counter_getCount::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Async_ClassMethod_WithThis/Counter
-				IL_001d: ldarg.0
-				IL_001e: ldfld object[] Modules.Async_ClassMethod_WithThis/Counter/FunctionObject_ClassMethod_00DEF71B_Counter_getCount::_transitionalScopes
-				IL_0023: ldnull
-				IL_0024: call instance object Modules.Async_ClassMethod_WithThis/Counter::getCount(object[], object)
-				IL_0029: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
-				IL_002e: ret
-			} // end of method FunctionObject_ClassMethod_00DEF71B_Counter_getCount::CallCoreAsync
-
-		} // end of class FunctionObject_ClassMethod_00DEF71B_Counter_getCount
 
 
 		// Fields
@@ -377,7 +381,7 @@
 			IL_0020: ldftn instance object Modules.Async_ClassMethod_WithThis/Counter::getCount(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.1
-			IL_002c: ldtoken Modules.Async_ClassMethod_WithThis/Counter/FunctionObject_ClassMethod_00DEF71B_Counter_getCount
+			IL_002c: ldtoken Modules.Async_ClassMethod_WithThis/Counter/Scope_getCount/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -507,7 +511,7 @@
 			[2] class Modules.Async_ClassMethod_WithThis/Counter,
 			[3] class [System.Runtime]System.Type,
 			[4] object[],
-			[5] class Modules.Async_ClassMethod_WithThis/Counter/FunctionObject_ClassConstructor_9194BF49_Counter,
+			[5] class Modules.Async_ClassMethod_WithThis/Counter/Scope_ctor/FunctionObject,
 			[6] class Modules.Async_ClassMethod_WithThis/Counter,
 			[7] object,
 			[8] class Modules.Async_ClassMethod_WithThis/ArrowFunction_L16C25/FunctionObject
@@ -589,14 +593,14 @@
 		IL_00a1: stelem.ref
 		IL_00a2: stloc.s 4
 		IL_00a4: ldloc.s 4
-		IL_00a6: newobj instance void Modules.Async_ClassMethod_WithThis/Counter/FunctionObject_ClassConstructor_9194BF49_Counter::.ctor(object[])
+		IL_00a6: newobj instance void Modules.Async_ClassMethod_WithThis/Counter/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_00ab: ldloc.3
 		IL_00ac: ldloc.s 4
 		IL_00ae: ldc.i4.0
 		IL_00af: conv.r8
 		IL_00b0: ldc.i4.0
 		IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_00b6: castclass Modules.Async_ClassMethod_WithThis/Counter/FunctionObject_ClassConstructor_9194BF49_Counter
+		IL_00b6: castclass Modules.Async_ClassMethod_WithThis/Counter/Scope_ctor/FunctionObject
 		IL_00bb: stloc.s 5
 		IL_00bd: ldloc.s 5
 		IL_00bf: stloc.1

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Inheritance_SuperAsyncMethod.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Inheritance_SuperAsyncMethod.verified.txt
@@ -157,6 +157,86 @@
 				61 69 74 65 64 31 3d 7b 5f 61 77 61 69 74 65 64
 				31 7d 00 00
 			)
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Base/Scope_inc/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 54 (0x36)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Base
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Base/Scope_inc/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Async_Inheritance_SuperAsyncMethod/Base
+					IL_001d: ldarg.0
+					IL_001e: ldfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Base/Scope_inc/FunctionObject::_transitionalScopes
+					IL_0023: ldnull
+					IL_0024: ldarg.2
+					IL_0025: ldc.i4.0
+					IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_002b: call instance object Modules.Async_Inheritance_SuperAsyncMethod/Base::inc(object[], object, object)
+					IL_0030: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
+					IL_0035: ret
+				} // end of method FunctionObject::CallCoreAsync
+
+			} // end of class FunctionObject
+
+
 			// Fields
 			.field public object _awaited1
 
@@ -176,7 +256,7 @@
 
 		} // end of class Scope_inc
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_398688B9_Base
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -196,9 +276,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Base/FunctionObject_ClassConstructor_398688B9_Base::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Base/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_398688B9_Base::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -209,7 +289,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_398688B9_Base::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -220,87 +300,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_398688B9_Base::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_398688B9_Base
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_F1077DEC_Base_inc
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Base/FunctionObject_ClassMethod_F1077DEC_Base_inc::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_F1077DEC_Base_inc::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_F1077DEC_Base_inc::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_F1077DEC_Base_inc::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 54 (0x36)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Base
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Base/FunctionObject_ClassMethod_F1077DEC_Base_inc::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Async_Inheritance_SuperAsyncMethod/Base
-				IL_001d: ldarg.0
-				IL_001e: ldfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Base/FunctionObject_ClassMethod_F1077DEC_Base_inc::_transitionalScopes
-				IL_0023: ldnull
-				IL_0024: ldarg.2
-				IL_0025: ldc.i4.0
-				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_002b: call instance object Modules.Async_Inheritance_SuperAsyncMethod/Base::inc(object[], object, object)
-				IL_0030: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
-				IL_0035: ret
-			} // end of method FunctionObject_ClassMethod_F1077DEC_Base_inc::CallCoreAsync
-
-		} // end of class FunctionObject_ClassMethod_F1077DEC_Base_inc
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -357,7 +359,7 @@
 			IL_0020: ldftn instance object Modules.Async_Inheritance_SuperAsyncMethod/Base::inc(object[], object, object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002b: ldarg.1
-			IL_002c: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Base/FunctionObject_ClassMethod_F1077DEC_Base_inc
+			IL_002c: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Base/Scope_inc/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.1
 			IL_0037: newarr [System.Runtime]System.Object
@@ -492,6 +494,117 @@
 				61 69 74 65 64 31 3d 7b 5f 61 77 61 69 74 65 64
 				31 7d 00 00
 			)
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0,
+						class [System.Runtime]System.Object capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Derived/Scope_run/FunctionObject::_transitionalScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class [System.Runtime]System.Object Modules.Async_Inheritance_SuperAsyncMethod/Derived/Scope_run/FunctionObject::_homeObject
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Derived/Scope_run/FunctionObject::_lexicalSuperScopes
+					IL_001b: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.Async_Inheritance_SuperAsyncMethod/Derived/Scope_run/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Derived/Scope_run/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+				.method family hidebysig virtual 
+					instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 47 (0x2f)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Derived
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Derived/Scope_run/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Async_Inheritance_SuperAsyncMethod/Derived
+					IL_001d: ldarg.0
+					IL_001e: ldfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Derived/Scope_run/FunctionObject::_transitionalScopes
+					IL_0023: ldnull
+					IL_0024: call instance object Modules.Async_Inheritance_SuperAsyncMethod/Derived::run(object[], object)
+					IL_0029: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
+					IL_002e: ret
+				} // end of method FunctionObject::CallCoreAsync
+
+			} // end of class FunctionObject
+
+
 			// Fields
 			.field public object _awaited1
 
@@ -511,7 +624,7 @@
 
 		} // end of class Scope_run
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_468B227D_Derived
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -531,9 +644,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject_ClassConstructor_468B227D_Derived::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_468B227D_Derived::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -544,7 +657,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_468B227D_Derived::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -555,118 +668,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_468B227D_Derived::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_468B227D_Derived
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B6E78F2B_Derived_run
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0,
-					class [System.Runtime]System.Object capture1,
-					object[] capture2
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 28 (0x1c)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject_ClassMethod_B6E78F2B_Derived_run::_transitionalScopes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject_ClassMethod_B6E78F2B_Derived_run::_homeObject
-				IL_0014: ldarg.0
-				IL_0015: ldarg.3
-				IL_0016: stfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject_ClassMethod_B6E78F2B_Derived_run::_lexicalSuperScopes
-				IL_001b: ret
-			} // end of method FunctionObject_ClassMethod_B6E78F2B_Derived_run::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B6E78F2B_Derived_run::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B6E78F2B_Derived_run::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject_ClassMethod_B6E78F2B_Derived_run::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_B6E78F2B_Derived_run::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject_ClassMethod_B6E78F2B_Derived_run::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_B6E78F2B_Derived_run::GetLexicalSuperScopesCore
-
-			.method family hidebysig virtual 
-				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 47 (0x2f)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Derived
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject_ClassMethod_B6E78F2B_Derived_run::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Async_Inheritance_SuperAsyncMethod/Derived
-				IL_001d: ldarg.0
-				IL_001e: ldfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject_ClassMethod_B6E78F2B_Derived_run::_transitionalScopes
-				IL_0023: ldnull
-				IL_0024: call instance object Modules.Async_Inheritance_SuperAsyncMethod/Derived::run(object[], object)
-				IL_0029: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
-				IL_002e: ret
-			} // end of method FunctionObject_ClassMethod_B6E78F2B_Derived_run::CallCoreAsync
-
-		} // end of class FunctionObject_ClassMethod_B6E78F2B_Derived_run
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -736,7 +740,7 @@
 			IL_0020: ldftn instance object Modules.Async_Inheritance_SuperAsyncMethod/Derived::run(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.1
-			IL_002c: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject_ClassMethod_B6E78F2B_Derived_run
+			IL_002c: ldtoken Modules.Async_Inheritance_SuperAsyncMethod/Derived/Scope_run/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -873,8 +877,8 @@
 			[1] object,
 			[2] class [System.Runtime]System.Type,
 			[3] object[],
-			[4] class Modules.Async_Inheritance_SuperAsyncMethod/Base/FunctionObject_ClassConstructor_398688B9_Base,
-			[5] class Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject_ClassConstructor_468B227D_Derived,
+			[4] class Modules.Async_Inheritance_SuperAsyncMethod/Base/FunctionObject,
+			[5] class Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject,
 			[6] object,
 			[7] class Modules.Async_Inheritance_SuperAsyncMethod/ArrowFunction_L15C26/FunctionObject
 		)
@@ -955,14 +959,14 @@
 		IL_009f: stelem.ref
 		IL_00a0: stloc.3
 		IL_00a1: ldloc.3
-		IL_00a2: newobj instance void Modules.Async_Inheritance_SuperAsyncMethod/Base/FunctionObject_ClassConstructor_398688B9_Base::.ctor(object[])
+		IL_00a2: newobj instance void Modules.Async_Inheritance_SuperAsyncMethod/Base/FunctionObject::.ctor(object[])
 		IL_00a7: ldloc.2
 		IL_00a8: ldloc.3
 		IL_00a9: ldc.i4.0
 		IL_00aa: conv.r8
 		IL_00ab: ldc.i4.0
 		IL_00ac: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_00b1: castclass Modules.Async_Inheritance_SuperAsyncMethod/Base/FunctionObject_ClassConstructor_398688B9_Base
+		IL_00b1: castclass Modules.Async_Inheritance_SuperAsyncMethod/Base/FunctionObject
 		IL_00b6: stloc.s 4
 		IL_00b8: ldloc.0
 		IL_00b9: ldloc.s 4
@@ -1040,14 +1044,14 @@
 		IL_0158: stelem.ref
 		IL_0159: stloc.3
 		IL_015a: ldloc.3
-		IL_015b: newobj instance void Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject_ClassConstructor_468B227D_Derived::.ctor(object[])
+		IL_015b: newobj instance void Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject::.ctor(object[])
 		IL_0160: ldloc.2
 		IL_0161: ldloc.3
 		IL_0162: ldc.i4.0
 		IL_0163: conv.r8
 		IL_0164: ldc.i4.0
 		IL_0165: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_016a: castclass Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject_ClassConstructor_468B227D_Derived
+		IL_016a: castclass Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject
 		IL_016f: stloc.s 5
 		IL_0171: ldloc.s 5
 		IL_0173: ldloc.s 4

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_StaticMethod_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_StaticMethod_SimpleAwait.verified.txt
@@ -162,6 +162,74 @@
 				20 5f 61 77 61 69 74 65 64 31 3d 7b 5f 61 77 61
 				69 74 65 64 31 7d 00 00
 			)
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Async_StaticMethod_SimpleAwait/Fetcher/Scope_getData/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 18 (0x12)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Async_StaticMethod_SimpleAwait/Fetcher/Scope_getData/FunctionObject::_transitionalScopes
+					IL_0006: ldnull
+					IL_0007: call object Modules.Async_StaticMethod_SimpleAwait/Fetcher::getData(object[], object)
+					IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
+					IL_0011: ret
+				} // end of method FunctionObject::CallCoreAsync
+
+			} // end of class FunctionObject
+
+
 			// Fields
 			.field public object _awaited1
 
@@ -181,7 +249,7 @@
 
 		} // end of class Scope_getData
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_0CEBEFB8_Fetcher
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -201,9 +269,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_StaticMethod_SimpleAwait/Fetcher/FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_StaticMethod_SimpleAwait/Fetcher/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -214,7 +282,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -225,75 +293,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_0CEBEFB8_Fetcher
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_StaticMethod_SimpleAwait/Fetcher/FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 18 (0x12)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_StaticMethod_SimpleAwait/Fetcher/FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData::_transitionalScopes
-				IL_0006: ldnull
-				IL_0007: call object Modules.Async_StaticMethod_SimpleAwait/Fetcher::getData(object[], object)
-				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
-				IL_0011: ret
-			} // end of method FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData::CallCoreAsync
-
-		} // end of class FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -348,7 +350,7 @@
 			IL_0020: ldftn object Modules.Async_StaticMethod_SimpleAwait/Fetcher::getData(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_StaticMethod_SimpleAwait/Fetcher/FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData
+			IL_002c: ldtoken Modules.Async_StaticMethod_SimpleAwait/Fetcher/Scope_getData/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -478,7 +480,7 @@
 			[1] object,
 			[2] class [System.Runtime]System.Type,
 			[3] object[],
-			[4] class Modules.Async_StaticMethod_SimpleAwait/Fetcher/FunctionObject_ClassConstructor_0CEBEFB8_Fetcher,
+			[4] class Modules.Async_StaticMethod_SimpleAwait/Fetcher/FunctionObject,
 			[5] object,
 			[6] class Modules.Async_StaticMethod_SimpleAwait/ArrowFunction_L9C24/FunctionObject
 		)
@@ -559,14 +561,14 @@
 		IL_009f: stelem.ref
 		IL_00a0: stloc.3
 		IL_00a1: ldloc.3
-		IL_00a2: newobj instance void Modules.Async_StaticMethod_SimpleAwait/Fetcher/FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::.ctor(object[])
+		IL_00a2: newobj instance void Modules.Async_StaticMethod_SimpleAwait/Fetcher/FunctionObject::.ctor(object[])
 		IL_00a7: ldloc.2
 		IL_00a8: ldloc.3
 		IL_00a9: ldc.i4.0
 		IL_00aa: conv.r8
 		IL_00ab: ldc.i4.0
 		IL_00ac: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_00b1: castclass Modules.Async_StaticMethod_SimpleAwait/Fetcher/FunctionObject_ClassConstructor_0CEBEFB8_Fetcher
+		IL_00b1: castclass Modules.Async_StaticMethod_SimpleAwait/Fetcher/FunctionObject
 		IL_00b6: stloc.s 4
 		IL_00b8: ldloc.s 4
 		IL_00ba: stloc.1

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_GeneratedFunctionObject_Semantics.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_GeneratedFunctionObject_Semantics.verified.txt
@@ -5279,6 +5279,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -5298,6 +5348,87 @@
 		.class nested public auto ansi beforefieldinit Scope_run
 			extends [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_run/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 55 (0x37)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_run/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass
+					IL_001d: ldarg.0
+					IL_001e: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_run/FunctionObject::_transitionalScopes
+					IL_0023: ldnull
+					IL_0024: ldarg.2
+					IL_0025: ldc.i4.0
+					IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_002b: call instance object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass::run(object[], object, object)
+					IL_0030: ldarg.0
+					IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
+					IL_0036: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -5317,6 +5448,74 @@
 		.class nested public auto ansi beforefieldinit Scope_callRun
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass::callRun(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -5336,6 +5535,78 @@
 		.class nested public auto ansi beforefieldinit Scope_twice
 			extends [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorScope
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_twice/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 26 (0x1a)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_twice/FunctionObject::_transitionalScopes
+					IL_0006: ldnull
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass::twice(object[], object, object)
+					IL_0013: ldarg.0
+					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
+					IL_0019: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -5351,269 +5622,6 @@
 			} // end of method Scope_twice::.ctor
 
 		} // end of class Scope_twice
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_AAD039E1_AsyncGeneratorClass
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassConstructor_AAD039E1_AsyncGeneratorClass::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_AAD039E1_AsyncGeneratorClass::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_AAD039E1_AsyncGeneratorClass::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_AAD039E1_AsyncGeneratorClass::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_AAD039E1_AsyncGeneratorClass
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B5ED7E37_AsyncGeneratorClass_run
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassMethod_B5ED7E37_AsyncGeneratorClass_run::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_B5ED7E37_AsyncGeneratorClass_run::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B5ED7E37_AsyncGeneratorClass_run::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B5ED7E37_AsyncGeneratorClass_run::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 55 (0x37)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassMethod_B5ED7E37_AsyncGeneratorClass_run::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass
-				IL_001d: ldarg.0
-				IL_001e: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassMethod_B5ED7E37_AsyncGeneratorClass_run::_transitionalScopes
-				IL_0023: ldnull
-				IL_0024: ldarg.2
-				IL_0025: ldc.i4.0
-				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_002b: call instance object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass::run(object[], object, object)
-				IL_0030: ldarg.0
-				IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
-				IL_0036: ret
-			} // end of method FunctionObject_ClassMethod_B5ED7E37_AsyncGeneratorClass_run::CallCore
-
-		} // end of class FunctionObject_ClassMethod_B5ED7E37_AsyncGeneratorClass_run
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_4A6554A3_AsyncGeneratorClass_callRun
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_4A6554A3_AsyncGeneratorClass_callRun::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_4A6554A3_AsyncGeneratorClass_callRun::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_4A6554A3_AsyncGeneratorClass_callRun::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass::callRun(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_4A6554A3_AsyncGeneratorClass_callRun::CallCore
-
-		} // end of class FunctionObject_ClassMethod_4A6554A3_AsyncGeneratorClass_callRun
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 26 (0x1a)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice::_transitionalScopes
-				IL_0006: ldnull
-				IL_0007: ldarg.2
-				IL_0008: ldc.i4.0
-				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_000e: call object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass::twice(object[], object, object)
-				IL_0013: ldarg.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
-				IL_0019: ret
-			} // end of method FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice::CallCore
-
-		} // end of class FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice
 
 
 		// Fields
@@ -5679,7 +5687,7 @@
 			IL_0020: ldftn instance object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass::run(object[], object, object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002b: ldarg.1
-			IL_002c: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassMethod_B5ED7E37_AsyncGeneratorClass_run
+			IL_002c: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_run/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.1
 			IL_0037: newarr [System.Runtime]System.Object
@@ -5954,7 +5962,7 @@
 			IL_0020: ldftn object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass::twice(object[], object, object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice
+			IL_002c: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_twice/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.1
 			IL_0037: newarr [System.Runtime]System.Object
@@ -6201,6 +6209,111 @@
 		.class nested public auto ansi beforefieldinit Scope_callSuper
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class [System.Runtime]System.Object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/Scope_callSuper/FunctionObject::_homeObject
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/Scope_callSuper/FunctionObject::_lexicalSuperScopes
+					IL_0014: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/Scope_callSuper/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/Scope_callSuper/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass::callSuper(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -6217,7 +6330,7 @@
 
 		} // end of class Scope_callSuper
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_D1DFCE32_DerivedAsyncGeneratorClass
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -6237,9 +6350,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassConstructor_D1DFCE32_DerivedAsyncGeneratorClass::_transitionalScopes
+				IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_D1DFCE32_DerivedAsyncGeneratorClass::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6250,7 +6363,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_D1DFCE32_DerivedAsyncGeneratorClass::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6261,112 +6374,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_D1DFCE32_DerivedAsyncGeneratorClass::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_D1DFCE32_DerivedAsyncGeneratorClass
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class [System.Runtime]System.Object capture0,
-					object[] capture1
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 21 (0x15)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper::_homeObject
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper::_lexicalSuperScopes
-				IL_0014: ret
-			} // end of method FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper::GetLexicalSuperScopesCore
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass::callSuper(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper::CallCore
-
-		} // end of class FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -6518,8 +6528,8 @@
 			[7] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject,
 			[8] class [System.Runtime]System.Type,
 			[9] object,
-			[10] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassConstructor_AAD039E1_AsyncGeneratorClass,
-			[11] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassConstructor_D1DFCE32_DerivedAsyncGeneratorClass
+			[10] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_ctor/FunctionObject,
+			[11] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -6656,29 +6666,29 @@
 		IL_0154: ldloc.s 9
 		IL_0156: ldstr "run"
 		IL_015b: ldloc.2
-		IL_015c: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassMethod_B5ED7E37_AsyncGeneratorClass_run::.ctor(object[])
+		IL_015c: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_run/FunctionObject::.ctor(object[])
 		IL_0161: ldc.i4.1
 		IL_0162: conv.r8
 		IL_0163: ldstr "run"
 		IL_0168: ldc.i4.1
 		IL_0169: ldc.i4.1
-		IL_016a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassMethod_B5ED7E37_AsyncGeneratorClass_run>(!!0, float64, string, bool, bool)
+		IL_016a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_run/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorFunction::InitializeFunctionObject(object)
-		IL_0174: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassMethod_B5ED7E37_AsyncGeneratorClass_run
+		IL_0174: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_run/FunctionObject
 		IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_017e: pop
 		IL_017f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0184: stloc.2
 		IL_0185: ldloc.s 9
 		IL_0187: ldstr "callRun"
-		IL_018c: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassMethod_4A6554A3_AsyncGeneratorClass_callRun::.ctor()
+		IL_018c: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_callRun/FunctionObject::.ctor()
 		IL_0191: ldc.i4.1
 		IL_0192: conv.r8
 		IL_0193: ldstr "callRun"
 		IL_0198: ldc.i4.1
 		IL_0199: ldc.i4.1
-		IL_019a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassMethod_4A6554A3_AsyncGeneratorClass_callRun>(!!0, float64, string, bool, bool)
-		IL_019f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassMethod_4A6554A3_AsyncGeneratorClass_callRun>(!!0)
+		IL_019a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_callRun/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_019f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_callRun/FunctionObject>(!!0)
 		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_01a9: pop
 		IL_01aa: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -6686,15 +6696,15 @@
 		IL_01b0: ldloc.s 8
 		IL_01b2: ldstr "twice"
 		IL_01b7: ldloc.2
-		IL_01b8: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice::.ctor(object[])
+		IL_01b8: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_twice/FunctionObject::.ctor(object[])
 		IL_01bd: ldc.i4.1
 		IL_01be: conv.r8
 		IL_01bf: ldstr "twice"
 		IL_01c4: ldc.i4.1
 		IL_01c5: ldc.i4.1
-		IL_01c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice>(!!0, float64, string, bool, bool)
+		IL_01c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_twice/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorFunction::InitializeFunctionObject(object)
-		IL_01d0: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassStaticMethod_2A88B5AC_AsyncGeneratorClass_twice
+		IL_01d0: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_twice/FunctionObject
 		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_01da: pop
 		IL_01db: ldc.i4.1
@@ -6705,14 +6715,14 @@
 		IL_01e4: stelem.ref
 		IL_01e5: stloc.2
 		IL_01e6: ldloc.2
-		IL_01e7: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassConstructor_AAD039E1_AsyncGeneratorClass::.ctor(object[])
+		IL_01e7: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_01ec: ldloc.s 8
 		IL_01ee: ldloc.2
 		IL_01ef: ldc.i4.1
 		IL_01f0: conv.r8
 		IL_01f1: ldc.i4.0
 		IL_01f2: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_01f7: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassConstructor_AAD039E1_AsyncGeneratorClass
+		IL_01f7: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/Scope_ctor/FunctionObject
 		IL_01fc: stloc.s 10
 		IL_01fe: ldloc.0
 		IL_01ff: ldloc.s 10
@@ -6732,14 +6742,14 @@
 		IL_0232: ldstr "callSuper"
 		IL_0237: ldloc.s 9
 		IL_0239: ldloc.2
-		IL_023a: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper::.ctor(class [System.Runtime]System.Object, object[])
+		IL_023a: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/Scope_callSuper/FunctionObject::.ctor(class [System.Runtime]System.Object, object[])
 		IL_023f: ldc.i4.1
 		IL_0240: conv.r8
 		IL_0241: ldstr "callSuper"
 		IL_0246: ldc.i4.1
 		IL_0247: ldc.i4.1
-		IL_0248: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper>(!!0, float64, string, bool, bool)
-		IL_024d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassMethod_C7D41110_DerivedAsyncGeneratorClass_callSuper>(!!0)
+		IL_0248: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/Scope_callSuper/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_024d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/Scope_callSuper/FunctionObject>(!!0)
 		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0257: pop
 		IL_0258: ldc.i4.1
@@ -6750,14 +6760,14 @@
 		IL_0261: stelem.ref
 		IL_0262: stloc.2
 		IL_0263: ldloc.2
-		IL_0264: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassConstructor_D1DFCE32_DerivedAsyncGeneratorClass::.ctor(object[])
+		IL_0264: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject::.ctor(object[])
 		IL_0269: ldloc.s 8
 		IL_026b: ldloc.2
 		IL_026c: ldc.i4.0
 		IL_026d: conv.r8
 		IL_026e: ldc.i4.0
 		IL_026f: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0274: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject_ClassConstructor_D1DFCE32_DerivedAsyncGeneratorClass
+		IL_0274: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/DerivedAsyncGeneratorClass/FunctionObject
 		IL_0279: stloc.s 11
 		IL_027b: ldloc.s 11
 		IL_027d: ldloc.s 10

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_AddDynamicThenToNumber_StringPreserved.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_AddDynamicThenToNumber_StringPreserved.verified.txt
@@ -33,6 +33,75 @@
 		.class nested public auto ansi beforefieldinit Scope_addAndCoerce
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 47 (0x2f)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance float64 Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator::addAndCoerce(object)
+					IL_0029: box [System.Runtime]System.Double
+					IL_002e: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +118,7 @@
 
 		} // end of class Scope_addAndCoerce
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7DCA0CAF_Accumulator
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -69,9 +138,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator/FunctionObject_ClassConstructor_7DCA0CAF_Accumulator::_transitionalScopes
+				IL_0008: stfld object[] Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_7DCA0CAF_Accumulator::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -82,7 +151,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7DCA0CAF_Accumulator::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -93,76 +162,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7DCA0CAF_Accumulator::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_7DCA0CAF_Accumulator
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 47 (0x2f)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance float64 Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator::addAndCoerce(object)
-				IL_0029: box [System.Runtime]System.Double
-				IL_002e: ret
-			} // end of method FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce::CallCore
-
-		} // end of class FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce
+		} // end of class FunctionObject
 
 
 		// Methods

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualMethodReturn.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualMethodReturn.verified.txt
@@ -33,6 +33,72 @@
 		.class nested public auto ansi beforefieldinit Scope_getValue
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.BinaryOperator_EqualMethodReturn/TestClass
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.BinaryOperator_EqualMethodReturn/TestClass
+					IL_001d: call instance float64 Modules.BinaryOperator_EqualMethodReturn/TestClass::getValue()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +115,7 @@
 
 		} // end of class Scope_getValue
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_013FD243_TestClass
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -69,9 +135,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.BinaryOperator_EqualMethodReturn/TestClass/FunctionObject_ClassConstructor_013FD243_TestClass::_transitionalScopes
+				IL_0008: stfld object[] Modules.BinaryOperator_EqualMethodReturn/TestClass/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_013FD243_TestClass::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -82,7 +148,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_013FD243_TestClass::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -93,73 +159,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_013FD243_TestClass::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_013FD243_TestClass
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_5E9218E3_TestClass_getValue
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_5E9218E3_TestClass_getValue::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_5E9218E3_TestClass_getValue::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_5E9218E3_TestClass_getValue::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.BinaryOperator_EqualMethodReturn/TestClass
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.BinaryOperator_EqualMethodReturn/TestClass
-				IL_001d: call instance float64 Modules.BinaryOperator_EqualMethodReturn/TestClass::getValue()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_5E9218E3_TestClass_getValue::CallCore
-
-		} // end of class FunctionObject_ClassMethod_5E9218E3_TestClass_getValue
+		} // end of class FunctionObject
 
 
 		// Methods

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualObjectPropertyVsMethodReturn.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualObjectPropertyVsMethodReturn.verified.txt
@@ -33,6 +33,80 @@
 		.class nested public auto ansi beforefieldinit Scope_count
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter/Scope_count/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter/Scope_count/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter
+					IL_001d: call instance float64 Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter::count()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -89,7 +163,7 @@
 
 		} // end of class Scope_For_L9C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_024EE388_Counter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -109,9 +183,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter/FunctionObject_ClassConstructor_024EE388_Counter::_transitionalScopes
+				IL_0008: stfld object[] Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_024EE388_Counter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -122,7 +196,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_024EE388_Counter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -133,81 +207,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_024EE388_Counter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_024EE388_Counter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_1ACE45B8_Counter_count
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter/FunctionObject_ClassMethod_1ACE45B8_Counter_count::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_1ACE45B8_Counter_count::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_1ACE45B8_Counter_count::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_1ACE45B8_Counter_count::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter/FunctionObject_ClassMethod_1ACE45B8_Counter_count::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter
-				IL_001d: call instance float64 Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter::count()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_1ACE45B8_Counter_count::CallCore
-
-		} // end of class FunctionObject_ClassMethod_1ACE45B8_Counter_count
+		} // end of class FunctionObject
 
 
 		// Fields

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse/K/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +102,74 @@
 		.class nested public auto ansi beforefieldinit Scope_calc
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse/K
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse/K
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse/K::calc(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -67,120 +185,6 @@
 			} // end of method Scope_calc::.ctor
 
 		} // end of class Scope_calc
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_19052360_K
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse/K/FunctionObject_ClassConstructor_19052360_K::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_19052360_K::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_19052360_K::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_19052360_K::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_19052360_K
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_49281A06_K_calc
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_49281A06_K_calc::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_49281A06_K_calc::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_49281A06_K_calc::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse/K
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse/K
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse/K::calc(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_49281A06_K_calc::CallCore
-
-		} // end of class FunctionObject_ClassMethod_49281A06_K_calc
 
 
 		// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_AccessorMethods_InstanceAndStatic.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_AccessorMethods_InstanceAndStatic.verified.txt
@@ -43,6 +43,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -62,6 +112,71 @@
 		.class nested public auto ansi beforefieldinit Scope_get_count
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+					IL_001d: call instance object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::get_count()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -78,9 +193,161 @@
 
 		} // end of class Scope_get_count
 
+		.class nested public auto ansi beforefieldinit Scope_set_count
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::set_count(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_set_count::.ctor
+
+		} // end of class Scope_set_count
+
 		.class nested public auto ansi beforefieldinit Scope_get_label
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+					IL_001d: call instance object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::get_label()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -100,6 +367,73 @@
 		.class nested public auto ansi beforefieldinit Scope_get_total
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_get_total/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_get_total/FunctionObject::_transitionalScopes
+					IL_0006: ldnull
+					IL_0007: call object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::get_total(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -116,378 +450,94 @@
 
 		} // end of class Scope_get_total
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_F76E5D0D_Counter
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+		.class nested public auto ansi beforefieldinit Scope_set_total
+			extends [System.Runtime]System.Object
 		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
+				// Fields
+				.field private initonly object[] _transitionalScopes
 
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassConstructor_F76E5D0D_Counter::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_F76E5D0D_Counter::.ctor
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
 
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_set_total/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
 
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_F76E5D0D_Counter::get_IsConstructor
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
 
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
 
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_F76E5D0D_Counter::get_RequiresInvocationContext
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
 
-		} // end of class FunctionObject_ClassConstructor_F76E5D0D_Counter
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassGetter_9E713C73_Counter_get_count
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
 
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassGetter_9E713C73_Counter_get_count::.ctor
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_set_total/FunctionObject::_transitionalScopes
+					IL_0006: ldnull
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::set_total(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject::CallCore
 
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
+			} // end of class FunctionObject
 
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassGetter_9E713C73_Counter_get_count::get_IsConstructor
 
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassGetter_9E713C73_Counter_get_count::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-				IL_001d: call instance object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::get_count()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassGetter_9E713C73_Counter_get_count::CallCore
-
-		} // end of class FunctionObject_ClassGetter_9E713C73_Counter_get_count
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassSetter_B7DCDE33_Counter_set_count
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
 			{
 				// Header size: 1
-				// Code size: 7 (0x7)
+				// Code size: 8 (0x8)
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::.ctor
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_set_total::.ctor
 
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::set_count(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::CallCore
-
-		} // end of class FunctionObject_ClassSetter_B7DCDE33_Counter_set_count
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassGetter_F992ED3A_Counter_get_label
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassGetter_F992ED3A_Counter_get_label::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassGetter_F992ED3A_Counter_get_label::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassGetter_F992ED3A_Counter_get_label::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-				IL_001d: call instance object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::get_label()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassGetter_F992ED3A_Counter_get_label::CallCore
-
-		} // end of class FunctionObject_ClassGetter_F992ED3A_Counter_get_label
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 13 (0xd)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::_transitionalScopes
-				IL_0006: ldnull
-				IL_0007: call object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::get_total(object[], object)
-				IL_000c: ret
-			} // end of method FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::CallCore
-
-		} // end of class FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticSetter_3B870468_Counter_set_total
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 20 (0x14)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::_transitionalScopes
-				IL_0006: ldnull
-				IL_0007: ldarg.2
-				IL_0008: ldc.i4.0
-				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_000e: call object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::set_total(object[], object, object)
-				IL_0013: ret
-			} // end of method FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::CallCore
-
-		} // end of class FunctionObject_ClassStaticSetter_3B870468_Counter_set_total
+		} // end of class Scope_set_total
 
 
 		// Fields
@@ -630,7 +680,7 @@
 			.locals init (
 				[0] object[],
 				[1] class [System.Runtime]System.Type,
-				[2] class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassConstructor_F76E5D0D_Counter,
+				[2] class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_ctor/FunctionObject,
 				[3] float64
 			)
 
@@ -642,14 +692,14 @@
 			IL_0011: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0016: stloc.1
 			IL_0017: ldloc.0
-			IL_0018: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassConstructor_F76E5D0D_Counter::.ctor(object[])
+			IL_0018: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_ctor/FunctionObject::.ctor(object[])
 			IL_001d: ldloc.1
 			IL_001e: ldloc.0
 			IL_001f: ldc.i4.1
 			IL_0020: conv.r8
 			IL_0021: ldc.i4.0
 			IL_0022: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-			IL_0027: castclass Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassConstructor_F76E5D0D_Counter
+			IL_0027: castclass Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_ctor/FunctionObject
 			IL_002c: stloc.2
 			IL_002d: ldarg.2
 			IL_002e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
@@ -722,7 +772,7 @@
 			[2] class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter,
 			[3] object[],
 			[4] class [System.Runtime]System.Type,
-			[5] class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassConstructor_F76E5D0D_Counter,
+			[5] class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_ctor/FunctionObject,
 			[6] object,
 			[7] class [System.Runtime]System.Type,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console
@@ -744,14 +794,14 @@
 		IL_0021: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0026: stloc.s 4
 		IL_0028: ldloc.3
-		IL_0029: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassConstructor_F76E5D0D_Counter::.ctor(object[])
+		IL_0029: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_002e: ldloc.s 4
 		IL_0030: ldloc.3
 		IL_0031: ldc.i4.1
 		IL_0032: conv.r8
 		IL_0033: ldc.i4.0
 		IL_0034: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0039: castclass Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassConstructor_F76E5D0D_Counter
+		IL_0039: castclass Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_ctor/FunctionObject
 		IL_003e: stloc.s 5
 		IL_0040: ldloc.s 5
 		IL_0042: stloc.1
@@ -771,14 +821,14 @@
 		IL_007f: stloc.3
 		IL_0080: ldloc.s 6
 		IL_0082: ldstr "count"
-		IL_0087: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count::.ctor()
+		IL_0087: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_get_count/FunctionObject::.ctor()
 		IL_008c: ldc.i4.0
 		IL_008d: conv.r8
 		IL_008e: ldstr "get count"
 		IL_0093: ldc.i4.1
 		IL_0094: ldc.i4.1
-		IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count>(!!0, float64, string, bool, bool)
-		IL_009a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_9E713C73_Counter_get_count>(!!0)
+		IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_get_count/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_009a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_get_count/FunctionObject>(!!0)
 		IL_009f: ldnull
 		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
 		IL_00a5: pop
@@ -791,14 +841,14 @@
 		IL_00ba: ldloc.s 6
 		IL_00bc: ldstr "count"
 		IL_00c1: ldnull
-		IL_00c2: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::.ctor()
+		IL_00c2: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_set_count/FunctionObject::.ctor()
 		IL_00c7: ldc.i4.1
 		IL_00c8: conv.r8
 		IL_00c9: ldstr "set count"
 		IL_00ce: ldc.i4.1
 		IL_00cf: ldc.i4.1
-		IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count>(!!0, float64, string, bool, bool)
-		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassSetter_B7DCDE33_Counter_set_count>(!!0)
+		IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_set_count/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_set_count/FunctionObject>(!!0)
 		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
 		IL_00df: pop
 		IL_00e0: ldloc.s 4
@@ -809,14 +859,14 @@
 		IL_00f3: stloc.3
 		IL_00f4: ldloc.s 6
 		IL_00f6: ldstr "label"
-		IL_00fb: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label::.ctor()
+		IL_00fb: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_get_label/FunctionObject::.ctor()
 		IL_0100: ldc.i4.0
 		IL_0101: conv.r8
 		IL_0102: ldstr "get label"
 		IL_0107: ldc.i4.1
 		IL_0108: ldc.i4.1
-		IL_0109: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label>(!!0, float64, string, bool, bool)
-		IL_010e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassGetter_F992ED3A_Counter_get_label>(!!0)
+		IL_0109: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_get_label/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_010e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_get_label/FunctionObject>(!!0)
 		IL_0113: ldnull
 		IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
 		IL_0119: pop
@@ -835,14 +885,14 @@
 		IL_013b: ldloc.s 7
 		IL_013d: ldstr "total"
 		IL_0142: ldloc.3
-		IL_0143: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::.ctor(object[])
+		IL_0143: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_get_total/FunctionObject::.ctor(object[])
 		IL_0148: ldc.i4.0
 		IL_0149: conv.r8
 		IL_014a: ldstr "get total"
 		IL_014f: ldc.i4.0
 		IL_0150: ldc.i4.1
-		IL_0151: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total>(!!0, float64, string, bool, bool)
-		IL_0156: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total>(!!0)
+		IL_0151: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_get_total/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0156: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_get_total/FunctionObject>(!!0)
 		IL_015b: ldnull
 		IL_015c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
 		IL_0161: pop
@@ -862,14 +912,14 @@
 		IL_0185: ldstr "total"
 		IL_018a: ldnull
 		IL_018b: ldloc.3
-		IL_018c: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::.ctor(object[])
+		IL_018c: newobj instance void Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_set_total/FunctionObject::.ctor(object[])
 		IL_0191: ldc.i4.1
 		IL_0192: conv.r8
 		IL_0193: ldstr "set total"
 		IL_0198: ldc.i4.0
 		IL_0199: ldc.i4.1
-		IL_019a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total>(!!0, float64, string, bool, bool)
-		IL_019f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassStaticSetter_3B870468_Counter_set_total>(!!0)
+		IL_019a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_set_total/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_019f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/Scope_set_total/FunctionObject>(!!0)
 		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
 		IL_01a9: pop
 		IL_01aa: ldc.i4.1

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_BitShiftInCtor_Int32Array.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_BitShiftInCtor_Int32Array.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_BitShiftInCtor_Int32Array/BitBag/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +102,74 @@
 		.class nested public auto ansi beforefieldinit Scope_set
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_BitShiftInCtor_Int32Array/BitBag
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_BitShiftInCtor_Int32Array/BitBag
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Classes_BitShiftInCtor_Int32Array/BitBag::set(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -71,6 +189,75 @@
 		.class nested public auto ansi beforefieldinit Scope_test
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 47 (0x2f)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_BitShiftInCtor_Int32Array/BitBag
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_BitShiftInCtor_Int32Array/BitBag
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance float64 Modules.Classes_BitShiftInCtor_Int32Array/BitBag::test(object)
+					IL_0029: box [System.Runtime]System.Double
+					IL_002e: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -86,187 +273,6 @@
 			} // end of method Scope_test::.ctor
 
 		} // end of class Scope_test
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_1DD5642E_BitBag
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_BitShiftInCtor_Int32Array/BitBag/FunctionObject_ClassConstructor_1DD5642E_BitBag::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_1DD5642E_BitBag::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_1DD5642E_BitBag::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_1DD5642E_BitBag::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_1DD5642E_BitBag
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B2E3F181_BitBag_set
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_B2E3F181_BitBag_set::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B2E3F181_BitBag_set::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B2E3F181_BitBag_set::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_BitShiftInCtor_Int32Array/BitBag
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_BitShiftInCtor_Int32Array/BitBag
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Classes_BitShiftInCtor_Int32Array/BitBag::set(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_B2E3F181_BitBag_set::CallCore
-
-		} // end of class FunctionObject_ClassMethod_B2E3F181_BitBag_set
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_79A57BD7_BitBag_test
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_79A57BD7_BitBag_test::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_79A57BD7_BitBag_test::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_79A57BD7_BitBag_test::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 47 (0x2f)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_BitShiftInCtor_Int32Array/BitBag
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_BitShiftInCtor_Int32Array/BitBag
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance float64 Modules.Classes_BitShiftInCtor_Int32Array/BitBag::test(object)
-				IL_0029: box [System.Runtime]System.Double
-				IL_002e: ret
-			} // end of method FunctionObject_ClassMethod_79A57BD7_BitBag_test::CallCore
-
-		} // end of class FunctionObject_ClassMethod_79A57BD7_BitBag_test
 
 
 		// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DeclarationOrder.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DeclarationOrder.verified.txt
@@ -33,6 +33,71 @@
 		.class nested public auto ansi beforefieldinit Scope_Method_L5C2
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
+					IL_001d: call instance object Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example::'method'()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +114,7 @@
 
 		} // end of class Scope_Method_L5C2
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_6BFCC015_Example
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -69,9 +134,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassConstructor_6BFCC015_Example::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_6BFCC015_Example::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -82,7 +147,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_6BFCC015_Example::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -93,72 +158,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_6BFCC015_Example::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_6BFCC015_Example
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_A6279509_Example_method
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_A6279509_Example_method::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_A6279509_Example_method::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_A6279509_Example_method::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
-				IL_001d: call instance object Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example::'method'()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_A6279509_Example_method::CallCore
-
-		} // end of class FunctionObject_ClassMethod_A6279509_Example_method
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -264,7 +266,7 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassConstructor_6BFCC015_Example,
+			[6] class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[8] class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
 		)
@@ -285,14 +287,14 @@
 		IL_002e: stloc.s 5
 		IL_0030: ldloc.s 4
 		IL_0032: ldstr "method"
-		IL_0037: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method::.ctor()
+		IL_0037: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/Scope_Method_L5C2/FunctionObject::.ctor()
 		IL_003c: ldc.i4.0
 		IL_003d: conv.r8
 		IL_003e: ldstr "method"
 		IL_0043: ldc.i4.1
 		IL_0044: ldc.i4.1
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method>(!!0, float64, string, bool, bool)
-		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassMethod_A6279509_Example_method>(!!0)
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/Scope_Method_L5C2/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/Scope_Method_L5C2/FunctionObject>(!!0)
 		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0054: pop
 		IL_0055: ldc.i4.1
@@ -303,14 +305,14 @@
 		IL_005e: stelem.ref
 		IL_005f: stloc.s 5
 		IL_0061: ldloc.s 5
-		IL_0063: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassConstructor_6BFCC015_Example::.ctor(object[])
+		IL_0063: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject::.ctor(object[])
 		IL_0068: ldloc.3
 		IL_0069: ldloc.s 5
 		IL_006b: ldc.i4.0
 		IL_006c: conv.r8
 		IL_006d: ldc.i4.0
 		IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0073: castclass Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassConstructor_6BFCC015_Example
+		IL_0073: castclass Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject
 		IL_0078: stloc.s 6
 		IL_007a: ldloc.s 6
 		IL_007c: stloc.1

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
@@ -154,7 +154,7 @@
 
 		} // end of class Scope_methodKey
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_901BD596_Example
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -174,9 +174,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example/FunctionObject_ClassConstructor_901BD596_Example::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_901BD596_Example::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -187,7 +187,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_901BD596_Example::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -198,9 +198,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_901BD596_Example::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_901BD596_Example
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -280,7 +280,7 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example/FunctionObject_ClassConstructor_901BD596_Example,
+			[6] class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example/FunctionObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[8] class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example,
 			[9] bool,
@@ -335,14 +335,14 @@
 		IL_007e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0083: stloc.3
 		IL_0084: ldloc.s 5
-		IL_0086: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example/FunctionObject_ClassConstructor_901BD596_Example::.ctor(object[])
+		IL_0086: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example/FunctionObject::.ctor(object[])
 		IL_008b: ldloc.3
 		IL_008c: ldloc.s 5
 		IL_008e: ldc.i4.0
 		IL_008f: conv.r8
 		IL_0090: ldc.i4.0
 		IL_0091: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0096: castclass Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example/FunctionObject_ClassConstructor_901BD596_Example
+		IL_0096: castclass Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example/FunctionObject
 		IL_009b: stloc.s 6
 		IL_009d: ldloc.s 6
 		IL_009f: stloc.1

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
@@ -37,6 +37,61 @@
 			.class nested public auto ansi beforefieldinit Scope_ctor
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+				{
+					// Fields
+					.field private initonly class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope _environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope capture0,
+							object[] capture1
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 21 (0x15)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/MyClass/Scope_ctor/FunctionObject::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld object[] Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/MyClass/Scope_ctor/FunctionObject::_transitionalScopes
+						IL_0014: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -52,59 +107,6 @@
 				} // end of method Scope_ctor::.ctor
 
 			} // end of class Scope_ctor
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_B79F2CB3_MyClass
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-			{
-				// Fields
-				.field private initonly class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope _environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
-				.field private initonly object[] _transitionalScopes
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor (
-						class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope capture0,
-						object[] capture1
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 21 (0x15)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-					IL_0006: ldarg.0
-					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/MyClass/FunctionObject_ClassConstructor_B79F2CB3_MyClass::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
-					IL_000d: ldarg.0
-					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/MyClass/FunctionObject_ClassConstructor_B79F2CB3_MyClass::_transitionalScopes
-					IL_0014: ret
-				} // end of method FunctionObject_ClassConstructor_B79F2CB3_MyClass::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.1
-					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_B79F2CB3_MyClass::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_B79F2CB3_MyClass::get_RequiresInvocationContext
-
-			} // end of class FunctionObject_ClassConstructor_B79F2CB3_MyClass
 
 
 			// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -37,6 +37,61 @@
 			.class nested public auto ansi beforefieldinit Scope_ctor
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+				{
+					// Fields
+					.field private initonly class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope _environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope capture0,
+							object[] capture1
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 21 (0x15)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass/Scope_ctor/FunctionObject::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld object[] Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass/Scope_ctor/FunctionObject::_transitionalScopes
+						IL_0014: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -52,59 +107,6 @@
 				} // end of method Scope_ctor::.ctor
 
 			} // end of class Scope_ctor
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_30E4CCE8_MyClass
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-			{
-				// Fields
-				.field private initonly class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope _environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
-				.field private initonly object[] _transitionalScopes
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor (
-						class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope capture0,
-						object[] capture1
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 21 (0x15)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-					IL_0006: ldarg.0
-					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass/FunctionObject_ClassConstructor_30E4CCE8_MyClass::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
-					IL_000d: ldarg.0
-					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass/FunctionObject_ClassConstructor_30E4CCE8_MyClass::_transitionalScopes
-					IL_0014: ret
-				} // end of method FunctionObject_ClassConstructor_30E4CCE8_MyClass::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.1
-					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_30E4CCE8_MyClass::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_30E4CCE8_MyClass::get_RequiresInvocationContext
-
-			} // end of class FunctionObject_ClassConstructor_30E4CCE8_MyClass
 
 
 			// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
@@ -37,6 +37,56 @@
 			.class nested public auto ansi beforefieldinit Scope_ctor
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+				{
+					// Fields
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							object[] capture0
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld object[] Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/MyClass/Scope_ctor/FunctionObject::_transitionalScopes
+						IL_000d: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -52,54 +102,6 @@
 				} // end of method Scope_ctor::.ctor
 
 			} // end of class Scope_ctor
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_69520357_MyClass
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-			{
-				// Fields
-				.field private initonly object[] _transitionalScopes
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor (
-						object[] capture0
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 14 (0xe)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-					IL_0006: ldarg.0
-					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/MyClass/FunctionObject_ClassConstructor_69520357_MyClass::_transitionalScopes
-					IL_000d: ret
-				} // end of method FunctionObject_ClassConstructor_69520357_MyClass::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.1
-					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_69520357_MyClass::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_69520357_MyClass::get_RequiresInvocationContext
-
-			} // end of class FunctionObject_ClassConstructor_69520357_MyClass
 
 
 			// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
@@ -37,6 +37,56 @@
 			.class nested public auto ansi beforefieldinit Scope_ctor
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+				{
+					// Fields
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							object[] capture0
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld object[] Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/MyClass/Scope_ctor/FunctionObject::_transitionalScopes
+						IL_000d: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -52,54 +102,6 @@
 				} // end of method Scope_ctor::.ctor
 
 			} // end of class Scope_ctor
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_016F80B4_MyClass
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-			{
-				// Fields
-				.field private initonly object[] _transitionalScopes
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor (
-						object[] capture0
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 14 (0xe)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-					IL_0006: ldarg.0
-					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/MyClass/FunctionObject_ClassConstructor_016F80B4_MyClass::_transitionalScopes
-					IL_000d: ret
-				} // end of method FunctionObject_ClassConstructor_016F80B4_MyClass::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.1
-					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_016F80B4_MyClass::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_016F80B4_MyClass::get_RequiresInvocationContext
-
-			} // end of class FunctionObject_ClassConstructor_016F80B4_MyClass
 
 
 			// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/MyClass/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,54 +98,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_9F35C9DD_MyClass
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/MyClass/FunctionObject_ClassConstructor_9F35C9DD_MyClass::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_9F35C9DD_MyClass::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_9F35C9DD_MyClass::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_9F35C9DD_MyClass::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_9F35C9DD_MyClass
 
 
 		// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariable_Log.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/MyClass/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,54 +98,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7A43705E_MyClass
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/MyClass/FunctionObject_ClassConstructor_7A43705E_MyClass::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_7A43705E_MyClass::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7A43705E_MyClass::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7A43705E_MyClass::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_7A43705E_MyClass
 
 
 		// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_NewClassReferencingGlobal.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_NewClassReferencingGlobal.verified.txt
@@ -33,6 +33,61 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope _environment0_Classes_ClassConstructor_NewClassReferencingGlobal
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner/Scope_ctor/FunctionObject::_environment0_Classes_ClassConstructor_NewClassReferencingGlobal
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,59 +103,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_53291FE3_Inner
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope _environment0_Classes_ClassConstructor_NewClassReferencingGlobal
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope capture0,
-					object[] capture1
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 21 (0x15)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner/FunctionObject_ClassConstructor_53291FE3_Inner::_environment0_Classes_ClassConstructor_NewClassReferencingGlobal
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner/FunctionObject_ClassConstructor_53291FE3_Inner::_transitionalScopes
-				IL_0014: ret
-			} // end of method FunctionObject_ClassConstructor_53291FE3_Inner::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_53291FE3_Inner::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_53291FE3_Inner::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_53291FE3_Inner
 
 
 		// Fields
@@ -164,6 +166,61 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope _environment0_Classes_ClassConstructor_NewClassReferencingGlobal
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer/Scope_ctor/FunctionObject::_environment0_Classes_ClassConstructor_NewClassReferencingGlobal
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -179,59 +236,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_4CBD5D48_Outer
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope _environment0_Classes_ClassConstructor_NewClassReferencingGlobal
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope capture0,
-					object[] capture1
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 21 (0x15)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer/FunctionObject_ClassConstructor_4CBD5D48_Outer::_environment0_Classes_ClassConstructor_NewClassReferencingGlobal
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer/FunctionObject_ClassConstructor_4CBD5D48_Outer::_transitionalScopes
-				IL_0014: ret
-			} // end of method FunctionObject_ClassConstructor_4CBD5D48_Outer::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_4CBD5D48_Outer::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_4CBD5D48_Outer::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_4CBD5D48_Outer
 
 
 		// Fields
@@ -319,8 +323,8 @@
 			[2] class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer,
 			[3] object[],
 			[4] class [System.Runtime]System.Type,
-			[5] class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner/FunctionObject_ClassConstructor_53291FE3_Inner,
-			[6] class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer/FunctionObject_ClassConstructor_4CBD5D48_Outer,
+			[5] class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner/Scope_ctor/FunctionObject,
+			[6] class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer/Scope_ctor/FunctionObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[8] object
 		)
@@ -345,14 +349,14 @@
 		IL_002a: ldelem.ref
 		IL_002b: castclass Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope
 		IL_0030: ldloc.3
-		IL_0031: newobj instance void Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner/FunctionObject_ClassConstructor_53291FE3_Inner::.ctor(class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope, object[])
+		IL_0031: newobj instance void Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner/Scope_ctor/FunctionObject::.ctor(class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope, object[])
 		IL_0036: ldloc.s 4
 		IL_0038: ldloc.3
 		IL_0039: ldc.i4.0
 		IL_003a: conv.r8
 		IL_003b: ldc.i4.0
 		IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0041: castclass Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner/FunctionObject_ClassConstructor_53291FE3_Inner
+		IL_0041: castclass Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner/Scope_ctor/FunctionObject
 		IL_0046: stloc.s 5
 		IL_0048: ldloc.0
 		IL_0049: ldloc.s 5
@@ -374,14 +378,14 @@
 		IL_0073: ldelem.ref
 		IL_0074: castclass Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope
 		IL_0079: ldloc.3
-		IL_007a: newobj instance void Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer/FunctionObject_ClassConstructor_4CBD5D48_Outer::.ctor(class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope, object[])
+		IL_007a: newobj instance void Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer/Scope_ctor/FunctionObject::.ctor(class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope, object[])
 		IL_007f: ldloc.s 4
 		IL_0081: ldloc.3
 		IL_0082: ldc.i4.0
 		IL_0083: conv.r8
 		IL_0084: ldc.i4.0
 		IL_0085: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_008a: castclass Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer/FunctionObject_ClassConstructor_4CBD5D48_Outer
+		IL_008a: castclass Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer/Scope_ctor/FunctionObject
 		IL_008f: stloc.s 6
 		IL_0091: ldloc.s 6
 		IL_0093: stloc.1

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_New_In_ArrowFunction.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_New_In_ArrowFunction.verified.txt
@@ -165,6 +165,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_New_In_ArrowFunction/PrimeSieve/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -180,54 +230,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_096DDC25_PrimeSieve
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassConstructor_New_In_ArrowFunction/PrimeSieve/FunctionObject_ClassConstructor_096DDC25_PrimeSieve::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_096DDC25_PrimeSieve::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_096DDC25_PrimeSieve::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_096DDC25_PrimeSieve::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_096DDC25_PrimeSieve
 
 
 		// Fields
@@ -302,7 +304,7 @@
 			[1] object,
 			[2] object[],
 			[3] class [System.Runtime]System.Type,
-			[4] class Modules.Classes_ClassConstructor_New_In_ArrowFunction/PrimeSieve/FunctionObject_ClassConstructor_096DDC25_PrimeSieve,
+			[4] class Modules.Classes_ClassConstructor_New_In_ArrowFunction/PrimeSieve/Scope_ctor/FunctionObject,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[6] object
 		)
@@ -323,14 +325,14 @@
 		IL_0021: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0026: stloc.3
 		IL_0027: ldloc.2
-		IL_0028: newobj instance void Modules.Classes_ClassConstructor_New_In_ArrowFunction/PrimeSieve/FunctionObject_ClassConstructor_096DDC25_PrimeSieve::.ctor(object[])
+		IL_0028: newobj instance void Modules.Classes_ClassConstructor_New_In_ArrowFunction/PrimeSieve/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_002d: ldloc.3
 		IL_002e: ldloc.2
 		IL_002f: ldc.i4.1
 		IL_0030: conv.r8
 		IL_0031: ldc.i4.0
 		IL_0032: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0037: castclass Modules.Classes_ClassConstructor_New_In_ArrowFunction/PrimeSieve/FunctionObject_ClassConstructor_096DDC25_PrimeSieve
+		IL_0037: castclass Modules.Classes_ClassConstructor_New_In_ArrowFunction/PrimeSieve/Scope_ctor/FunctionObject
 		IL_003c: stloc.s 4
 		IL_003e: ldloc.0
 		IL_003f: ldloc.s 4

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_Param_Field_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_Param_Field_Log.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_Param_Field_Log/Greeter/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +102,71 @@
 		.class nested public auto ansi beforefieldinit Scope_sayName
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassConstructor_Param_Field_Log/Greeter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassConstructor_Param_Field_Log/Greeter
+					IL_001d: call instance object Modules.Classes_ClassConstructor_Param_Field_Log/Greeter::sayName()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -67,117 +182,6 @@
 			} // end of method Scope_sayName::.ctor
 
 		} // end of class Scope_sayName
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_A5FD9DE9_Greeter
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassConstructor_Param_Field_Log/Greeter/FunctionObject_ClassConstructor_A5FD9DE9_Greeter::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_A5FD9DE9_Greeter::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_A5FD9DE9_Greeter::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_A5FD9DE9_Greeter::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_A5FD9DE9_Greeter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_3AF307DC_Greeter_sayName
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_3AF307DC_Greeter_sayName::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_3AF307DC_Greeter_sayName::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_3AF307DC_Greeter_sayName::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassConstructor_Param_Field_Log/Greeter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassConstructor_Param_Field_Log/Greeter
-				IL_001d: call instance object Modules.Classes_ClassConstructor_Param_Field_Log/Greeter::sayName()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_3AF307DC_Greeter_sayName::CallCore
-
-		} // end of class FunctionObject_ClassMethod_3AF307DC_Greeter_sayName
 
 
 		// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_ParameterDestructuring.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_ParameterDestructuring.verified.txt
@@ -37,6 +37,56 @@
 				01 00 17 53 63 6f 70 65 5f 63 74 6f 72 20 78 3d
 				7b 78 7d 2c 20 79 3d 7b 79 7d 00 00
 			)
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_ParameterDestructuring/Point/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Fields
 			.field public object x
 			.field public object y
@@ -60,6 +110,71 @@
 		.class nested public auto ansi beforefieldinit Scope_display
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassConstructor_ParameterDestructuring/Point
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassConstructor_ParameterDestructuring/Point
+					IL_001d: call instance object Modules.Classes_ClassConstructor_ParameterDestructuring/Point::display()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -75,117 +190,6 @@
 			} // end of method Scope_display::.ctor
 
 		} // end of class Scope_display
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_6F38F35C_Point
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassConstructor_ParameterDestructuring/Point/FunctionObject_ClassConstructor_6F38F35C_Point::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_6F38F35C_Point::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_6F38F35C_Point::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_6F38F35C_Point::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_6F38F35C_Point
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_0A30C2A1_Point_display
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_0A30C2A1_Point_display::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_0A30C2A1_Point_display::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_0A30C2A1_Point_display::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassConstructor_ParameterDestructuring/Point
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassConstructor_ParameterDestructuring/Point
-				IL_001d: call instance object Modules.Classes_ClassConstructor_ParameterDestructuring/Point::display()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_0A30C2A1_Point_display::CallCore
-
-		} // end of class FunctionObject_ClassMethod_0A30C2A1_Point_display
 
 
 		// Fields
@@ -316,6 +320,56 @@
 				61 67 65 7d 2c 20 63 69 74 79 3d 7b 63 69 74 79
 				7d 00 00
 			)
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_ParameterDestructuring/Person/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Fields
 			.field public object name
 			.field public object age
@@ -340,6 +394,71 @@
 		.class nested public auto ansi beforefieldinit Scope_greet
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassConstructor_ParameterDestructuring/Person
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassConstructor_ParameterDestructuring/Person
+					IL_001d: call instance object Modules.Classes_ClassConstructor_ParameterDestructuring/Person::greet()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -355,117 +474,6 @@
 			} // end of method Scope_greet::.ctor
 
 		} // end of class Scope_greet
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_CF97FAD7_Person
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassConstructor_ParameterDestructuring/Person/FunctionObject_ClassConstructor_CF97FAD7_Person::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_CF97FAD7_Person::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_CF97FAD7_Person::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_CF97FAD7_Person::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_CF97FAD7_Person
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_8CCBBF9B_Person_greet
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_8CCBBF9B_Person_greet::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_8CCBBF9B_Person_greet::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_8CCBBF9B_Person_greet::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassConstructor_ParameterDestructuring/Person
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassConstructor_ParameterDestructuring/Person
-				IL_001d: call instance object Modules.Classes_ClassConstructor_ParameterDestructuring/Person::greet()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_8CCBBF9B_Person_greet::CallCore
-
-		} // end of class FunctionObject_ClassMethod_8CCBBF9B_Person_greet
 
 
 		// Fields
@@ -626,6 +634,54 @@
 
 			} // end of class Block_L28C69
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_ParameterDestructuring/Config/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
 
 			// Fields
 			.field public object host
@@ -651,6 +707,71 @@
 		.class nested public auto ansi beforefieldinit Scope_display
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassConstructor_ParameterDestructuring/Config
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassConstructor_ParameterDestructuring/Config
+					IL_001d: call instance object Modules.Classes_ClassConstructor_ParameterDestructuring/Config::display()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -666,117 +787,6 @@
 			} // end of method Scope_display::.ctor
 
 		} // end of class Scope_display
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7646F544_Config
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassConstructor_ParameterDestructuring/Config/FunctionObject_ClassConstructor_7646F544_Config::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_7646F544_Config::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7646F544_Config::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7646F544_Config::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_7646F544_Config
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C1E38EFF_Config_display
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_C1E38EFF_Config_display::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C1E38EFF_Config_display::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C1E38EFF_Config_display::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassConstructor_ParameterDestructuring/Config
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassConstructor_ParameterDestructuring/Config
-				IL_001d: call instance object Modules.Classes_ClassConstructor_ParameterDestructuring/Config::display()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_C1E38EFF_Config_display::CallCore
-
-		} // end of class FunctionObject_ClassMethod_C1E38EFF_Config_display
 
 
 		// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TwoParams_AddMethod.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TwoParams_AddMethod.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +102,71 @@
 		.class nested public auto ansi beforefieldinit Scope_add
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder
+					IL_001d: call instance object Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder::'add'()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -67,117 +182,6 @@
 			} // end of method Scope_add::.ctor
 
 		} // end of class Scope_add
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_3E5F8A45_Adder
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder/FunctionObject_ClassConstructor_3E5F8A45_Adder::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_3E5F8A45_Adder::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_3E5F8A45_Adder::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_3E5F8A45_Adder::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_3E5F8A45_Adder
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_BBF2F92B_Adder_add
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_BBF2F92B_Adder_add::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_BBF2F92B_Adder_add::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_BBF2F92B_Adder_add::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder
-				IL_001d: call instance object Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder::'add'()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_BBF2F92B_Adder_add::CallCore
-
-		} // end of class FunctionObject_ClassMethod_BBF2F92B_Adder_add
 
 
 		// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TwoParams_SubtractMethod.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TwoParams_SubtractMethod.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +102,71 @@
 		.class nested public auto ansi beforefieldinit Scope_sub
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber
+					IL_001d: call instance object Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber::'sub'()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -67,117 +182,6 @@
 			} // end of method Scope_sub::.ctor
 
 		} // end of class Scope_sub
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_DC85BC97_Subber
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber/FunctionObject_ClassConstructor_DC85BC97_Subber::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_DC85BC97_Subber::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_DC85BC97_Subber::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_DC85BC97_Subber::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_DC85BC97_Subber
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_6E1B7D68_Subber_sub
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_6E1B7D68_Subber_sub::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_6E1B7D68_Subber_sub::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_6E1B7D68_Subber_sub::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber
-				IL_001d: call instance object Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber::'sub'()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_6E1B7D68_Subber_sub::CallCore
-
-		} // end of class FunctionObject_ClassMethod_6E1B7D68_Subber_sub
 
 
 		// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TypedNestedNew_FieldStore.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TypedNestedNew_FieldStore.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Bar/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,54 +98,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_B4BBA70C_Bar
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Bar/FunctionObject_ClassConstructor_B4BBA70C_Bar::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_B4BBA70C_Bar::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_B4BBA70C_Bar::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_B4BBA70C_Bar::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_B4BBA70C_Bar
 
 
 		// Fields
@@ -150,6 +152,61 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Scope _environment0_Classes_ClassConstructor_TypedNestedNew_FieldStore
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Scope Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Foo/Scope_ctor/FunctionObject::_environment0_Classes_ClassConstructor_TypedNestedNew_FieldStore
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Foo/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -165,59 +222,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7E70C62D_Foo
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Scope _environment0_Classes_ClassConstructor_TypedNestedNew_FieldStore
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Scope capture0,
-					object[] capture1
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 21 (0x15)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Scope Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Foo/FunctionObject_ClassConstructor_7E70C62D_Foo::_environment0_Classes_ClassConstructor_TypedNestedNew_FieldStore
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Foo/FunctionObject_ClassConstructor_7E70C62D_Foo::_transitionalScopes
-				IL_0014: ret
-			} // end of method FunctionObject_ClassConstructor_7E70C62D_Foo::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7E70C62D_Foo::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7E70C62D_Foo::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_7E70C62D_Foo
 
 
 		// Fields
@@ -303,8 +307,8 @@
 			[2] class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Foo,
 			[3] object[],
 			[4] class [System.Runtime]System.Type,
-			[5] class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Bar/FunctionObject_ClassConstructor_B4BBA70C_Bar,
-			[6] class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Foo/FunctionObject_ClassConstructor_7E70C62D_Foo,
+			[5] class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Bar/Scope_ctor/FunctionObject,
+			[6] class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Foo/Scope_ctor/FunctionObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[8] object
 		)
@@ -324,14 +328,14 @@
 		IL_0020: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0025: stloc.s 4
 		IL_0027: ldloc.3
-		IL_0028: newobj instance void Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Bar/FunctionObject_ClassConstructor_B4BBA70C_Bar::.ctor(object[])
+		IL_0028: newobj instance void Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Bar/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_002d: ldloc.s 4
 		IL_002f: ldloc.3
 		IL_0030: ldc.i4.1
 		IL_0031: conv.r8
 		IL_0032: ldc.i4.0
 		IL_0033: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0038: castclass Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Bar/FunctionObject_ClassConstructor_B4BBA70C_Bar
+		IL_0038: castclass Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Bar/Scope_ctor/FunctionObject
 		IL_003d: stloc.s 5
 		IL_003f: ldloc.0
 		IL_0040: ldloc.s 5
@@ -353,14 +357,14 @@
 		IL_006a: ldelem.ref
 		IL_006b: castclass Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Scope
 		IL_0070: ldloc.3
-		IL_0071: newobj instance void Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Foo/FunctionObject_ClassConstructor_7E70C62D_Foo::.ctor(class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Scope, object[])
+		IL_0071: newobj instance void Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Foo/Scope_ctor/FunctionObject::.ctor(class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Scope, object[])
 		IL_0076: ldloc.s 4
 		IL_0078: ldloc.3
 		IL_0079: ldc.i4.0
 		IL_007a: conv.r8
 		IL_007b: ldc.i4.0
 		IL_007c: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0081: castclass Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Foo/FunctionObject_ClassConstructor_7E70C62D_Foo
+		IL_0081: castclass Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Foo/Scope_ctor/FunctionObject
 		IL_0086: stloc.s 6
 		IL_0088: ldloc.s 6
 		IL_008a: stloc.1

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_WithMultipleParameters.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_WithMultipleParameters.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C1/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,54 +98,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_757F8F94_C1
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C1/FunctionObject_ClassConstructor_757F8F94_C1::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_757F8F94_C1::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_757F8F94_C1::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_757F8F94_C1::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_757F8F94_C1
 
 
 		// Methods
@@ -155,6 +157,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C2/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -170,54 +222,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_787F944D_C2
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C2/FunctionObject_ClassConstructor_787F944D_C2::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_787F944D_C2::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_787F944D_C2::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_787F944D_C2::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_787F944D_C2
 
 
 		// Methods
@@ -280,6 +284,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C3/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -295,54 +349,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_777F92BA_C3
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C3/FunctionObject_ClassConstructor_777F92BA_C3::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_777F92BA_C3::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_777F92BA_C3::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_777F92BA_C3::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_777F92BA_C3
 
 
 		// Methods
@@ -422,6 +428,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C4/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -437,54 +493,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_727F8ADB_C4
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C4/FunctionObject_ClassConstructor_727F8ADB_C4::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_727F8ADB_C4::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_727F8ADB_C4::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_727F8ADB_C4::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_727F8ADB_C4
 
 
 		// Methods
@@ -570,6 +578,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C5/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -585,54 +643,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_717F8948_C5
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C5/FunctionObject_ClassConstructor_717F8948_C5::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_717F8948_C5::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_717F8948_C5::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_717F8948_C5::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_717F8948_C5
 
 
 		// Methods
@@ -724,6 +734,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C6/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -739,54 +799,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_747F8E01_C6
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C6/FunctionObject_ClassConstructor_747F8E01_C6::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_747F8E01_C6::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_747F8E01_C6::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_747F8E01_C6::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_747F8E01_C6
 
 
 		// Methods

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassExpression_LazyPrototypeMetadata.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassExpression_LazyPrototypeMetadata.verified.txt
@@ -33,6 +33,71 @@
 		.class nested public auto ansi beforefieldinit Scope_greet
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17
+					IL_001d: call instance object Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17::greet()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +114,7 @@
 
 		} // end of class Scope_greet
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -69,9 +134,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -82,7 +147,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -93,72 +158,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17
-				IL_001d: call instance object Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17::greet()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::CallCore
-
-		} // end of class FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -234,7 +236,7 @@
 			[4] class [System.Runtime]System.Type,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17,
+			[7] class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[9] object,
 			[10] bool,
@@ -267,14 +269,14 @@
 		IL_0057: stloc.s 6
 		IL_0059: ldloc.s 5
 		IL_005b: ldstr "greet"
-		IL_0060: newobj instance void Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::.ctor()
+		IL_0060: newobj instance void Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/Scope_greet/FunctionObject::.ctor()
 		IL_0065: ldc.i4.0
 		IL_0066: conv.r8
 		IL_0067: ldstr "greet"
 		IL_006c: ldc.i4.0
 		IL_006d: ldc.i4.1
-		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet>(!!0, float64, string, bool, bool)
-		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet>(!!0)
+		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/Scope_greet/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/Scope_greet/FunctionObject>(!!0)
 		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_007d: pop
 		IL_007e: ldc.i4.1
@@ -285,14 +287,14 @@
 		IL_0087: stelem.ref
 		IL_0088: stloc.s 6
 		IL_008a: ldloc.s 6
-		IL_008c: newobj instance void Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::.ctor(object[])
+		IL_008c: newobj instance void Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject::.ctor(object[])
 		IL_0091: ldloc.s 4
 		IL_0093: ldloc.s 6
 		IL_0095: ldc.i4.0
 		IL_0096: conv.r8
 		IL_0097: ldc.i4.1
 		IL_0098: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_009d: castclass Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17
+		IL_009d: castclass Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject
 		IL_00a2: stloc.s 7
 		IL_00a4: ldloc.s 7
 		IL_00a6: ldstr "Greeter"

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassFieldTypeInference_Primitives.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassFieldTypeInference_Primitives.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassFieldTypeInference_Primitives/Counter/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +102,71 @@
 		.class nested public auto ansi beforefieldinit Scope_increment
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassFieldTypeInference_Primitives/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassFieldTypeInference_Primitives/Counter
+					IL_001d: call instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -67,117 +182,6 @@
 			} // end of method Scope_increment::.ctor
 
 		} // end of class Scope_increment
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_E57E053D_Counter
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassConstructor_E57E053D_Counter::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_E57E053D_Counter::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_E57E053D_Counter::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_E57E053D_Counter::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_E57E053D_Counter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_8D75F331_Counter_increment
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_8D75F331_Counter_increment::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_8D75F331_Counter_increment::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_8D75F331_Counter_increment::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassFieldTypeInference_Primitives/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassFieldTypeInference_Primitives/Counter
-				IL_001d: call instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_8D75F331_Counter_increment::CallCore
-
-		} // end of class FunctionObject_ClassMethod_8D75F331_Counter_increment
 
 
 		// Fields
@@ -277,7 +281,7 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassConstructor_E57E053D_Counter,
+			[6] class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/Scope_ctor/FunctionObject,
 			[7] class Modules.Classes_ClassFieldTypeInference_Primitives/Counter,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -298,14 +302,14 @@
 		IL_002e: stloc.s 5
 		IL_0030: ldloc.s 4
 		IL_0032: ldstr "increment"
-		IL_0037: newobj instance void Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment::.ctor()
+		IL_0037: newobj instance void Modules.Classes_ClassFieldTypeInference_Primitives/Counter/Scope_increment/FunctionObject::.ctor()
 		IL_003c: ldc.i4.0
 		IL_003d: conv.r8
 		IL_003e: ldstr "increment"
 		IL_0043: ldc.i4.1
 		IL_0044: ldc.i4.1
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment>(!!0, float64, string, bool, bool)
-		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassMethod_8D75F331_Counter_increment>(!!0)
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/Scope_increment/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassFieldTypeInference_Primitives/Counter/Scope_increment/FunctionObject>(!!0)
 		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0054: pop
 		IL_0055: ldc.i4.1
@@ -316,14 +320,14 @@
 		IL_005e: stelem.ref
 		IL_005f: stloc.s 5
 		IL_0061: ldloc.s 5
-		IL_0063: newobj instance void Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassConstructor_E57E053D_Counter::.ctor(object[])
+		IL_0063: newobj instance void Modules.Classes_ClassFieldTypeInference_Primitives/Counter/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_0068: ldloc.3
 		IL_0069: ldloc.s 5
 		IL_006b: ldc.i4.0
 		IL_006c: conv.r8
 		IL_006d: ldc.i4.0
 		IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0073: castclass Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassConstructor_E57E053D_Counter
+		IL_0073: castclass Modules.Classes_ClassFieldTypeInference_Primitives/Counter/Scope_ctor/FunctionObject
 		IL_0078: stloc.s 6
 		IL_007a: ldloc.s 6
 		IL_007c: stloc.1

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassLocal_ReassignedClass_FallsBack.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassLocal_ReassignedClass_FallsBack.verified.txt
@@ -299,6 +299,72 @@
 		.class nested public auto ansi beforefieldinit Scope_read
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box
+					IL_001d: call instance float64 Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box::read()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -315,7 +381,7 @@
 
 		} // end of class Scope_read
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_BF595FDD_Box
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -335,9 +401,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassConstructor_BF595FDD_Box::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_BF595FDD_Box::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -348,7 +414,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_BF595FDD_Box::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -359,73 +425,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_BF595FDD_Box::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_BF595FDD_Box
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_F961BB76_Box_read
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_F961BB76_Box_read::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_F961BB76_Box_read::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_F961BB76_Box_read::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box
-				IL_001d: call instance float64 Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box::read()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_F961BB76_Box_read::CallCore
-
-		} // end of class FunctionObject_ClassMethod_F961BB76_Box_read
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -507,7 +509,7 @@
 			[2] object[],
 			[3] class [System.Runtime]System.Type,
 			[4] object,
-			[5] class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassConstructor_BF595FDD_Box
+			[5] class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope::.ctor()
@@ -545,14 +547,14 @@
 		IL_0059: stloc.2
 		IL_005a: ldloc.s 4
 		IL_005c: ldstr "read"
-		IL_0061: newobj instance void Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read::.ctor()
+		IL_0061: newobj instance void Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/Scope_read/FunctionObject::.ctor()
 		IL_0066: ldc.i4.0
 		IL_0067: conv.r8
 		IL_0068: ldstr "read"
 		IL_006d: ldc.i4.0
 		IL_006e: ldc.i4.1
-		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read>(!!0, float64, string, bool, bool)
-		IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassMethod_F961BB76_Box_read>(!!0)
+		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/Scope_read/FunctionObject>(!!0)
 		IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_007e: pop
 		IL_007f: ldc.i4.1
@@ -563,14 +565,14 @@
 		IL_0088: stelem.ref
 		IL_0089: stloc.2
 		IL_008a: ldloc.2
-		IL_008b: newobj instance void Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassConstructor_BF595FDD_Box::.ctor(object[])
+		IL_008b: newobj instance void Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject::.ctor(object[])
 		IL_0090: ldloc.3
 		IL_0091: ldloc.2
 		IL_0092: ldc.i4.0
 		IL_0093: conv.r8
 		IL_0094: ldc.i4.0
 		IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_009a: castclass Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassConstructor_BF595FDD_Box
+		IL_009a: castclass Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject
 		IL_009f: stloc.s 5
 		IL_00a1: ldloc.0
 		IL_00a2: ldloc.s 5

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -37,6 +37,79 @@
 			.class nested public auto ansi beforefieldinit Scope_logValues
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							object[] capture0
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass/Scope_logValues/FunctionObject::_transitionalScopes
+						IL_000d: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 35 (0x23)
+						.maxstack 8
+
+						IL_0000: ldarg.1
+						IL_0001: ldtoken Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass
+						IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+						IL_000b: ldarg.0
+						IL_000c: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass/Scope_logValues/FunctionObject::_transitionalScopes
+						IL_0011: ldnull
+						IL_0012: ldarg.0
+						IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+						IL_0018: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass
+						IL_001d: call instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::logValues()
+						IL_0022: ret
+					} // end of method FunctionObject::CallCore
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -53,7 +126,7 @@
 
 			} // end of class Scope_logValues
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_15D265B3_MyClass
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 			{
 				// Fields
@@ -73,9 +146,9 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass/FunctionObject_ClassConstructor_15D265B3_MyClass::_transitionalScopes
+					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass/FunctionObject::_transitionalScopes
 					IL_000d: ret
-				} // end of method FunctionObject_ClassConstructor_15D265B3_MyClass::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -86,7 +159,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_15D265B3_MyClass::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -97,80 +170,9 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_15D265B3_MyClass::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
-			} // end of class FunctionObject_ClassConstructor_15D265B3_MyClass
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-			{
-				// Fields
-				.field private initonly object[] _transitionalScopes
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor (
-						object[] capture0
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 14 (0xe)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-					IL_0006: ldarg.0
-					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass/FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues::_transitionalScopes
-					IL_000d: ret
-				} // end of method FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues::get_RequiresInvocationContext
-
-				.method family hidebysig virtual 
-					instance object CallCore (
-						object thisArgument,
-						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 35 (0x23)
-					.maxstack 8
-
-					IL_0000: ldarg.1
-					IL_0001: ldtoken Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass
-					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-					IL_000b: ldarg.0
-					IL_000c: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass/FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues::_transitionalScopes
-					IL_0011: ldnull
-					IL_0012: ldarg.0
-					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-					IL_0018: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass
-					IL_001d: call instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::logValues()
-					IL_0022: ret
-				} // end of method FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues::CallCore
-
-			} // end of class FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues
+			} // end of class FunctionObject
 
 
 			// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
@@ -37,6 +37,79 @@
 			.class nested public auto ansi beforefieldinit Scope_logValue
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							object[] capture0
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass/Scope_logValue/FunctionObject::_transitionalScopes
+						IL_000d: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 35 (0x23)
+						.maxstack 8
+
+						IL_0000: ldarg.1
+						IL_0001: ldtoken Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass
+						IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+						IL_000b: ldarg.0
+						IL_000c: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass/Scope_logValue/FunctionObject::_transitionalScopes
+						IL_0011: ldnull
+						IL_0012: ldarg.0
+						IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+						IL_0018: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass
+						IL_001d: call instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::logValue()
+						IL_0022: ret
+					} // end of method FunctionObject::CallCore
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -53,7 +126,7 @@
 
 			} // end of class Scope_logValue
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_D311ADDD_MyClass
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 			{
 				// Fields
@@ -73,9 +146,9 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass/FunctionObject_ClassConstructor_D311ADDD_MyClass::_transitionalScopes
+					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass/FunctionObject::_transitionalScopes
 					IL_000d: ret
-				} // end of method FunctionObject_ClassConstructor_D311ADDD_MyClass::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -86,7 +159,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_D311ADDD_MyClass::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -97,80 +170,9 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_D311ADDD_MyClass::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
-			} // end of class FunctionObject_ClassConstructor_D311ADDD_MyClass
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B4D5C393_MyClass_logValue
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-			{
-				// Fields
-				.field private initonly object[] _transitionalScopes
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor (
-						object[] capture0
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 14 (0xe)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-					IL_0006: ldarg.0
-					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass/FunctionObject_ClassMethod_B4D5C393_MyClass_logValue::_transitionalScopes
-					IL_000d: ret
-				} // end of method FunctionObject_ClassMethod_B4D5C393_MyClass_logValue::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_B4D5C393_MyClass_logValue::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_B4D5C393_MyClass_logValue::get_RequiresInvocationContext
-
-				.method family hidebysig virtual 
-					instance object CallCore (
-						object thisArgument,
-						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 35 (0x23)
-					.maxstack 8
-
-					IL_0000: ldarg.1
-					IL_0001: ldtoken Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass
-					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-					IL_000b: ldarg.0
-					IL_000c: ldfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass/FunctionObject_ClassMethod_B4D5C393_MyClass_logValue::_transitionalScopes
-					IL_0011: ldnull
-					IL_0012: ldarg.0
-					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-					IL_0018: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass
-					IL_001d: call instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::logValue()
-					IL_0022: ret
-				} // end of method FunctionObject_ClassMethod_B4D5C393_MyClass_logValue::CallCore
-
-			} // end of class FunctionObject_ClassMethod_B4D5C393_MyClass_logValue
+			} // end of class FunctionObject
 
 
 			// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -37,6 +37,79 @@
 			.class nested public auto ansi beforefieldinit Scope_logValues
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							object[] capture0
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass/Scope_logValues/FunctionObject::_transitionalScopes
+						IL_000d: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 35 (0x23)
+						.maxstack 8
+
+						IL_0000: ldarg.1
+						IL_0001: ldtoken Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass
+						IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+						IL_000b: ldarg.0
+						IL_000c: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass/Scope_logValues/FunctionObject::_transitionalScopes
+						IL_0011: ldnull
+						IL_0012: ldarg.0
+						IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+						IL_0018: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass
+						IL_001d: call instance object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::logValues()
+						IL_0022: ret
+					} // end of method FunctionObject::CallCore
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -53,7 +126,7 @@
 
 			} // end of class Scope_logValues
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_D442CEB1_MyClass
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 			{
 				// Fields
@@ -73,9 +146,9 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass/FunctionObject_ClassConstructor_D442CEB1_MyClass::_transitionalScopes
+					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass/FunctionObject::_transitionalScopes
 					IL_000d: ret
-				} // end of method FunctionObject_ClassConstructor_D442CEB1_MyClass::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -86,7 +159,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_D442CEB1_MyClass::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -97,80 +170,9 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_D442CEB1_MyClass::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
-			} // end of class FunctionObject_ClassConstructor_D442CEB1_MyClass
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-			{
-				// Fields
-				.field private initonly object[] _transitionalScopes
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor (
-						object[] capture0
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 14 (0xe)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-					IL_0006: ldarg.0
-					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass/FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues::_transitionalScopes
-					IL_000d: ret
-				} // end of method FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues::get_RequiresInvocationContext
-
-				.method family hidebysig virtual 
-					instance object CallCore (
-						object thisArgument,
-						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 35 (0x23)
-					.maxstack 8
-
-					IL_0000: ldarg.1
-					IL_0001: ldtoken Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass
-					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-					IL_000b: ldarg.0
-					IL_000c: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass/FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues::_transitionalScopes
-					IL_0011: ldnull
-					IL_0012: ldarg.0
-					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-					IL_0018: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass
-					IL_001d: call instance object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::logValues()
-					IL_0022: ret
-				} // end of method FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues::CallCore
-
-			} // end of class FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues
+			} // end of class FunctionObject
 
 
 			// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
@@ -37,6 +37,79 @@
 			.class nested public auto ansi beforefieldinit Scope_logValue
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							object[] capture0
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass/Scope_logValue/FunctionObject::_transitionalScopes
+						IL_000d: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 35 (0x23)
+						.maxstack 8
+
+						IL_0000: ldarg.1
+						IL_0001: ldtoken Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass
+						IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+						IL_000b: ldarg.0
+						IL_000c: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass/Scope_logValue/FunctionObject::_transitionalScopes
+						IL_0011: ldnull
+						IL_0012: ldarg.0
+						IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+						IL_0018: castclass Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass
+						IL_001d: call instance object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::logValue()
+						IL_0022: ret
+					} // end of method FunctionObject::CallCore
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -53,7 +126,7 @@
 
 			} // end of class Scope_logValue
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_674B927B_MyClass
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 			{
 				// Fields
@@ -73,9 +146,9 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass/FunctionObject_ClassConstructor_674B927B_MyClass::_transitionalScopes
+					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass/FunctionObject::_transitionalScopes
 					IL_000d: ret
-				} // end of method FunctionObject_ClassConstructor_674B927B_MyClass::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -86,7 +159,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_674B927B_MyClass::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -97,80 +170,9 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_674B927B_MyClass::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
-			} // end of class FunctionObject_ClassConstructor_674B927B_MyClass
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C626B0F5_MyClass_logValue
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-			{
-				// Fields
-				.field private initonly object[] _transitionalScopes
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor (
-						object[] capture0
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 14 (0xe)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-					IL_0006: ldarg.0
-					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass/FunctionObject_ClassMethod_C626B0F5_MyClass_logValue::_transitionalScopes
-					IL_000d: ret
-				} // end of method FunctionObject_ClassMethod_C626B0F5_MyClass_logValue::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_C626B0F5_MyClass_logValue::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_C626B0F5_MyClass_logValue::get_RequiresInvocationContext
-
-				.method family hidebysig virtual 
-					instance object CallCore (
-						object thisArgument,
-						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 35 (0x23)
-					.maxstack 8
-
-					IL_0000: ldarg.1
-					IL_0001: ldtoken Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass
-					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-					IL_000b: ldarg.0
-					IL_000c: ldfld object[] Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass/FunctionObject_ClassMethod_C626B0F5_MyClass_logValue::_transitionalScopes
-					IL_0011: ldnull
-					IL_0012: ldarg.0
-					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-					IL_0018: castclass Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass
-					IL_001d: call instance object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::logValue()
-					IL_0022: ret
-				} // end of method FunctionObject_ClassMethod_C626B0F5_MyClass_logValue::CallCore
-
-			} // end of class FunctionObject_ClassMethod_C626B0F5_MyClass_logValue
+			} // end of class FunctionObject
 
 
 			// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessGlobalVariable_Log.verified.txt
@@ -33,6 +33,79 @@
 		.class nested public auto ansi beforefieldinit Scope_logGlobal
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass/Scope_logGlobal/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass/Scope_logGlobal/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass
+					IL_001d: call instance object Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::logGlobal()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +122,7 @@
 
 		} // end of class Scope_logGlobal
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_6011F0C3_MyClass
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -69,9 +142,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass/FunctionObject_ClassConstructor_6011F0C3_MyClass::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_6011F0C3_MyClass::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -82,7 +155,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_6011F0C3_MyClass::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -93,80 +166,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_6011F0C3_MyClass::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_6011F0C3_MyClass
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass/FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass/FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass
-				IL_001d: call instance object Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::logGlobal()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal::CallCore
-
-		} // end of class FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal
+		} // end of class FunctionObject
 
 
 		// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_CallsAnotherMethod.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_CallsAnotherMethod.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +102,71 @@
 		.class nested public auto ansi beforefieldinit Scope_hello
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
+					IL_001d: call instance object Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::hello()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -71,6 +186,71 @@
 		.class nested public auto ansi beforefieldinit Scope_prefix
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
+					IL_001d: call instance object Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::prefix()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -90,6 +270,71 @@
 		.class nested public auto ansi beforefieldinit Scope_logHello
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
+					IL_001d: call instance object Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::logHello()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -105,243 +350,6 @@
 			} // end of method Scope_logHello::.ctor
 
 		} // end of class Scope_logHello
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_8162E6C8_Greeter
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter/FunctionObject_ClassConstructor_8162E6C8_Greeter::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_8162E6C8_Greeter::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_8162E6C8_Greeter::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_8162E6C8_Greeter::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_8162E6C8_Greeter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B6B72DA7_Greeter_hello
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_B6B72DA7_Greeter_hello::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B6B72DA7_Greeter_hello::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B6B72DA7_Greeter_hello::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
-				IL_001d: call instance object Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::hello()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_B6B72DA7_Greeter_hello::CallCore
-
-		} // end of class FunctionObject_ClassMethod_B6B72DA7_Greeter_hello
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_D09AE85D_Greeter_prefix
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_D09AE85D_Greeter_prefix::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_D09AE85D_Greeter_prefix::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_D09AE85D_Greeter_prefix::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
-				IL_001d: call instance object Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::prefix()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_D09AE85D_Greeter_prefix::CallCore
-
-		} // end of class FunctionObject_ClassMethod_D09AE85D_Greeter_prefix
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_E52A68FB_Greeter_logHello
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_E52A68FB_Greeter_logHello::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_E52A68FB_Greeter_logHello::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_E52A68FB_Greeter_logHello::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
-				IL_001d: call instance object Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::logHello()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_E52A68FB_Greeter_logHello::CallCore
-
-		} // end of class FunctionObject_ClassMethod_E52A68FB_Greeter_logHello
 
 
 		// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ForLoop_CallsAnotherMethod.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ForLoop_CallsAnotherMethod.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +102,75 @@
 		.class nested public auto ansi beforefieldinit Scope_add
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 47 (0x2f)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0029: call instance object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::'add'(float64)
+					IL_002e: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -71,6 +190,82 @@
 		.class nested public auto ansi beforefieldinit Scope_addRange
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/Scope_addRange/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/Scope_addRange/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::addRange(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -130,6 +325,71 @@
 		.class nested public auto ansi beforefieldinit Scope_log
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
+					IL_001d: call instance object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::log()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -145,258 +405,6 @@
 			} // end of method Scope_log::.ctor
 
 		} // end of class Scope_log
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_85134ECE_Accumulator
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/FunctionObject_ClassConstructor_85134ECE_Accumulator::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_85134ECE_Accumulator::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_85134ECE_Accumulator::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_85134ECE_Accumulator::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_85134ECE_Accumulator
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_7BB25A56_Accumulator_add
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_7BB25A56_Accumulator_add::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_7BB25A56_Accumulator_add::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_7BB25A56_Accumulator_add::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 47 (0x2f)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0029: call instance object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::'add'(float64)
-				IL_002e: ret
-			} // end of method FunctionObject_ClassMethod_7BB25A56_Accumulator_add::CallCore
-
-		} // end of class FunctionObject_ClassMethod_7BB25A56_Accumulator_add
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::addRange(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange::CallCore
-
-		} // end of class FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_E2587F73_Accumulator_log
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_E2587F73_Accumulator_log::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_E2587F73_Accumulator_log::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_E2587F73_Accumulator_log::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
-				IL_001d: call instance object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::log()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_E2587F73_Accumulator_log::CallCore
-
-		} // end of class FunctionObject_ClassMethod_E2587F73_Accumulator_log
 
 
 		// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +102,72 @@
 		.class nested public auto ansi beforefieldinit Scope_getNext
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter
+					IL_001d: call instance float64 Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter::getNext()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -67,118 +183,6 @@
 			} // end of method Scope_getNext::.ctor
 
 		} // end of class Scope_getNext
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_AB7DA7FA_Counter
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassConstructor_AB7DA7FA_Counter::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_AB7DA7FA_Counter::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_AB7DA7FA_Counter::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_AB7DA7FA_Counter::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_AB7DA7FA_Counter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_2BC95740_Counter_getNext
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_2BC95740_Counter_getNext::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_2BC95740_Counter_getNext::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_2BC95740_Counter_getNext::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter
-				IL_001d: call instance float64 Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter::getNext()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_2BC95740_Counter_getNext::CallCore
-
-		} // end of class FunctionObject_ClassMethod_2BC95740_Counter_getNext
 
 
 		// Fields
@@ -257,6 +261,61 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope _environment0_Classes_ClassMethod_LocalVar_ReassignedFromMethodCall
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator/Scope_ctor/FunctionObject::_environment0_Classes_ClassMethod_LocalVar_ReassignedFromMethodCall
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -276,6 +335,72 @@
 		.class nested public auto ansi beforefieldinit Scope_compute
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
+					IL_001d: call instance float64 Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::compute()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -291,123 +416,6 @@
 			} // end of method Scope_compute::.ctor
 
 		} // end of class Scope_compute
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_2721F182_Calculator
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope _environment0_Classes_ClassMethod_LocalVar_ReassignedFromMethodCall
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope capture0,
-					object[] capture1
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 21 (0x15)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator/FunctionObject_ClassConstructor_2721F182_Calculator::_environment0_Classes_ClassMethod_LocalVar_ReassignedFromMethodCall
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator/FunctionObject_ClassConstructor_2721F182_Calculator::_transitionalScopes
-				IL_0014: ret
-			} // end of method FunctionObject_ClassConstructor_2721F182_Calculator::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_2721F182_Calculator::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_2721F182_Calculator::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_2721F182_Calculator
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_DAB46382_Calculator_compute
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_DAB46382_Calculator_compute::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_DAB46382_Calculator_compute::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_DAB46382_Calculator_compute::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
-				IL_001d: call instance float64 Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::compute()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_DAB46382_Calculator_compute::CallCore
-
-		} // end of class FunctionObject_ClassMethod_DAB46382_Calculator_compute
 
 
 		// Fields
@@ -552,7 +560,7 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassConstructor_AB7DA7FA_Counter,
+			[6] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/Scope_ctor/FunctionObject,
 			[7] class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator,
 			[8] float64,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console
@@ -574,14 +582,14 @@
 		IL_002e: stloc.s 5
 		IL_0030: ldloc.s 4
 		IL_0032: ldstr "getNext"
-		IL_0037: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext::.ctor()
+		IL_0037: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/Scope_getNext/FunctionObject::.ctor()
 		IL_003c: ldc.i4.0
 		IL_003d: conv.r8
 		IL_003e: ldstr "getNext"
 		IL_0043: ldc.i4.1
 		IL_0044: ldc.i4.1
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext>(!!0, float64, string, bool, bool)
-		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassMethod_2BC95740_Counter_getNext>(!!0)
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/Scope_getNext/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/Scope_getNext/FunctionObject>(!!0)
 		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0054: pop
 		IL_0055: ldc.i4.1
@@ -592,14 +600,14 @@
 		IL_005e: stelem.ref
 		IL_005f: stloc.s 5
 		IL_0061: ldloc.s 5
-		IL_0063: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassConstructor_AB7DA7FA_Counter::.ctor(object[])
+		IL_0063: newobj instance void Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_0068: ldloc.3
 		IL_0069: ldloc.s 5
 		IL_006b: ldc.i4.0
 		IL_006c: conv.r8
 		IL_006d: ldc.i4.0
 		IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0073: castclass Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassConstructor_AB7DA7FA_Counter
+		IL_0073: castclass Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/Scope_ctor/FunctionObject
 		IL_0078: stloc.s 6
 		IL_007a: ldloc.0
 		IL_007b: ldloc.s 6

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_MaxParameters_32.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_MaxParameters_32.verified.txt
@@ -33,6 +33,167 @@
 		.class nested public auto ansi beforefieldinit Scope_m
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 12
+					// Code size: 282 (0x11a)
+					.maxstack 35
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_MaxParameters_32/C
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_MaxParameters_32/C
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: ldarg.2
+					IL_0025: ldc.i4.1
+					IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_002b: ldarg.2
+					IL_002c: ldc.i4.2
+					IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0032: ldarg.2
+					IL_0033: ldc.i4.3
+					IL_0034: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0039: ldarg.2
+					IL_003a: ldc.i4.4
+					IL_003b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0040: ldarg.2
+					IL_0041: ldc.i4.5
+					IL_0042: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0047: ldarg.2
+					IL_0048: ldc.i4.6
+					IL_0049: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_004e: ldarg.2
+					IL_004f: ldc.i4.7
+					IL_0050: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0055: ldarg.2
+					IL_0056: ldc.i4.8
+					IL_0057: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_005c: ldarg.2
+					IL_005d: ldc.i4.s 9
+					IL_005f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0064: ldarg.2
+					IL_0065: ldc.i4.s 10
+					IL_0067: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_006c: ldarg.2
+					IL_006d: ldc.i4.s 11
+					IL_006f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0074: ldarg.2
+					IL_0075: ldc.i4.s 12
+					IL_0077: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_007c: ldarg.2
+					IL_007d: ldc.i4.s 13
+					IL_007f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0084: ldarg.2
+					IL_0085: ldc.i4.s 14
+					IL_0087: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_008c: ldarg.2
+					IL_008d: ldc.i4.s 15
+					IL_008f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0094: ldarg.2
+					IL_0095: ldc.i4.s 16
+					IL_0097: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_009c: ldarg.2
+					IL_009d: ldc.i4.s 17
+					IL_009f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_00a4: ldarg.2
+					IL_00a5: ldc.i4.s 18
+					IL_00a7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_00ac: ldarg.2
+					IL_00ad: ldc.i4.s 19
+					IL_00af: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_00b4: ldarg.2
+					IL_00b5: ldc.i4.s 20
+					IL_00b7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_00bc: ldarg.2
+					IL_00bd: ldc.i4.s 21
+					IL_00bf: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_00c4: ldarg.2
+					IL_00c5: ldc.i4.s 22
+					IL_00c7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_00cc: ldarg.2
+					IL_00cd: ldc.i4.s 23
+					IL_00cf: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_00d4: ldarg.2
+					IL_00d5: ldc.i4.s 24
+					IL_00d7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_00dc: ldarg.2
+					IL_00dd: ldc.i4.s 25
+					IL_00df: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_00e4: ldarg.2
+					IL_00e5: ldc.i4.s 26
+					IL_00e7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_00ec: ldarg.2
+					IL_00ed: ldc.i4.s 27
+					IL_00ef: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_00f4: ldarg.2
+					IL_00f5: ldc.i4.s 28
+					IL_00f7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_00fc: ldarg.2
+					IL_00fd: ldc.i4.s 29
+					IL_00ff: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0104: ldarg.2
+					IL_0105: ldc.i4.s 30
+					IL_0107: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_010c: ldarg.2
+					IL_010d: ldc.i4.s 31
+					IL_010f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0114: call instance object Modules.Classes_ClassMethod_MaxParameters_32/C::m(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
+					IL_0119: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +210,7 @@
 
 		} // end of class Scope_m
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_85D6A1FA_C
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -69,9 +230,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_MaxParameters_32/C/FunctionObject_ClassConstructor_85D6A1FA_C::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_MaxParameters_32/C/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_85D6A1FA_C::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -82,7 +243,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_85D6A1FA_C::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -93,168 +254,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_85D6A1FA_C::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_85D6A1FA_C
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_CE844044_C_m
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_CE844044_C_m::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_CE844044_C_m::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_CE844044_C_m::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 12
-				// Code size: 282 (0x11a)
-				.maxstack 35
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_MaxParameters_32/C
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_MaxParameters_32/C
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: ldarg.2
-				IL_0025: ldc.i4.1
-				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_002b: ldarg.2
-				IL_002c: ldc.i4.2
-				IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0032: ldarg.2
-				IL_0033: ldc.i4.3
-				IL_0034: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0039: ldarg.2
-				IL_003a: ldc.i4.4
-				IL_003b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0040: ldarg.2
-				IL_0041: ldc.i4.5
-				IL_0042: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0047: ldarg.2
-				IL_0048: ldc.i4.6
-				IL_0049: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_004e: ldarg.2
-				IL_004f: ldc.i4.7
-				IL_0050: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0055: ldarg.2
-				IL_0056: ldc.i4.8
-				IL_0057: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_005c: ldarg.2
-				IL_005d: ldc.i4.s 9
-				IL_005f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0064: ldarg.2
-				IL_0065: ldc.i4.s 10
-				IL_0067: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_006c: ldarg.2
-				IL_006d: ldc.i4.s 11
-				IL_006f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0074: ldarg.2
-				IL_0075: ldc.i4.s 12
-				IL_0077: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_007c: ldarg.2
-				IL_007d: ldc.i4.s 13
-				IL_007f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0084: ldarg.2
-				IL_0085: ldc.i4.s 14
-				IL_0087: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_008c: ldarg.2
-				IL_008d: ldc.i4.s 15
-				IL_008f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0094: ldarg.2
-				IL_0095: ldc.i4.s 16
-				IL_0097: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_009c: ldarg.2
-				IL_009d: ldc.i4.s 17
-				IL_009f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_00a4: ldarg.2
-				IL_00a5: ldc.i4.s 18
-				IL_00a7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_00ac: ldarg.2
-				IL_00ad: ldc.i4.s 19
-				IL_00af: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_00b4: ldarg.2
-				IL_00b5: ldc.i4.s 20
-				IL_00b7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_00bc: ldarg.2
-				IL_00bd: ldc.i4.s 21
-				IL_00bf: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_00c4: ldarg.2
-				IL_00c5: ldc.i4.s 22
-				IL_00c7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_00cc: ldarg.2
-				IL_00cd: ldc.i4.s 23
-				IL_00cf: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_00d4: ldarg.2
-				IL_00d5: ldc.i4.s 24
-				IL_00d7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_00dc: ldarg.2
-				IL_00dd: ldc.i4.s 25
-				IL_00df: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_00e4: ldarg.2
-				IL_00e5: ldc.i4.s 26
-				IL_00e7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_00ec: ldarg.2
-				IL_00ed: ldc.i4.s 27
-				IL_00ef: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_00f4: ldarg.2
-				IL_00f5: ldc.i4.s 28
-				IL_00f7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_00fc: ldarg.2
-				IL_00fd: ldc.i4.s 29
-				IL_00ff: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0104: ldarg.2
-				IL_0105: ldc.i4.s 30
-				IL_0107: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_010c: ldarg.2
-				IL_010d: ldc.i4.s 31
-				IL_010f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0114: call instance object Modules.Classes_ClassMethod_MaxParameters_32/C::m(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
-				IL_0119: ret
-			} // end of method FunctionObject_ClassMethod_CE844044_C_m::CallCore
-
-		} // end of class FunctionObject_ClassMethod_CE844044_C_m
+		} // end of class FunctionObject
 
 
 		// Methods

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_MethodValueRequiresMetadata.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_MethodValueRequiresMetadata.verified.txt
@@ -33,6 +33,71 @@
 		.class nested public auto ansi beforefieldinit Scope_greet
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
+					IL_001d: call instance object Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::greet()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +117,71 @@
 		.class nested public auto ansi beforefieldinit Scope_getGreet
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
+					IL_001d: call instance object Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::getGreet()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -68,7 +198,7 @@
 
 		} // end of class Scope_getGreet
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_6B77E7C6_Greeter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -88,9 +218,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassConstructor_6B77E7C6_Greeter::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_6B77E7C6_Greeter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -101,7 +231,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_6B77E7C6_Greeter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -112,135 +242,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_6B77E7C6_Greeter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_6B77E7C6_Greeter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_55D3FD98_Greeter_greet
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_55D3FD98_Greeter_greet::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_55D3FD98_Greeter_greet::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_55D3FD98_Greeter_greet::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
-				IL_001d: call instance object Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::greet()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_55D3FD98_Greeter_greet::CallCore
-
-		} // end of class FunctionObject_ClassMethod_55D3FD98_Greeter_greet
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
-				IL_001d: call instance object Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::getGreet()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::CallCore
-
-		} // end of class FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -336,7 +340,7 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassConstructor_6B77E7C6_Greeter,
+			[6] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[8] class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter,
 			[9] string
@@ -357,28 +361,28 @@
 		IL_002d: stloc.s 5
 		IL_002f: ldloc.s 4
 		IL_0031: ldstr "greet"
-		IL_0036: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet::.ctor()
+		IL_0036: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/Scope_greet/FunctionObject::.ctor()
 		IL_003b: ldc.i4.0
 		IL_003c: conv.r8
 		IL_003d: ldstr "greet"
 		IL_0042: ldc.i4.0
 		IL_0043: ldc.i4.1
-		IL_0044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet>(!!0, float64, string, bool, bool)
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_55D3FD98_Greeter_greet>(!!0)
+		IL_0044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/Scope_greet/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/Scope_greet/FunctionObject>(!!0)
 		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0053: pop
 		IL_0054: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0059: stloc.s 5
 		IL_005b: ldloc.s 4
 		IL_005d: ldstr "getGreet"
-		IL_0062: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::.ctor()
+		IL_0062: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/Scope_getGreet/FunctionObject::.ctor()
 		IL_0067: ldc.i4.0
 		IL_0068: conv.r8
 		IL_0069: ldstr "getGreet"
 		IL_006e: ldc.i4.1
 		IL_006f: ldc.i4.1
-		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet>(!!0, float64, string, bool, bool)
-		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet>(!!0)
+		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/Scope_getGreet/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/Scope_getGreet/FunctionObject>(!!0)
 		IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_007f: pop
 		IL_0080: ldc.i4.1
@@ -389,14 +393,14 @@
 		IL_0089: stelem.ref
 		IL_008a: stloc.s 5
 		IL_008c: ldloc.s 5
-		IL_008e: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassConstructor_6B77E7C6_Greeter::.ctor(object[])
+		IL_008e: newobj instance void Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject::.ctor(object[])
 		IL_0093: ldloc.3
 		IL_0094: ldloc.s 5
 		IL_0096: ldc.i4.0
 		IL_0097: conv.r8
 		IL_0098: ldc.i4.0
 		IL_0099: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_009e: castclass Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassConstructor_6B77E7C6_Greeter
+		IL_009e: castclass Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject
 		IL_00a3: stloc.s 6
 		IL_00a5: ldloc.s 6
 		IL_00a7: stloc.1

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ParameterDestructuring.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ParameterDestructuring.verified.txt
@@ -37,6 +37,74 @@
 				01 00 16 53 63 6f 70 65 5f 61 64 64 20 61 3d 7b
 				61 7d 2c 20 62 3d 7b 62 7d 00 00
 			)
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_ParameterDestructuring/Calculator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Calculator
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Calculator::'add'(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Fields
 			.field public object a
 			.field public object b
@@ -64,6 +132,74 @@
 				01 00 1b 53 63 6f 70 65 5f 6d 75 6c 74 69 70 6c
 				79 20 78 3d 7b 78 7d 2c 20 79 3d 7b 79 7d 00 00
 			)
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_ParameterDestructuring/Calculator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Calculator
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Calculator::multiply(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Fields
 			.field public object x
 			.field public object y
@@ -84,7 +220,7 @@
 
 		} // end of class Scope_multiply
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_22853239_Calculator
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -104,9 +240,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_ParameterDestructuring/Calculator/FunctionObject_ClassConstructor_22853239_Calculator::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_ParameterDestructuring/Calculator/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_22853239_Calculator::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -117,7 +253,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_22853239_Calculator::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -128,141 +264,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_22853239_Calculator::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_22853239_Calculator
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B8BF3D91_Calculator_add
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_B8BF3D91_Calculator_add::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B8BF3D91_Calculator_add::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B8BF3D91_Calculator_add::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_ParameterDestructuring/Calculator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Calculator
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Calculator::'add'(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_B8BF3D91_Calculator_add::CallCore
-
-		} // end of class FunctionObject_ClassMethod_B8BF3D91_Calculator_add
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_ParameterDestructuring/Calculator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Calculator
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Calculator::multiply(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply::CallCore
-
-		} // end of class FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -411,6 +415,74 @@
 				7d 2c 20 61 67 65 3d 7b 61 67 65 7d 2c 20 63 69
 				74 79 3d 7b 63 69 74 79 7d 00 00
 			)
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_ParameterDestructuring/Formatter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Formatter
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Formatter::formatPerson(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Fields
 			.field public object name
 			.field public object age
@@ -441,6 +513,74 @@
 				20 6d 6f 6e 74 68 3d 7b 6d 6f 6e 74 68 7d 2c 20
 				64 61 79 3d 7b 64 61 79 7d 00 00
 			)
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_ParameterDestructuring/Formatter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Formatter
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Formatter::formatDate(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Fields
 			.field public object year
 			.field public object month
@@ -462,7 +602,7 @@
 
 		} // end of class Scope_formatDate
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7862EBA1_Formatter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -482,9 +622,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_ParameterDestructuring/Formatter/FunctionObject_ClassConstructor_7862EBA1_Formatter::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_ParameterDestructuring/Formatter/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_7862EBA1_Formatter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -495,7 +635,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7862EBA1_Formatter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -506,141 +646,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7862EBA1_Formatter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_7862EBA1_Formatter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_ParameterDestructuring/Formatter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Formatter
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Formatter::formatPerson(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson::CallCore
-
-		} // end of class FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_ParameterDestructuring/Formatter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Formatter
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Formatter::formatDate(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate::CallCore
-
-		} // end of class FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -848,6 +856,72 @@
 
 			} // end of class Block_L25C71
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_ParameterDestructuring/Config
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Config
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Config::setConnection(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Fields
 			.field public object host
@@ -870,7 +944,7 @@
 
 		} // end of class Scope_setConnection
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_39E5F53B_Config
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -890,9 +964,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_ParameterDestructuring/Config/FunctionObject_ClassConstructor_39E5F53B_Config::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_ParameterDestructuring/Config/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_39E5F53B_Config::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -903,7 +977,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_39E5F53B_Config::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -914,75 +988,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_39E5F53B_Config::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_39E5F53B_Config
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_BBE88488_Config_setConnection
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_BBE88488_Config_setConnection::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_BBE88488_Config_setConnection::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_BBE88488_Config_setConnection::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_ParameterDestructuring/Config
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Config
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Config::setConnection(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_BBE88488_Config_setConnection::CallCore
-
-		} // end of class FunctionObject_ClassMethod_BBE88488_Config_setConnection
+		} // end of class FunctionObject
 
 
 		// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number.verified.txt
@@ -33,6 +33,71 @@
 		.class nested public auto ansi beforefieldinit Scope_run
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator
+					IL_001d: call instance object Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator::run()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +117,80 @@
 		.class nested public auto ansi beforefieldinit Scope_add
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 12
+					// Code size: 64 (0x40)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0029: ldarg.2
+					IL_002a: ldc.i4.1
+					IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0035: call instance float64 Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator::'add'(float64, float64)
+					IL_003a: box [System.Runtime]System.Double
+					IL_003f: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -68,7 +207,7 @@
 
 		} // end of class Scope_add
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_3AE3B93D_Accumulator
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -88,9 +227,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator/FunctionObject_ClassConstructor_3AE3B93D_Accumulator::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_3AE3B93D_Accumulator::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -101,7 +240,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_3AE3B93D_Accumulator::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -112,144 +251,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_3AE3B93D_Accumulator::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_3AE3B93D_Accumulator
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator
-				IL_001d: call instance object Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator::run()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run::CallCore
-
-		} // end of class FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_53BDE38B_Accumulator_add
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_53BDE38B_Accumulator_add::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_53BDE38B_Accumulator_add::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_53BDE38B_Accumulator_add::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 12
-				// Code size: 64 (0x40)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0029: ldarg.2
-				IL_002a: ldc.i4.1
-				IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0035: call instance float64 Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator::'add'(float64, float64)
-				IL_003a: box [System.Runtime]System.Double
-				IL_003f: ret
-			} // end of method FunctionObject_ClassMethod_53BDE38B_Accumulator_add::CallCore
-
-		} // end of class FunctionObject_ClassMethod_53BDE38B_Accumulator_add
+		} // end of class FunctionObject
 
 
 		// Methods

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ReturnsThis_IsSelf_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ReturnsThis_IsSelf_Log.verified.txt
@@ -33,6 +33,71 @@
 		.class nested public auto ansi beforefieldinit Scope_isSelf
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self
+					IL_001d: call instance class Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self::isSelf()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +114,7 @@
 
 		} // end of class Scope_isSelf
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_28EE6FB2_Self
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -69,9 +134,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self/FunctionObject_ClassConstructor_28EE6FB2_Self::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_28EE6FB2_Self::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -82,7 +147,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_28EE6FB2_Self::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -93,72 +158,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_28EE6FB2_Self::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_28EE6FB2_Self
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_47927AE7_Self_isSelf
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_47927AE7_Self_isSelf::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_47927AE7_Self_isSelf::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_47927AE7_Self_isSelf::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self
-				IL_001d: call instance class Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self::isSelf()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_47927AE7_Self_isSelf::CallCore
-
-		} // end of class FunctionObject_ClassMethod_47927AE7_Self_isSelf
+		} // end of class FunctionObject
 
 
 		// Methods

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Postfix.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Postfix.verified.txt
@@ -53,6 +53,72 @@
 
 			} // end of class Block_L5C18
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_While_Increment_Param_Postfix/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_While_Increment_Param_Postfix/Counter
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Classes_ClassMethod_While_Increment_Param_Postfix/Counter::run(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -70,7 +136,7 @@
 
 		} // end of class Scope_run
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_75B77750_Counter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -90,9 +156,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_While_Increment_Param_Postfix/Counter/FunctionObject_ClassConstructor_75B77750_Counter::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_While_Increment_Param_Postfix/Counter/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_75B77750_Counter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -103,7 +169,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_75B77750_Counter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -114,75 +180,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_75B77750_Counter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_75B77750_Counter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_7AC55D46_Counter_run
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_7AC55D46_Counter_run::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_7AC55D46_Counter_run::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_7AC55D46_Counter_run::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_While_Increment_Param_Postfix/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_While_Increment_Param_Postfix/Counter
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Classes_ClassMethod_While_Increment_Param_Postfix/Counter::run(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_7AC55D46_Counter_run::CallCore
-
-		} // end of class FunctionObject_ClassMethod_7AC55D46_Counter_run
+		} // end of class FunctionObject
 
 
 		// Methods

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Prefix.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Prefix.verified.txt
@@ -53,6 +53,72 @@
 
 			} // end of class Block_L5C18
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_While_Increment_Param_Prefix/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_While_Increment_Param_Prefix/Counter
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Classes_ClassMethod_While_Increment_Param_Prefix/Counter::run(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -70,7 +136,7 @@
 
 		} // end of class Scope_run
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_DBC1CA27_Counter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -90,9 +156,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_While_Increment_Param_Prefix/Counter/FunctionObject_ClassConstructor_DBC1CA27_Counter::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_While_Increment_Param_Prefix/Counter/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_DBC1CA27_Counter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -103,7 +169,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_DBC1CA27_Counter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -114,75 +180,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_DBC1CA27_Counter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_DBC1CA27_Counter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C04B0C77_Counter_run
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_C04B0C77_Counter_run::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C04B0C77_Counter_run::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C04B0C77_Counter_run::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_While_Increment_Param_Prefix/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_While_Increment_Param_Prefix/Counter
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Classes_ClassMethod_While_Increment_Param_Prefix/Counter::run(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_C04B0C77_Counter_run::CallCore
-
-		} // end of class FunctionObject_ClassMethod_C04B0C77_Counter_run
+		} // end of class FunctionObject
 
 
 		// Methods

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Postfix.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Postfix.verified.txt
@@ -53,6 +53,72 @@
 
 			} // end of class Block_L6C18
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_While_Increment_Postfix/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_While_Increment_Postfix/Counter
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Classes_ClassMethod_While_Increment_Postfix/Counter::run(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -70,7 +136,7 @@
 
 		} // end of class Scope_run
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_3A0313C6_Counter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -90,9 +156,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_While_Increment_Postfix/Counter/FunctionObject_ClassConstructor_3A0313C6_Counter::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_While_Increment_Postfix/Counter/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_3A0313C6_Counter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -103,7 +169,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_3A0313C6_Counter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -114,75 +180,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_3A0313C6_Counter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_3A0313C6_Counter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_05AA4598_Counter_run
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_05AA4598_Counter_run::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_05AA4598_Counter_run::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_05AA4598_Counter_run::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_While_Increment_Postfix/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_While_Increment_Postfix/Counter
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Classes_ClassMethod_While_Increment_Postfix/Counter::run(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_05AA4598_Counter_run::CallCore
-
-		} // end of class FunctionObject_ClassMethod_05AA4598_Counter_run
+		} // end of class FunctionObject
 
 
 		// Methods

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Prefix.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Prefix.verified.txt
@@ -53,6 +53,72 @@
 
 			} // end of class Block_L6C18
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassMethod_While_Increment_Prefix/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassMethod_While_Increment_Prefix/Counter
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Classes_ClassMethod_While_Increment_Prefix/Counter::run(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -70,7 +136,7 @@
 
 		} // end of class Scope_run
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7A4E996D_Counter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -90,9 +156,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassMethod_While_Increment_Prefix/Counter/FunctionObject_ClassConstructor_7A4E996D_Counter::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_While_Increment_Prefix/Counter/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_7A4E996D_Counter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -103,7 +169,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7A4E996D_Counter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -114,75 +180,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7A4E996D_Counter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_7A4E996D_Counter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_5B0B0D19_Counter_run
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_5B0B0D19_Counter_run::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_5B0B0D19_Counter_run::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_5B0B0D19_Counter_run::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassMethod_While_Increment_Prefix/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassMethod_While_Increment_Prefix/Counter
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Classes_ClassMethod_While_Increment_Prefix/Counter::run(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_5B0B0D19_Counter_run::CallCore
-
-		} // end of class FunctionObject_ClassMethod_5B0B0D19_Counter_run
+		} // end of class FunctionObject
 
 
 		// Methods

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_ClassExpression_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_ClassExpression_Log.verified.txt
@@ -33,6 +33,72 @@
 		.class nested public auto ansi beforefieldinit Scope_get_Method_L4C2
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
+					IL_001d: call instance float64 Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17::__jroc_priv_get_value()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +118,80 @@
 		.class nested public auto ansi beforefieldinit Scope_log
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _privateBrand
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/Scope_log/FunctionObject::_privateBrand
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldarg.0
+					IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/Scope_log/FunctionObject::_privateBrand
+					IL_0017: ldarg.0
+					IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_001d: castclass Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
+					IL_0022: call instance object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17::log()
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -68,7 +208,7 @@
 
 		} // end of class Scope_log
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -90,12 +230,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject::_transitionalScopes
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::_privateBrand
+				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject::_privateBrand
 				IL_0014: ret
-			} // end of method FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -106,7 +246,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -117,145 +257,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
-				IL_001d: call instance float64 Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17::__jroc_priv_get_value()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::CallCore
-
-		} // end of class FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly class [System.Runtime]System.Object _privateBrand
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class [System.Runtime]System.Object capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::_privateBrand
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldarg.0
-				IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::_privateBrand
-				IL_0017: ldarg.0
-				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_001d: castclass Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
-				IL_0022: call instance object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17::log()
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::CallCore
-
-		} // end of class FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -358,7 +362,7 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17
+			[6] class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/Scope::.ctor()
@@ -386,14 +390,14 @@
 		IL_004f: stloc.s 5
 		IL_0051: ldloc.s 4
 		IL_0053: ldstr "value"
-		IL_0058: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::.ctor()
+		IL_0058: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/Scope_get_Method_L4C2/FunctionObject::.ctor()
 		IL_005d: ldc.i4.0
 		IL_005e: conv.r8
 		IL_005f: ldstr "get value"
 		IL_0064: ldc.i4.0
 		IL_0065: ldc.i4.1
-		IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value>(!!0, float64, string, bool, bool)
-		IL_006b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value>(!!0)
+		IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/Scope_get_Method_L4C2/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_006b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/Scope_get_Method_L4C2/FunctionObject>(!!0)
 		IL_0070: ldnull
 		IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
 		IL_0076: pop
@@ -406,14 +410,14 @@
 		IL_008b: ldloc.s 4
 		IL_008d: ldstr "log"
 		IL_0092: ldloc.3
-		IL_0093: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::.ctor(class [System.Runtime]System.Object)
+		IL_0093: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/Scope_log/FunctionObject::.ctor(class [System.Runtime]System.Object)
 		IL_0098: ldc.i4.0
 		IL_0099: conv.r8
 		IL_009a: ldstr "log"
 		IL_009f: ldc.i4.1
 		IL_00a0: ldc.i4.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log>(!!0, float64, string, bool, bool)
-		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log>(!!0)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/Scope_log/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/Scope_log/FunctionObject>(!!0)
 		IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_00b0: pop
 		IL_00b1: ldc.i4.1
@@ -425,14 +429,14 @@
 		IL_00bb: stloc.s 5
 		IL_00bd: ldloc.s 5
 		IL_00bf: ldnull
-		IL_00c0: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::.ctor(object[], class [System.Runtime]System.Object)
+		IL_00c0: newobj instance void Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject::.ctor(object[], class [System.Runtime]System.Object)
 		IL_00c5: ldloc.3
 		IL_00c6: ldloc.s 5
 		IL_00c8: ldc.i4.0
 		IL_00c9: conv.r8
 		IL_00ca: ldc.i4.1
 		IL_00cb: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_00d0: castclass Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17
+		IL_00d0: castclass Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject
 		IL_00d5: stloc.s 6
 		IL_00d7: ldloc.s 6
 		IL_00d9: ldstr "Counter"

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
@@ -33,6 +33,72 @@
 		.class nested public auto ansi beforefieldinit Scope_get_Method_L4C2
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+					IL_001d: call instance float64 Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_get_readOnly()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +118,74 @@
 		.class nested public auto ansi beforefieldinit Scope_set_Method_L8C2
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_set_writeOnly(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -110,6 +244,78 @@
 
 			} // end of class Block_L17C20
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _privateBrand
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/Scope_log/FunctionObject::_privateBrand
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldarg.0
+					IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/Scope_log/FunctionObject::_privateBrand
+					IL_0017: ldarg.0
+					IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_001d: castclass Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+					IL_0022: call instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::log()
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -127,7 +333,7 @@
 
 		} // end of class Scope_log
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_C167C688_AccessorEdges
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -149,12 +355,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassConstructor_C167C688_AccessorEdges::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject::_transitionalScopes
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassConstructor_C167C688_AccessorEdges::_privateBrand
+				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject::_privateBrand
 				IL_0014: ret
-			} // end of method FunctionObject_ClassConstructor_C167C688_AccessorEdges::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -165,7 +371,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_C167C688_AccessorEdges::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -176,211 +382,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_C167C688_AccessorEdges::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_C167C688_AccessorEdges
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-				IL_001d: call instance float64 Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_get_readOnly()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::CallCore
-
-		} // end of class FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_set_writeOnly(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::CallCore
-
-		} // end of class FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_0783223B_AccessorEdges_log
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly class [System.Runtime]System.Object _privateBrand
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class [System.Runtime]System.Object capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log::_privateBrand
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_0783223B_AccessorEdges_log::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_0783223B_AccessorEdges_log::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_0783223B_AccessorEdges_log::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldarg.0
-				IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log::_privateBrand
-				IL_0017: ldarg.0
-				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_001d: castclass Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-				IL_0022: call instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::log()
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_0783223B_AccessorEdges_log::CallCore
-
-		} // end of class FunctionObject_ClassMethod_0783223B_AccessorEdges_log
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -601,7 +605,7 @@
 			[2] class [System.Runtime]System.Type,
 			[3] object,
 			[4] object[],
-			[5] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassConstructor_C167C688_AccessorEdges,
+			[5] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject,
 			[6] class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
 		)
 
@@ -621,14 +625,14 @@
 		IL_002d: stloc.s 4
 		IL_002f: ldloc.3
 		IL_0030: ldstr "readOnly"
-		IL_0035: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::.ctor()
+		IL_0035: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/Scope_get_Method_L4C2/FunctionObject::.ctor()
 		IL_003a: ldc.i4.0
 		IL_003b: conv.r8
 		IL_003c: ldstr "get readOnly"
 		IL_0041: ldc.i4.0
 		IL_0042: ldc.i4.1
-		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly>(!!0, float64, string, bool, bool)
-		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly>(!!0)
+		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/Scope_get_Method_L4C2/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/Scope_get_Method_L4C2/FunctionObject>(!!0)
 		IL_004d: ldnull
 		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
 		IL_0053: pop
@@ -641,14 +645,14 @@
 		IL_0067: ldloc.3
 		IL_0068: ldstr "writeOnly"
 		IL_006d: ldnull
-		IL_006e: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::.ctor()
+		IL_006e: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/Scope_set_Method_L8C2/FunctionObject::.ctor()
 		IL_0073: ldc.i4.1
 		IL_0074: conv.r8
 		IL_0075: ldstr "set writeOnly"
 		IL_007a: ldc.i4.1
 		IL_007b: ldc.i4.1
-		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly>(!!0, float64, string, bool, bool)
-		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly>(!!0)
+		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/Scope_set_Method_L8C2/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/Scope_set_Method_L8C2/FunctionObject>(!!0)
 		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
 		IL_008b: pop
 		IL_008c: ldloc.2
@@ -660,14 +664,14 @@
 		IL_009f: ldloc.3
 		IL_00a0: ldstr "log"
 		IL_00a5: ldloc.2
-		IL_00a6: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log::.ctor(class [System.Runtime]System.Object)
+		IL_00a6: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/Scope_log/FunctionObject::.ctor(class [System.Runtime]System.Object)
 		IL_00ab: ldc.i4.0
 		IL_00ac: conv.r8
 		IL_00ad: ldstr "log"
 		IL_00b2: ldc.i4.1
 		IL_00b3: ldc.i4.1
-		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log>(!!0, float64, string, bool, bool)
-		IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassMethod_0783223B_AccessorEdges_log>(!!0)
+		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/Scope_log/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/Scope_log/FunctionObject>(!!0)
 		IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_00c3: pop
 		IL_00c4: ldc.i4.1
@@ -679,14 +683,14 @@
 		IL_00ce: stloc.s 4
 		IL_00d0: ldloc.s 4
 		IL_00d2: ldnull
-		IL_00d3: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassConstructor_C167C688_AccessorEdges::.ctor(object[], class [System.Runtime]System.Object)
+		IL_00d3: newobj instance void Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject::.ctor(object[], class [System.Runtime]System.Object)
 		IL_00d8: ldloc.2
 		IL_00d9: ldloc.s 4
 		IL_00db: ldc.i4.0
 		IL_00dc: conv.r8
 		IL_00dd: ldc.i4.0
 		IL_00de: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_00e3: castclass Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassConstructor_C167C688_AccessorEdges
+		IL_00e3: castclass Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject
 		IL_00e8: stloc.s 5
 		IL_00ea: ldloc.s 5
 		IL_00ec: stloc.1

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateField_HelperMethod_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateField_HelperMethod_Log.verified.txt
@@ -33,6 +33,80 @@
 		.class nested public auto ansi beforefieldinit Scope_logSecret
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _privateBrand
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/Scope_logSecret/FunctionObject::_privateBrand
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldarg.0
+					IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/Scope_logSecret/FunctionObject::_privateBrand
+					IL_0017: ldarg.0
+					IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_001d: castclass Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
+					IL_0022: call instance object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::logSecret()
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +123,7 @@
 
 		} // end of class Scope_logSecret
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_B2B50D0B_Greeter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -71,12 +145,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassConstructor_B2B50D0B_Greeter::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject::_transitionalScopes
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassConstructor_B2B50D0B_Greeter::_privateBrand
+				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject::_privateBrand
 				IL_0014: ret
-			} // end of method FunctionObject_ClassConstructor_B2B50D0B_Greeter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -87,7 +161,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_B2B50D0B_Greeter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -98,81 +172,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_B2B50D0B_Greeter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_B2B50D0B_Greeter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_96735848_Greeter_logSecret
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly class [System.Runtime]System.Object _privateBrand
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class [System.Runtime]System.Object capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret::_privateBrand
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_96735848_Greeter_logSecret::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_96735848_Greeter_logSecret::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_96735848_Greeter_logSecret::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldarg.0
-				IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret::_privateBrand
-				IL_0017: ldarg.0
-				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_001d: castclass Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
-				IL_0022: call instance object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::logSecret()
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_96735848_Greeter_logSecret::CallCore
-
-		} // end of class FunctionObject_ClassMethod_96735848_Greeter_logSecret
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -274,7 +276,7 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassConstructor_B2B50D0B_Greeter,
+			[6] class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject,
 			[7] class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
 		)
 
@@ -295,14 +297,14 @@
 		IL_0030: ldloc.s 4
 		IL_0032: ldstr "logSecret"
 		IL_0037: ldloc.3
-		IL_0038: newobj instance void Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret::.ctor(class [System.Runtime]System.Object)
+		IL_0038: newobj instance void Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/Scope_logSecret/FunctionObject::.ctor(class [System.Runtime]System.Object)
 		IL_003d: ldc.i4.0
 		IL_003e: conv.r8
 		IL_003f: ldstr "logSecret"
 		IL_0044: ldc.i4.1
 		IL_0045: ldc.i4.1
-		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret>(!!0, float64, string, bool, bool)
-		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassMethod_96735848_Greeter_logSecret>(!!0)
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/Scope_logSecret/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/Scope_logSecret/FunctionObject>(!!0)
 		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0055: pop
 		IL_0056: ldc.i4.1
@@ -314,14 +316,14 @@
 		IL_0060: stloc.s 5
 		IL_0062: ldloc.s 5
 		IL_0064: ldnull
-		IL_0065: newobj instance void Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassConstructor_B2B50D0B_Greeter::.ctor(object[], class [System.Runtime]System.Object)
+		IL_0065: newobj instance void Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject::.ctor(object[], class [System.Runtime]System.Object)
 		IL_006a: ldloc.3
 		IL_006b: ldloc.s 5
 		IL_006d: ldc.i4.0
 		IL_006e: conv.r8
 		IL_006f: ldc.i4.0
 		IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0075: castclass Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassConstructor_B2B50D0B_Greeter
+		IL_0075: castclass Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject
 		IL_007a: stloc.s 6
 		IL_007c: ldloc.s 6
 		IL_007e: stloc.1

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateMethodAndAccessor_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateMethodAndAccessor_Log.verified.txt
@@ -33,6 +33,80 @@
 		.class nested public auto ansi beforefieldinit Scope_Method_L6C2
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _privateBrand
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_Method_L6C2/FunctionObject::_privateBrand
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldarg.0
+					IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_Method_L6C2/FunctionObject::_privateBrand
+					IL_0017: ldarg.0
+					IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_001d: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
+					IL_0022: call instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::__jroc_priv_method_double()
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +126,80 @@
 		.class nested public auto ansi beforefieldinit Scope_get_Method_L10C2
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _privateBrand
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_get_Method_L10C2/FunctionObject::_privateBrand
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldarg.0
+					IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_get_Method_L10C2/FunctionObject::_privateBrand
+					IL_0017: ldarg.0
+					IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_001d: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
+					IL_0022: call instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::__jroc_priv_get_secret()
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -71,6 +219,83 @@
 		.class nested public auto ansi beforefieldinit Scope_set_Method_L14C2
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _privateBrand
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_set_Method_L14C2/FunctionObject::_privateBrand
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 47 (0x2f)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldarg.0
+					IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_set_Method_L14C2/FunctionObject::_privateBrand
+					IL_0017: ldarg.0
+					IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_001d: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
+					IL_0022: ldarg.2
+					IL_0023: ldc.i4.0
+					IL_0024: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0029: call instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::__jroc_priv_set_secret(object)
+					IL_002e: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -90,6 +315,80 @@
 		.class nested public auto ansi beforefieldinit Scope_log
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _privateBrand
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_log/FunctionObject::_privateBrand
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldarg.0
+					IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_log/FunctionObject::_privateBrand
+					IL_0017: ldarg.0
+					IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_001d: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
+					IL_0022: call instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::log()
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -106,7 +405,7 @@
 
 		} // end of class Scope_log
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_B44AC0DC_Counter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -128,12 +427,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassConstructor_B44AC0DC_Counter::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject::_transitionalScopes
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassConstructor_B44AC0DC_Counter::_privateBrand
+				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject::_privateBrand
 				IL_0014: ret
-			} // end of method FunctionObject_ClassConstructor_B44AC0DC_Counter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -144,7 +443,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_B44AC0DC_Counter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -155,300 +454,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_B44AC0DC_Counter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_B44AC0DC_Counter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly class [System.Runtime]System.Object _privateBrand
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class [System.Runtime]System.Object capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::_privateBrand
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldarg.0
-				IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::_privateBrand
-				IL_0017: ldarg.0
-				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_001d: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-				IL_0022: call instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::__jroc_priv_method_double()
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::CallCore
-
-		} // end of class FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly class [System.Runtime]System.Object _privateBrand
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class [System.Runtime]System.Object capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::_privateBrand
-				IL_000d: ret
-			} // end of method FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldarg.0
-				IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::_privateBrand
-				IL_0017: ldarg.0
-				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_001d: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-				IL_0022: call instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::__jroc_priv_get_secret()
-				IL_0027: ret
-			} // end of method FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::CallCore
-
-		} // end of class FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly class [System.Runtime]System.Object _privateBrand
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class [System.Runtime]System.Object capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::_privateBrand
-				IL_000d: ret
-			} // end of method FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 47 (0x2f)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldarg.0
-				IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::_privateBrand
-				IL_0017: ldarg.0
-				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_001d: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-				IL_0022: ldarg.2
-				IL_0023: ldc.i4.0
-				IL_0024: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0029: call instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::__jroc_priv_set_secret(object)
-				IL_002e: ret
-			} // end of method FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::CallCore
-
-		} // end of class FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_A23FC391_Counter_log
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly class [System.Runtime]System.Object _privateBrand
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class [System.Runtime]System.Object capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log::_privateBrand
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_A23FC391_Counter_log::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_A23FC391_Counter_log::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_A23FC391_Counter_log::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldarg.0
-				IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log::_privateBrand
-				IL_0017: ldarg.0
-				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_001d: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-				IL_0022: call instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::log()
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_A23FC391_Counter_log::CallCore
-
-		} // end of class FunctionObject_ClassMethod_A23FC391_Counter_log
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -641,7 +649,7 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassConstructor_B44AC0DC_Counter,
+			[6] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject,
 			[7] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -663,14 +671,14 @@
 		IL_0030: ldloc.s 4
 		IL_0032: ldstr "__jroc_priv_method_double"
 		IL_0037: ldloc.3
-		IL_0038: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::.ctor(class [System.Runtime]System.Object)
+		IL_0038: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_Method_L6C2/FunctionObject::.ctor(class [System.Runtime]System.Object)
 		IL_003d: ldc.i4.0
 		IL_003e: conv.r8
 		IL_003f: ldstr "#double"
 		IL_0044: ldc.i4.1
 		IL_0045: ldc.i4.1
-		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double>(!!0, float64, string, bool, bool)
-		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double>(!!0)
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_Method_L6C2/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_Method_L6C2/FunctionObject>(!!0)
 		IL_0050: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0055: pop
 		IL_0056: ldloc.3
@@ -682,14 +690,14 @@
 		IL_006a: ldloc.s 4
 		IL_006c: ldstr "secret"
 		IL_0071: ldloc.3
-		IL_0072: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::.ctor(class [System.Runtime]System.Object)
+		IL_0072: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_get_Method_L10C2/FunctionObject::.ctor(class [System.Runtime]System.Object)
 		IL_0077: ldc.i4.0
 		IL_0078: conv.r8
 		IL_0079: ldstr "get secret"
 		IL_007e: ldc.i4.1
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret>(!!0, float64, string, bool, bool)
-		IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret>(!!0)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_get_Method_L10C2/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_get_Method_L10C2/FunctionObject>(!!0)
 		IL_008a: ldnull
 		IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
 		IL_0090: pop
@@ -703,14 +711,14 @@
 		IL_00a7: ldstr "secret"
 		IL_00ac: ldnull
 		IL_00ad: ldloc.3
-		IL_00ae: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::.ctor(class [System.Runtime]System.Object)
+		IL_00ae: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_set_Method_L14C2/FunctionObject::.ctor(class [System.Runtime]System.Object)
 		IL_00b3: ldc.i4.1
 		IL_00b4: conv.r8
 		IL_00b5: ldstr "set secret"
 		IL_00ba: ldc.i4.1
 		IL_00bb: ldc.i4.1
-		IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret>(!!0, float64, string, bool, bool)
-		IL_00c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret>(!!0)
+		IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_set_Method_L14C2/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_set_Method_L14C2/FunctionObject>(!!0)
 		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
 		IL_00cb: pop
 		IL_00cc: ldloc.3
@@ -722,14 +730,14 @@
 		IL_00e0: ldloc.s 4
 		IL_00e2: ldstr "log"
 		IL_00e7: ldloc.3
-		IL_00e8: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log::.ctor(class [System.Runtime]System.Object)
+		IL_00e8: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_log/FunctionObject::.ctor(class [System.Runtime]System.Object)
 		IL_00ed: ldc.i4.0
 		IL_00ee: conv.r8
 		IL_00ef: ldstr "log"
 		IL_00f4: ldc.i4.1
 		IL_00f5: ldc.i4.1
-		IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log>(!!0, float64, string, bool, bool)
-		IL_00fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_A23FC391_Counter_log>(!!0)
+		IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_log/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/Scope_log/FunctionObject>(!!0)
 		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0105: pop
 		IL_0106: ldc.i4.1
@@ -741,14 +749,14 @@
 		IL_0110: stloc.s 5
 		IL_0112: ldloc.s 5
 		IL_0114: ldnull
-		IL_0115: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassConstructor_B44AC0DC_Counter::.ctor(object[], class [System.Runtime]System.Object)
+		IL_0115: newobj instance void Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject::.ctor(object[], class [System.Runtime]System.Object)
 		IL_011a: ldloc.3
 		IL_011b: ldloc.s 5
 		IL_011d: ldc.i4.0
 		IL_011e: conv.r8
 		IL_011f: ldc.i4.0
 		IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0125: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassConstructor_B44AC0DC_Counter
+		IL_0125: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject
 		IL_012a: stloc.s 6
 		IL_012c: ldloc.s 6
 		IL_012e: stloc.1

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateProperty_HelperMethod_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateProperty_HelperMethod_Log.verified.txt
@@ -33,6 +33,71 @@
 		.class nested public auto ansi beforefieldinit Scope_logSecret
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassPrivateProperty_HelperMethod_Log/Greeter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassPrivateProperty_HelperMethod_Log/Greeter
+					IL_001d: call instance object Modules.Classes_ClassPrivateProperty_HelperMethod_Log/Greeter::logSecret()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +114,7 @@
 
 		} // end of class Scope_logSecret
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_38BA3FA4_Greeter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -69,9 +134,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassPrivateProperty_HelperMethod_Log/Greeter/FunctionObject_ClassConstructor_38BA3FA4_Greeter::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassPrivateProperty_HelperMethod_Log/Greeter/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_38BA3FA4_Greeter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -82,7 +147,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_38BA3FA4_Greeter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -93,72 +158,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_38BA3FA4_Greeter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_38BA3FA4_Greeter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassPrivateProperty_HelperMethod_Log/Greeter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassPrivateProperty_HelperMethod_Log/Greeter
-				IL_001d: call instance object Modules.Classes_ClassPrivateProperty_HelperMethod_Log/Greeter::logSecret()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret::CallCore
-
-		} // end of class FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret
+		} // end of class FunctionObject
 
 
 		// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassProperty_DefaultAndLog.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassProperty_DefaultAndLog.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_EC4BBDDB_Greeter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassProperty_DefaultAndLog/Greeter/FunctionObject_ClassConstructor_EC4BBDDB_Greeter::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassProperty_DefaultAndLog/Greeter/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_EC4BBDDB_Greeter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_EC4BBDDB_Greeter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,9 +74,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_EC4BBDDB_Greeter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_EC4BBDDB_Greeter
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -153,7 +153,7 @@
 			[2] class Modules.Classes_ClassProperty_DefaultAndLog/Greeter,
 			[3] object[],
 			[4] class [System.Runtime]System.Type,
-			[5] class Modules.Classes_ClassProperty_DefaultAndLog/Greeter/FunctionObject_ClassConstructor_EC4BBDDB_Greeter,
+			[5] class Modules.Classes_ClassProperty_DefaultAndLog/Greeter/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[7] object
 		)
@@ -174,14 +174,14 @@
 		IL_0021: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0026: stloc.s 4
 		IL_0028: ldloc.3
-		IL_0029: newobj instance void Modules.Classes_ClassProperty_DefaultAndLog/Greeter/FunctionObject_ClassConstructor_EC4BBDDB_Greeter::.ctor(object[])
+		IL_0029: newobj instance void Modules.Classes_ClassProperty_DefaultAndLog/Greeter/FunctionObject::.ctor(object[])
 		IL_002e: ldloc.s 4
 		IL_0030: ldloc.3
 		IL_0031: ldc.i4.0
 		IL_0032: conv.r8
 		IL_0033: ldc.i4.0
 		IL_0034: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0039: castclass Modules.Classes_ClassProperty_DefaultAndLog/Greeter/FunctionObject_ClassConstructor_EC4BBDDB_Greeter
+		IL_0039: castclass Modules.Classes_ClassProperty_DefaultAndLog/Greeter/FunctionObject
 		IL_003e: stloc.s 5
 		IL_0040: ldloc.s 5
 		IL_0042: stloc.1

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassStaticBlock_DeclarationOrder.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassStaticBlock_DeclarationOrder.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_5DBD46D9_Example
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassStaticBlock_DeclarationOrder/Example/FunctionObject_ClassConstructor_5DBD46D9_Example::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassStaticBlock_DeclarationOrder/Example/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_5DBD46D9_Example::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_5DBD46D9_Example::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,9 +74,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_5DBD46D9_Example::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_5DBD46D9_Example
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -160,7 +160,7 @@
 			[1] object,
 			[2] object[],
 			[3] class [System.Runtime]System.Type,
-			[4] class Modules.Classes_ClassStaticBlock_DeclarationOrder/Example/FunctionObject_ClassConstructor_5DBD46D9_Example,
+			[4] class Modules.Classes_ClassStaticBlock_DeclarationOrder/Example/FunctionObject,
 			[5] object,
 			[6] object,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console
@@ -182,14 +182,14 @@
 		IL_0021: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0026: stloc.3
 		IL_0027: ldloc.2
-		IL_0028: newobj instance void Modules.Classes_ClassStaticBlock_DeclarationOrder/Example/FunctionObject_ClassConstructor_5DBD46D9_Example::.ctor(object[])
+		IL_0028: newobj instance void Modules.Classes_ClassStaticBlock_DeclarationOrder/Example/FunctionObject::.ctor(object[])
 		IL_002d: ldloc.3
 		IL_002e: ldloc.2
 		IL_002f: ldc.i4.0
 		IL_0030: conv.r8
 		IL_0031: ldc.i4.0
 		IL_0032: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0037: castclass Modules.Classes_ClassStaticBlock_DeclarationOrder/Example/FunctionObject_ClassConstructor_5DBD46D9_Example
+		IL_0037: castclass Modules.Classes_ClassStaticBlock_DeclarationOrder/Example/FunctionObject
 		IL_003c: stloc.s 4
 		IL_003e: ldloc.s 4
 		IL_0040: stloc.1
@@ -209,14 +209,14 @@
 		IL_006e: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0073: stloc.3
 		IL_0074: ldloc.2
-		IL_0075: newobj instance void Modules.Classes_ClassStaticBlock_DeclarationOrder/Example/FunctionObject_ClassConstructor_5DBD46D9_Example::.ctor(object[])
+		IL_0075: newobj instance void Modules.Classes_ClassStaticBlock_DeclarationOrder/Example/FunctionObject::.ctor(object[])
 		IL_007a: ldloc.3
 		IL_007b: ldloc.2
 		IL_007c: ldc.i4.0
 		IL_007d: conv.r8
 		IL_007e: ldc.i4.0
 		IL_007f: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0084: castclass Modules.Classes_ClassStaticBlock_DeclarationOrder/Example/FunctionObject_ClassConstructor_5DBD46D9_Example
+		IL_0084: castclass Modules.Classes_ClassStaticBlock_DeclarationOrder/Example/FunctionObject
 		IL_0089: stloc.s 4
 		IL_008b: ldsfld object Modules.Classes_ClassStaticBlock_DeclarationOrder/Example::'value'
 		IL_0090: stloc.s 5

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithMethod_HelloWorld.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithMethod_HelloWorld.verified.txt
@@ -33,6 +33,71 @@
 		.class nested public auto ansi beforefieldinit Scope_helloWorld
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassWithMethod_HelloWorld/Greeter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassWithMethod_HelloWorld/Greeter
+					IL_001d: call instance object Modules.Classes_ClassWithMethod_HelloWorld/Greeter::helloWorld()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +114,7 @@
 
 		} // end of class Scope_helloWorld
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_C6F9F277_Greeter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -69,9 +134,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassWithMethod_HelloWorld/Greeter/FunctionObject_ClassConstructor_C6F9F277_Greeter::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassWithMethod_HelloWorld/Greeter/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_C6F9F277_Greeter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -82,7 +147,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_C6F9F277_Greeter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -93,72 +158,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_C6F9F277_Greeter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_C6F9F277_Greeter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B367284E_Greeter_helloWorld
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_B367284E_Greeter_helloWorld::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B367284E_Greeter_helloWorld::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B367284E_Greeter_helloWorld::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassWithMethod_HelloWorld/Greeter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassWithMethod_HelloWorld/Greeter
-				IL_001d: call instance object Modules.Classes_ClassWithMethod_HelloWorld/Greeter::helloWorld()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_B367284E_Greeter_helloWorld::CallCore
-
-		} // end of class FunctionObject_ClassMethod_B367284E_Greeter_helloWorld
+		} // end of class FunctionObject
 
 
 		// Methods

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithMethod_NoInstantiation.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithMethod_NoInstantiation.verified.txt
@@ -33,6 +33,72 @@
 		.class nested public auto ansi beforefieldinit Scope_hello
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ClassWithMethod_NoInstantiation/Greeter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ClassWithMethod_NoInstantiation/Greeter
+					IL_001d: call instance float64 Modules.Classes_ClassWithMethod_NoInstantiation/Greeter::hello()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +115,7 @@
 
 		} // end of class Scope_hello
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_E2E07B97_Greeter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -69,9 +135,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassWithMethod_NoInstantiation/Greeter/FunctionObject_ClassConstructor_E2E07B97_Greeter::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassWithMethod_NoInstantiation/Greeter/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_E2E07B97_Greeter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -82,7 +148,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_E2E07B97_Greeter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -93,73 +159,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_E2E07B97_Greeter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_E2E07B97_Greeter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_47BE6AB2_Greeter_hello
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_47BE6AB2_Greeter_hello::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_47BE6AB2_Greeter_hello::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_47BE6AB2_Greeter_hello::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ClassWithMethod_NoInstantiation/Greeter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ClassWithMethod_NoInstantiation/Greeter
-				IL_001d: call instance float64 Modules.Classes_ClassWithMethod_NoInstantiation/Greeter::hello()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_47BE6AB2_Greeter_hello::CallCore
-
-		} // end of class FunctionObject_ClassMethod_47BE6AB2_Greeter_hello
+		} // end of class FunctionObject
 
 
 		// Methods

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithStaticMethod_HelloWorld.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithStaticMethod_HelloWorld.verified.txt
@@ -33,6 +33,62 @@
 		.class nested public auto ansi beforefieldinit Scope_helloWorld
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 6 (0x6)
+					.maxstack 8
+
+					IL_0000: call object Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter::helloWorld()
+					IL_0005: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +105,7 @@
 
 		} // end of class Scope_helloWorld
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_CA02D6DD_Greeter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -69,9 +125,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassConstructor_CA02D6DD_Greeter::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_CA02D6DD_Greeter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -82,7 +138,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_CA02D6DD_Greeter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -93,63 +149,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_CA02D6DD_Greeter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_CA02D6DD_Greeter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 6 (0x6)
-				.maxstack 8
-
-				IL_0000: call object Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter::helloWorld()
-				IL_0005: ret
-			} // end of method FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::CallCore
-
-		} // end of class FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -231,7 +233,7 @@
 			[1] object,
 			[2] class [System.Runtime]System.Type,
 			[3] object[],
-			[4] class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassConstructor_CA02D6DD_Greeter
+			[4] class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Classes_ClassWithStaticMethod_HelloWorld/Scope::.ctor()
@@ -250,14 +252,14 @@
 		IL_002d: stloc.3
 		IL_002e: ldloc.2
 		IL_002f: ldstr "helloWorld"
-		IL_0034: newobj instance void Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::.ctor()
+		IL_0034: newobj instance void Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/Scope_helloWorld/FunctionObject::.ctor()
 		IL_0039: ldc.i4.0
 		IL_003a: conv.r8
 		IL_003b: ldstr "helloWorld"
 		IL_0040: ldc.i4.0
 		IL_0041: ldc.i4.1
-		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld>(!!0, float64, string, bool, bool)
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld>(!!0)
+		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/Scope_helloWorld/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/Scope_helloWorld/FunctionObject>(!!0)
 		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0051: pop
 		IL_0052: ldc.i4.1
@@ -268,14 +270,14 @@
 		IL_005b: stelem.ref
 		IL_005c: stloc.3
 		IL_005d: ldloc.3
-		IL_005e: newobj instance void Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassConstructor_CA02D6DD_Greeter::.ctor(object[])
+		IL_005e: newobj instance void Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject::.ctor(object[])
 		IL_0063: ldloc.2
 		IL_0064: ldloc.3
 		IL_0065: ldc.i4.0
 		IL_0066: conv.r8
 		IL_0067: ldc.i4.0
 		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_006d: castclass Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassConstructor_CA02D6DD_Greeter
+		IL_006d: castclass Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject
 		IL_0072: stloc.s 4
 		IL_0074: ldloc.s 4
 		IL_0076: stloc.1

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithStaticProperty_DefaultAndLog.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithStaticProperty_DefaultAndLog.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_FEF6303D_Greeter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ClassWithStaticProperty_DefaultAndLog/Greeter/FunctionObject_ClassConstructor_FEF6303D_Greeter::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ClassWithStaticProperty_DefaultAndLog/Greeter/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_FEF6303D_Greeter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_FEF6303D_Greeter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,9 +74,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_FEF6303D_Greeter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_FEF6303D_Greeter
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -159,7 +159,7 @@
 			[1] object,
 			[2] object[],
 			[3] class [System.Runtime]System.Type,
-			[4] class Modules.Classes_ClassWithStaticProperty_DefaultAndLog/Greeter/FunctionObject_ClassConstructor_FEF6303D_Greeter,
+			[4] class Modules.Classes_ClassWithStaticProperty_DefaultAndLog/Greeter/FunctionObject,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[6] object
 		)
@@ -180,14 +180,14 @@
 		IL_0021: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0026: stloc.3
 		IL_0027: ldloc.2
-		IL_0028: newobj instance void Modules.Classes_ClassWithStaticProperty_DefaultAndLog/Greeter/FunctionObject_ClassConstructor_FEF6303D_Greeter::.ctor(object[])
+		IL_0028: newobj instance void Modules.Classes_ClassWithStaticProperty_DefaultAndLog/Greeter/FunctionObject::.ctor(object[])
 		IL_002d: ldloc.3
 		IL_002e: ldloc.2
 		IL_002f: ldc.i4.0
 		IL_0030: conv.r8
 		IL_0031: ldc.i4.0
 		IL_0032: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0037: castclass Modules.Classes_ClassWithStaticProperty_DefaultAndLog/Greeter/FunctionObject_ClassConstructor_FEF6303D_Greeter
+		IL_0037: castclass Modules.Classes_ClassWithStaticProperty_DefaultAndLog/Greeter/FunctionObject
 		IL_003c: stloc.s 4
 		IL_003e: ldloc.s 4
 		IL_0040: stloc.1

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Constructor_ExplicitReturnThis.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Constructor_ExplicitReturnThis.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_Constructor_ExplicitReturnThis/WithExplicitReturn/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,54 +98,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_Constructor_ExplicitReturnThis/WithExplicitReturn/FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn
 
 
 		// Fields
@@ -152,6 +154,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_Constructor_ExplicitReturnThis/WithVoidReturn/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -167,54 +219,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_Constructor_ExplicitReturnThis/WithVoidReturn/FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn
 
 
 		// Fields
@@ -280,7 +284,7 @@
 			[2] object,
 			[3] object[],
 			[4] class [System.Runtime]System.Type,
-			[5] class Modules.Classes_Constructor_ExplicitReturnThis/WithExplicitReturn/FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn,
+			[5] class Modules.Classes_Constructor_ExplicitReturnThis/WithExplicitReturn/Scope_ctor/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[7] object
 		)
@@ -301,14 +305,14 @@
 		IL_0021: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0026: stloc.s 4
 		IL_0028: ldloc.3
-		IL_0029: newobj instance void Modules.Classes_Constructor_ExplicitReturnThis/WithExplicitReturn/FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::.ctor(object[])
+		IL_0029: newobj instance void Modules.Classes_Constructor_ExplicitReturnThis/WithExplicitReturn/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_002e: ldloc.s 4
 		IL_0030: ldloc.3
 		IL_0031: ldc.i4.0
 		IL_0032: conv.r8
 		IL_0033: ldc.i4.0
 		IL_0034: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0039: castclass Modules.Classes_Constructor_ExplicitReturnThis/WithExplicitReturn/FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn
+		IL_0039: castclass Modules.Classes_Constructor_ExplicitReturnThis/WithExplicitReturn/Scope_ctor/FunctionObject
 		IL_003e: stloc.s 5
 		IL_0040: ldloc.s 5
 		IL_0042: stloc.1

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Constructor_ImplicitlyReturnsThis.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Constructor_ImplicitlyReturnsThis.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_Constructor_ImplicitlyReturnsThis/Simple/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,54 +98,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_AC2B377B_Simple
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_Constructor_ImplicitlyReturnsThis/Simple/FunctionObject_ClassConstructor_AC2B377B_Simple::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_AC2B377B_Simple::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_AC2B377B_Simple::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_AC2B377B_Simple::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_AC2B377B_Simple
 
 
 		// Fields
@@ -148,6 +150,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_Constructor_ImplicitlyReturnsThis/WithParams/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -163,54 +215,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_5D6F96DB_WithParams
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_Constructor_ImplicitlyReturnsThis/WithParams/FunctionObject_ClassConstructor_5D6F96DB_WithParams::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_5D6F96DB_WithParams::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_5D6F96DB_WithParams::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_5D6F96DB_WithParams::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_5D6F96DB_WithParams
 
 
 		// Fields
@@ -289,8 +293,8 @@
 			[5] class Modules.Classes_Constructor_ImplicitlyReturnsThis/WithParams,
 			[6] object[],
 			[7] class [System.Runtime]System.Type,
-			[8] class Modules.Classes_Constructor_ImplicitlyReturnsThis/Simple/FunctionObject_ClassConstructor_AC2B377B_Simple,
-			[9] class Modules.Classes_Constructor_ImplicitlyReturnsThis/WithParams/FunctionObject_ClassConstructor_5D6F96DB_WithParams,
+			[8] class Modules.Classes_Constructor_ImplicitlyReturnsThis/Simple/Scope_ctor/FunctionObject,
+			[9] class Modules.Classes_Constructor_ImplicitlyReturnsThis/WithParams/Scope_ctor/FunctionObject,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[11] object,
 			[12] bool
@@ -312,14 +316,14 @@
 		IL_0022: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0027: stloc.s 7
 		IL_0029: ldloc.s 6
-		IL_002b: newobj instance void Modules.Classes_Constructor_ImplicitlyReturnsThis/Simple/FunctionObject_ClassConstructor_AC2B377B_Simple::.ctor(object[])
+		IL_002b: newobj instance void Modules.Classes_Constructor_ImplicitlyReturnsThis/Simple/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_0030: ldloc.s 7
 		IL_0032: ldloc.s 6
 		IL_0034: ldc.i4.0
 		IL_0035: conv.r8
 		IL_0036: ldc.i4.0
 		IL_0037: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_003c: castclass Modules.Classes_Constructor_ImplicitlyReturnsThis/Simple/FunctionObject_ClassConstructor_AC2B377B_Simple
+		IL_003c: castclass Modules.Classes_Constructor_ImplicitlyReturnsThis/Simple/Scope_ctor/FunctionObject
 		IL_0041: stloc.s 8
 		IL_0043: ldloc.s 8
 		IL_0045: stloc.1
@@ -336,14 +340,14 @@
 		IL_0061: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0066: stloc.s 7
 		IL_0068: ldloc.s 6
-		IL_006a: newobj instance void Modules.Classes_Constructor_ImplicitlyReturnsThis/WithParams/FunctionObject_ClassConstructor_5D6F96DB_WithParams::.ctor(object[])
+		IL_006a: newobj instance void Modules.Classes_Constructor_ImplicitlyReturnsThis/WithParams/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_006f: ldloc.s 7
 		IL_0071: ldloc.s 6
 		IL_0073: ldc.i4.2
 		IL_0074: conv.r8
 		IL_0075: ldc.i4.0
 		IL_0076: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_007b: castclass Modules.Classes_Constructor_ImplicitlyReturnsThis/WithParams/FunctionObject_ClassConstructor_5D6F96DB_WithParams
+		IL_007b: castclass Modules.Classes_Constructor_ImplicitlyReturnsThis/WithParams/Scope_ctor/FunctionObject
 		IL_0080: stloc.s 9
 		IL_0082: ldloc.s 9
 		IL_0084: stloc.2

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Constructor_ReturnObjectOverridesThis.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Constructor_ReturnObjectOverridesThis.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_Constructor_ReturnObjectOverridesThis/A/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,54 +98,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_5FE4D647_A
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_Constructor_ReturnObjectOverridesThis/A/FunctionObject_ClassConstructor_5FE4D647_A::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_5FE4D647_A::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_5FE4D647_A::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_5FE4D647_A::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_5FE4D647_A
 
 
 		// Fields
@@ -170,6 +172,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_Constructor_ReturnObjectOverridesThis/B/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -185,54 +237,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_60E4D7DA_B
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_Constructor_ReturnObjectOverridesThis/B/FunctionObject_ClassConstructor_60E4D7DA_B::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_60E4D7DA_B::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_60E4D7DA_B::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_60E4D7DA_B::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_60E4D7DA_B
 
 
 		// Fields
@@ -305,8 +309,8 @@
 			[4] object,
 			[5] object[],
 			[6] class [System.Runtime]System.Type,
-			[7] class Modules.Classes_Constructor_ReturnObjectOverridesThis/A/FunctionObject_ClassConstructor_5FE4D647_A,
-			[8] class Modules.Classes_Constructor_ReturnObjectOverridesThis/B/FunctionObject_ClassConstructor_60E4D7DA_B,
+			[7] class Modules.Classes_Constructor_ReturnObjectOverridesThis/A/Scope_ctor/FunctionObject,
+			[8] class Modules.Classes_Constructor_ReturnObjectOverridesThis/B/Scope_ctor/FunctionObject,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[10] object
 		)
@@ -327,14 +331,14 @@
 		IL_0022: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0027: stloc.s 6
 		IL_0029: ldloc.s 5
-		IL_002b: newobj instance void Modules.Classes_Constructor_ReturnObjectOverridesThis/A/FunctionObject_ClassConstructor_5FE4D647_A::.ctor(object[])
+		IL_002b: newobj instance void Modules.Classes_Constructor_ReturnObjectOverridesThis/A/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_0030: ldloc.s 6
 		IL_0032: ldloc.s 5
 		IL_0034: ldc.i4.0
 		IL_0035: conv.r8
 		IL_0036: ldc.i4.0
 		IL_0037: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_003c: castclass Modules.Classes_Constructor_ReturnObjectOverridesThis/A/FunctionObject_ClassConstructor_5FE4D647_A
+		IL_003c: castclass Modules.Classes_Constructor_ReturnObjectOverridesThis/A/Scope_ctor/FunctionObject
 		IL_0041: stloc.s 7
 		IL_0043: ldloc.s 7
 		IL_0045: stloc.1
@@ -351,14 +355,14 @@
 		IL_0061: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0066: stloc.s 6
 		IL_0068: ldloc.s 5
-		IL_006a: newobj instance void Modules.Classes_Constructor_ReturnObjectOverridesThis/B/FunctionObject_ClassConstructor_60E4D7DA_B::.ctor(object[])
+		IL_006a: newobj instance void Modules.Classes_Constructor_ReturnObjectOverridesThis/B/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_006f: ldloc.s 6
 		IL_0071: ldloc.s 5
 		IL_0073: ldc.i4.0
 		IL_0074: conv.r8
 		IL_0075: ldc.i4.0
 		IL_0076: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_007b: castclass Modules.Classes_Constructor_ReturnObjectOverridesThis/B/FunctionObject_ClassConstructor_60E4D7DA_B
+		IL_007b: castclass Modules.Classes_Constructor_ReturnObjectOverridesThis/B/Scope_ctor/FunctionObject
 		IL_0080: stloc.s 8
 		IL_0082: ldloc.s 8
 		IL_0084: stloc.2

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_DeclareEmptyClass.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_DeclareEmptyClass.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_D3CE27CC_Foo
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_DeclareEmptyClass/Foo/FunctionObject_ClassConstructor_D3CE27CC_Foo::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_DeclareEmptyClass/Foo/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_D3CE27CC_Foo::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_D3CE27CC_Foo::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,9 +74,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_D3CE27CC_Foo::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_D3CE27CC_Foo
+		} // end of class FunctionObject
 
 
 		// Methods

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_DefaultParameterValue_Constructor.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_DefaultParameterValue_Constructor.verified.txt
@@ -53,6 +53,54 @@
 
 			} // end of class Block_L5C43
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_DefaultParameterValue_Constructor/Person/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -73,6 +121,71 @@
 		.class nested public auto ansi beforefieldinit Scope_display
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_DefaultParameterValue_Constructor/Person
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_DefaultParameterValue_Constructor/Person
+					IL_001d: call instance object Modules.Classes_DefaultParameterValue_Constructor/Person::display()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -88,117 +201,6 @@
 			} // end of method Scope_display::.ctor
 
 		} // end of class Scope_display
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7BAAAA4E_Person
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_DefaultParameterValue_Constructor/Person/FunctionObject_ClassConstructor_7BAAAA4E_Person::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_7BAAAA4E_Person::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7BAAAA4E_Person::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7BAAAA4E_Person::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_7BAAAA4E_Person
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_85CC56A3_Person_display
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_85CC56A3_Person_display::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_85CC56A3_Person_display::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_85CC56A3_Person_display::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_DefaultParameterValue_Constructor/Person
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_DefaultParameterValue_Constructor/Person
-				IL_001d: call instance object Modules.Classes_DefaultParameterValue_Constructor/Person::display()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_85CC56A3_Person_display::CallCore
-
-		} // end of class FunctionObject_ClassMethod_85CC56A3_Person_display
 
 
 		// Fields
@@ -329,6 +331,54 @@
 
 			} // end of class Block_L16C47
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_DefaultParameterValue_Constructor/Box/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -349,6 +399,71 @@
 		.class nested public auto ansi beforefieldinit Scope_volume
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_DefaultParameterValue_Constructor/Box
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_DefaultParameterValue_Constructor/Box
+					IL_001d: call instance object Modules.Classes_DefaultParameterValue_Constructor/Box::volume()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -364,117 +479,6 @@
 			} // end of method Scope_volume::.ctor
 
 		} // end of class Scope_volume
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_9983F234_Box
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_DefaultParameterValue_Constructor/Box/FunctionObject_ClassConstructor_9983F234_Box::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_9983F234_Box::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_9983F234_Box::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_9983F234_Box::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_9983F234_Box
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_3225487D_Box_volume
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_3225487D_Box_volume::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_3225487D_Box_volume::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_3225487D_Box_volume::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_DefaultParameterValue_Constructor/Box
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_DefaultParameterValue_Constructor/Box
-				IL_001d: call instance object Modules.Classes_DefaultParameterValue_Constructor/Box::volume()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_3225487D_Box_volume::CallCore
-
-		} // end of class FunctionObject_ClassMethod_3225487D_Box_volume
 
 
 		// Fields
@@ -614,6 +618,54 @@
 
 			} // end of class Block_L51C39
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_DefaultParameterValue_Constructor/Rectangle/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -634,6 +686,71 @@
 		.class nested public auto ansi beforefieldinit Scope_area
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_DefaultParameterValue_Constructor/Rectangle
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_DefaultParameterValue_Constructor/Rectangle
+					IL_001d: call instance object Modules.Classes_DefaultParameterValue_Constructor/Rectangle::area()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -649,117 +766,6 @@
 			} // end of method Scope_area::.ctor
 
 		} // end of class Scope_area
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7B6BA518_Rectangle
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_DefaultParameterValue_Constructor/Rectangle/FunctionObject_ClassConstructor_7B6BA518_Rectangle::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_7B6BA518_Rectangle::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7B6BA518_Rectangle::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7B6BA518_Rectangle::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_7B6BA518_Rectangle
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_840B970A_Rectangle_area
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_840B970A_Rectangle_area::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_840B970A_Rectangle_area::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_840B970A_Rectangle_area::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_DefaultParameterValue_Constructor/Rectangle
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_DefaultParameterValue_Constructor/Rectangle
-				IL_001d: call instance object Modules.Classes_DefaultParameterValue_Constructor/Rectangle::area()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_840B970A_Rectangle_area::CallCore
-
-		} // end of class FunctionObject_ClassMethod_840B970A_Rectangle_area
 
 
 		// Fields

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_DefaultParameterValue_Method.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_DefaultParameterValue_Method.verified.txt
@@ -53,6 +53,75 @@
 
 			} // end of class Block_L5C19
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 49 (0x31)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_DefaultParameterValue_Method/Calculator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: ldarg.2
+					IL_0025: ldc.i4.1
+					IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_002b: call instance object Modules.Classes_DefaultParameterValue_Method/Calculator::'add'(object, object)
+					IL_0030: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -92,6 +161,78 @@
 				} // end of method Block_L9C34::.ctor
 
 			} // end of class Block_L9C34
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 56 (0x38)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_DefaultParameterValue_Method/Calculator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: ldarg.2
+					IL_0025: ldc.i4.1
+					IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_002b: ldarg.2
+					IL_002c: ldc.i4.2
+					IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0032: call instance object Modules.Classes_DefaultParameterValue_Method/Calculator::multiply(object, object, object)
+					IL_0037: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -133,6 +274,72 @@
 
 			} // end of class Block_L13C26
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_DefaultParameterValue_Method/Calculator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Classes_DefaultParameterValue_Method/Calculator::greet(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -173,6 +380,78 @@
 
 			} // end of class Block_L17C39
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 56 (0x38)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_DefaultParameterValue_Method/Calculator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: ldarg.2
+					IL_0025: ldc.i4.1
+					IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_002b: ldarg.2
+					IL_002c: ldc.i4.2
+					IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0032: call instance object Modules.Classes_DefaultParameterValue_Method/Calculator::calculate(object, object, object)
+					IL_0037: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -190,7 +469,7 @@
 
 		} // end of class Scope_calculate
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_99088752_Calculator
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -210,9 +489,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_DefaultParameterValue_Method/Calculator/FunctionObject_ClassConstructor_99088752_Calculator::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_DefaultParameterValue_Method/Calculator/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_99088752_Calculator::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -223,7 +502,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_99088752_Calculator::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -234,288 +513,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_99088752_Calculator::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_99088752_Calculator
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_EAF53F0C_Calculator_add
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_EAF53F0C_Calculator_add::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_EAF53F0C_Calculator_add::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_EAF53F0C_Calculator_add::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 49 (0x31)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_DefaultParameterValue_Method/Calculator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: ldarg.2
-				IL_0025: ldc.i4.1
-				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_002b: call instance object Modules.Classes_DefaultParameterValue_Method/Calculator::'add'(object, object)
-				IL_0030: ret
-			} // end of method FunctionObject_ClassMethod_EAF53F0C_Calculator_add::CallCore
-
-		} // end of class FunctionObject_ClassMethod_EAF53F0C_Calculator_add
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_E8EF129D_Calculator_multiply
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_E8EF129D_Calculator_multiply::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_E8EF129D_Calculator_multiply::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_E8EF129D_Calculator_multiply::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 56 (0x38)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_DefaultParameterValue_Method/Calculator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: ldarg.2
-				IL_0025: ldc.i4.1
-				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_002b: ldarg.2
-				IL_002c: ldc.i4.2
-				IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0032: call instance object Modules.Classes_DefaultParameterValue_Method/Calculator::multiply(object, object, object)
-				IL_0037: ret
-			} // end of method FunctionObject_ClassMethod_E8EF129D_Calculator_multiply::CallCore
-
-		} // end of class FunctionObject_ClassMethod_E8EF129D_Calculator_multiply
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_71FF28E2_Calculator_greet
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_71FF28E2_Calculator_greet::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_71FF28E2_Calculator_greet::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_71FF28E2_Calculator_greet::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_DefaultParameterValue_Method/Calculator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Classes_DefaultParameterValue_Method/Calculator::greet(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_71FF28E2_Calculator_greet::CallCore
-
-		} // end of class FunctionObject_ClassMethod_71FF28E2_Calculator_greet
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 56 (0x38)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_DefaultParameterValue_Method/Calculator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: ldarg.2
-				IL_0025: ldc.i4.1
-				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_002b: ldarg.2
-				IL_002c: ldc.i4.2
-				IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0032: call instance object Modules.Classes_DefaultParameterValue_Method/Calculator::calculate(object, object, object)
-				IL_0037: ret
-			} // end of method FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate::CallCore
-
-		} // end of class FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate
+		} // end of class FunctionObject
 
 
 		// Methods

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ForLoopMin.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ForLoopMin.verified.txt
@@ -53,6 +53,70 @@
 
 			} // end of class Block_L2C57
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_ForLoopMin/C
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_ForLoopMin/C
+					IL_001d: call instance float64 Modules.Classes_ForLoopMin/C::run()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -70,7 +134,7 @@
 
 		} // end of class Scope_run
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_889FA173_C
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -90,9 +154,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_ForLoopMin/C/FunctionObject_ClassConstructor_889FA173_C::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_ForLoopMin/C/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_889FA173_C::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -103,7 +167,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_889FA173_C::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -114,73 +178,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_889FA173_C::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_889FA173_C
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_A226B3E5_C_run
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_A226B3E5_C_run::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_A226B3E5_C_run::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_A226B3E5_C_run::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_ForLoopMin/C
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_ForLoopMin/C
-				IL_001d: call instance float64 Modules.Classes_ForLoopMin/C::run()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_A226B3E5_C_run::CallCore
-
-		} // end of class FunctionObject_ClassMethod_A226B3E5_C_run
+		} // end of class FunctionObject
 
 
 		// Methods

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_GeneratedConstructorFunctionObjects.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_GeneratedConstructorFunctionObjects.verified.txt
@@ -53,6 +53,54 @@
 
 			} // end of class Block_L4C25
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/Base/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -73,6 +121,62 @@
 		.class nested public auto ansi beforefieldinit Scope_label
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 6 (0x6)
+					.maxstack 8
+
+					IL_0000: call object Modules.Classes_GeneratedConstructorFunctionObjects/Base::label()
+					IL_0005: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -88,108 +192,6 @@
 			} // end of method Scope_label::.ctor
 
 		} // end of class Scope_label
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_C9E5FF55_Base
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/Base/FunctionObject_ClassConstructor_C9E5FF55_Base::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_C9E5FF55_Base::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_C9E5FF55_Base::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_C9E5FF55_Base::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_C9E5FF55_Base
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_0CE0460C_Base_label
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassStaticMethod_0CE0460C_Base_label::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_0CE0460C_Base_label::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_0CE0460C_Base_label::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 6 (0x6)
-				.maxstack 8
-
-				IL_0000: call object Modules.Classes_GeneratedConstructorFunctionObjects/Base::label()
-				IL_0005: ret
-			} // end of method FunctionObject_ClassStaticMethod_0CE0460C_Base_label::CallCore
-
-		} // end of class FunctionObject_ClassStaticMethod_0CE0460C_Base_label
 
 
 		// Fields
@@ -265,6 +267,90 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0,
+						class [System.Runtime]System.Object capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/Derived/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_GeneratedConstructorFunctionObjects/Derived/Scope_ctor/FunctionObject::_homeObject
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/Derived/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_001b: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_GeneratedConstructorFunctionObjects/Derived/Scope_ctor/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/Derived/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -280,88 +366,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7F3EFC11_Derived
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0,
-					class [System.Runtime]System.Object capture1,
-					object[] capture2
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 28 (0x1c)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/Derived/FunctionObject_ClassConstructor_7F3EFC11_Derived::_transitionalScopes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_GeneratedConstructorFunctionObjects/Derived/FunctionObject_ClassConstructor_7F3EFC11_Derived::_homeObject
-				IL_0014: ldarg.0
-				IL_0015: ldarg.3
-				IL_0016: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/Derived/FunctionObject_ClassConstructor_7F3EFC11_Derived::_lexicalSuperScopes
-				IL_001b: ret
-			} // end of method FunctionObject_ClassConstructor_7F3EFC11_Derived::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7F3EFC11_Derived::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7F3EFC11_Derived::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_GeneratedConstructorFunctionObjects/Derived/FunctionObject_ClassConstructor_7F3EFC11_Derived::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_7F3EFC11_Derived::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/Derived/FunctionObject_ClassConstructor_7F3EFC11_Derived::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_7F3EFC11_Derived::GetLexicalSuperScopesCore
-
-		} // end of class FunctionObject_ClassConstructor_7F3EFC11_Derived
 
 
 		// Fields
@@ -435,7 +439,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_CD2A9E26_Alternate
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -455,9 +459,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/Alternate/FunctionObject_ClassConstructor_CD2A9E26_Alternate::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/Alternate/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_CD2A9E26_Alternate::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -468,7 +472,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_CD2A9E26_Alternate::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -479,9 +483,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_CD2A9E26_Alternate::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_CD2A9E26_Alternate
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -525,7 +529,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_BFEAC8C2_Renamed
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -545,9 +549,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/Renamed/FunctionObject_ClassConstructor_BFEAC8C2_Renamed::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/Renamed/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_BFEAC8C2_Renamed::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -558,7 +562,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_BFEAC8C2_Renamed::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -569,9 +573,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_BFEAC8C2_Renamed::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_BFEAC8C2_Renamed
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -642,6 +646,62 @@
 		.class nested public auto ansi beforefieldinit Scope_name
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 6 (0x6)
+					.maxstack 8
+
+					IL_0000: call object Modules.Classes_GeneratedConstructorFunctionObjects/NamedMethod::name()
+					IL_0005: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -658,7 +718,7 @@
 
 		} // end of class Scope_name
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_5DF56B20_NamedMethod
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -678,9 +738,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/NamedMethod/FunctionObject_ClassConstructor_5DF56B20_NamedMethod::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/NamedMethod/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_5DF56B20_NamedMethod::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -691,7 +751,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_5DF56B20_NamedMethod::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -702,63 +762,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_5DF56B20_NamedMethod::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_5DF56B20_NamedMethod
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_A503FE90_NamedMethod_name
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassStaticMethod_A503FE90_NamedMethod_name::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_A503FE90_NamedMethod_name::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_A503FE90_NamedMethod_name::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 6 (0x6)
-				.maxstack 8
-
-				IL_0000: call object Modules.Classes_GeneratedConstructorFunctionObjects/NamedMethod::name()
-				IL_0005: ret
-			} // end of method FunctionObject_ClassStaticMethod_A503FE90_NamedMethod_name::CallCore
-
-		} // end of class FunctionObject_ClassStaticMethod_A503FE90_NamedMethod_name
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -816,7 +822,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_765962BF_ClassExpression_L57C18
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -836,9 +842,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L57C18/FunctionObject_ClassConstructor_765962BF_ClassExpression_L57C18::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L57C18/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_765962BF_ClassExpression_L57C18::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -849,7 +855,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_765962BF_ClassExpression_L57C18::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -860,9 +866,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_765962BF_ClassExpression_L57C18::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_765962BF_ClassExpression_L57C18
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -906,7 +912,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_11E7A486_ClassExpression_L60C15
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -926,9 +932,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L60C15/FunctionObject_ClassConstructor_11E7A486_ClassExpression_L60C15::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L60C15/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_11E7A486_ClassExpression_L60C15::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -939,7 +945,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_11E7A486_ClassExpression_L60C15::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -950,9 +956,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_11E7A486_ClassExpression_L60C15::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_11E7A486_ClassExpression_L60C15
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -996,7 +1002,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_F1CEF73E_ClassExpression_L61C16
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -1016,9 +1022,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L61C16/FunctionObject_ClassConstructor_F1CEF73E_ClassExpression_L61C16::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L61C16/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_F1CEF73E_ClassExpression_L61C16::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1029,7 +1035,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_F1CEF73E_ClassExpression_L61C16::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1040,9 +1046,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_F1CEF73E_ClassExpression_L61C16::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_F1CEF73E_ClassExpression_L61C16
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1164,8 +1170,8 @@
 			[17] object,
 			[18] class [System.Runtime]System.Type,
 			[19] object[],
-			[20] class Modules.Classes_GeneratedConstructorFunctionObjects/Base/FunctionObject_ClassConstructor_C9E5FF55_Base,
-			[21] class Modules.Classes_GeneratedConstructorFunctionObjects/Derived/FunctionObject_ClassConstructor_7F3EFC11_Derived,
+			[20] class Modules.Classes_GeneratedConstructorFunctionObjects/Base/Scope_ctor/FunctionObject,
+			[21] class Modules.Classes_GeneratedConstructorFunctionObjects/Derived/Scope_ctor/FunctionObject,
 			[22] object,
 			[23] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[24] string,
@@ -1173,14 +1179,14 @@
 			[26] object,
 			[27] class Modules.Classes_GeneratedConstructorFunctionObjects/Base,
 			[28] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[29] class Modules.Classes_GeneratedConstructorFunctionObjects/Alternate/FunctionObject_ClassConstructor_CD2A9E26_Alternate,
+			[29] class Modules.Classes_GeneratedConstructorFunctionObjects/Alternate/FunctionObject,
 			[30] object,
 			[31] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[32] class Modules.Classes_GeneratedConstructorFunctionObjects/Renamed/FunctionObject_ClassConstructor_BFEAC8C2_Renamed,
-			[33] class Modules.Classes_GeneratedConstructorFunctionObjects/NamedMethod/FunctionObject_ClassConstructor_5DF56B20_NamedMethod,
-			[34] class Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L57C18/FunctionObject_ClassConstructor_765962BF_ClassExpression_L57C18,
-			[35] class Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L60C15/FunctionObject_ClassConstructor_11E7A486_ClassExpression_L60C15,
-			[36] class Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L61C16/FunctionObject_ClassConstructor_F1CEF73E_ClassExpression_L61C16
+			[32] class Modules.Classes_GeneratedConstructorFunctionObjects/Renamed/FunctionObject,
+			[33] class Modules.Classes_GeneratedConstructorFunctionObjects/NamedMethod/FunctionObject,
+			[34] class Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L57C18/FunctionObject,
+			[35] class Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L60C15/FunctionObject,
+			[36] class Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L61C16/FunctionObject
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -1200,14 +1206,14 @@
 		IL_0034: stloc.s 19
 		IL_0036: ldloc.s 18
 		IL_0038: ldstr "label"
-		IL_003d: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/Base/FunctionObject_ClassStaticMethod_0CE0460C_Base_label::.ctor()
+		IL_003d: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/Base/Scope_label/FunctionObject::.ctor()
 		IL_0042: ldc.i4.0
 		IL_0043: conv.r8
 		IL_0044: ldstr "label"
 		IL_0049: ldc.i4.0
 		IL_004a: ldc.i4.1
-		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedConstructorFunctionObjects/Base/FunctionObject_ClassStaticMethod_0CE0460C_Base_label>(!!0, float64, string, bool, bool)
-		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedConstructorFunctionObjects/Base/FunctionObject_ClassStaticMethod_0CE0460C_Base_label>(!!0)
+		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedConstructorFunctionObjects/Base/Scope_label/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedConstructorFunctionObjects/Base/Scope_label/FunctionObject>(!!0)
 		IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_005a: pop
 		IL_005b: ldc.i4.1
@@ -1218,14 +1224,14 @@
 		IL_0064: stelem.ref
 		IL_0065: stloc.s 19
 		IL_0067: ldloc.s 19
-		IL_0069: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/Base/FunctionObject_ClassConstructor_C9E5FF55_Base::.ctor(object[])
+		IL_0069: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/Base/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_006e: ldloc.s 18
 		IL_0070: ldloc.s 19
 		IL_0072: ldc.i4.0
 		IL_0073: conv.r8
 		IL_0074: ldc.i4.0
 		IL_0075: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_007a: castclass Modules.Classes_GeneratedConstructorFunctionObjects/Base/FunctionObject_ClassConstructor_C9E5FF55_Base
+		IL_007a: castclass Modules.Classes_GeneratedConstructorFunctionObjects/Base/Scope_ctor/FunctionObject
 		IL_007f: stloc.s 20
 		IL_0081: ldloc.0
 		IL_0082: ldloc.s 20
@@ -1250,14 +1256,14 @@
 		IL_00b9: ldc.i4.0
 		IL_00ba: ldloc.0
 		IL_00bb: stelem.ref
-		IL_00bc: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/Derived/FunctionObject_ClassConstructor_7F3EFC11_Derived::.ctor(object[], class [System.Runtime]System.Object, object[])
+		IL_00bc: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/Derived/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object, object[])
 		IL_00c1: ldloc.s 18
 		IL_00c3: ldloc.s 19
 		IL_00c5: ldc.i4.1
 		IL_00c6: conv.r8
 		IL_00c7: ldc.i4.0
 		IL_00c8: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_00cd: castclass Modules.Classes_GeneratedConstructorFunctionObjects/Derived/FunctionObject_ClassConstructor_7F3EFC11_Derived
+		IL_00cd: castclass Modules.Classes_GeneratedConstructorFunctionObjects/Derived/Scope_ctor/FunctionObject
 		IL_00d2: stloc.s 21
 		IL_00d4: ldloc.s 21
 		IL_00d6: ldloc.s 20
@@ -1414,14 +1420,14 @@
 		IL_02ad: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_02b2: stloc.s 18
 		IL_02b4: ldloc.s 19
-		IL_02b6: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/Alternate/FunctionObject_ClassConstructor_CD2A9E26_Alternate::.ctor(object[])
+		IL_02b6: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/Alternate/FunctionObject::.ctor(object[])
 		IL_02bb: ldloc.s 18
 		IL_02bd: ldloc.s 19
 		IL_02bf: ldc.i4.0
 		IL_02c0: conv.r8
 		IL_02c1: ldc.i4.0
 		IL_02c2: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_02c7: castclass Modules.Classes_GeneratedConstructorFunctionObjects/Alternate/FunctionObject_ClassConstructor_CD2A9E26_Alternate
+		IL_02c7: castclass Modules.Classes_GeneratedConstructorFunctionObjects/Alternate/FunctionObject
 		IL_02cc: stloc.s 29
 		IL_02ce: ldloc.s 29
 		IL_02d0: stloc.2
@@ -1558,14 +1564,14 @@
 		IL_0441: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0446: stloc.s 18
 		IL_0448: ldloc.s 19
-		IL_044a: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/Renamed/FunctionObject_ClassConstructor_BFEAC8C2_Renamed::.ctor(object[])
+		IL_044a: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/Renamed/FunctionObject::.ctor(object[])
 		IL_044f: ldloc.s 18
 		IL_0451: ldloc.s 19
 		IL_0453: ldc.i4.0
 		IL_0454: conv.r8
 		IL_0455: ldc.i4.0
 		IL_0456: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_045b: castclass Modules.Classes_GeneratedConstructorFunctionObjects/Renamed/FunctionObject_ClassConstructor_BFEAC8C2_Renamed
+		IL_045b: castclass Modules.Classes_GeneratedConstructorFunctionObjects/Renamed/FunctionObject
 		IL_0460: stloc.s 32
 		IL_0462: ldloc.s 32
 		IL_0464: stloc.s 9
@@ -1592,14 +1598,14 @@
 		IL_04b0: stloc.s 19
 		IL_04b2: ldloc.s 18
 		IL_04b4: ldstr "name"
-		IL_04b9: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/NamedMethod/FunctionObject_ClassStaticMethod_A503FE90_NamedMethod_name::.ctor()
+		IL_04b9: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/NamedMethod/Scope_name/FunctionObject::.ctor()
 		IL_04be: ldc.i4.0
 		IL_04bf: conv.r8
 		IL_04c0: ldstr "name"
 		IL_04c5: ldc.i4.0
 		IL_04c6: ldc.i4.1
-		IL_04c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedConstructorFunctionObjects/NamedMethod/FunctionObject_ClassStaticMethod_A503FE90_NamedMethod_name>(!!0, float64, string, bool, bool)
-		IL_04cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedConstructorFunctionObjects/NamedMethod/FunctionObject_ClassStaticMethod_A503FE90_NamedMethod_name>(!!0)
+		IL_04c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedConstructorFunctionObjects/NamedMethod/Scope_name/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedConstructorFunctionObjects/NamedMethod/Scope_name/FunctionObject>(!!0)
 		IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_04d6: pop
 		IL_04d7: ldc.i4.1
@@ -1610,14 +1616,14 @@
 		IL_04e0: stelem.ref
 		IL_04e1: stloc.s 19
 		IL_04e3: ldloc.s 19
-		IL_04e5: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/NamedMethod/FunctionObject_ClassConstructor_5DF56B20_NamedMethod::.ctor(object[])
+		IL_04e5: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/NamedMethod/FunctionObject::.ctor(object[])
 		IL_04ea: ldloc.s 18
 		IL_04ec: ldloc.s 19
 		IL_04ee: ldc.i4.0
 		IL_04ef: conv.r8
 		IL_04f0: ldc.i4.0
 		IL_04f1: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_04f6: castclass Modules.Classes_GeneratedConstructorFunctionObjects/NamedMethod/FunctionObject_ClassConstructor_5DF56B20_NamedMethod
+		IL_04f6: castclass Modules.Classes_GeneratedConstructorFunctionObjects/NamedMethod/FunctionObject
 		IL_04fb: stloc.s 33
 		IL_04fd: ldloc.s 33
 		IL_04ff: stloc.s 10
@@ -1653,14 +1659,14 @@
 		IL_055f: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0564: stloc.s 18
 		IL_0566: ldloc.s 19
-		IL_0568: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L57C18/FunctionObject_ClassConstructor_765962BF_ClassExpression_L57C18::.ctor(object[])
+		IL_0568: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L57C18/FunctionObject::.ctor(object[])
 		IL_056d: ldloc.s 18
 		IL_056f: ldloc.s 19
 		IL_0571: ldc.i4.0
 		IL_0572: conv.r8
 		IL_0573: ldc.i4.1
 		IL_0574: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0579: castclass Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L57C18/FunctionObject_ClassConstructor_765962BF_ClassExpression_L57C18
+		IL_0579: castclass Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L57C18/FunctionObject
 		IL_057e: stloc.s 34
 		IL_0580: ldloc.s 34
 		IL_0582: ldstr "Inferred"
@@ -1702,14 +1708,14 @@
 		IL_05fa: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_05ff: stloc.s 18
 		IL_0601: ldloc.s 19
-		IL_0603: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L60C15/FunctionObject_ClassConstructor_11E7A486_ClassExpression_L60C15::.ctor(object[])
+		IL_0603: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L60C15/FunctionObject::.ctor(object[])
 		IL_0608: ldloc.s 18
 		IL_060a: ldloc.s 19
 		IL_060c: ldc.i4.0
 		IL_060d: conv.r8
 		IL_060e: ldc.i4.1
 		IL_060f: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0614: castclass Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L60C15/FunctionObject_ClassConstructor_11E7A486_ClassExpression_L60C15
+		IL_0614: castclass Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L60C15/FunctionObject
 		IL_0619: stloc.s 35
 		IL_061b: ldloc.s 35
 		IL_061d: ldstr "First"
@@ -1741,14 +1747,14 @@
 		IL_0676: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_067b: stloc.s 18
 		IL_067d: ldloc.s 19
-		IL_067f: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L61C16/FunctionObject_ClassConstructor_F1CEF73E_ClassExpression_L61C16::.ctor(object[])
+		IL_067f: newobj instance void Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L61C16/FunctionObject::.ctor(object[])
 		IL_0684: ldloc.s 18
 		IL_0686: ldloc.s 19
 		IL_0688: ldc.i4.0
 		IL_0689: conv.r8
 		IL_068a: ldc.i4.1
 		IL_068b: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0690: castclass Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L61C16/FunctionObject_ClassConstructor_F1CEF73E_ClassExpression_L61C16
+		IL_0690: castclass Modules.Classes_GeneratedConstructorFunctionObjects/ClassExpression_L61C16/FunctionObject
 		IL_0695: stloc.s 36
 		IL_0697: ldloc.s 36
 		IL_0699: ldstr "Second"

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_GeneratedMethodFunctionObjects.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_GeneratedMethodFunctionObjects.verified.txt
@@ -37,6 +37,72 @@
 			.class nested public auto ansi beforefieldinit Scope_method
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 40 (0x28)
+						.maxstack 8
+
+						IL_0000: ldarg.1
+						IL_0001: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12
+						IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+						IL_000b: ldc.i4.1
+						IL_000c: newarr [System.Runtime]System.Object
+						IL_0011: ldnull
+						IL_0012: ldarg.0
+						IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+						IL_0018: castclass Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12
+						IL_001d: call instance float64 Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12::'method'()
+						IL_0022: box [System.Runtime]System.Double
+						IL_0027: ret
+					} // end of method FunctionObject::CallCore
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -53,7 +119,7 @@
 
 			} // end of class Scope_method
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_31BBFF30_ClassExpression_L89C12
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 			{
 				// Fields
@@ -73,9 +139,9 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassConstructor_31BBFF30_ClassExpression_L89C12::_transitionalScopes
+					IL_0008: stfld object[] Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject::_transitionalScopes
 					IL_000d: ret
-				} // end of method FunctionObject_ClassConstructor_31BBFF30_ClassExpression_L89C12::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -86,7 +152,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_31BBFF30_ClassExpression_L89C12::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -97,73 +163,9 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_31BBFF30_ClassExpression_L89C12::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
-			} // end of class FunctionObject_ClassConstructor_31BBFF30_ClassExpression_L89C12
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 7 (0x7)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-					IL_0006: ret
-				} // end of method FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method::get_RequiresInvocationContext
-
-				.method family hidebysig virtual 
-					instance object CallCore (
-						object thisArgument,
-						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 40 (0x28)
-					.maxstack 8
-
-					IL_0000: ldarg.1
-					IL_0001: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12
-					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-					IL_000b: ldc.i4.1
-					IL_000c: newarr [System.Runtime]System.Object
-					IL_0011: ldnull
-					IL_0012: ldarg.0
-					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-					IL_0018: castclass Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12
-					IL_001d: call instance float64 Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12::'method'()
-					IL_0022: box [System.Runtime]System.Double
-					IL_0027: ret
-				} // end of method FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method::CallCore
-
-			} // end of class FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -324,7 +326,7 @@
 				[1] class [System.Runtime]System.Type,
 				[2] object,
 				[3] object[],
-				[4] class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassConstructor_31BBFF30_ClassExpression_L89C12
+				[4] class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeClass/Scope::.ctor()
@@ -342,27 +344,27 @@
 			IL_002c: stloc.3
 			IL_002d: ldloc.2
 			IL_002e: ldstr "method"
-			IL_0033: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method::.ctor()
+			IL_0033: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/Scope_method/FunctionObject::.ctor()
 			IL_0038: ldc.i4.0
 			IL_0039: conv.r8
 			IL_003a: ldstr "method"
 			IL_003f: ldc.i4.0
 			IL_0040: ldc.i4.1
-			IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method>(!!0, float64, string, bool, bool)
-			IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassMethod_CB96056A_ClassExpression_L89C12_method>(!!0)
+			IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/Scope_method/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/Scope_method/FunctionObject>(!!0)
 			IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 			IL_0050: pop
 			IL_0051: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_0056: stloc.3
 			IL_0057: ldloc.3
-			IL_0058: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassConstructor_31BBFF30_ClassExpression_L89C12::.ctor(object[])
+			IL_0058: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject::.ctor(object[])
 			IL_005d: ldloc.1
 			IL_005e: ldloc.3
 			IL_005f: ldc.i4.0
 			IL_0060: conv.r8
 			IL_0061: ldc.i4.1
 			IL_0062: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-			IL_0067: castclass Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject_ClassConstructor_31BBFF30_ClassExpression_L89C12
+			IL_0067: castclass Modules.Classes_GeneratedMethodFunctionObjects/makeClass/ClassExpression_L89C12/FunctionObject
 			IL_006c: stloc.s 4
 			IL_006e: ldloc.s 4
 			IL_0070: ret
@@ -400,6 +402,61 @@
 			.class nested public auto ansi beforefieldinit Scope_ctor
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+				{
+					// Fields
+					.field private initonly object[] _transitionalScopes
+					.field private initonly class [System.Runtime]System.Object _privateBrand
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							object[] capture0,
+							class [System.Runtime]System.Object capture1
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 21 (0x15)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld object[] Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_ctor/FunctionObject::_transitionalScopes
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_ctor/FunctionObject::_privateBrand
+						IL_0014: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -419,6 +476,80 @@
 			.class nested public auto ansi beforefieldinit Scope_read
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class [System.Runtime]System.Object _privateBrand
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class [System.Runtime]System.Object capture0
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_read/FunctionObject::_privateBrand
+						IL_000d: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 40 (0x28)
+						.maxstack 8
+
+						IL_0000: ldarg.1
+						IL_0001: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12
+						IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+						IL_000b: ldc.i4.1
+						IL_000c: newarr [System.Runtime]System.Object
+						IL_0011: ldarg.0
+						IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_read/FunctionObject::_privateBrand
+						IL_0017: ldarg.0
+						IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+						IL_001d: castclass Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12
+						IL_0022: call instance object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12::read()
+						IL_0027: ret
+					} // end of method FunctionObject::CallCore
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -438,6 +569,63 @@
 			.class nested public auto ansi beforefieldinit Scope_Method_L112C8
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 11 (0xb)
+						.maxstack 8
+
+						IL_0000: call float64 Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12::__jroc_priv_method_hidden()
+						IL_0005: box [System.Runtime]System.Double
+						IL_000a: ret
+					} // end of method FunctionObject::CallCore
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -457,6 +645,78 @@
 			.class nested public auto ansi beforefieldinit Scope_readStatic
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class [System.Runtime]System.Object _privateBrand
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class [System.Runtime]System.Object capture0
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_readStatic/FunctionObject::_privateBrand
+						IL_000d: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 30 (0x1e)
+						.maxstack 8
+
+						IL_0000: ldarg.1
+						IL_0001: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12
+						IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+						IL_000b: ldarg.0
+						IL_000c: ldfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_readStatic/FunctionObject::_privateBrand
+						IL_0011: ldarg.0
+						IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ValidateGeneratedStaticMethodReceiver(object, class [System.Runtime]System.Type, object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+						IL_0017: pop
+						IL_0018: call object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12::readStatic()
+						IL_001d: ret
+					} // end of method FunctionObject::CallCore
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -472,256 +732,6 @@
 				} // end of method Scope_readStatic::.ctor
 
 			} // end of class Scope_readStatic
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_D78DBE13_ClassExpression_L101C12
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-			{
-				// Fields
-				.field private initonly object[] _transitionalScopes
-				.field private initonly class [System.Runtime]System.Object _privateBrand
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor (
-						object[] capture0,
-						class [System.Runtime]System.Object capture1
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 21 (0x15)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-					IL_0006: ldarg.0
-					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassConstructor_D78DBE13_ClassExpression_L101C12::_transitionalScopes
-					IL_000d: ldarg.0
-					IL_000e: ldarg.2
-					IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassConstructor_D78DBE13_ClassExpression_L101C12::_privateBrand
-					IL_0014: ret
-				} // end of method FunctionObject_ClassConstructor_D78DBE13_ClassExpression_L101C12::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.1
-					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_D78DBE13_ClassExpression_L101C12::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.1
-					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_D78DBE13_ClassExpression_L101C12::get_RequiresInvocationContext
-
-			} // end of class FunctionObject_ClassConstructor_D78DBE13_ClassExpression_L101C12
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-			{
-				// Fields
-				.field private initonly class [System.Runtime]System.Object _privateBrand
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor (
-						class [System.Runtime]System.Object capture0
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 14 (0xe)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-					IL_0006: ldarg.0
-					IL_0007: ldarg.1
-					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read::_privateBrand
-					IL_000d: ret
-				} // end of method FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.1
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read::get_RequiresInvocationContext
-
-				.method family hidebysig virtual 
-					instance object CallCore (
-						object thisArgument,
-						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 40 (0x28)
-					.maxstack 8
-
-					IL_0000: ldarg.1
-					IL_0001: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12
-					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-					IL_000b: ldc.i4.1
-					IL_000c: newarr [System.Runtime]System.Object
-					IL_0011: ldarg.0
-					IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read::_privateBrand
-					IL_0017: ldarg.0
-					IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-					IL_001d: castclass Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12
-					IL_0022: call instance object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12::read()
-					IL_0027: ret
-				} // end of method FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read::CallCore
-
-			} // end of class FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 7 (0x7)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-					IL_0006: ret
-				} // end of method FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden::get_RequiresInvocationContext
-
-				.method family hidebysig virtual 
-					instance object CallCore (
-						object thisArgument,
-						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 11 (0xb)
-					.maxstack 8
-
-					IL_0000: call float64 Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12::__jroc_priv_method_hidden()
-					IL_0005: box [System.Runtime]System.Double
-					IL_000a: ret
-				} // end of method FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden::CallCore
-
-			} // end of class FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-			{
-				// Fields
-				.field private initonly class [System.Runtime]System.Object _privateBrand
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor (
-						class [System.Runtime]System.Object capture0
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 14 (0xe)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-					IL_0006: ldarg.0
-					IL_0007: ldarg.1
-					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic::_privateBrand
-					IL_000d: ret
-				} // end of method FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.1
-					IL_0001: ret
-				} // end of method FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic::get_RequiresInvocationContext
-
-				.method family hidebysig virtual 
-					instance object CallCore (
-						object thisArgument,
-						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 30 (0x1e)
-					.maxstack 8
-
-					IL_0000: ldarg.1
-					IL_0001: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12
-					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-					IL_000b: ldarg.0
-					IL_000c: ldfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic::_privateBrand
-					IL_0011: ldarg.0
-					IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ValidateGeneratedStaticMethodReceiver(object, class [System.Runtime]System.Type, object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-					IL_0017: pop
-					IL_0018: call object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12::readStatic()
-					IL_001d: ret
-				} // end of method FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic::CallCore
-
-			} // end of class FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic
 
 
 			// Fields
@@ -950,7 +960,7 @@
 				[2] object,
 				[3] object[],
 				[4] object[],
-				[5] class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassConstructor_D78DBE13_ClassExpression_L101C12
+				[5] class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_ctor/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/Scope::.ctor()
@@ -971,28 +981,28 @@
 			IL_0034: ldloc.2
 			IL_0035: ldstr "read"
 			IL_003a: ldloc.1
-			IL_003b: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read::.ctor(class [System.Runtime]System.Object)
+			IL_003b: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_read/FunctionObject::.ctor(class [System.Runtime]System.Object)
 			IL_0040: ldc.i4.0
 			IL_0041: conv.r8
 			IL_0042: ldstr "read"
 			IL_0047: ldc.i4.1
 			IL_0048: ldc.i4.1
-			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read>(!!0, float64, string, bool, bool)
-			IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassMethod_97888EB0_ClassExpression_L101C12_read>(!!0)
+			IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_read/FunctionObject>(!!0)
 			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 			IL_0058: pop
 			IL_0059: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_005e: stloc.s 4
 			IL_0060: ldloc.1
 			IL_0061: ldstr "__jroc_priv_method_hidden"
-			IL_0066: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden::.ctor()
+			IL_0066: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_Method_L112C8/FunctionObject::.ctor()
 			IL_006b: ldc.i4.0
 			IL_006c: conv.r8
 			IL_006d: ldstr "#hidden"
 			IL_0072: ldc.i4.0
 			IL_0073: ldc.i4.1
-			IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden>(!!0, float64, string, bool, bool)
-			IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_D35D6A4F_ClassExpression_L101C12___jroc_priv_method_hidden>(!!0)
+			IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_Method_L112C8/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_Method_L112C8/FunctionObject>(!!0)
 			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 			IL_0083: pop
 			IL_0084: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -1000,26 +1010,26 @@
 			IL_008b: ldloc.1
 			IL_008c: ldstr "readStatic"
 			IL_0091: ldloc.1
-			IL_0092: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic::.ctor(class [System.Runtime]System.Object)
+			IL_0092: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_readStatic/FunctionObject::.ctor(class [System.Runtime]System.Object)
 			IL_0097: ldc.i4.0
 			IL_0098: conv.r8
 			IL_0099: ldstr "readStatic"
 			IL_009e: ldc.i4.1
 			IL_009f: ldc.i4.1
-			IL_00a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic>(!!0, float64, string, bool, bool)
-			IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassStaticMethod_B51E2D14_ClassExpression_L101C12_readStatic>(!!0)
+			IL_00a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_readStatic/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_readStatic/FunctionObject>(!!0)
 			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 			IL_00af: pop
 			IL_00b0: ldloc.3
 			IL_00b1: ldnull
-			IL_00b2: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassConstructor_D78DBE13_ClassExpression_L101C12::.ctor(object[], class [System.Runtime]System.Object)
+			IL_00b2: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object)
 			IL_00b7: ldloc.1
 			IL_00b8: ldloc.3
 			IL_00b9: ldc.i4.1
 			IL_00ba: conv.r8
 			IL_00bb: ldc.i4.1
 			IL_00bc: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-			IL_00c1: castclass Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/FunctionObject_ClassConstructor_D78DBE13_ClassExpression_L101C12
+			IL_00c1: castclass Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/ClassExpression_L101C12/Scope_ctor/FunctionObject
 			IL_00c6: stloc.s 5
 			IL_00c8: ldloc.s 5
 			IL_00ca: ret
@@ -1053,6 +1063,71 @@
 		.class nested public auto ansi beforefieldinit Scope_label
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Base
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_GeneratedMethodFunctionObjects/Base
+					IL_001d: call instance object Modules.Classes_GeneratedMethodFunctionObjects/Base::label()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1069,7 +1144,7 @@
 
 		} // end of class Scope_label
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_4C540758_Base
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -1089,9 +1164,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassConstructor_4C540758_Base::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_4C540758_Base::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1102,7 +1177,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_4C540758_Base::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1113,72 +1188,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_4C540758_Base::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_4C540758_Base
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_7A5AE36D_Base_label
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_7A5AE36D_Base_label::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_7A5AE36D_Base_label::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_7A5AE36D_Base_label::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Base
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_GeneratedMethodFunctionObjects/Base
-				IL_001d: call instance object Modules.Classes_GeneratedMethodFunctionObjects/Base::label()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_7A5AE36D_Base_label::CallCore
-
-		} // end of class FunctionObject_ClassMethod_7A5AE36D_Base_label
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1239,6 +1251,90 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0,
+						class [System.Runtime]System.Object capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_ctor/FunctionObject::_homeObject
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_001b: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_ctor/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1258,6 +1354,111 @@
 		.class nested public auto ansi beforefieldinit Scope_add
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_add/FunctionObject::_homeObject
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_add/FunctionObject::_lexicalSuperScopes
+					IL_0014: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_add/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_add/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_GeneratedMethodFunctionObjects/Example
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Classes_GeneratedMethodFunctionObjects/Example::'add'(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1277,6 +1478,71 @@
 		.class nested public auto ansi beforefieldinit Scope_get_current
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_GeneratedMethodFunctionObjects/Example
+					IL_001d: call instance object Modules.Classes_GeneratedMethodFunctionObjects/Example::get_current()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1293,9 +1559,155 @@
 
 		} // end of class Scope_get_current
 
+		.class nested public auto ansi beforefieldinit Scope_set_current
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_GeneratedMethodFunctionObjects/Example
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Classes_GeneratedMethodFunctionObjects/Example::set_current(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_set_current::.ctor
+
+		} // end of class Scope_set_current
+
 		.class nested public auto ansi beforefieldinit Scope_identify
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.2
+					IL_0001: ldc.i4.0
+					IL_0002: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0007: call object Modules.Classes_GeneratedMethodFunctionObjects/Example::identify(object)
+					IL_000c: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1311,377 +1723,6 @@
 			} // end of method Scope_identify::.ctor
 
 		} // end of class Scope_identify
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_2D004A21_Example
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0,
-					class [System.Runtime]System.Object capture1,
-					object[] capture2
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 28 (0x1c)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassConstructor_2D004A21_Example::_transitionalScopes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassConstructor_2D004A21_Example::_homeObject
-				IL_0014: ldarg.0
-				IL_0015: ldarg.3
-				IL_0016: stfld object[] Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassConstructor_2D004A21_Example::_lexicalSuperScopes
-				IL_001b: ret
-			} // end of method FunctionObject_ClassConstructor_2D004A21_Example::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_2D004A21_Example::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_2D004A21_Example::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassConstructor_2D004A21_Example::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_2D004A21_Example::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassConstructor_2D004A21_Example::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_2D004A21_Example::GetLexicalSuperScopesCore
-
-		} // end of class FunctionObject_ClassConstructor_2D004A21_Example
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_000A557F_Example_add
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class [System.Runtime]System.Object capture0,
-					object[] capture1
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 21 (0x15)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add::_homeObject
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add::_lexicalSuperScopes
-				IL_0014: ret
-			} // end of method FunctionObject_ClassMethod_000A557F_Example_add::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_000A557F_Example_add::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_000A557F_Example_add::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_000A557F_Example_add::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_000A557F_Example_add::GetLexicalSuperScopesCore
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_GeneratedMethodFunctionObjects/Example
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Classes_GeneratedMethodFunctionObjects/Example::'add'(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_000A557F_Example_add::CallCore
-
-		} // end of class FunctionObject_ClassMethod_000A557F_Example_add
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassGetter_D6443AA5_Example_get_current
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassGetter_D6443AA5_Example_get_current::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassGetter_D6443AA5_Example_get_current::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassGetter_D6443AA5_Example_get_current::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_GeneratedMethodFunctionObjects/Example
-				IL_001d: call instance object Modules.Classes_GeneratedMethodFunctionObjects/Example::get_current()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassGetter_D6443AA5_Example_get_current::CallCore
-
-		} // end of class FunctionObject_ClassGetter_D6443AA5_Example_get_current
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassSetter_D35A8F6D_Example_set_current
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassSetter_D35A8F6D_Example_set_current::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassSetter_D35A8F6D_Example_set_current::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassSetter_D35A8F6D_Example_set_current::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Example
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_GeneratedMethodFunctionObjects/Example
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Classes_GeneratedMethodFunctionObjects/Example::set_current(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassSetter_D35A8F6D_Example_set_current::CallCore
-
-		} // end of class FunctionObject_ClassSetter_D35A8F6D_Example_set_current
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_6909A856_Example_identify
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassStaticMethod_6909A856_Example_identify::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_6909A856_Example_identify::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_6909A856_Example_identify::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 13 (0xd)
-				.maxstack 8
-
-				IL_0000: ldarg.2
-				IL_0001: ldc.i4.0
-				IL_0002: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0007: call object Modules.Classes_GeneratedMethodFunctionObjects/Example::identify(object)
-				IL_000c: ret
-			} // end of method FunctionObject_ClassStaticMethod_6909A856_Example_identify::CallCore
-
-		} // end of class FunctionObject_ClassStaticMethod_6909A856_Example_identify
 
 
 		// Fields
@@ -1861,6 +1902,61 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+				.field private initonly class [System.Runtime]System.Object _privateBrand
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0,
+						class [System.Runtime]System.Object capture1
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_ctor/FunctionObject::_privateBrand
+					IL_0014: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1880,6 +1976,80 @@
 		.class nested public auto ansi beforefieldinit Scope_read
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _privateBrand
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_read/FunctionObject::_privateBrand
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldarg.0
+					IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_read/FunctionObject::_privateBrand
+					IL_0017: ldarg.0
+					IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_001d: castclass Modules.Classes_GeneratedMethodFunctionObjects/Secret
+					IL_0022: call instance object Modules.Classes_GeneratedMethodFunctionObjects/Secret::read()
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1895,131 +2065,6 @@
 			} // end of method Scope_read::.ctor
 
 		} // end of class Scope_read
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_270B5F91_Secret
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-			.field private initonly class [System.Runtime]System.Object _privateBrand
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0,
-					class [System.Runtime]System.Object capture1
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 21 (0x15)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassConstructor_270B5F91_Secret::_transitionalScopes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassConstructor_270B5F91_Secret::_privateBrand
-				IL_0014: ret
-			} // end of method FunctionObject_ClassConstructor_270B5F91_Secret::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_270B5F91_Secret::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_270B5F91_Secret::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_270B5F91_Secret
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_13CEBD82_Secret_read
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly class [System.Runtime]System.Object _privateBrand
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class [System.Runtime]System.Object capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read::_privateBrand
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_13CEBD82_Secret_read::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_13CEBD82_Secret_read::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_13CEBD82_Secret_read::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Secret
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldarg.0
-				IL_0012: ldfld class [System.Runtime]System.Object Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read::_privateBrand
-				IL_0017: ldarg.0
-				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_001d: castclass Modules.Classes_GeneratedMethodFunctionObjects/Secret
-				IL_0022: call instance object Modules.Classes_GeneratedMethodFunctionObjects/Secret::read()
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_13CEBD82_Secret_read::CallCore
-
-		} // end of class FunctionObject_ClassMethod_13CEBD82_Secret_read
 
 
 		// Fields
@@ -2313,8 +2358,8 @@
 			[34] object[],
 			[35] class [System.Runtime]System.Type,
 			[36] object,
-			[37] class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassConstructor_4C540758_Base,
-			[38] class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassConstructor_2D004A21_Example,
+			[37] class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject,
+			[38] class Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_ctor/FunctionObject,
 			[39] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[40] object,
 			[41] object,
@@ -2325,7 +2370,7 @@
 			[46] object,
 			[47] object,
 			[48] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[49] class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassConstructor_270B5F91_Secret,
+			[49] class Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_ctor/FunctionObject,
 			[50] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
@@ -2375,14 +2420,14 @@
 		IL_0070: stloc.s 34
 		IL_0072: ldloc.s 36
 		IL_0074: ldstr "label"
-		IL_0079: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label::.ctor()
+		IL_0079: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Base/Scope_label/FunctionObject::.ctor()
 		IL_007e: ldc.i4.0
 		IL_007f: conv.r8
 		IL_0080: ldstr "label"
 		IL_0085: ldc.i4.0
 		IL_0086: ldc.i4.1
-		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label>(!!0, float64, string, bool, bool)
-		IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassMethod_7A5AE36D_Base_label>(!!0)
+		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Base/Scope_label/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Base/Scope_label/FunctionObject>(!!0)
 		IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0096: pop
 		IL_0097: ldc.i4.1
@@ -2393,14 +2438,14 @@
 		IL_00a0: stelem.ref
 		IL_00a1: stloc.s 34
 		IL_00a3: ldloc.s 34
-		IL_00a5: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassConstructor_4C540758_Base::.ctor(object[])
+		IL_00a5: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject::.ctor(object[])
 		IL_00aa: ldloc.s 35
 		IL_00ac: ldloc.s 34
 		IL_00ae: ldc.i4.0
 		IL_00af: conv.r8
 		IL_00b0: ldc.i4.0
 		IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_00b6: castclass Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject_ClassConstructor_4C540758_Base
+		IL_00b6: castclass Modules.Classes_GeneratedMethodFunctionObjects/Base/FunctionObject
 		IL_00bb: stloc.s 37
 		IL_00bd: ldloc.0
 		IL_00be: ldloc.s 37
@@ -2420,14 +2465,14 @@
 		IL_00f2: ldstr "add"
 		IL_00f7: ldloc.s 36
 		IL_00f9: ldloc.s 34
-		IL_00fb: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add::.ctor(class [System.Runtime]System.Object, object[])
+		IL_00fb: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_add/FunctionObject::.ctor(class [System.Runtime]System.Object, object[])
 		IL_0100: ldc.i4.1
 		IL_0101: conv.r8
 		IL_0102: ldstr "add"
 		IL_0107: ldc.i4.1
 		IL_0108: ldc.i4.1
-		IL_0109: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add>(!!0, float64, string, bool, bool)
-		IL_010e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassMethod_000A557F_Example_add>(!!0)
+		IL_0109: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_add/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_010e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_add/FunctionObject>(!!0)
 		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0118: pop
 		IL_0119: ldloc.s 35
@@ -2438,14 +2483,14 @@
 		IL_012c: stloc.s 34
 		IL_012e: ldloc.s 36
 		IL_0130: ldstr "current"
-		IL_0135: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current::.ctor()
+		IL_0135: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_get_current/FunctionObject::.ctor()
 		IL_013a: ldc.i4.0
 		IL_013b: conv.r8
 		IL_013c: ldstr "get current"
 		IL_0141: ldc.i4.1
 		IL_0142: ldc.i4.1
-		IL_0143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current>(!!0, float64, string, bool, bool)
-		IL_0148: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassGetter_D6443AA5_Example_get_current>(!!0)
+		IL_0143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_get_current/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0148: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_get_current/FunctionObject>(!!0)
 		IL_014d: ldnull
 		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
 		IL_0153: pop
@@ -2458,14 +2503,14 @@
 		IL_0169: ldloc.s 36
 		IL_016b: ldstr "current"
 		IL_0170: ldnull
-		IL_0171: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current::.ctor()
+		IL_0171: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_set_current/FunctionObject::.ctor()
 		IL_0176: ldc.i4.1
 		IL_0177: conv.r8
 		IL_0178: ldstr "set current"
 		IL_017d: ldc.i4.1
 		IL_017e: ldc.i4.1
-		IL_017f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current>(!!0, float64, string, bool, bool)
-		IL_0184: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassSetter_D35A8F6D_Example_set_current>(!!0)
+		IL_017f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_set_current/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0184: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_set_current/FunctionObject>(!!0)
 		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementAccessorProperty(object, object, object, object)
 		IL_018e: pop
 		IL_018f: ldloc.s 35
@@ -2476,14 +2521,14 @@
 		IL_01a1: stloc.s 34
 		IL_01a3: ldloc.s 35
 		IL_01a5: ldstr "identify"
-		IL_01aa: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify::.ctor()
+		IL_01aa: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_identify/FunctionObject::.ctor()
 		IL_01af: ldc.i4.1
 		IL_01b0: conv.r8
 		IL_01b1: ldstr "identify"
 		IL_01b6: ldc.i4.1
 		IL_01b7: ldc.i4.1
-		IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify>(!!0, float64, string, bool, bool)
-		IL_01bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassStaticMethod_6909A856_Example_identify>(!!0)
+		IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_identify/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_identify/FunctionObject>(!!0)
 		IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_01c7: pop
 		IL_01c8: ldc.i4.1
@@ -2501,14 +2546,14 @@
 		IL_01e2: ldc.i4.0
 		IL_01e3: ldloc.0
 		IL_01e4: stelem.ref
-		IL_01e5: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassConstructor_2D004A21_Example::.ctor(object[], class [System.Runtime]System.Object, object[])
+		IL_01e5: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object, object[])
 		IL_01ea: ldloc.s 35
 		IL_01ec: ldloc.s 34
 		IL_01ee: ldc.i4.1
 		IL_01ef: conv.r8
 		IL_01f0: ldc.i4.0
 		IL_01f1: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_01f6: castclass Modules.Classes_GeneratedMethodFunctionObjects/Example/FunctionObject_ClassConstructor_2D004A21_Example
+		IL_01f6: castclass Modules.Classes_GeneratedMethodFunctionObjects/Example/Scope_ctor/FunctionObject
 		IL_01fb: stloc.s 38
 		IL_01fd: ldloc.s 38
 		IL_01ff: ldloc.s 37
@@ -2925,14 +2970,14 @@
 		IL_06ef: ldloc.s 43
 		IL_06f1: ldstr "read"
 		IL_06f6: ldloc.s 35
-		IL_06f8: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read::.ctor(class [System.Runtime]System.Object)
+		IL_06f8: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_read/FunctionObject::.ctor(class [System.Runtime]System.Object)
 		IL_06fd: ldc.i4.0
 		IL_06fe: conv.r8
 		IL_06ff: ldstr "read"
 		IL_0704: ldc.i4.1
 		IL_0705: ldc.i4.1
-		IL_0706: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read>(!!0, float64, string, bool, bool)
-		IL_070b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassMethod_13CEBD82_Secret_read>(!!0)
+		IL_0706: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_070b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_read/FunctionObject>(!!0)
 		IL_0710: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0715: pop
 		IL_0716: ldc.i4.1
@@ -2944,14 +2989,14 @@
 		IL_0720: stloc.s 34
 		IL_0722: ldloc.s 34
 		IL_0724: ldnull
-		IL_0725: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassConstructor_270B5F91_Secret::.ctor(object[], class [System.Runtime]System.Object)
+		IL_0725: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object)
 		IL_072a: ldloc.s 35
 		IL_072c: ldloc.s 34
 		IL_072e: ldc.i4.1
 		IL_072f: conv.r8
 		IL_0730: ldc.i4.0
 		IL_0731: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0736: castclass Modules.Classes_GeneratedMethodFunctionObjects/Secret/FunctionObject_ClassConstructor_270B5F91_Secret
+		IL_0736: castclass Modules.Classes_GeneratedMethodFunctionObjects/Secret/Scope_ctor/FunctionObject
 		IL_073b: stloc.s 49
 		IL_073d: ldloc.s 49
 		IL_073f: stloc.s 12

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
@@ -37,6 +37,108 @@
 			.class nested public auto ansi beforefieldinit Scope_n
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class [System.Runtime]System.Object _homeObject
+					.field private initonly object[] _lexicalSuperScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class [System.Runtime]System.Object capture0,
+							object[] capture1
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 21 (0x15)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/Scope_n/FunctionObject::_homeObject
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld object[] Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/Scope_n/FunctionObject::_lexicalSuperScopes
+						IL_0014: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object GetLexicalSuperReceiverCore () cil managed 
+					{
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/Scope_n/FunctionObject::_homeObject
+						IL_0006: ret
+					} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+					.method family hidebysig virtual 
+						instance object[] GetLexicalSuperScopesCore () cil managed 
+					{
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/Scope_n/FunctionObject::_lexicalSuperScopes
+						IL_0006: ret
+					} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 35 (0x23)
+						.maxstack 8
+
+						IL_0000: ldarg.1
+						IL_0001: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
+						IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+						IL_000b: ldc.i4.1
+						IL_000c: newarr [System.Runtime]System.Object
+						IL_0011: ldnull
+						IL_0012: ldarg.0
+						IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+						IL_0018: castclass Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
+						IL_001d: call instance object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::n()
+						IL_0022: ret
+					} // end of method FunctionObject::CallCore
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -53,7 +155,7 @@
 
 			} // end of class Scope_n
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_0C45EDF4_NestedDerived
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 			{
 				// Fields
@@ -73,9 +175,9 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::_transitionalScopes
+					IL_0008: stfld object[] Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject::_transitionalScopes
 					IL_000d: ret
-				} // end of method FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -86,7 +188,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -97,109 +199,9 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
-			} // end of class FunctionObject_ClassConstructor_0C45EDF4_NestedDerived
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_A5621FA9_NestedDerived_n
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-			{
-				// Fields
-				.field private initonly class [System.Runtime]System.Object _homeObject
-				.field private initonly object[] _lexicalSuperScopes
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor (
-						class [System.Runtime]System.Object capture0,
-						object[] capture1
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 21 (0x15)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-					IL_0006: ldarg.0
-					IL_0007: ldarg.1
-					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::_homeObject
-					IL_000d: ldarg.0
-					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::_lexicalSuperScopes
-					IL_0014: ret
-				} // end of method FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.1
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::get_RequiresInvocationContext
-
-				.method family hidebysig virtual 
-					instance object GetLexicalSuperReceiverCore () cil managed 
-				{
-					// Header size: 1
-					// Code size: 7 (0x7)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::_homeObject
-					IL_0006: ret
-				} // end of method FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::GetLexicalSuperReceiverCore
-
-				.method family hidebysig virtual 
-					instance object[] GetLexicalSuperScopesCore () cil managed 
-				{
-					// Header size: 1
-					// Code size: 7 (0x7)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::_lexicalSuperScopes
-					IL_0006: ret
-				} // end of method FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::GetLexicalSuperScopesCore
-
-				.method family hidebysig virtual 
-					instance object CallCore (
-						object thisArgument,
-						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 35 (0x23)
-					.maxstack 8
-
-					IL_0000: ldarg.1
-					IL_0001: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
-					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-					IL_000b: ldc.i4.1
-					IL_000c: newarr [System.Runtime]System.Object
-					IL_0011: ldnull
-					IL_0012: ldarg.0
-					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-					IL_0018: castclass Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
-					IL_001d: call instance object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::n()
-					IL_0022: ret
-				} // end of method FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::CallCore
-
-			} // end of class FunctionObject_ClassMethod_A5621FA9_NestedDerived_n
+			} // end of class FunctionObject
 
 
 			// Fields
@@ -400,7 +402,7 @@
 				[2] class [System.Runtime]System.Type,
 				[3] object,
 				[4] object[],
-				[5] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassConstructor_0C45EDF4_NestedDerived,
+				[5] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject,
 				[6] class [JavaScriptRuntime]JavaScriptRuntime.Console
 			)
 
@@ -421,14 +423,14 @@
 			IL_002f: ldstr "n"
 			IL_0034: ldloc.3
 			IL_0035: ldloc.s 4
-			IL_0037: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::.ctor(class [System.Runtime]System.Object, object[])
+			IL_0037: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/Scope_n/FunctionObject::.ctor(class [System.Runtime]System.Object, object[])
 			IL_003c: ldc.i4.0
 			IL_003d: conv.r8
 			IL_003e: ldstr "n"
 			IL_0043: ldc.i4.1
 			IL_0044: ldc.i4.1
-			IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n>(!!0, float64, string, bool, bool)
-			IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassMethod_A5621FA9_NestedDerived_n>(!!0)
+			IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/Scope_n/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/Scope_n/FunctionObject>(!!0)
 			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 			IL_0054: pop
 			IL_0055: ldc.i4.2
@@ -443,14 +445,14 @@
 			IL_0062: stelem.ref
 			IL_0063: stloc.s 4
 			IL_0065: ldloc.s 4
-			IL_0067: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::.ctor(object[])
+			IL_0067: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject::.ctor(object[])
 			IL_006c: ldloc.2
 			IL_006d: ldloc.s 4
 			IL_006f: ldc.i4.0
 			IL_0070: conv.r8
 			IL_0071: ldc.i4.0
 			IL_0072: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-			IL_0077: castclass Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassConstructor_0C45EDF4_NestedDerived
+			IL_0077: castclass Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject
 			IL_007c: stloc.s 5
 			IL_007e: ldarg.0
 			IL_007f: ldfld object Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope::GlobalBase
@@ -548,6 +550,72 @@
 		.class nested public auto ansi beforefieldinit Scope_m
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
+					IL_001d: call instance float64 Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase::m()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -564,7 +632,7 @@
 
 		} // end of class Scope_m
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_F01B26D3_GlobalBase
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -584,9 +652,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassConstructor_F01B26D3_GlobalBase::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_F01B26D3_GlobalBase::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -597,7 +665,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_F01B26D3_GlobalBase::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -608,73 +676,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_F01B26D3_GlobalBase::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_F01B26D3_GlobalBase
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
-				IL_001d: call instance float64 Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase::m()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::CallCore
-
-		} // end of class FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -758,7 +762,7 @@
 			[2] object[],
 			[3] class [System.Runtime]System.Type,
 			[4] object,
-			[5] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassConstructor_F01B26D3_GlobalBase
+			[5] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope::.ctor()
@@ -796,14 +800,14 @@
 		IL_0055: stloc.2
 		IL_0056: ldloc.s 4
 		IL_0058: ldstr "m"
-		IL_005d: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::.ctor()
+		IL_005d: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/Scope_m/FunctionObject::.ctor()
 		IL_0062: ldc.i4.0
 		IL_0063: conv.r8
 		IL_0064: ldstr "m"
 		IL_0069: ldc.i4.0
 		IL_006a: ldc.i4.1
-		IL_006b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m>(!!0, float64, string, bool, bool)
-		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m>(!!0)
+		IL_006b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/Scope_m/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/Scope_m/FunctionObject>(!!0)
 		IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_007a: pop
 		IL_007b: ldc.i4.1
@@ -814,14 +818,14 @@
 		IL_0084: stelem.ref
 		IL_0085: stloc.2
 		IL_0086: ldloc.2
-		IL_0087: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassConstructor_F01B26D3_GlobalBase::.ctor(object[])
+		IL_0087: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject::.ctor(object[])
 		IL_008c: ldloc.3
 		IL_008d: ldloc.2
 		IL_008e: ldc.i4.0
 		IL_008f: conv.r8
 		IL_0090: ldc.i4.0
 		IL_0091: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0096: castclass Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassConstructor_F01B26D3_GlobalBase
+		IL_0096: castclass Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject
 		IL_009b: stloc.s 5
 		IL_009d: ldloc.0
 		IL_009e: ldloc.s 5

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
@@ -37,6 +37,80 @@
 			.class nested public auto ansi beforefieldinit Scope_m
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							object[] capture0
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/Scope_m/FunctionObject::_transitionalScopes
+						IL_000d: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 40 (0x28)
+						.maxstack 8
+
+						IL_0000: ldarg.1
+						IL_0001: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
+						IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+						IL_000b: ldarg.0
+						IL_000c: ldfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/Scope_m/FunctionObject::_transitionalScopes
+						IL_0011: ldnull
+						IL_0012: ldarg.0
+						IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+						IL_0018: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
+						IL_001d: call instance float64 Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base::m()
+						IL_0022: box [System.Runtime]System.Double
+						IL_0027: ret
+					} // end of method FunctionObject::CallCore
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -53,7 +127,7 @@
 
 			} // end of class Scope_m
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_D9ED61CF_Base
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 			{
 				// Fields
@@ -73,9 +147,9 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassConstructor_D9ED61CF_Base::_transitionalScopes
+					IL_0008: stfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject::_transitionalScopes
 					IL_000d: ret
-				} // end of method FunctionObject_ClassConstructor_D9ED61CF_Base::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -86,7 +160,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_D9ED61CF_Base::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -97,81 +171,9 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_D9ED61CF_Base::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
-			} // end of class FunctionObject_ClassConstructor_D9ED61CF_Base
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_85F9A249_Base_m
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-			{
-				// Fields
-				.field private initonly object[] _transitionalScopes
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor (
-						object[] capture0
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 14 (0xe)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-					IL_0006: ldarg.0
-					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m::_transitionalScopes
-					IL_000d: ret
-				} // end of method FunctionObject_ClassMethod_85F9A249_Base_m::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_85F9A249_Base_m::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_85F9A249_Base_m::get_RequiresInvocationContext
-
-				.method family hidebysig virtual 
-					instance object CallCore (
-						object thisArgument,
-						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 40 (0x28)
-					.maxstack 8
-
-					IL_0000: ldarg.1
-					IL_0001: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
-					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-					IL_000b: ldarg.0
-					IL_000c: ldfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m::_transitionalScopes
-					IL_0011: ldnull
-					IL_0012: ldarg.0
-					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-					IL_0018: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
-					IL_001d: call instance float64 Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base::m()
-					IL_0022: box [System.Runtime]System.Double
-					IL_0027: ret
-				} // end of method FunctionObject_ClassMethod_85F9A249_Base_m::CallCore
-
-			} // end of class FunctionObject_ClassMethod_85F9A249_Base_m
+			} // end of class FunctionObject
 
 
 			// Fields
@@ -245,6 +247,108 @@
 			.class nested public auto ansi beforefieldinit Scope_n
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class [System.Runtime]System.Object _homeObject
+					.field private initonly object[] _lexicalSuperScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class [System.Runtime]System.Object capture0,
+							object[] capture1
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 21 (0x15)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/Scope_n/FunctionObject::_homeObject
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/Scope_n/FunctionObject::_lexicalSuperScopes
+						IL_0014: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object GetLexicalSuperReceiverCore () cil managed 
+					{
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/Scope_n/FunctionObject::_homeObject
+						IL_0006: ret
+					} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+					.method family hidebysig virtual 
+						instance object[] GetLexicalSuperScopesCore () cil managed 
+					{
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/Scope_n/FunctionObject::_lexicalSuperScopes
+						IL_0006: ret
+					} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 35 (0x23)
+						.maxstack 8
+
+						IL_0000: ldarg.1
+						IL_0001: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+						IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+						IL_000b: ldc.i4.1
+						IL_000c: newarr [System.Runtime]System.Object
+						IL_0011: ldnull
+						IL_0012: ldarg.0
+						IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+						IL_0018: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+						IL_001d: call instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
+						IL_0022: ret
+					} // end of method FunctionObject::CallCore
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -261,7 +365,7 @@
 
 			} // end of class Scope_n
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_9C573247_Derived
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 			{
 				// Fields
@@ -281,9 +385,9 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassConstructor_9C573247_Derived::_transitionalScopes
+					IL_0008: stfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject::_transitionalScopes
 					IL_000d: ret
-				} // end of method FunctionObject_ClassConstructor_9C573247_Derived::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -294,7 +398,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_9C573247_Derived::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -305,109 +409,9 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_9C573247_Derived::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
-			} // end of class FunctionObject_ClassConstructor_9C573247_Derived
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_95B677B6_Derived_n
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-			{
-				// Fields
-				.field private initonly class [System.Runtime]System.Object _homeObject
-				.field private initonly object[] _lexicalSuperScopes
-
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor (
-						class [System.Runtime]System.Object capture0,
-						object[] capture1
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 21 (0x15)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-					IL_0006: ldarg.0
-					IL_0007: ldarg.1
-					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n::_homeObject
-					IL_000d: ldarg.0
-					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n::_lexicalSuperScopes
-					IL_0014: ret
-				} // end of method FunctionObject_ClassMethod_95B677B6_Derived_n::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_95B677B6_Derived_n::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.1
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_95B677B6_Derived_n::get_RequiresInvocationContext
-
-				.method family hidebysig virtual 
-					instance object GetLexicalSuperReceiverCore () cil managed 
-				{
-					// Header size: 1
-					// Code size: 7 (0x7)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n::_homeObject
-					IL_0006: ret
-				} // end of method FunctionObject_ClassMethod_95B677B6_Derived_n::GetLexicalSuperReceiverCore
-
-				.method family hidebysig virtual 
-					instance object[] GetLexicalSuperScopesCore () cil managed 
-				{
-					// Header size: 1
-					// Code size: 7 (0x7)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n::_lexicalSuperScopes
-					IL_0006: ret
-				} // end of method FunctionObject_ClassMethod_95B677B6_Derived_n::GetLexicalSuperScopesCore
-
-				.method family hidebysig virtual 
-					instance object CallCore (
-						object thisArgument,
-						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 35 (0x23)
-					.maxstack 8
-
-					IL_0000: ldarg.1
-					IL_0001: ldtoken Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-					IL_000b: ldc.i4.1
-					IL_000c: newarr [System.Runtime]System.Object
-					IL_0011: ldnull
-					IL_0012: ldarg.0
-					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-					IL_0018: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-					IL_001d: call instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
-					IL_0022: ret
-				} // end of method FunctionObject_ClassMethod_95B677B6_Derived_n::CallCore
-
-			} // end of class FunctionObject_ClassMethod_95B677B6_Derived_n
+			} // end of class FunctionObject
 
 
 			// Fields
@@ -614,8 +618,8 @@
 				[2] class [System.Runtime]System.Type,
 				[3] object,
 				[4] object[],
-				[5] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassConstructor_D9ED61CF_Base,
-				[6] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassConstructor_9C573247_Derived,
+				[5] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject,
+				[6] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject,
 				[7] class [JavaScriptRuntime]JavaScriptRuntime.Console
 			)
 
@@ -644,14 +648,14 @@
 			IL_0037: ldloc.3
 			IL_0038: ldstr "m"
 			IL_003d: ldloc.s 4
-			IL_003f: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m::.ctor(object[])
+			IL_003f: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/Scope_m/FunctionObject::.ctor(object[])
 			IL_0044: ldc.i4.0
 			IL_0045: conv.r8
 			IL_0046: ldstr "m"
 			IL_004b: ldc.i4.0
 			IL_004c: ldc.i4.1
-			IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m>(!!0, float64, string, bool, bool)
-			IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassMethod_85F9A249_Base_m>(!!0)
+			IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/Scope_m/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/Scope_m/FunctionObject>(!!0)
 			IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 			IL_005c: pop
 			IL_005d: ldc.i4.2
@@ -666,14 +670,14 @@
 			IL_006a: stelem.ref
 			IL_006b: stloc.s 4
 			IL_006d: ldloc.s 4
-			IL_006f: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassConstructor_D9ED61CF_Base::.ctor(object[])
+			IL_006f: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject::.ctor(object[])
 			IL_0074: ldloc.2
 			IL_0075: ldloc.s 4
 			IL_0077: ldc.i4.0
 			IL_0078: conv.r8
 			IL_0079: ldc.i4.0
 			IL_007a: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-			IL_007f: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassConstructor_D9ED61CF_Base
+			IL_007f: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject
 			IL_0084: stloc.s 5
 			IL_0086: ldloc.0
 			IL_0087: ldloc.s 5
@@ -693,14 +697,14 @@
 			IL_00b7: ldstr "n"
 			IL_00bc: ldloc.3
 			IL_00bd: ldloc.s 4
-			IL_00bf: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n::.ctor(class [System.Runtime]System.Object, object[])
+			IL_00bf: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/Scope_n/FunctionObject::.ctor(class [System.Runtime]System.Object, object[])
 			IL_00c4: ldc.i4.0
 			IL_00c5: conv.r8
 			IL_00c6: ldstr "n"
 			IL_00cb: ldc.i4.1
 			IL_00cc: ldc.i4.1
-			IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n>(!!0, float64, string, bool, bool)
-			IL_00d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassMethod_95B677B6_Derived_n>(!!0)
+			IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/Scope_n/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/Scope_n/FunctionObject>(!!0)
 			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 			IL_00dc: pop
 			IL_00dd: ldc.i4.2
@@ -715,14 +719,14 @@
 			IL_00ea: stelem.ref
 			IL_00eb: stloc.s 4
 			IL_00ed: ldloc.s 4
-			IL_00ef: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassConstructor_9C573247_Derived::.ctor(object[])
+			IL_00ef: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject::.ctor(object[])
 			IL_00f4: ldloc.2
 			IL_00f5: ldloc.s 4
 			IL_00f7: ldc.i4.0
 			IL_00f8: conv.r8
 			IL_00f9: ldc.i4.0
 			IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-			IL_00ff: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassConstructor_9C573247_Derived
+			IL_00ff: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject
 			IL_0104: stloc.s 6
 			IL_0106: ldloc.s 6
 			IL_0108: ldloc.s 5

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperConstructor_Args.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperConstructor_Args.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_Inheritance_SuperConstructor_Args/B/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,54 +98,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_AD8F3CC5_B
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_Inheritance_SuperConstructor_Args/B/FunctionObject_ClassConstructor_AD8F3CC5_B::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_AD8F3CC5_B::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_AD8F3CC5_B::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_AD8F3CC5_B::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_AD8F3CC5_B
 
 
 		// Fields
@@ -150,6 +152,90 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0,
+						class [System.Runtime]System.Object capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_Inheritance_SuperConstructor_Args/D/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_Inheritance_SuperConstructor_Args/D/Scope_ctor/FunctionObject::_homeObject
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Classes_Inheritance_SuperConstructor_Args/D/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_001b: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_Inheritance_SuperConstructor_Args/D/Scope_ctor/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Classes_Inheritance_SuperConstructor_Args/D/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -165,88 +251,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_A78F3353_D
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0,
-					class [System.Runtime]System.Object capture1,
-					object[] capture2
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 28 (0x1c)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_Inheritance_SuperConstructor_Args/D/FunctionObject_ClassConstructor_A78F3353_D::_transitionalScopes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_Inheritance_SuperConstructor_Args/D/FunctionObject_ClassConstructor_A78F3353_D::_homeObject
-				IL_0014: ldarg.0
-				IL_0015: ldarg.3
-				IL_0016: stfld object[] Modules.Classes_Inheritance_SuperConstructor_Args/D/FunctionObject_ClassConstructor_A78F3353_D::_lexicalSuperScopes
-				IL_001b: ret
-			} // end of method FunctionObject_ClassConstructor_A78F3353_D::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_A78F3353_D::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_A78F3353_D::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_Inheritance_SuperConstructor_Args/D/FunctionObject_ClassConstructor_A78F3353_D::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_A78F3353_D::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Classes_Inheritance_SuperConstructor_Args/D/FunctionObject_ClassConstructor_A78F3353_D::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_A78F3353_D::GetLexicalSuperScopesCore
-
-		} // end of class FunctionObject_ClassConstructor_A78F3353_D
 
 
 		// Fields
@@ -337,8 +341,8 @@
 			[1] object,
 			[2] object[],
 			[3] class [System.Runtime]System.Type,
-			[4] class Modules.Classes_Inheritance_SuperConstructor_Args/B/FunctionObject_ClassConstructor_AD8F3CC5_B,
-			[5] class Modules.Classes_Inheritance_SuperConstructor_Args/D/FunctionObject_ClassConstructor_A78F3353_D,
+			[4] class Modules.Classes_Inheritance_SuperConstructor_Args/B/Scope_ctor/FunctionObject,
+			[5] class Modules.Classes_Inheritance_SuperConstructor_Args/D/Scope_ctor/FunctionObject,
 			[6] object,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -359,14 +363,14 @@
 		IL_0021: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0026: stloc.3
 		IL_0027: ldloc.2
-		IL_0028: newobj instance void Modules.Classes_Inheritance_SuperConstructor_Args/B/FunctionObject_ClassConstructor_AD8F3CC5_B::.ctor(object[])
+		IL_0028: newobj instance void Modules.Classes_Inheritance_SuperConstructor_Args/B/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_002d: ldloc.3
 		IL_002e: ldloc.2
 		IL_002f: ldc.i4.1
 		IL_0030: conv.r8
 		IL_0031: ldc.i4.0
 		IL_0032: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0037: castclass Modules.Classes_Inheritance_SuperConstructor_Args/B/FunctionObject_ClassConstructor_AD8F3CC5_B
+		IL_0037: castclass Modules.Classes_Inheritance_SuperConstructor_Args/B/Scope_ctor/FunctionObject
 		IL_003c: stloc.s 4
 		IL_003e: ldloc.0
 		IL_003f: ldloc.s 4
@@ -391,14 +395,14 @@
 		IL_0073: ldc.i4.0
 		IL_0074: ldloc.0
 		IL_0075: stelem.ref
-		IL_0076: newobj instance void Modules.Classes_Inheritance_SuperConstructor_Args/D/FunctionObject_ClassConstructor_A78F3353_D::.ctor(object[], class [System.Runtime]System.Object, object[])
+		IL_0076: newobj instance void Modules.Classes_Inheritance_SuperConstructor_Args/D/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object, object[])
 		IL_007b: ldloc.3
 		IL_007c: ldloc.2
 		IL_007d: ldc.i4.0
 		IL_007e: conv.r8
 		IL_007f: ldc.i4.0
 		IL_0080: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0085: castclass Modules.Classes_Inheritance_SuperConstructor_Args/D/FunctionObject_ClassConstructor_A78F3353_D
+		IL_0085: castclass Modules.Classes_Inheritance_SuperConstructor_Args/D/Scope_ctor/FunctionObject
 		IL_008a: stloc.s 5
 		IL_008c: ldloc.s 5
 		IL_008e: ldloc.s 4

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperMethodCall.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperMethodCall.verified.txt
@@ -33,6 +33,72 @@
 		.class nested public auto ansi beforefieldinit Scope_m
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_Inheritance_SuperMethodCall/B
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_Inheritance_SuperMethodCall/B
+					IL_001d: call instance float64 Modules.Classes_Inheritance_SuperMethodCall/B::m()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +115,7 @@
 
 		} // end of class Scope_m
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_1D7D808A_B
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -69,9 +135,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassConstructor_1D7D808A_B::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_1D7D808A_B::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -82,7 +148,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_1D7D808A_B::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -93,73 +159,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_1D7D808A_B::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_1D7D808A_B
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_1807B0B6_B_m
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_1807B0B6_B_m::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_1807B0B6_B_m::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_1807B0B6_B_m::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_Inheritance_SuperMethodCall/B
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_Inheritance_SuperMethodCall/B
-				IL_001d: call instance float64 Modules.Classes_Inheritance_SuperMethodCall/B::m()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_1807B0B6_B_m::CallCore
-
-		} // end of class FunctionObject_ClassMethod_1807B0B6_B_m
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -220,6 +222,108 @@
 		.class nested public auto ansi beforefieldinit Scope_m
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_Inheritance_SuperMethodCall/D/Scope_m/FunctionObject::_homeObject
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Classes_Inheritance_SuperMethodCall/D/Scope_m/FunctionObject::_lexicalSuperScopes
+					IL_0014: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_Inheritance_SuperMethodCall/D/Scope_m/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Classes_Inheritance_SuperMethodCall/D/Scope_m/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_Inheritance_SuperMethodCall/D
+					IL_001d: call instance object Modules.Classes_Inheritance_SuperMethodCall/D::m()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -236,7 +340,7 @@
 
 		} // end of class Scope_m
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_177D7718_D
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -256,9 +360,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassConstructor_177D7718_D::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_177D7718_D::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -269,7 +373,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_177D7718_D::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -280,109 +384,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_177D7718_D::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_177D7718_D
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_8204A1AC_D_m
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class [System.Runtime]System.Object capture0,
-					object[] capture1
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 21 (0x15)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m::_homeObject
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m::_lexicalSuperScopes
-				IL_0014: ret
-			} // end of method FunctionObject_ClassMethod_8204A1AC_D_m::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_8204A1AC_D_m::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_8204A1AC_D_m::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_8204A1AC_D_m::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_8204A1AC_D_m::GetLexicalSuperScopesCore
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_Inheritance_SuperMethodCall/D
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_Inheritance_SuperMethodCall/D
-				IL_001d: call instance object Modules.Classes_Inheritance_SuperMethodCall/D::m()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_8204A1AC_D_m::CallCore
-
-		} // end of class FunctionObject_ClassMethod_8204A1AC_D_m
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -486,8 +490,8 @@
 			[2] class [System.Runtime]System.Type,
 			[3] object,
 			[4] object[],
-			[5] class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassConstructor_1D7D808A_B,
-			[6] class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassConstructor_177D7718_D,
+			[5] class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject,
+			[6] class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
 
@@ -507,14 +511,14 @@
 		IL_002d: stloc.s 4
 		IL_002f: ldloc.3
 		IL_0030: ldstr "m"
-		IL_0035: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m::.ctor()
+		IL_0035: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/B/Scope_m/FunctionObject::.ctor()
 		IL_003a: ldc.i4.0
 		IL_003b: conv.r8
 		IL_003c: ldstr "m"
 		IL_0041: ldc.i4.0
 		IL_0042: ldc.i4.1
-		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m>(!!0, float64, string, bool, bool)
-		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassMethod_1807B0B6_B_m>(!!0)
+		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperMethodCall/B/Scope_m/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/B/Scope_m/FunctionObject>(!!0)
 		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0052: pop
 		IL_0053: ldc.i4.1
@@ -525,14 +529,14 @@
 		IL_005c: stelem.ref
 		IL_005d: stloc.s 4
 		IL_005f: ldloc.s 4
-		IL_0061: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassConstructor_1D7D808A_B::.ctor(object[])
+		IL_0061: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject::.ctor(object[])
 		IL_0066: ldloc.2
 		IL_0067: ldloc.s 4
 		IL_0069: ldc.i4.0
 		IL_006a: conv.r8
 		IL_006b: ldc.i4.0
 		IL_006c: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0071: castclass Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassConstructor_1D7D808A_B
+		IL_0071: castclass Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject
 		IL_0076: stloc.s 5
 		IL_0078: ldloc.0
 		IL_0079: ldloc.s 5
@@ -552,14 +556,14 @@
 		IL_00a9: ldstr "m"
 		IL_00ae: ldloc.3
 		IL_00af: ldloc.s 4
-		IL_00b1: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m::.ctor(class [System.Runtime]System.Object, object[])
+		IL_00b1: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/D/Scope_m/FunctionObject::.ctor(class [System.Runtime]System.Object, object[])
 		IL_00b6: ldc.i4.0
 		IL_00b7: conv.r8
 		IL_00b8: ldstr "m"
 		IL_00bd: ldc.i4.1
 		IL_00be: ldc.i4.1
-		IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m>(!!0, float64, string, bool, bool)
-		IL_00c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassMethod_8204A1AC_D_m>(!!0)
+		IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperMethodCall/D/Scope_m/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Inheritance_SuperMethodCall/D/Scope_m/FunctionObject>(!!0)
 		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_00ce: pop
 		IL_00cf: ldc.i4.1
@@ -570,14 +574,14 @@
 		IL_00d8: stelem.ref
 		IL_00d9: stloc.s 4
 		IL_00db: ldloc.s 4
-		IL_00dd: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassConstructor_177D7718_D::.ctor(object[])
+		IL_00dd: newobj instance void Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject::.ctor(object[])
 		IL_00e2: ldloc.2
 		IL_00e3: ldloc.s 4
 		IL_00e5: ldc.i4.0
 		IL_00e6: conv.r8
 		IL_00e7: ldc.i4.0
 		IL_00e8: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_00ed: castclass Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassConstructor_177D7718_D
+		IL_00ed: castclass Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject
 		IL_00f2: stloc.s 6
 		IL_00f4: ldloc.s 6
 		IL_00f6: ldloc.s 5

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_ThisBeforeSuper_Throws.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_ThisBeforeSuper_Throws.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_Inheritance_ThisBeforeSuper_Throws/B/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,54 +98,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_4745A670_B
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_Inheritance_ThisBeforeSuper_Throws/B/FunctionObject_ClassConstructor_4745A670_B::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_4745A670_B::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_4745A670_B::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_4745A670_B::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_4745A670_B
 
 
 		// Fields
@@ -189,6 +191,88 @@
 
 			} // end of class Block_L14C16
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0,
+						class [System.Runtime]System.Object capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/Scope_ctor/FunctionObject::_homeObject
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_001b: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/Scope_ctor/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -205,88 +289,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_4D45AFE2_D
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0,
-					class [System.Runtime]System.Object capture1,
-					object[] capture2
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 28 (0x1c)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/FunctionObject_ClassConstructor_4D45AFE2_D::_transitionalScopes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/FunctionObject_ClassConstructor_4D45AFE2_D::_homeObject
-				IL_0014: ldarg.0
-				IL_0015: ldarg.3
-				IL_0016: stfld object[] Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/FunctionObject_ClassConstructor_4D45AFE2_D::_lexicalSuperScopes
-				IL_001b: ret
-			} // end of method FunctionObject_ClassConstructor_4D45AFE2_D::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_4D45AFE2_D::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_4D45AFE2_D::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/FunctionObject_ClassConstructor_4D45AFE2_D::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_4D45AFE2_D::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/FunctionObject_ClassConstructor_4D45AFE2_D::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_4D45AFE2_D::GetLexicalSuperScopesCore
-
-		} // end of class FunctionObject_ClassConstructor_4D45AFE2_D
 
 
 		// Fields
@@ -466,8 +468,8 @@
 			[1] object,
 			[2] object[],
 			[3] class [System.Runtime]System.Type,
-			[4] class Modules.Classes_Inheritance_ThisBeforeSuper_Throws/B/FunctionObject_ClassConstructor_4745A670_B,
-			[5] class Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/FunctionObject_ClassConstructor_4D45AFE2_D,
+			[4] class Modules.Classes_Inheritance_ThisBeforeSuper_Throws/B/Scope_ctor/FunctionObject,
+			[5] class Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/Scope_ctor/FunctionObject,
 			[6] object
 		)
 
@@ -487,14 +489,14 @@
 		IL_0021: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0026: stloc.3
 		IL_0027: ldloc.2
-		IL_0028: newobj instance void Modules.Classes_Inheritance_ThisBeforeSuper_Throws/B/FunctionObject_ClassConstructor_4745A670_B::.ctor(object[])
+		IL_0028: newobj instance void Modules.Classes_Inheritance_ThisBeforeSuper_Throws/B/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_002d: ldloc.3
 		IL_002e: ldloc.2
 		IL_002f: ldc.i4.1
 		IL_0030: conv.r8
 		IL_0031: ldc.i4.0
 		IL_0032: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0037: castclass Modules.Classes_Inheritance_ThisBeforeSuper_Throws/B/FunctionObject_ClassConstructor_4745A670_B
+		IL_0037: castclass Modules.Classes_Inheritance_ThisBeforeSuper_Throws/B/Scope_ctor/FunctionObject
 		IL_003c: stloc.s 4
 		IL_003e: ldloc.0
 		IL_003f: ldloc.s 4
@@ -519,14 +521,14 @@
 		IL_0073: ldc.i4.0
 		IL_0074: ldloc.0
 		IL_0075: stelem.ref
-		IL_0076: newobj instance void Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/FunctionObject_ClassConstructor_4D45AFE2_D::.ctor(object[], class [System.Runtime]System.Object, object[])
+		IL_0076: newobj instance void Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object, object[])
 		IL_007b: ldloc.3
 		IL_007c: ldloc.2
 		IL_007d: ldc.i4.0
 		IL_007e: conv.r8
 		IL_007f: ldc.i4.0
 		IL_0080: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0085: castclass Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/FunctionObject_ClassConstructor_4D45AFE2_D
+		IL_0085: castclass Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/Scope_ctor/FunctionObject
 		IL_008a: stloc.s 5
 		IL_008c: ldloc.s 5
 		IL_008e: ldloc.s 4

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_IntrinsicInheritance_ExtendsArray_SuperLength.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_IntrinsicInheritance_ExtendsArray_SuperLength.verified.txt
@@ -33,6 +33,90 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0,
+						class [System.Runtime]System.Object capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/Scope_ctor/FunctionObject::_homeObject
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_001b: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/Scope_ctor/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,88 +132,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_13C3A4AD_NodeList
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0,
-					class [System.Runtime]System.Object capture1,
-					object[] capture2
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 28 (0x1c)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/FunctionObject_ClassConstructor_13C3A4AD_NodeList::_transitionalScopes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/FunctionObject_ClassConstructor_13C3A4AD_NodeList::_homeObject
-				IL_0014: ldarg.0
-				IL_0015: ldarg.3
-				IL_0016: stfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/FunctionObject_ClassConstructor_13C3A4AD_NodeList::_lexicalSuperScopes
-				IL_001b: ret
-			} // end of method FunctionObject_ClassConstructor_13C3A4AD_NodeList::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_13C3A4AD_NodeList::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_13C3A4AD_NodeList::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/FunctionObject_ClassConstructor_13C3A4AD_NodeList::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_13C3A4AD_NodeList::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/FunctionObject_ClassConstructor_13C3A4AD_NodeList::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_13C3A4AD_NodeList::GetLexicalSuperScopesCore
-
-		} // end of class FunctionObject_ClassConstructor_13C3A4AD_NodeList
 
 
 		// Methods
@@ -230,6 +232,90 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0,
+						class [System.Runtime]System.Object capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/Scope_ctor/FunctionObject::_homeObject
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_001b: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/Scope_ctor/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -245,88 +331,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_FCCAD460_Y
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0,
-					class [System.Runtime]System.Object capture1,
-					object[] capture2
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 28 (0x1c)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/FunctionObject_ClassConstructor_FCCAD460_Y::_transitionalScopes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/FunctionObject_ClassConstructor_FCCAD460_Y::_homeObject
-				IL_0014: ldarg.0
-				IL_0015: ldarg.3
-				IL_0016: stfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/FunctionObject_ClassConstructor_FCCAD460_Y::_lexicalSuperScopes
-				IL_001b: ret
-			} // end of method FunctionObject_ClassConstructor_FCCAD460_Y::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_FCCAD460_Y::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_FCCAD460_Y::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/FunctionObject_ClassConstructor_FCCAD460_Y::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_FCCAD460_Y::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/FunctionObject_ClassConstructor_FCCAD460_Y::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_FCCAD460_Y::GetLexicalSuperScopesCore
-
-		} // end of class FunctionObject_ClassConstructor_FCCAD460_Y
 
 
 		// Methods
@@ -418,11 +422,11 @@
 			[4] object,
 			[5] object[],
 			[6] class [System.Runtime]System.Type,
-			[7] class Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/FunctionObject_ClassConstructor_13C3A4AD_NodeList,
+			[7] class Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/Scope_ctor/FunctionObject,
 			[8] object,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[11] class Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/FunctionObject_ClassConstructor_FCCAD460_Y
+			[11] class Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/Scope_ctor/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Scope::.ctor()
@@ -448,14 +452,14 @@
 		IL_0037: ldc.i4.0
 		IL_0038: ldloc.0
 		IL_0039: stelem.ref
-		IL_003a: newobj instance void Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/FunctionObject_ClassConstructor_13C3A4AD_NodeList::.ctor(object[], class [System.Runtime]System.Object, object[])
+		IL_003a: newobj instance void Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object, object[])
 		IL_003f: ldloc.s 6
 		IL_0041: ldloc.s 5
 		IL_0043: ldc.i4.1
 		IL_0044: conv.r8
 		IL_0045: ldc.i4.0
 		IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_004b: castclass Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/FunctionObject_ClassConstructor_13C3A4AD_NodeList
+		IL_004b: castclass Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/Scope_ctor/FunctionObject
 		IL_0050: stloc.s 7
 		IL_0052: ldstr "Array"
 		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
@@ -561,14 +565,14 @@
 		IL_01a0: ldc.i4.0
 		IL_01a1: ldloc.0
 		IL_01a2: stelem.ref
-		IL_01a3: newobj instance void Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/FunctionObject_ClassConstructor_FCCAD460_Y::.ctor(object[], class [System.Runtime]System.Object, object[])
+		IL_01a3: newobj instance void Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object, object[])
 		IL_01a8: ldloc.s 6
 		IL_01aa: ldloc.s 5
 		IL_01ac: ldc.i4.0
 		IL_01ad: conv.r8
 		IL_01ae: ldc.i4.0
 		IL_01af: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_01b4: castclass Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/FunctionObject_ClassConstructor_FCCAD460_Y
+		IL_01b4: castclass Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/Scope_ctor/FunctionObject
 		IL_01b9: stloc.s 11
 		IL_01bb: ldstr "Array"
 		IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs.verified.txt
@@ -33,6 +33,90 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0,
+						class [System.Runtime]System.Object capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/Scope_ctor/FunctionObject::_homeObject
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_001b: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/Scope_ctor/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,88 +132,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_84833B4B_Z
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0,
-					class [System.Runtime]System.Object capture1,
-					object[] capture2
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 28 (0x1c)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/FunctionObject_ClassConstructor_84833B4B_Z::_transitionalScopes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/FunctionObject_ClassConstructor_84833B4B_Z::_homeObject
-				IL_0014: ldarg.0
-				IL_0015: ldarg.3
-				IL_0016: stfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/FunctionObject_ClassConstructor_84833B4B_Z::_lexicalSuperScopes
-				IL_001b: ret
-			} // end of method FunctionObject_ClassConstructor_84833B4B_Z::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_84833B4B_Z::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_84833B4B_Z::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/FunctionObject_ClassConstructor_84833B4B_Z::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_84833B4B_Z::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/FunctionObject_ClassConstructor_84833B4B_Z::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_84833B4B_Z::GetLexicalSuperScopesCore
-
-		} // end of class FunctionObject_ClassConstructor_84833B4B_Z
 
 
 		// Methods
@@ -195,7 +197,7 @@
 			[2] object,
 			[3] object[],
 			[4] class [System.Runtime]System.Type,
-			[5] class Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/FunctionObject_ClassConstructor_84833B4B_Z,
+			[5] class Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/Scope_ctor/FunctionObject,
 			[6] object,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -223,14 +225,14 @@
 		IL_0035: ldc.i4.0
 		IL_0036: ldloc.0
 		IL_0037: stelem.ref
-		IL_0038: newobj instance void Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/FunctionObject_ClassConstructor_84833B4B_Z::.ctor(object[], class [System.Runtime]System.Object, object[])
+		IL_0038: newobj instance void Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object, object[])
 		IL_003d: ldloc.s 4
 		IL_003f: ldloc.3
 		IL_0040: ldc.i4.0
 		IL_0041: conv.r8
 		IL_0042: ldc.i4.0
 		IL_0043: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0048: castclass Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/FunctionObject_ClassConstructor_84833B4B_Z
+		IL_0048: castclass Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/Scope_ctor/FunctionObject
 		IL_004d: stloc.s 5
 		IL_004f: ldstr "Array"
 		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Method_DefaultReturnUndefined.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Method_DefaultReturnUndefined.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_Method_DefaultReturnUndefined/Calculator/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +102,71 @@
 		.class nested public auto ansi beforefieldinit Scope_doNothing
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
+					IL_001d: call instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::doNothing()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -71,6 +186,71 @@
 		.class nested public auto ansi beforefieldinit Scope_returnsUndefined
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
+					IL_001d: call instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsUndefined()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -90,6 +270,72 @@
 		.class nested public auto ansi beforefieldinit Scope_returnsValue
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
+					IL_001d: call instance float64 Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsValue()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -109,6 +355,71 @@
 		.class nested public auto ansi beforefieldinit Scope_returnsThis
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
+					IL_001d: call instance class Modules.Classes_Method_DefaultReturnUndefined/Calculator Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsThis()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -124,307 +435,6 @@
 			} // end of method Scope_returnsThis::.ctor
 
 		} // end of class Scope_returnsThis
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_10F28F0E_Calculator
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassConstructor_10F28F0E_Calculator::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_10F28F0E_Calculator::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_10F28F0E_Calculator::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_10F28F0E_Calculator::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_10F28F0E_Calculator
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
-				IL_001d: call instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::doNothing()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::CallCore
-
-		} // end of class FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
-				IL_001d: call instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsUndefined()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::CallCore
-
-		} // end of class FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
-				IL_001d: call instance float64 Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsValue()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::CallCore
-
-		} // end of class FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_Method_DefaultReturnUndefined/Calculator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
-				IL_001d: call instance class Modules.Classes_Method_DefaultReturnUndefined/Calculator Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsThis()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::CallCore
-
-		} // end of class FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis
 
 
 		// Fields
@@ -565,7 +575,7 @@
 			[10] class [System.Runtime]System.Type,
 			[11] object,
 			[12] object[],
-			[13] class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassConstructor_10F28F0E_Calculator,
+			[13] class Modules.Classes_Method_DefaultReturnUndefined/Calculator/Scope_ctor/FunctionObject,
 			[14] class Modules.Classes_Method_DefaultReturnUndefined/Calculator,
 			[15] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[16] bool,
@@ -588,56 +598,56 @@
 		IL_0030: stloc.s 12
 		IL_0032: ldloc.s 11
 		IL_0034: ldstr "doNothing"
-		IL_0039: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::.ctor()
+		IL_0039: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/Scope_doNothing/FunctionObject::.ctor()
 		IL_003e: ldc.i4.0
 		IL_003f: conv.r8
 		IL_0040: ldstr "doNothing"
 		IL_0045: ldc.i4.1
 		IL_0046: ldc.i4.1
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing>(!!0, float64, string, bool, bool)
-		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing>(!!0)
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/Scope_doNothing/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/Scope_doNothing/FunctionObject>(!!0)
 		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0056: pop
 		IL_0057: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_005c: stloc.s 12
 		IL_005e: ldloc.s 11
 		IL_0060: ldstr "returnsUndefined"
-		IL_0065: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::.ctor()
+		IL_0065: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/Scope_returnsUndefined/FunctionObject::.ctor()
 		IL_006a: ldc.i4.0
 		IL_006b: conv.r8
 		IL_006c: ldstr "returnsUndefined"
 		IL_0071: ldc.i4.0
 		IL_0072: ldc.i4.1
-		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined>(!!0, float64, string, bool, bool)
-		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined>(!!0)
+		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/Scope_returnsUndefined/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/Scope_returnsUndefined/FunctionObject>(!!0)
 		IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0082: pop
 		IL_0083: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0088: stloc.s 12
 		IL_008a: ldloc.s 11
 		IL_008c: ldstr "returnsValue"
-		IL_0091: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::.ctor()
+		IL_0091: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/Scope_returnsValue/FunctionObject::.ctor()
 		IL_0096: ldc.i4.0
 		IL_0097: conv.r8
 		IL_0098: ldstr "returnsValue"
 		IL_009d: ldc.i4.1
 		IL_009e: ldc.i4.1
-		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue>(!!0, float64, string, bool, bool)
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue>(!!0)
+		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/Scope_returnsValue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/Scope_returnsValue/FunctionObject>(!!0)
 		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_00ae: pop
 		IL_00af: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_00b4: stloc.s 12
 		IL_00b6: ldloc.s 11
 		IL_00b8: ldstr "returnsThis"
-		IL_00bd: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::.ctor()
+		IL_00bd: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/Scope_returnsThis/FunctionObject::.ctor()
 		IL_00c2: ldc.i4.0
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "returnsThis"
 		IL_00c9: ldc.i4.1
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis>(!!0, float64, string, bool, bool)
-		IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis>(!!0)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/Scope_returnsThis/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_Method_DefaultReturnUndefined/Calculator/Scope_returnsThis/FunctionObject>(!!0)
 		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_00da: pop
 		IL_00db: ldc.i4.1
@@ -648,14 +658,14 @@
 		IL_00e4: stelem.ref
 		IL_00e5: stloc.s 12
 		IL_00e7: ldloc.s 12
-		IL_00e9: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassConstructor_10F28F0E_Calculator::.ctor(object[])
+		IL_00e9: newobj instance void Modules.Classes_Method_DefaultReturnUndefined/Calculator/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_00ee: ldloc.s 10
 		IL_00f0: ldloc.s 12
 		IL_00f2: ldc.i4.1
 		IL_00f3: conv.r8
 		IL_00f4: ldc.i4.0
 		IL_00f5: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_00fa: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassConstructor_10F28F0E_Calculator
+		IL_00fa: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator/Scope_ctor/FunctionObject
 		IL_00ff: stloc.s 13
 		IL_0101: ldloc.s 13
 		IL_0103: stloc.1

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_PrimeCtor_BitArrayAdd.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_PrimeCtor_BitArrayAdd.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_PrimeCtor_BitArrayAdd/BitArray/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,54 +98,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_AEE7AD70_BitArray
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_PrimeCtor_BitArrayAdd/BitArray/FunctionObject_ClassConstructor_AEE7AD70_BitArray::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_AEE7AD70_BitArray::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_AEE7AD70_BitArray::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_AEE7AD70_BitArray::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_AEE7AD70_BitArray
 
 
 		// Fields
@@ -150,6 +152,61 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly class Modules.Classes_PrimeCtor_BitArrayAdd/Scope _environment0_Classes_PrimeCtor_BitArrayAdd
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Classes_PrimeCtor_BitArrayAdd/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Classes_PrimeCtor_BitArrayAdd/Scope Modules.Classes_PrimeCtor_BitArrayAdd/PrimeSieve/Scope_ctor/FunctionObject::_environment0_Classes_PrimeCtor_BitArrayAdd
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Classes_PrimeCtor_BitArrayAdd/PrimeSieve/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -165,59 +222,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_920AE9BF_PrimeSieve
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly class Modules.Classes_PrimeCtor_BitArrayAdd/Scope _environment0_Classes_PrimeCtor_BitArrayAdd
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class Modules.Classes_PrimeCtor_BitArrayAdd/Scope capture0,
-					object[] capture1
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 21 (0x15)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Classes_PrimeCtor_BitArrayAdd/Scope Modules.Classes_PrimeCtor_BitArrayAdd/PrimeSieve/FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::_environment0_Classes_PrimeCtor_BitArrayAdd
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Classes_PrimeCtor_BitArrayAdd/PrimeSieve/FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::_transitionalScopes
-				IL_0014: ret
-			} // end of method FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_920AE9BF_PrimeSieve
 
 
 		// Fields
@@ -324,7 +328,7 @@
 			[0] class Modules.Classes_PrimeCtor_BitArrayAdd/Scope,
 			[1] object[],
 			[2] class [System.Runtime]System.Type,
-			[3] class Modules.Classes_PrimeCtor_BitArrayAdd/BitArray/FunctionObject_ClassConstructor_AEE7AD70_BitArray,
+			[3] class Modules.Classes_PrimeCtor_BitArrayAdd/BitArray/Scope_ctor/FunctionObject,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
 
@@ -344,14 +348,14 @@
 		IL_0021: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0026: stloc.2
 		IL_0027: ldloc.1
-		IL_0028: newobj instance void Modules.Classes_PrimeCtor_BitArrayAdd/BitArray/FunctionObject_ClassConstructor_AEE7AD70_BitArray::.ctor(object[])
+		IL_0028: newobj instance void Modules.Classes_PrimeCtor_BitArrayAdd/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_002d: ldloc.2
 		IL_002e: ldloc.1
 		IL_002f: ldc.i4.1
 		IL_0030: conv.r8
 		IL_0031: ldc.i4.0
 		IL_0032: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0037: castclass Modules.Classes_PrimeCtor_BitArrayAdd/BitArray/FunctionObject_ClassConstructor_AEE7AD70_BitArray
+		IL_0037: castclass Modules.Classes_PrimeCtor_BitArrayAdd/BitArray/Scope_ctor/FunctionObject
 		IL_003c: stloc.3
 		IL_003d: ldloc.0
 		IL_003e: ldloc.3

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_PrivateBrandCheck.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_PrivateBrandCheck.verified.txt
@@ -33,6 +33,61 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+				.field private initonly class [System.Runtime]System.Object _privateBrand
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0,
+						class [System.Runtime]System.Object capture1
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_PrivateBrandCheck/Example/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_PrivateBrandCheck/Example/Scope_ctor/FunctionObject::_privateBrand
+					IL_0014: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +107,81 @@
 		.class nested public auto ansi beforefieldinit Scope_hasBrand
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _privateBrand
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_PrivateBrandCheck/Example/Scope_hasBrand/FunctionObject::_privateBrand
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 37 (0x25)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_PrivateBrandCheck/Example
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld class [System.Runtime]System.Object Modules.Classes_PrivateBrandCheck/Example/Scope_hasBrand/FunctionObject::_privateBrand
+					IL_0011: ldarg.0
+					IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ValidateGeneratedStaticMethodReceiver(object, class [System.Runtime]System.Type, object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0017: pop
+					IL_0018: ldarg.2
+					IL_0019: ldc.i4.0
+					IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_001f: call object Modules.Classes_PrivateBrandCheck/Example::hasBrand(object)
+					IL_0024: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -71,6 +201,81 @@
 		.class nested public auto ansi beforefieldinit Scope_read
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _privateBrand
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_PrivateBrandCheck/Example/Scope_read/FunctionObject::_privateBrand
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 37 (0x25)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_PrivateBrandCheck/Example
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld class [System.Runtime]System.Object Modules.Classes_PrivateBrandCheck/Example/Scope_read/FunctionObject::_privateBrand
+					IL_0011: ldarg.0
+					IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ValidateGeneratedStaticMethodReceiver(object, class [System.Runtime]System.Type, object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0017: pop
+					IL_0018: ldarg.2
+					IL_0019: ldc.i4.0
+					IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_001f: call object Modules.Classes_PrivateBrandCheck/Example::read(object)
+					IL_0024: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -90,6 +295,84 @@
 		.class nested public auto ansi beforefieldinit Scope_write
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _privateBrand
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_PrivateBrandCheck/Example/Scope_write/FunctionObject::_privateBrand
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 44 (0x2c)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Classes_PrivateBrandCheck/Example
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld class [System.Runtime]System.Object Modules.Classes_PrivateBrandCheck/Example/Scope_write/FunctionObject::_privateBrand
+					IL_0011: ldarg.0
+					IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ValidateGeneratedStaticMethodReceiver(object, class [System.Runtime]System.Type, object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0017: pop
+					IL_0018: ldarg.2
+					IL_0019: ldc.i4.0
+					IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_001f: ldarg.2
+					IL_0020: ldc.i4.1
+					IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0026: call object Modules.Classes_PrivateBrandCheck/Example::write(object, object)
+					IL_002b: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -105,281 +388,6 @@
 			} // end of method Scope_write::.ctor
 
 		} // end of class Scope_write
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_9D4431D5_Example
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-			.field private initonly class [System.Runtime]System.Object _privateBrand
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0,
-					class [System.Runtime]System.Object capture1
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 21 (0x15)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassConstructor_9D4431D5_Example::_transitionalScopes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassConstructor_9D4431D5_Example::_privateBrand
-				IL_0014: ret
-			} // end of method FunctionObject_ClassConstructor_9D4431D5_Example::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_9D4431D5_Example::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_9D4431D5_Example::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_9D4431D5_Example
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_C1D86EAB_Example_hasBrand
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly class [System.Runtime]System.Object _privateBrand
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class [System.Runtime]System.Object capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassStaticMethod_C1D86EAB_Example_hasBrand::_privateBrand
-				IL_000d: ret
-			} // end of method FunctionObject_ClassStaticMethod_C1D86EAB_Example_hasBrand::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_C1D86EAB_Example_hasBrand::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_C1D86EAB_Example_hasBrand::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 37 (0x25)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_PrivateBrandCheck/Example
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld class [System.Runtime]System.Object Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassStaticMethod_C1D86EAB_Example_hasBrand::_privateBrand
-				IL_0011: ldarg.0
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ValidateGeneratedStaticMethodReceiver(object, class [System.Runtime]System.Type, object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0017: pop
-				IL_0018: ldarg.2
-				IL_0019: ldc.i4.0
-				IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_001f: call object Modules.Classes_PrivateBrandCheck/Example::hasBrand(object)
-				IL_0024: ret
-			} // end of method FunctionObject_ClassStaticMethod_C1D86EAB_Example_hasBrand::CallCore
-
-		} // end of class FunctionObject_ClassStaticMethod_C1D86EAB_Example_hasBrand
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_0D98644E_Example_read
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly class [System.Runtime]System.Object _privateBrand
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class [System.Runtime]System.Object capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassStaticMethod_0D98644E_Example_read::_privateBrand
-				IL_000d: ret
-			} // end of method FunctionObject_ClassStaticMethod_0D98644E_Example_read::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_0D98644E_Example_read::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_0D98644E_Example_read::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 37 (0x25)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_PrivateBrandCheck/Example
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld class [System.Runtime]System.Object Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassStaticMethod_0D98644E_Example_read::_privateBrand
-				IL_0011: ldarg.0
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ValidateGeneratedStaticMethodReceiver(object, class [System.Runtime]System.Type, object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0017: pop
-				IL_0018: ldarg.2
-				IL_0019: ldc.i4.0
-				IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_001f: call object Modules.Classes_PrivateBrandCheck/Example::read(object)
-				IL_0024: ret
-			} // end of method FunctionObject_ClassStaticMethod_0D98644E_Example_read::CallCore
-
-		} // end of class FunctionObject_ClassStaticMethod_0D98644E_Example_read
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_7FC71C11_Example_write
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly class [System.Runtime]System.Object _privateBrand
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class [System.Runtime]System.Object capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassStaticMethod_7FC71C11_Example_write::_privateBrand
-				IL_000d: ret
-			} // end of method FunctionObject_ClassStaticMethod_7FC71C11_Example_write::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_7FC71C11_Example_write::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_7FC71C11_Example_write::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 44 (0x2c)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Classes_PrivateBrandCheck/Example
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld class [System.Runtime]System.Object Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassStaticMethod_7FC71C11_Example_write::_privateBrand
-				IL_0011: ldarg.0
-				IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ValidateGeneratedStaticMethodReceiver(object, class [System.Runtime]System.Type, object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0017: pop
-				IL_0018: ldarg.2
-				IL_0019: ldc.i4.0
-				IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_001f: ldarg.2
-				IL_0020: ldc.i4.1
-				IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0026: call object Modules.Classes_PrivateBrandCheck/Example::write(object, object)
-				IL_002b: ret
-			} // end of method FunctionObject_ClassStaticMethod_7FC71C11_Example_write::CallCore
-
-		} // end of class FunctionObject_ClassStaticMethod_7FC71C11_Example_write
 
 
 		// Fields
@@ -532,7 +540,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_E9613B62_Derived
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -552,9 +560,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_PrivateBrandCheck/Derived/FunctionObject_ClassConstructor_E9613B62_Derived::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_PrivateBrandCheck/Derived/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_E9613B62_Derived::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -565,7 +573,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_E9613B62_Derived::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -576,9 +584,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_E9613B62_Derived::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_E9613B62_Derived
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -797,8 +805,8 @@
 			[12] object,
 			[13] class [System.Runtime]System.Type,
 			[14] object[],
-			[15] class Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassConstructor_9D4431D5_Example,
-			[16] class Modules.Classes_PrivateBrandCheck/Derived/FunctionObject_ClassConstructor_E9613B62_Derived,
+			[15] class Modules.Classes_PrivateBrandCheck/Example/Scope_ctor/FunctionObject,
+			[16] class Modules.Classes_PrivateBrandCheck/Derived/FunctionObject,
 			[17] object,
 			[18] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[19] class Modules.Classes_PrivateBrandCheck/Example,
@@ -825,14 +833,14 @@
 		IL_0031: ldloc.s 13
 		IL_0033: ldstr "hasBrand"
 		IL_0038: ldloc.s 13
-		IL_003a: newobj instance void Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassStaticMethod_C1D86EAB_Example_hasBrand::.ctor(class [System.Runtime]System.Object)
+		IL_003a: newobj instance void Modules.Classes_PrivateBrandCheck/Example/Scope_hasBrand/FunctionObject::.ctor(class [System.Runtime]System.Object)
 		IL_003f: ldc.i4.1
 		IL_0040: conv.r8
 		IL_0041: ldstr "hasBrand"
 		IL_0046: ldc.i4.0
 		IL_0047: ldc.i4.1
-		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassStaticMethod_C1D86EAB_Example_hasBrand>(!!0, float64, string, bool, bool)
-		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassStaticMethod_C1D86EAB_Example_hasBrand>(!!0)
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_PrivateBrandCheck/Example/Scope_hasBrand/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_PrivateBrandCheck/Example/Scope_hasBrand/FunctionObject>(!!0)
 		IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0057: pop
 		IL_0058: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -840,14 +848,14 @@
 		IL_005f: ldloc.s 13
 		IL_0061: ldstr "read"
 		IL_0066: ldloc.s 13
-		IL_0068: newobj instance void Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassStaticMethod_0D98644E_Example_read::.ctor(class [System.Runtime]System.Object)
+		IL_0068: newobj instance void Modules.Classes_PrivateBrandCheck/Example/Scope_read/FunctionObject::.ctor(class [System.Runtime]System.Object)
 		IL_006d: ldc.i4.1
 		IL_006e: conv.r8
 		IL_006f: ldstr "read"
 		IL_0074: ldc.i4.0
 		IL_0075: ldc.i4.1
-		IL_0076: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassStaticMethod_0D98644E_Example_read>(!!0, float64, string, bool, bool)
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassStaticMethod_0D98644E_Example_read>(!!0)
+		IL_0076: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_PrivateBrandCheck/Example/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_PrivateBrandCheck/Example/Scope_read/FunctionObject>(!!0)
 		IL_0080: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0085: pop
 		IL_0086: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -855,14 +863,14 @@
 		IL_008d: ldloc.s 13
 		IL_008f: ldstr "write"
 		IL_0094: ldloc.s 13
-		IL_0096: newobj instance void Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassStaticMethod_7FC71C11_Example_write::.ctor(class [System.Runtime]System.Object)
+		IL_0096: newobj instance void Modules.Classes_PrivateBrandCheck/Example/Scope_write/FunctionObject::.ctor(class [System.Runtime]System.Object)
 		IL_009b: ldc.i4.2
 		IL_009c: conv.r8
 		IL_009d: ldstr "write"
 		IL_00a2: ldc.i4.0
 		IL_00a3: ldc.i4.1
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassStaticMethod_7FC71C11_Example_write>(!!0, float64, string, bool, bool)
-		IL_00a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassStaticMethod_7FC71C11_Example_write>(!!0)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_PrivateBrandCheck/Example/Scope_write/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_PrivateBrandCheck/Example/Scope_write/FunctionObject>(!!0)
 		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_00b3: pop
 		IL_00b4: ldc.i4.1
@@ -874,14 +882,14 @@
 		IL_00be: stloc.s 14
 		IL_00c0: ldloc.s 14
 		IL_00c2: ldnull
-		IL_00c3: newobj instance void Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassConstructor_9D4431D5_Example::.ctor(object[], class [System.Runtime]System.Object)
+		IL_00c3: newobj instance void Modules.Classes_PrivateBrandCheck/Example/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object)
 		IL_00c8: ldloc.s 13
 		IL_00ca: ldloc.s 14
 		IL_00cc: ldc.i4.1
 		IL_00cd: conv.r8
 		IL_00ce: ldc.i4.0
 		IL_00cf: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_00d4: castclass Modules.Classes_PrivateBrandCheck/Example/FunctionObject_ClassConstructor_9D4431D5_Example
+		IL_00d4: castclass Modules.Classes_PrivateBrandCheck/Example/Scope_ctor/FunctionObject
 		IL_00d9: stloc.s 15
 		IL_00db: ldloc.0
 		IL_00dc: ldloc.s 15
@@ -899,14 +907,14 @@
 		IL_00fe: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0103: stloc.s 13
 		IL_0105: ldloc.s 14
-		IL_0107: newobj instance void Modules.Classes_PrivateBrandCheck/Derived/FunctionObject_ClassConstructor_E9613B62_Derived::.ctor(object[])
+		IL_0107: newobj instance void Modules.Classes_PrivateBrandCheck/Derived/FunctionObject::.ctor(object[])
 		IL_010c: ldloc.s 13
 		IL_010e: ldloc.s 14
 		IL_0110: ldc.i4.0
 		IL_0111: conv.r8
 		IL_0112: ldc.i4.0
 		IL_0113: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0118: castclass Modules.Classes_PrivateBrandCheck/Derived/FunctionObject_ClassConstructor_E9613B62_Derived
+		IL_0118: castclass Modules.Classes_PrivateBrandCheck/Derived/FunctionObject
 		IL_011d: stloc.s 16
 		IL_011f: ldloc.s 16
 		IL_0121: ldloc.s 15

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_StaticMethod_Reassignment.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_StaticMethod_Reassignment.verified.txt
@@ -131,6 +131,62 @@
 		.class nested public auto ansi beforefieldinit Scope_identify
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 6 (0x6)
+					.maxstack 8
+
+					IL_0000: call object Modules.Classes_StaticMethod_Reassignment/Example::identify()
+					IL_0005: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -147,7 +203,7 @@
 
 		} // end of class Scope_identify
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_A6582C51_Example
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -167,9 +223,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Classes_StaticMethod_Reassignment/Example/FunctionObject_ClassConstructor_A6582C51_Example::_transitionalScopes
+				IL_0008: stfld object[] Modules.Classes_StaticMethod_Reassignment/Example/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_A6582C51_Example::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -180,7 +236,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_A6582C51_Example::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -191,63 +247,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_A6582C51_Example::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_A6582C51_Example
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_626381C6_Example_identify
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassStaticMethod_626381C6_Example_identify::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_626381C6_Example_identify::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_626381C6_Example_identify::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 6 (0x6)
-				.maxstack 8
-
-				IL_0000: call object Modules.Classes_StaticMethod_Reassignment/Example::identify()
-				IL_0005: ret
-			} // end of method FunctionObject_ClassStaticMethod_626381C6_Example_identify::CallCore
-
-		} // end of class FunctionObject_ClassStaticMethod_626381C6_Example_identify
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -320,7 +322,7 @@
 			[1] object,
 			[2] class [System.Runtime]System.Type,
 			[3] object[],
-			[4] class Modules.Classes_StaticMethod_Reassignment/Example/FunctionObject_ClassConstructor_A6582C51_Example,
+			[4] class Modules.Classes_StaticMethod_Reassignment/Example/FunctionObject,
 			[5] class Modules.Classes_StaticMethod_Reassignment/ArrowFunction_L9C20/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[7] object
@@ -342,14 +344,14 @@
 		IL_002d: stloc.3
 		IL_002e: ldloc.2
 		IL_002f: ldstr "identify"
-		IL_0034: newobj instance void Modules.Classes_StaticMethod_Reassignment/Example/FunctionObject_ClassStaticMethod_626381C6_Example_identify::.ctor()
+		IL_0034: newobj instance void Modules.Classes_StaticMethod_Reassignment/Example/Scope_identify/FunctionObject::.ctor()
 		IL_0039: ldc.i4.0
 		IL_003a: conv.r8
 		IL_003b: ldstr "identify"
 		IL_0040: ldc.i4.0
 		IL_0041: ldc.i4.1
-		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_StaticMethod_Reassignment/Example/FunctionObject_ClassStaticMethod_626381C6_Example_identify>(!!0, float64, string, bool, bool)
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_StaticMethod_Reassignment/Example/FunctionObject_ClassStaticMethod_626381C6_Example_identify>(!!0)
+		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_StaticMethod_Reassignment/Example/Scope_identify/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_StaticMethod_Reassignment/Example/Scope_identify/FunctionObject>(!!0)
 		IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0051: pop
 		IL_0052: ldc.i4.1
@@ -360,14 +362,14 @@
 		IL_005b: stelem.ref
 		IL_005c: stloc.3
 		IL_005d: ldloc.3
-		IL_005e: newobj instance void Modules.Classes_StaticMethod_Reassignment/Example/FunctionObject_ClassConstructor_A6582C51_Example::.ctor(object[])
+		IL_005e: newobj instance void Modules.Classes_StaticMethod_Reassignment/Example/FunctionObject::.ctor(object[])
 		IL_0063: ldloc.2
 		IL_0064: ldloc.3
 		IL_0065: ldc.i4.0
 		IL_0066: conv.r8
 		IL_0067: ldc.i4.0
 		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_006d: castclass Modules.Classes_StaticMethod_Reassignment/Example/FunctionObject_ClassConstructor_A6582C51_Example
+		IL_006d: castclass Modules.Classes_StaticMethod_Reassignment/Example/FunctionObject
 		IL_0072: stloc.s 4
 		IL_0074: ldloc.s 4
 		IL_0076: stloc.1

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Class.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Class.verified.txt
@@ -160,6 +160,77 @@
 		.class nested public auto ansi beforefieldinit Scope_add
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 49 (0x31)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.CommonJS_Export_Class_Lib/Calculator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.CommonJS_Export_Class_Lib/Calculator
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: ldarg.2
+					IL_0025: ldc.i4.1
+					IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_002b: call instance object Modules.CommonJS_Export_Class_Lib/Calculator::'add'(object, object)
+					IL_0030: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -179,6 +250,77 @@
 		.class nested public auto ansi beforefieldinit Scope_multiply
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 49 (0x31)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.CommonJS_Export_Class_Lib/Calculator
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.CommonJS_Export_Class_Lib/Calculator
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: ldarg.2
+					IL_0025: ldc.i4.1
+					IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_002b: call instance object Modules.CommonJS_Export_Class_Lib/Calculator::multiply(object, object)
+					IL_0030: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -195,7 +337,7 @@
 
 		} // end of class Scope_multiply
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_4A903940_Calculator
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -215,9 +357,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassConstructor_4A903940_Calculator::_transitionalScopes
+				IL_0008: stfld object[] Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_4A903940_Calculator::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -228,7 +370,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_4A903940_Calculator::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -239,147 +381,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_4A903940_Calculator::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_4A903940_Calculator
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C6420A76_Calculator_add
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_C6420A76_Calculator_add::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C6420A76_Calculator_add::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C6420A76_Calculator_add::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 49 (0x31)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.CommonJS_Export_Class_Lib/Calculator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.CommonJS_Export_Class_Lib/Calculator
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: ldarg.2
-				IL_0025: ldc.i4.1
-				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_002b: call instance object Modules.CommonJS_Export_Class_Lib/Calculator::'add'(object, object)
-				IL_0030: ret
-			} // end of method FunctionObject_ClassMethod_C6420A76_Calculator_add::CallCore
-
-		} // end of class FunctionObject_ClassMethod_C6420A76_Calculator_add
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_56B18E5B_Calculator_multiply
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 49 (0x31)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.CommonJS_Export_Class_Lib/Calculator
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.CommonJS_Export_Class_Lib/Calculator
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: ldarg.2
-				IL_0025: ldc.i4.1
-				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_002b: call instance object Modules.CommonJS_Export_Class_Lib/Calculator::multiply(object, object)
-				IL_0030: ret
-			} // end of method FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::CallCore
-
-		} // end of class FunctionObject_ClassMethod_56B18E5B_Calculator_multiply
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -485,7 +489,7 @@
 			[2] class [System.Runtime]System.Type,
 			[3] object,
 			[4] object[],
-			[5] class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassConstructor_4A903940_Calculator
+			[5] class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Export_Class_Lib/Scope::.ctor()
@@ -504,28 +508,28 @@
 		IL_002d: stloc.s 4
 		IL_002f: ldloc.3
 		IL_0030: ldstr "add"
-		IL_0035: newobj instance void Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add::.ctor()
+		IL_0035: newobj instance void Modules.CommonJS_Export_Class_Lib/Calculator/Scope_add/FunctionObject::.ctor()
 		IL_003a: ldc.i4.2
 		IL_003b: conv.r8
 		IL_003c: ldstr "add"
 		IL_0041: ldc.i4.0
 		IL_0042: ldc.i4.1
-		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add>(!!0, float64, string, bool, bool)
-		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_C6420A76_Calculator_add>(!!0)
+		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Class_Lib/Calculator/Scope_add/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/Scope_add/FunctionObject>(!!0)
 		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0052: pop
 		IL_0053: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0058: stloc.s 4
 		IL_005a: ldloc.3
 		IL_005b: ldstr "multiply"
-		IL_0060: newobj instance void Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::.ctor()
+		IL_0060: newobj instance void Modules.CommonJS_Export_Class_Lib/Calculator/Scope_multiply/FunctionObject::.ctor()
 		IL_0065: ldc.i4.2
 		IL_0066: conv.r8
 		IL_0067: ldstr "multiply"
 		IL_006c: ldc.i4.0
 		IL_006d: ldc.i4.1
-		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply>(!!0, float64, string, bool, bool)
-		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassMethod_56B18E5B_Calculator_multiply>(!!0)
+		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Class_Lib/Calculator/Scope_multiply/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0073: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_Class_Lib/Calculator/Scope_multiply/FunctionObject>(!!0)
 		IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_007d: pop
 		IL_007e: ldc.i4.1
@@ -536,14 +540,14 @@
 		IL_0087: stelem.ref
 		IL_0088: stloc.s 4
 		IL_008a: ldloc.s 4
-		IL_008c: newobj instance void Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassConstructor_4A903940_Calculator::.ctor(object[])
+		IL_008c: newobj instance void Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject::.ctor(object[])
 		IL_0091: ldloc.2
 		IL_0092: ldloc.s 4
 		IL_0094: ldc.i4.0
 		IL_0095: conv.r8
 		IL_0096: ldc.i4.0
 		IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_009c: castclass Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassConstructor_4A903940_Calculator
+		IL_009c: castclass Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject
 		IL_00a1: stloc.s 5
 		IL_00a3: ldloc.s 5
 		IL_00a5: stloc.1

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
@@ -177,6 +177,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -196,6 +246,71 @@
 		.class nested public auto ansi beforefieldinit Scope_greet
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.CommonJS_Export_ClassWithConstructor_Lib/Person
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.CommonJS_Export_ClassWithConstructor_Lib/Person
+					IL_001d: call instance object Modules.CommonJS_Export_ClassWithConstructor_Lib/Person::greet()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -211,117 +326,6 @@
 			} // end of method Scope_greet::.ctor
 
 		} // end of class Scope_greet
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_8A4450FF_Person
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassConstructor_8A4450FF_Person::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_8A4450FF_Person::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_8A4450FF_Person::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_8A4450FF_Person::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_8A4450FF_Person
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_FC1697C3_Person_greet
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_FC1697C3_Person_greet::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_FC1697C3_Person_greet::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_FC1697C3_Person_greet::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.CommonJS_Export_ClassWithConstructor_Lib/Person
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.CommonJS_Export_ClassWithConstructor_Lib/Person
-				IL_001d: call instance object Modules.CommonJS_Export_ClassWithConstructor_Lib/Person::greet()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_FC1697C3_Person_greet::CallCore
-
-		} // end of class FunctionObject_ClassMethod_FC1697C3_Person_greet
 
 
 		// Fields
@@ -429,7 +433,7 @@
 			[2] class [System.Runtime]System.Type,
 			[3] object,
 			[4] object[],
-			[5] class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassConstructor_8A4450FF_Person
+			[5] class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/Scope_ctor/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Export_ClassWithConstructor_Lib/Scope::.ctor()
@@ -448,14 +452,14 @@
 		IL_002d: stloc.s 4
 		IL_002f: ldloc.3
 		IL_0030: ldstr "greet"
-		IL_0035: newobj instance void Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet::.ctor()
+		IL_0035: newobj instance void Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/Scope_greet/FunctionObject::.ctor()
 		IL_003a: ldc.i4.0
 		IL_003b: conv.r8
 		IL_003c: ldstr "greet"
 		IL_0041: ldc.i4.1
 		IL_0042: ldc.i4.1
-		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet>(!!0, float64, string, bool, bool)
-		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassMethod_FC1697C3_Person_greet>(!!0)
+		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/Scope_greet/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/Scope_greet/FunctionObject>(!!0)
 		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0052: pop
 		IL_0053: ldc.i4.1
@@ -466,14 +470,14 @@
 		IL_005c: stelem.ref
 		IL_005d: stloc.s 4
 		IL_005f: ldloc.s 4
-		IL_0061: newobj instance void Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassConstructor_8A4450FF_Person::.ctor(object[])
+		IL_0061: newobj instance void Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_0066: ldloc.2
 		IL_0067: ldloc.s 4
 		IL_0069: ldc.i4.2
 		IL_006a: conv.r8
 		IL_006b: ldc.i4.0
 		IL_006c: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0071: castclass Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassConstructor_8A4450FF_Person
+		IL_0071: castclass Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/Scope_ctor/FunctionObject
 		IL_0076: stloc.s 5
 		IL_0078: ldloc.s 5
 		IL_007a: stloc.1

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ClassExpression_ExtendsArray.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ClassExpression_ExtendsArray.verified.txt
@@ -74,6 +74,88 @@
 
 			} // end of class Block_L9C15
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0,
+						class [System.Runtime]System.Object capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class [System.Runtime]System.Object Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/Scope_ctor/FunctionObject::_homeObject
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_001b: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/Scope_ctor/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -94,6 +176,74 @@
 		.class nested public auto ansi beforefieldinit Scope_item
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList::item(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -109,154 +259,6 @@
 			} // end of method Scope_item::.ctor
 
 		} // end of class Scope_item
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_A071EBE1_NodeList
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0,
-					class [System.Runtime]System.Object capture1,
-					object[] capture2
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 28 (0x1c)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassConstructor_A071EBE1_NodeList::_transitionalScopes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassConstructor_A071EBE1_NodeList::_homeObject
-				IL_0014: ldarg.0
-				IL_0015: ldarg.3
-				IL_0016: stfld object[] Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassConstructor_A071EBE1_NodeList::_lexicalSuperScopes
-				IL_001b: ret
-			} // end of method FunctionObject_ClassConstructor_A071EBE1_NodeList::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_A071EBE1_NodeList::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_A071EBE1_NodeList::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassConstructor_A071EBE1_NodeList::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_A071EBE1_NodeList::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassConstructor_A071EBE1_NodeList::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_A071EBE1_NodeList::GetLexicalSuperScopesCore
-
-		} // end of class FunctionObject_ClassConstructor_A071EBE1_NodeList
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_017B4079_NodeList_item
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_017B4079_NodeList_item::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_017B4079_NodeList_item::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_017B4079_NodeList_item::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList::item(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_017B4079_NodeList_item::CallCore
-
-		} // end of class FunctionObject_ClassMethod_017B4079_NodeList_item
 
 
 		// Methods
@@ -435,7 +437,7 @@
 			[0] class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/Scope,
 			[1] object[],
 			[2] class [System.Runtime]System.Type,
-			[3] class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassConstructor_A071EBE1_NodeList,
+			[3] class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/Scope_ctor/FunctionObject,
 			[4] object,
 			[5] object,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console
@@ -464,14 +466,14 @@
 		IL_0034: ldc.i4.0
 		IL_0035: ldloc.0
 		IL_0036: stelem.ref
-		IL_0037: newobj instance void Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassConstructor_A071EBE1_NodeList::.ctor(object[], class [System.Runtime]System.Object, object[])
+		IL_0037: newobj instance void Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object, object[])
 		IL_003c: ldloc.2
 		IL_003d: ldloc.1
 		IL_003e: ldc.i4.1
 		IL_003f: conv.r8
 		IL_0040: ldc.i4.1
 		IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0046: castclass Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassConstructor_A071EBE1_NodeList
+		IL_0046: castclass Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/Scope_ctor/FunctionObject
 		IL_004b: stloc.3
 		IL_004c: ldstr "Array"
 		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
@@ -493,14 +495,14 @@
 		IL_0089: stloc.1
 		IL_008a: ldloc.s 5
 		IL_008c: ldstr "item"
-		IL_0091: newobj instance void Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item::.ctor()
+		IL_0091: newobj instance void Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/Scope_item/FunctionObject::.ctor()
 		IL_0096: ldc.i4.1
 		IL_0097: conv.r8
 		IL_0098: ldstr "item"
 		IL_009d: ldc.i4.1
 		IL_009e: ldc.i4.1
-		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item>(!!0, float64, string, bool, bool)
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassMethod_017B4079_NodeList_item>(!!0)
+		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/Scope_item/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/Scope_item/FunctionObject>(!!0)
 		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_00ae: pop
 		IL_00af: ldarg.2

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
@@ -310,6 +310,79 @@
 		.class nested public auto ansi beforefieldinit Scope_Log
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.CommonJS_Require_Basic/CommonClassName/Scope_Log/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.CommonJS_Require_Basic/CommonClassName
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.CommonJS_Require_Basic/CommonClassName/Scope_Log/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.CommonJS_Require_Basic/CommonClassName
+					IL_001d: call instance object Modules.CommonJS_Require_Basic/CommonClassName::Log()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -326,7 +399,7 @@
 
 		} // end of class Scope_Log
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_9A3BC299_CommonClassName
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -346,9 +419,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.CommonJS_Require_Basic/CommonClassName/FunctionObject_ClassConstructor_9A3BC299_CommonClassName::_transitionalScopes
+				IL_0008: stfld object[] Modules.CommonJS_Require_Basic/CommonClassName/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_9A3BC299_CommonClassName::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -359,7 +432,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_9A3BC299_CommonClassName::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -370,80 +443,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_9A3BC299_CommonClassName::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_9A3BC299_CommonClassName
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.CommonJS_Require_Basic/CommonClassName/FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.CommonJS_Require_Basic/CommonClassName
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.CommonJS_Require_Basic/CommonClassName/FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.CommonJS_Require_Basic/CommonClassName
-				IL_001d: call instance object Modules.CommonJS_Require_Basic/CommonClassName::Log()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log::CallCore
-
-		} // end of class FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -993,6 +995,79 @@
 		.class nested public auto ansi beforefieldinit Scope_Log
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.CommonJS_Require_Dependency/CommonClassName/Scope_Log/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.CommonJS_Require_Dependency/CommonClassName
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.CommonJS_Require_Dependency/CommonClassName/Scope_Log/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.CommonJS_Require_Dependency/CommonClassName
+					IL_001d: call instance object Modules.CommonJS_Require_Dependency/CommonClassName::Log()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1009,7 +1084,7 @@
 
 		} // end of class Scope_Log
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_561FA58C_CommonClassName
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -1029,9 +1104,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.CommonJS_Require_Dependency/CommonClassName/FunctionObject_ClassConstructor_561FA58C_CommonClassName::_transitionalScopes
+				IL_0008: stfld object[] Modules.CommonJS_Require_Dependency/CommonClassName/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_561FA58C_CommonClassName::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1042,7 +1117,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_561FA58C_CommonClassName::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1053,80 +1128,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_561FA58C_CommonClassName::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_561FA58C_CommonClassName
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.CommonJS_Require_Dependency/CommonClassName/FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.CommonJS_Require_Dependency/CommonClassName
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.CommonJS_Require_Dependency/CommonClassName/FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.CommonJS_Require_Dependency/CommonClassName
-				IL_001d: call instance object Modules.CommonJS_Require_Dependency/CommonClassName::Log()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log::CallCore
-
-		} // end of class FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log
+		} // end of class FunctionObject
 
 
 		// Fields

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
@@ -374,6 +374,79 @@
 		.class nested public auto ansi beforefieldinit Scope_Log
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.b/CommonClassName/Scope_Log/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.b/CommonClassName
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.b/CommonClassName/Scope_Log/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.b/CommonClassName
+					IL_001d: call instance object Modules.b/CommonClassName::Log()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -390,7 +463,7 @@
 
 		} // end of class Scope_Log
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_E9658844_CommonClassName
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -410,9 +483,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.b/CommonClassName/FunctionObject_ClassConstructor_E9658844_CommonClassName::_transitionalScopes
+				IL_0008: stfld object[] Modules.b/CommonClassName/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_E9658844_CommonClassName::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -423,7 +496,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_E9658844_CommonClassName::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -434,80 +507,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_E9658844_CommonClassName::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_E9658844_CommonClassName
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_65FB7589_CommonClassName_Log
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.b/CommonClassName/FunctionObject_ClassMethod_65FB7589_CommonClassName_Log::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_65FB7589_CommonClassName_Log::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_65FB7589_CommonClassName_Log::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_65FB7589_CommonClassName_Log::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.b/CommonClassName
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.b/CommonClassName/FunctionObject_ClassMethod_65FB7589_CommonClassName_Log::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.b/CommonClassName
-				IL_001d: call instance object Modules.b/CommonClassName::Log()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_65FB7589_CommonClassName_Log::CallCore
-
-		} // end of class FunctionObject_ClassMethod_65FB7589_CommonClassName_Log
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -1046,6 +1048,79 @@
 		.class nested public auto ansi beforefieldinit Scope_Log
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.helpers_b/CommonClassName/Scope_Log/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.helpers_b/CommonClassName
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.helpers_b/CommonClassName/Scope_Log/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.helpers_b/CommonClassName
+					IL_001d: call instance object Modules.helpers_b/CommonClassName::Log()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1062,7 +1137,7 @@
 
 		} // end of class Scope_Log
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -1082,9 +1157,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.helpers_b/CommonClassName/FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName::_transitionalScopes
+				IL_0008: stfld object[] Modules.helpers_b/CommonClassName/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1095,7 +1170,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1106,80 +1181,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.helpers_b/CommonClassName/FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.helpers_b/CommonClassName
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.helpers_b/CommonClassName/FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.helpers_b/CommonClassName
-				IL_001d: call instance object Modules.helpers_b/CommonClassName::Log()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log::CallCore
-
-		} // end of class FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log
+		} // end of class FunctionObject
 
 
 		// Fields

--- a/tests/Jroc.Tests/CompoundAssignment/Snapshots/GeneratorTests.CompoundAssignment_LocalVarIndex.verified.txt
+++ b/tests/Jroc.Tests/CompoundAssignment/Snapshots/GeneratorTests.CompoundAssignment_LocalVarIndex.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.CompoundAssignment_LocalVarIndex/TestClass/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +102,71 @@
 		.class nested public auto ansi beforefieldinit Scope_test
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.CompoundAssignment_LocalVarIndex/TestClass
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.CompoundAssignment_LocalVarIndex/TestClass
+					IL_001d: call instance object Modules.CompoundAssignment_LocalVarIndex/TestClass::test()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -67,117 +182,6 @@
 			} // end of method Scope_test::.ctor
 
 		} // end of class Scope_test
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_3F6DB619_TestClass
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.CompoundAssignment_LocalVarIndex/TestClass/FunctionObject_ClassConstructor_3F6DB619_TestClass::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_3F6DB619_TestClass::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_3F6DB619_TestClass::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_3F6DB619_TestClass::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_3F6DB619_TestClass
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_49028540_TestClass_test
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_49028540_TestClass_test::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_49028540_TestClass_test::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_49028540_TestClass_test::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.CompoundAssignment_LocalVarIndex/TestClass
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.CompoundAssignment_LocalVarIndex/TestClass
-				IL_001d: call instance object Modules.CompoundAssignment_LocalVarIndex/TestClass::test()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_49028540_TestClass_test::CallCore
-
-		} // end of class FunctionObject_ClassMethod_49028540_TestClass_test
 
 
 		// Fields

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_ClassFields_BaseAndDerived.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_ClassFields_BaseAndDerived.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Base/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,54 +98,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_EA345C77_Base
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Base/FunctionObject_ClassConstructor_EA345C77_Base::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_EA345C77_Base::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_EA345C77_Base::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_EA345C77_Base::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_EA345C77_Base
 
 
 		// Fields
@@ -148,6 +150,90 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0,
+						class [System.Runtime]System.Object capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class [System.Runtime]System.Object Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/Scope_ctor/FunctionObject::_homeObject
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_001b: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/Scope_ctor/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -163,88 +249,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_E4082CCF_Derived
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0,
-					class [System.Runtime]System.Object capture1,
-					object[] capture2
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 28 (0x1c)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/FunctionObject_ClassConstructor_E4082CCF_Derived::_transitionalScopes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/FunctionObject_ClassConstructor_E4082CCF_Derived::_homeObject
-				IL_0014: ldarg.0
-				IL_0015: ldarg.3
-				IL_0016: stfld object[] Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/FunctionObject_ClassConstructor_E4082CCF_Derived::_lexicalSuperScopes
-				IL_001b: ret
-			} // end of method FunctionObject_ClassConstructor_E4082CCF_Derived::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_E4082CCF_Derived::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_E4082CCF_Derived::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/FunctionObject_ClassConstructor_E4082CCF_Derived::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_E4082CCF_Derived::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/FunctionObject_ClassConstructor_E4082CCF_Derived::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_E4082CCF_Derived::GetLexicalSuperScopesCore
-
-		} // end of class FunctionObject_ClassConstructor_E4082CCF_Derived
 
 
 		// Fields
@@ -387,8 +391,8 @@
 			[5] object,
 			[6] object[],
 			[7] class [System.Runtime]System.Type,
-			[8] class Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Base/FunctionObject_ClassConstructor_EA345C77_Base,
-			[9] class Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/FunctionObject_ClassConstructor_E4082CCF_Derived,
+			[8] class Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Base/Scope_ctor/FunctionObject,
+			[9] class Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/Scope_ctor/FunctionObject,
 			[10] object,
 			[11] bool,
 			[12] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -411,14 +415,14 @@
 		IL_0022: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0027: stloc.s 7
 		IL_0029: ldloc.s 6
-		IL_002b: newobj instance void Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Base/FunctionObject_ClassConstructor_EA345C77_Base::.ctor(object[])
+		IL_002b: newobj instance void Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Base/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_0030: ldloc.s 7
 		IL_0032: ldloc.s 6
 		IL_0034: ldc.i4.0
 		IL_0035: conv.r8
 		IL_0036: ldc.i4.0
 		IL_0037: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_003c: castclass Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Base/FunctionObject_ClassConstructor_EA345C77_Base
+		IL_003c: castclass Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Base/Scope_ctor/FunctionObject
 		IL_0041: stloc.s 8
 		IL_0043: ldloc.0
 		IL_0044: ldloc.s 8
@@ -443,14 +447,14 @@
 		IL_007b: ldc.i4.0
 		IL_007c: ldloc.0
 		IL_007d: stelem.ref
-		IL_007e: newobj instance void Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/FunctionObject_ClassConstructor_E4082CCF_Derived::.ctor(object[], class [System.Runtime]System.Object, object[])
+		IL_007e: newobj instance void Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object, object[])
 		IL_0083: ldloc.s 7
 		IL_0085: ldloc.s 6
 		IL_0087: ldc.i4.0
 		IL_0088: conv.r8
 		IL_0089: ldc.i4.0
 		IL_008a: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_008f: castclass Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/FunctionObject_ClassConstructor_E4082CCF_Derived
+		IL_008f: castclass Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/Scope_ctor/FunctionObject
 		IL_0094: stloc.s 9
 		IL_0096: ldloc.s 9
 		IL_0098: ldloc.s 8

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_Shadowing_NoDuplicateKeys.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_Shadowing_NoDuplicateKeys.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Base/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,54 +98,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_190F5919_Base
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Base/FunctionObject_ClassConstructor_190F5919_Base::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_190F5919_Base::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_190F5919_Base::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_190F5919_Base::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_190F5919_Base
 
 
 		// Fields
@@ -148,6 +150,90 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0,
+						class [System.Runtime]System.Object capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class [System.Runtime]System.Object Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/Scope_ctor/FunctionObject::_homeObject
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_001b: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/Scope_ctor/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -163,88 +249,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_B41CF45D_Derived
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0,
-					class [System.Runtime]System.Object capture1,
-					object[] capture2
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 28 (0x1c)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/FunctionObject_ClassConstructor_B41CF45D_Derived::_transitionalScopes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/FunctionObject_ClassConstructor_B41CF45D_Derived::_homeObject
-				IL_0014: ldarg.0
-				IL_0015: ldarg.3
-				IL_0016: stfld object[] Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/FunctionObject_ClassConstructor_B41CF45D_Derived::_lexicalSuperScopes
-				IL_001b: ret
-			} // end of method FunctionObject_ClassConstructor_B41CF45D_Derived::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_B41CF45D_Derived::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_B41CF45D_Derived::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/FunctionObject_ClassConstructor_B41CF45D_Derived::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_B41CF45D_Derived::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/FunctionObject_ClassConstructor_B41CF45D_Derived::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_B41CF45D_Derived::GetLexicalSuperScopesCore
-
-		} // end of class FunctionObject_ClassConstructor_B41CF45D_Derived
 
 
 		// Fields
@@ -405,8 +409,8 @@
 			[5] object,
 			[6] object[],
 			[7] class [System.Runtime]System.Type,
-			[8] class Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Base/FunctionObject_ClassConstructor_190F5919_Base,
-			[9] class Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/FunctionObject_ClassConstructor_B41CF45D_Derived,
+			[8] class Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Base/Scope_ctor/FunctionObject,
+			[9] class Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/Scope_ctor/FunctionObject,
 			[10] object,
 			[11] bool,
 			[12] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -429,14 +433,14 @@
 		IL_0022: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_0027: stloc.s 7
 		IL_0029: ldloc.s 6
-		IL_002b: newobj instance void Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Base/FunctionObject_ClassConstructor_190F5919_Base::.ctor(object[])
+		IL_002b: newobj instance void Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Base/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_0030: ldloc.s 7
 		IL_0032: ldloc.s 6
 		IL_0034: ldc.i4.0
 		IL_0035: conv.r8
 		IL_0036: ldc.i4.0
 		IL_0037: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_003c: castclass Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Base/FunctionObject_ClassConstructor_190F5919_Base
+		IL_003c: castclass Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Base/Scope_ctor/FunctionObject
 		IL_0041: stloc.s 8
 		IL_0043: ldloc.0
 		IL_0044: ldloc.s 8
@@ -461,14 +465,14 @@
 		IL_007b: ldc.i4.0
 		IL_007c: ldloc.0
 		IL_007d: stelem.ref
-		IL_007e: newobj instance void Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/FunctionObject_ClassConstructor_B41CF45D_Derived::.ctor(object[], class [System.Runtime]System.Object, object[])
+		IL_007e: newobj instance void Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object, object[])
 		IL_0083: ldloc.s 7
 		IL_0085: ldloc.s 6
 		IL_0087: ldc.i4.0
 		IL_0088: conv.r8
 		IL_0089: ldc.i4.0
 		IL_008a: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_008f: castclass Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/FunctionObject_ClassConstructor_B41CF45D_Derived
+		IL_008f: castclass Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/Scope_ctor/FunctionObject
 		IL_0094: stloc.s 9
 		IL_0096: ldloc.s 9
 		IL_0098: ldloc.s 8

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_BoundFunctionObject_UnifiedTargets.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_BoundFunctionObject_UnifiedTargets.verified.txt
@@ -570,6 +570,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Function_BoundFunctionObject_UnifiedTargets/Box/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -585,54 +635,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_5F154764_Box
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Function_BoundFunctionObject_UnifiedTargets/Box/FunctionObject_ClassConstructor_5F154764_Box::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_5F154764_Box::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_5F154764_Box::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_5F154764_Box::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_5F154764_Box
 
 
 		// Fields
@@ -791,7 +793,7 @@
 			[30] class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject,
 			[31] class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject,
 			[32] class [System.Runtime]System.Type,
-			[33] class Modules.Function_BoundFunctionObject_UnifiedTargets/Box/FunctionObject_ClassConstructor_5F154764_Box,
+			[33] class Modules.Function_BoundFunctionObject_UnifiedTargets/Box/Scope_ctor/FunctionObject,
 			[34] class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject
 		)
 
@@ -1221,14 +1223,14 @@
 		IL_0519: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_051e: stloc.s 32
 		IL_0520: ldloc.s 16
-		IL_0522: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/Box/FunctionObject_ClassConstructor_5F154764_Box::.ctor(object[])
+		IL_0522: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/Box/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_0527: ldloc.s 32
 		IL_0529: ldloc.s 16
 		IL_052b: ldc.i4.2
 		IL_052c: conv.r8
 		IL_052d: ldc.i4.0
 		IL_052e: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0533: castclass Modules.Function_BoundFunctionObject_UnifiedTargets/Box/FunctionObject_ClassConstructor_5F154764_Box
+		IL_0533: castclass Modules.Function_BoundFunctionObject_UnifiedTargets/Box/Scope_ctor/FunctionObject
 		IL_0538: stloc.s 33
 		IL_053a: ldloc.s 33
 		IL_053c: stloc.s 12

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
@@ -1441,6 +1441,65 @@
 		.class nested public auto ansi beforefieldinit Scope_read
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.2
+					IL_0001: ldc.i4.0
+					IL_0002: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0007: call object Modules.Function_ConstructedInstance_ObjectSemantics/PointReader::read(object)
+					IL_000c: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1457,7 +1516,7 @@
 
 		} // end of class Scope_read
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_3BB98598_PointReader
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -1477,9 +1536,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassConstructor_3BB98598_PointReader::_transitionalScopes
+				IL_0008: stfld object[] Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_3BB98598_PointReader::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1490,7 +1549,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_3BB98598_PointReader::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1501,66 +1560,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_3BB98598_PointReader::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_3BB98598_PointReader
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_94C5E765_PointReader_read
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 13 (0xd)
-				.maxstack 8
-
-				IL_0000: ldarg.2
-				IL_0001: ldc.i4.0
-				IL_0002: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0007: call object Modules.Function_ConstructedInstance_ObjectSemantics/PointReader::read(object)
-				IL_000c: ret
-			} // end of method FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::CallCore
-
-		} // end of class FunctionObject_ClassStaticMethod_94C5E765_PointReader_read
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1688,7 +1690,7 @@
 			[23] object,
 			[24] object,
 			[25] class [System.Runtime]System.Type,
-			[26] class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassConstructor_3BB98598_PointReader
+			[26] class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -2257,14 +2259,14 @@
 		IL_0674: stloc.s 16
 		IL_0676: ldloc.s 25
 		IL_0678: ldstr "read"
-		IL_067d: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::.ctor()
+		IL_067d: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject::.ctor()
 		IL_0682: ldc.i4.1
 		IL_0683: conv.r8
 		IL_0684: ldstr "read"
 		IL_0689: ldc.i4.0
 		IL_068a: ldc.i4.1
-		IL_068b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read>(!!0, float64, string, bool, bool)
-		IL_0690: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassStaticMethod_94C5E765_PointReader_read>(!!0)
+		IL_068b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0690: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/Scope_read/FunctionObject>(!!0)
 		IL_0695: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_069a: pop
 		IL_069b: ldc.i4.1
@@ -2275,14 +2277,14 @@
 		IL_06a4: stelem.ref
 		IL_06a5: stloc.s 16
 		IL_06a7: ldloc.s 16
-		IL_06a9: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassConstructor_3BB98598_PointReader::.ctor(object[])
+		IL_06a9: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject::.ctor(object[])
 		IL_06ae: ldloc.s 25
 		IL_06b0: ldloc.s 16
 		IL_06b2: ldc.i4.0
 		IL_06b3: conv.r8
 		IL_06b4: ldc.i4.0
 		IL_06b5: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_06ba: castclass Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassConstructor_3BB98598_PointReader
+		IL_06ba: castclass Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject
 		IL_06bf: stloc.s 26
 		IL_06c1: ldloc.s 26
 		IL_06c3: stloc.s 15

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_New_ShadowedLocal_NoSyntaxError.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_New_ShadowedLocal_NoSyntaxError.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Function_Constructor_New_ShadowedLocal_NoSyntaxError/ClassExpression_L3C16/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -48,54 +98,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Function_Constructor_New_ShadowedLocal_NoSyntaxError/ClassExpression_L3C16/FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16
 
 
 		// Fields
@@ -164,7 +166,7 @@
 			[3] object,
 			[4] class [System.Runtime]System.Type,
 			[5] object[],
-			[6] class Modules.Function_Constructor_New_ShadowedLocal_NoSyntaxError/ClassExpression_L3C16/FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16,
+			[6] class Modules.Function_Constructor_New_ShadowedLocal_NoSyntaxError/ClassExpression_L3C16/Scope_ctor/FunctionObject,
 			[7] object,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -194,14 +196,14 @@
 		IL_0045: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_004a: stloc.s 4
 		IL_004c: ldloc.s 5
-		IL_004e: newobj instance void Modules.Function_Constructor_New_ShadowedLocal_NoSyntaxError/ClassExpression_L3C16/FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::.ctor(object[])
+		IL_004e: newobj instance void Modules.Function_Constructor_New_ShadowedLocal_NoSyntaxError/ClassExpression_L3C16/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_0053: ldloc.s 4
 		IL_0055: ldloc.s 5
 		IL_0057: ldc.i4.1
 		IL_0058: conv.r8
 		IL_0059: ldc.i4.1
 		IL_005a: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_005f: castclass Modules.Function_Constructor_New_ShadowedLocal_NoSyntaxError/ClassExpression_L3C16/FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16
+		IL_005f: castclass Modules.Function_Constructor_New_ShadowedLocal_NoSyntaxError/ClassExpression_L3C16/Scope_ctor/FunctionObject
 		IL_0064: stloc.s 6
 		IL_0066: ldloc.s 6
 		IL_0068: ldstr "Function"

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GeneratedConstruction_Semantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GeneratedConstruction_Semantics.verified.txt
@@ -1136,7 +1136,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -1156,9 +1156,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject/FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::_transitionalScopes
+				IL_0008: stfld object[] Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1169,7 +1169,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1180,9 +1180,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -1412,7 +1412,7 @@
 			[37] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[38] object,
 			[39] class [System.Runtime]System.Type,
-			[40] class Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject/FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject,
+			[40] class Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject/FunctionObject,
 			[41] class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject,
 			[42] class Modules.Function_GeneratedConstruction_Semantics/ArrowFunction_L95C15/FunctionObject,
 			[43] class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject,
@@ -1899,14 +1899,14 @@
 		IL_04e3: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_04e8: stloc.s 39
 		IL_04ea: ldloc.s 28
-		IL_04ec: newobj instance void Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject/FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::.ctor(object[])
+		IL_04ec: newobj instance void Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject/FunctionObject::.ctor(object[])
 		IL_04f1: ldloc.s 39
 		IL_04f3: ldloc.s 28
 		IL_04f5: ldc.i4.0
 		IL_04f6: conv.r8
 		IL_04f7: ldc.i4.0
 		IL_04f8: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_04fd: castclass Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject/FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject
+		IL_04fd: castclass Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject/FunctionObject
 		IL_0502: stloc.s 40
 		IL_0504: ldc.i4.1
 		IL_0505: newarr [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_BinaryArguments.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_BinaryArguments.verified.txt
@@ -11,25 +11,6 @@
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
 		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
@@ -165,6 +146,76 @@
 		.class nested public auto ansi beforefieldinit Scope_add
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 52 (0x34)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0029: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::'add'(float64)
+					IL_002e: box [System.Runtime]System.Double
+					IL_0033: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -184,6 +235,76 @@
 		.class nested public auto ansi beforefieldinit Scope_multiply
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 52 (0x34)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0029: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::multiply(float64)
+					IL_002e: box [System.Runtime]System.Double
+					IL_0033: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -203,6 +324,76 @@
 		.class nested public auto ansi beforefieldinit Scope_shift
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 52 (0x34)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0029: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::shift(float64)
+					IL_002e: box [System.Runtime]System.Double
+					IL_0033: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -222,6 +413,76 @@
 		.class nested public auto ansi beforefieldinit Scope_increment
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 52 (0x34)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0029: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::increment(float64)
+					IL_002e: box [System.Runtime]System.Double
+					IL_0033: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -241,6 +502,75 @@
 		.class nested public auto ansi beforefieldinit Scope_incrementBoolean
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 47 (0x2f)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::incrementBoolean(object)
+					IL_0029: box [System.Runtime]System.Double
+					IL_002e: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -260,6 +590,74 @@
 		.class nested public auto ansi beforefieldinit Scope_dynamicAdd
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::dynamicAdd(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -279,6 +677,74 @@
 		.class nested public auto ansi beforefieldinit Scope_bigint
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::bigint(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -298,6 +764,74 @@
 		.class nested public auto ansi beforefieldinit Scope_destructure
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::destructure(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -336,6 +870,72 @@
 				} // end of method Block_L42C28::.ctor
 
 			} // end of class Block_L42C28
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::iterate(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -377,6 +977,72 @@
 
 			} // end of class Block_L49C32
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::iterateVar(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -417,6 +1083,80 @@
 
 			} // end of class Block_L56C38
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver/Scope_iterateVarIn/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver/Scope_iterateVarIn/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::iterateVarIn(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -437,6 +1177,74 @@
 		.class nested public auto ansi beforefieldinit Scope_redeclare
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::redeclare(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -456,6 +1264,101 @@
 		.class nested public auto ansi beforefieldinit Scope_functionRedeclare
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver/Scope_functionRedeclare/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver/Scope_functionRedeclare/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::functionRedeclare(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -495,6 +1398,69 @@
 
 			} // end of class Block_L91C15
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+					IL_001d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::run()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -512,7 +1478,7 @@
 
 		} // end of class Scope_run
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -532,9 +1498,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver/FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver::_transitionalScopes
+				IL_0008: stfld object[] Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -545,7 +1511,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -556,955 +1522,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_19915569_BinaryReceiver_add
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_19915569_BinaryReceiver_add::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_19915569_BinaryReceiver_add::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_19915569_BinaryReceiver_add::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 52 (0x34)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0029: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::'add'(float64)
-				IL_002e: box [System.Runtime]System.Double
-				IL_0033: ret
-			} // end of method FunctionObject_ClassMethod_19915569_BinaryReceiver_add::CallCore
-
-		} // end of class FunctionObject_ClassMethod_19915569_BinaryReceiver_add
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 52 (0x34)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0029: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::multiply(float64)
-				IL_002e: box [System.Runtime]System.Double
-				IL_0033: ret
-			} // end of method FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply::CallCore
-
-		} // end of class FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 52 (0x34)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0029: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::shift(float64)
-				IL_002e: box [System.Runtime]System.Double
-				IL_0033: ret
-			} // end of method FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift::CallCore
-
-		} // end of class FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 52 (0x34)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0029: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::increment(float64)
-				IL_002e: box [System.Runtime]System.Double
-				IL_0033: ret
-			} // end of method FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment::CallCore
-
-		} // end of class FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 47 (0x2f)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::incrementBoolean(object)
-				IL_0029: box [System.Runtime]System.Double
-				IL_002e: ret
-			} // end of method FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean::CallCore
-
-		} // end of class FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::dynamicAdd(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd::CallCore
-
-		} // end of class FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::bigint(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint::CallCore
-
-		} // end of class FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::destructure(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure::CallCore
-
-		} // end of class FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::iterate(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate::CallCore
-
-		} // end of class FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::iterateVar(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar::CallCore
-
-		} // end of class FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver/FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver/FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::iterateVarIn(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn::CallCore
-
-		} // end of class FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::redeclare(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare::CallCore
-
-		} // end of class FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver/FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver/FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::functionRedeclare(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare::CallCore
-
-		} // end of class FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-				IL_001d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::run()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run::CallCore
-
-		} // end of class FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run
+		} // end of class FunctionObject
 
 
 		// Fields

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerCallResults.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerCallResults.verified.txt
@@ -2920,6 +2920,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Function_SchedulerCallResults/Counter/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -2939,6 +2989,74 @@
 		.class nested public auto ansi beforefieldinit Scope_add
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance class Modules.Function_SchedulerCallResults/Counter Modules.Function_SchedulerCallResults/Counter::'add'(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -2958,6 +3076,71 @@
 		.class nested public auto ansi beforefieldinit Scope_getValue
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
+					IL_001d: call instance object Modules.Function_SchedulerCallResults/Counter::getValue()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -2977,6 +3160,71 @@
 		.class nested public auto ansi beforefieldinit Scope_chain
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
+					IL_001d: call instance object Modules.Function_SchedulerCallResults/Counter::chain()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -2996,6 +3244,71 @@
 		.class nested public auto ansi beforefieldinit Scope_addOnce
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
+					IL_001d: call instance object Modules.Function_SchedulerCallResults/Counter::addOnce()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -3015,6 +3328,71 @@
 		.class nested public auto ansi beforefieldinit Scope_next
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
+					IL_001d: call instance object Modules.Function_SchedulerCallResults/Counter::next()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -3034,6 +3412,72 @@
 		.class nested public auto ansi beforefieldinit Scope_maxNext
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
+					IL_001d: call instance float64 Modules.Function_SchedulerCallResults/Counter::maxNext()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -3053,6 +3497,108 @@
 		.class nested public auto ansi beforefieldinit Scope_sum
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 12
+					// Code size: 148 (0x94)
+					.maxstack 12
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0029: ldarg.2
+					IL_002a: ldc.i4.1
+					IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0035: ldarg.2
+					IL_0036: ldc.i4.2
+					IL_0037: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0041: ldarg.2
+					IL_0042: ldc.i4.3
+					IL_0043: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0048: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_004d: ldarg.2
+					IL_004e: ldc.i4.4
+					IL_004f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0054: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0059: ldarg.2
+					IL_005a: ldc.i4.5
+					IL_005b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0065: ldarg.2
+					IL_0066: ldc.i4.6
+					IL_0067: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_006c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0071: ldarg.2
+					IL_0072: ldc.i4.7
+					IL_0073: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0078: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_007d: ldarg.2
+					IL_007e: ldc.i4.8
+					IL_007f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0084: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0089: call instance float64 Modules.Function_SchedulerCallResults/Counter::sum(float64, float64, float64, float64, float64, float64, float64, float64, float64)
+					IL_008e: box [System.Runtime]System.Double
+					IL_0093: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -3072,6 +3618,72 @@
 		.class nested public auto ansi beforefieldinit Scope_maxSum
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
+					IL_001d: call instance float64 Modules.Function_SchedulerCallResults/Counter::maxSum()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -3091,6 +3703,72 @@
 		.class nested public auto ansi beforefieldinit Scope_maxSumWithFloor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
+					IL_001d: call instance float64 Modules.Function_SchedulerCallResults/Counter::maxSumWithFloor()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -3106,664 +3784,6 @@
 			} // end of method Scope_maxSumWithFloor::.ctor
 
 		} // end of class Scope_maxSumWithFloor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_AD25A3C2_Counter
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassConstructor_AD25A3C2_Counter::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_AD25A3C2_Counter::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_AD25A3C2_Counter::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_AD25A3C2_Counter::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_AD25A3C2_Counter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_3AF3677E_Counter_add
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_3AF3677E_Counter_add::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_3AF3677E_Counter_add::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_3AF3677E_Counter_add::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance class Modules.Function_SchedulerCallResults/Counter Modules.Function_SchedulerCallResults/Counter::'add'(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_3AF3677E_Counter_add::CallCore
-
-		} // end of class FunctionObject_ClassMethod_3AF3677E_Counter_add
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_1144290A_Counter_getValue
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_1144290A_Counter_getValue::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_1144290A_Counter_getValue::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_1144290A_Counter_getValue::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
-				IL_001d: call instance object Modules.Function_SchedulerCallResults/Counter::getValue()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_1144290A_Counter_getValue::CallCore
-
-		} // end of class FunctionObject_ClassMethod_1144290A_Counter_getValue
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_CA685DB0_Counter_chain
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_CA685DB0_Counter_chain::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_CA685DB0_Counter_chain::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_CA685DB0_Counter_chain::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
-				IL_001d: call instance object Modules.Function_SchedulerCallResults/Counter::chain()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_CA685DB0_Counter_chain::CallCore
-
-		} // end of class FunctionObject_ClassMethod_CA685DB0_Counter_chain
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
-				IL_001d: call instance object Modules.Function_SchedulerCallResults/Counter::addOnce()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::CallCore
-
-		} // end of class FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_7D3B0342_Counter_next
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_7D3B0342_Counter_next::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_7D3B0342_Counter_next::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_7D3B0342_Counter_next::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
-				IL_001d: call instance object Modules.Function_SchedulerCallResults/Counter::next()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_7D3B0342_Counter_next::CallCore
-
-		} // end of class FunctionObject_ClassMethod_7D3B0342_Counter_next
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_F11C223A_Counter_maxNext
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_F11C223A_Counter_maxNext::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_F11C223A_Counter_maxNext::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_F11C223A_Counter_maxNext::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
-				IL_001d: call instance float64 Modules.Function_SchedulerCallResults/Counter::maxNext()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_F11C223A_Counter_maxNext::CallCore
-
-		} // end of class FunctionObject_ClassMethod_F11C223A_Counter_maxNext
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_2830FF5E_Counter_sum
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_2830FF5E_Counter_sum::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_2830FF5E_Counter_sum::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_2830FF5E_Counter_sum::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 12
-				// Code size: 148 (0x94)
-				.maxstack 12
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0029: ldarg.2
-				IL_002a: ldc.i4.1
-				IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0035: ldarg.2
-				IL_0036: ldc.i4.2
-				IL_0037: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0041: ldarg.2
-				IL_0042: ldc.i4.3
-				IL_0043: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0048: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_004d: ldarg.2
-				IL_004e: ldc.i4.4
-				IL_004f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0054: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0059: ldarg.2
-				IL_005a: ldc.i4.5
-				IL_005b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0065: ldarg.2
-				IL_0066: ldc.i4.6
-				IL_0067: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_006c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0071: ldarg.2
-				IL_0072: ldc.i4.7
-				IL_0073: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0078: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_007d: ldarg.2
-				IL_007e: ldc.i4.8
-				IL_007f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0084: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0089: call instance float64 Modules.Function_SchedulerCallResults/Counter::sum(float64, float64, float64, float64, float64, float64, float64, float64, float64)
-				IL_008e: box [System.Runtime]System.Double
-				IL_0093: ret
-			} // end of method FunctionObject_ClassMethod_2830FF5E_Counter_sum::CallCore
-
-		} // end of class FunctionObject_ClassMethod_2830FF5E_Counter_sum
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_A75B52F6_Counter_maxSum
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
-				IL_001d: call instance float64 Modules.Function_SchedulerCallResults/Counter::maxSum()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::CallCore
-
-		} // end of class FunctionObject_ClassMethod_A75B52F6_Counter_maxSum
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_SchedulerCallResults/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_SchedulerCallResults/Counter
-				IL_001d: call instance float64 Modules.Function_SchedulerCallResults/Counter::maxSumWithFloor()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::CallCore
-
-		} // end of class FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor
 
 
 		// Fields
@@ -4180,7 +4200,7 @@
 			[16] class Modules.Function_SchedulerCallResults/h/FunctionObject,
 			[17] class [System.Runtime]System.Type,
 			[18] object,
-			[19] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassConstructor_AD25A3C2_Counter,
+			[19] class Modules.Function_SchedulerCallResults/Counter/Scope_ctor/FunctionObject,
 			[20] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[21] float64,
 			[22] object
@@ -4486,126 +4506,126 @@
 		IL_029b: stloc.s 14
 		IL_029d: ldloc.s 18
 		IL_029f: ldstr "add"
-		IL_02a4: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add::.ctor()
+		IL_02a4: newobj instance void Modules.Function_SchedulerCallResults/Counter/Scope_add/FunctionObject::.ctor()
 		IL_02a9: ldc.i4.1
 		IL_02aa: conv.r8
 		IL_02ab: ldstr "add"
 		IL_02b0: ldc.i4.1
 		IL_02b1: ldc.i4.1
-		IL_02b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add>(!!0, float64, string, bool, bool)
-		IL_02b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_3AF3677E_Counter_add>(!!0)
+		IL_02b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/Scope_add/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/Scope_add/FunctionObject>(!!0)
 		IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_02c1: pop
 		IL_02c2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_02c7: stloc.s 14
 		IL_02c9: ldloc.s 18
 		IL_02cb: ldstr "getValue"
-		IL_02d0: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue::.ctor()
+		IL_02d0: newobj instance void Modules.Function_SchedulerCallResults/Counter/Scope_getValue/FunctionObject::.ctor()
 		IL_02d5: ldc.i4.0
 		IL_02d6: conv.r8
 		IL_02d7: ldstr "getValue"
 		IL_02dc: ldc.i4.1
 		IL_02dd: ldc.i4.1
-		IL_02de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue>(!!0, float64, string, bool, bool)
-		IL_02e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_1144290A_Counter_getValue>(!!0)
+		IL_02de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/Scope_getValue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/Scope_getValue/FunctionObject>(!!0)
 		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_02ed: pop
 		IL_02ee: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_02f3: stloc.s 14
 		IL_02f5: ldloc.s 18
 		IL_02f7: ldstr "chain"
-		IL_02fc: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain::.ctor()
+		IL_02fc: newobj instance void Modules.Function_SchedulerCallResults/Counter/Scope_chain/FunctionObject::.ctor()
 		IL_0301: ldc.i4.0
 		IL_0302: conv.r8
 		IL_0303: ldstr "chain"
 		IL_0308: ldc.i4.1
 		IL_0309: ldc.i4.1
-		IL_030a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain>(!!0, float64, string, bool, bool)
-		IL_030f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_CA685DB0_Counter_chain>(!!0)
+		IL_030a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/Scope_chain/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_030f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/Scope_chain/FunctionObject>(!!0)
 		IL_0314: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0319: pop
 		IL_031a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_031f: stloc.s 14
 		IL_0321: ldloc.s 18
 		IL_0323: ldstr "addOnce"
-		IL_0328: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::.ctor()
+		IL_0328: newobj instance void Modules.Function_SchedulerCallResults/Counter/Scope_addOnce/FunctionObject::.ctor()
 		IL_032d: ldc.i4.0
 		IL_032e: conv.r8
 		IL_032f: ldstr "addOnce"
 		IL_0334: ldc.i4.1
 		IL_0335: ldc.i4.1
-		IL_0336: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce>(!!0, float64, string, bool, bool)
-		IL_033b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce>(!!0)
+		IL_0336: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/Scope_addOnce/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_033b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/Scope_addOnce/FunctionObject>(!!0)
 		IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0345: pop
 		IL_0346: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_034b: stloc.s 14
 		IL_034d: ldloc.s 18
 		IL_034f: ldstr "next"
-		IL_0354: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next::.ctor()
+		IL_0354: newobj instance void Modules.Function_SchedulerCallResults/Counter/Scope_next/FunctionObject::.ctor()
 		IL_0359: ldc.i4.0
 		IL_035a: conv.r8
 		IL_035b: ldstr "next"
 		IL_0360: ldc.i4.1
 		IL_0361: ldc.i4.1
-		IL_0362: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next>(!!0, float64, string, bool, bool)
-		IL_0367: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_7D3B0342_Counter_next>(!!0)
+		IL_0362: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/Scope_next/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0367: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/Scope_next/FunctionObject>(!!0)
 		IL_036c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0371: pop
 		IL_0372: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0377: stloc.s 14
 		IL_0379: ldloc.s 18
 		IL_037b: ldstr "maxNext"
-		IL_0380: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext::.ctor()
+		IL_0380: newobj instance void Modules.Function_SchedulerCallResults/Counter/Scope_maxNext/FunctionObject::.ctor()
 		IL_0385: ldc.i4.0
 		IL_0386: conv.r8
 		IL_0387: ldstr "maxNext"
 		IL_038c: ldc.i4.1
 		IL_038d: ldc.i4.1
-		IL_038e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext>(!!0, float64, string, bool, bool)
-		IL_0393: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_F11C223A_Counter_maxNext>(!!0)
+		IL_038e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/Scope_maxNext/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0393: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/Scope_maxNext/FunctionObject>(!!0)
 		IL_0398: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_039d: pop
 		IL_039e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_03a3: stloc.s 14
 		IL_03a5: ldloc.s 18
 		IL_03a7: ldstr "sum"
-		IL_03ac: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum::.ctor()
+		IL_03ac: newobj instance void Modules.Function_SchedulerCallResults/Counter/Scope_sum/FunctionObject::.ctor()
 		IL_03b1: ldc.i4.s 9
 		IL_03b3: conv.r8
 		IL_03b4: ldstr "sum"
 		IL_03b9: ldc.i4.0
 		IL_03ba: ldc.i4.1
-		IL_03bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum>(!!0, float64, string, bool, bool)
-		IL_03c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_2830FF5E_Counter_sum>(!!0)
+		IL_03bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/Scope_sum/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/Scope_sum/FunctionObject>(!!0)
 		IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_03ca: pop
 		IL_03cb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_03d0: stloc.s 14
 		IL_03d2: ldloc.s 18
 		IL_03d4: ldstr "maxSum"
-		IL_03d9: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::.ctor()
+		IL_03d9: newobj instance void Modules.Function_SchedulerCallResults/Counter/Scope_maxSum/FunctionObject::.ctor()
 		IL_03de: ldc.i4.0
 		IL_03df: conv.r8
 		IL_03e0: ldstr "maxSum"
 		IL_03e5: ldc.i4.1
 		IL_03e6: ldc.i4.1
-		IL_03e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum>(!!0, float64, string, bool, bool)
-		IL_03ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_A75B52F6_Counter_maxSum>(!!0)
+		IL_03e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/Scope_maxSum/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/Scope_maxSum/FunctionObject>(!!0)
 		IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_03f6: pop
 		IL_03f7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_03fc: stloc.s 14
 		IL_03fe: ldloc.s 18
 		IL_0400: ldstr "maxSumWithFloor"
-		IL_0405: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::.ctor()
+		IL_0405: newobj instance void Modules.Function_SchedulerCallResults/Counter/Scope_maxSumWithFloor/FunctionObject::.ctor()
 		IL_040a: ldc.i4.0
 		IL_040b: conv.r8
 		IL_040c: ldstr "maxSumWithFloor"
 		IL_0411: ldc.i4.1
 		IL_0412: ldc.i4.1
-		IL_0413: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor>(!!0, float64, string, bool, bool)
-		IL_0418: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor>(!!0)
+		IL_0413: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/Counter/Scope_maxSumWithFloor/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0418: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerCallResults/Counter/Scope_maxSumWithFloor/FunctionObject>(!!0)
 		IL_041d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0422: pop
 		IL_0423: ldc.i4.1
@@ -4616,14 +4636,14 @@
 		IL_042c: stelem.ref
 		IL_042d: stloc.s 14
 		IL_042f: ldloc.s 14
-		IL_0431: newobj instance void Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassConstructor_AD25A3C2_Counter::.ctor(object[])
+		IL_0431: newobj instance void Modules.Function_SchedulerCallResults/Counter/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_0436: ldloc.s 17
 		IL_0438: ldloc.s 14
 		IL_043a: ldc.i4.1
 		IL_043b: conv.r8
 		IL_043c: ldc.i4.0
 		IL_043d: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0442: castclass Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassConstructor_AD25A3C2_Counter
+		IL_0442: castclass Modules.Function_SchedulerCallResults/Counter/Scope_ctor/FunctionObject
 		IL_0447: stloc.s 19
 		IL_0449: ldloc.0
 		IL_044a: ldloc.s 19

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_StableConstCallable_Direct.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_StableConstCallable_Direct.verified.txt
@@ -1611,6 +1611,71 @@
 			.class nested public auto ansi beforefieldinit Scope_read
 				extends [System.Runtime]System.Object
 			{
+				// Nested Types
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ret
+					} // end of method FunctionObject::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Header size: 1
+						// Code size: 35 (0x23)
+						.maxstack 8
+
+						IL_0000: ldarg.1
+						IL_0001: ldtoken Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis
+						IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+						IL_000b: ldc.i4.1
+						IL_000c: newarr [System.Runtime]System.Object
+						IL_0011: ldnull
+						IL_0012: ldarg.0
+						IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+						IL_0018: castclass Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis
+						IL_001d: call instance object Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis::read()
+						IL_0022: ret
+					} // end of method FunctionObject::CallCore
+
+				} // end of class FunctionObject
+
+
 				// Methods
 				.method public hidebysig specialname rtspecialname 
 					instance void .ctor () cil managed 
@@ -1627,7 +1692,7 @@
 
 			} // end of class Scope_read
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_895C327D_ReadsOwnThis
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 			{
 				// Fields
@@ -1647,9 +1712,9 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis/FunctionObject_ClassConstructor_895C327D_ReadsOwnThis::_transitionalScopes
+					IL_0008: stfld object[] Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis/FunctionObject::_transitionalScopes
 					IL_000d: ret
-				} // end of method FunctionObject_ClassConstructor_895C327D_ReadsOwnThis::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1660,7 +1725,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_895C327D_ReadsOwnThis::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1671,72 +1736,9 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_ClassConstructor_895C327D_ReadsOwnThis::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
-			} // end of class FunctionObject_ClassConstructor_895C327D_ReadsOwnThis
-
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C05F8838_ReadsOwnThis_read
-				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-			{
-				// Methods
-				.method public hidebysig specialname rtspecialname 
-					instance void .ctor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 7 (0x7)
-					.maxstack 8
-
-					IL_0000: ldarg.0
-					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-					IL_0006: ret
-				} // end of method FunctionObject_ClassMethod_C05F8838_ReadsOwnThis_read::.ctor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_IsConstructor () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.0
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_C05F8838_ReadsOwnThis_read::get_IsConstructor
-
-				.method public hidebysig specialname virtual 
-					instance bool get_RequiresInvocationContext () cil managed 
-				{
-					// Header size: 1
-					// Code size: 2 (0x2)
-					.maxstack 8
-
-					IL_0000: ldc.i4.1
-					IL_0001: ret
-				} // end of method FunctionObject_ClassMethod_C05F8838_ReadsOwnThis_read::get_RequiresInvocationContext
-
-				.method family hidebysig virtual 
-					instance object CallCore (
-						object thisArgument,
-						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-					) cil managed 
-				{
-					// Header size: 1
-					// Code size: 35 (0x23)
-					.maxstack 8
-
-					IL_0000: ldarg.1
-					IL_0001: ldtoken Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis
-					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-					IL_000b: ldc.i4.1
-					IL_000c: newarr [System.Runtime]System.Object
-					IL_0011: ldnull
-					IL_0012: ldarg.0
-					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-					IL_0018: castclass Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis
-					IL_001d: call instance object Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis::read()
-					IL_0022: ret
-				} // end of method FunctionObject_ClassMethod_C05F8838_ReadsOwnThis_read::CallCore
-
-			} // end of class FunctionObject_ClassMethod_C05F8838_ReadsOwnThis_read
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1919,7 +1921,7 @@
 				[2] class [System.Runtime]System.Type,
 				[3] object,
 				[4] object[],
-				[5] class Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis/FunctionObject_ClassConstructor_895C327D_ReadsOwnThis,
+				[5] class Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis/FunctionObject,
 				[6] string
 			)
 
@@ -1938,27 +1940,27 @@
 			IL_002c: stloc.s 4
 			IL_002e: ldloc.3
 			IL_002f: ldstr "read"
-			IL_0034: newobj instance void Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis/FunctionObject_ClassMethod_C05F8838_ReadsOwnThis_read::.ctor()
+			IL_0034: newobj instance void Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis/Scope_read/FunctionObject::.ctor()
 			IL_0039: ldc.i4.0
 			IL_003a: conv.r8
 			IL_003b: ldstr "read"
 			IL_0040: ldc.i4.1
 			IL_0041: ldc.i4.1
-			IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis/FunctionObject_ClassMethod_C05F8838_ReadsOwnThis_read>(!!0, float64, string, bool, bool)
-			IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis/FunctionObject_ClassMethod_C05F8838_ReadsOwnThis_read>(!!0)
+			IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis/Scope_read/FunctionObject>(!!0)
 			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 			IL_0051: pop
 			IL_0052: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_0057: stloc.s 4
 			IL_0059: ldloc.s 4
-			IL_005b: newobj instance void Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis/FunctionObject_ClassConstructor_895C327D_ReadsOwnThis::.ctor(object[])
+			IL_005b: newobj instance void Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis/FunctionObject::.ctor(object[])
 			IL_0060: ldloc.2
 			IL_0061: ldloc.s 4
 			IL_0063: ldc.i4.0
 			IL_0064: conv.r8
 			IL_0065: ldc.i4.0
 			IL_0066: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-			IL_006b: castclass Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis/FunctionObject_ClassConstructor_895C327D_ReadsOwnThis
+			IL_006b: castclass Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass/ReadsOwnThis/FunctionObject
 			IL_0070: stloc.s 5
 			IL_0072: ldloc.s 5
 			IL_0074: stloc.1

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_StableConstCallable_Fallbacks.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_StableConstCallable_Fallbacks.verified.txt
@@ -3165,25 +3165,6 @@
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested public auto ansi beforefieldinit Scope
-			extends [System.Runtime]System.Object
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 8 (0x8)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
-				IL_0006: nop
-				IL_0007: ret
-			} // end of method Scope::.ctor
-
-		} // end of class Scope
-
 		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
@@ -3349,6 +3330,72 @@
 		.class nested public auto ansi beforefieldinit Scope_read
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_StableConstCallable_Fallbacks/StableConstBase
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_StableConstCallable_Fallbacks/StableConstBase
+					IL_001d: call instance float64 Modules.Function_StableConstCallable_Fallbacks/StableConstBase::read()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -3365,7 +3412,7 @@
 
 		} // end of class Scope_read
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_FF86048C_StableConstBase
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -3385,9 +3432,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Function_StableConstCallable_Fallbacks/StableConstBase/FunctionObject_ClassConstructor_FF86048C_StableConstBase::_transitionalScopes
+				IL_0008: stfld object[] Modules.Function_StableConstCallable_Fallbacks/StableConstBase/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_FF86048C_StableConstBase::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3398,7 +3445,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_FF86048C_StableConstBase::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3409,73 +3456,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_FF86048C_StableConstBase::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_FF86048C_StableConstBase
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_D5ADD173_StableConstBase_read
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_D5ADD173_StableConstBase_read::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_D5ADD173_StableConstBase_read::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_D5ADD173_StableConstBase_read::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_StableConstCallable_Fallbacks/StableConstBase
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_StableConstCallable_Fallbacks/StableConstBase
-				IL_001d: call instance float64 Modules.Function_StableConstCallable_Fallbacks/StableConstBase::read()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_D5ADD173_StableConstBase_read::CallCore
-
-		} // end of class FunctionObject_ClassMethod_D5ADD173_StableConstBase_read
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3536,6 +3519,98 @@
 		.class nested public auto ansi beforefieldinit Scope_read
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/Scope_read/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Function_StableConstCallable_Fallbacks/StableConstDerived
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/Scope_read/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Function_StableConstCallable_Fallbacks/StableConstDerived
+					IL_001d: call instance object Modules.Function_StableConstCallable_Fallbacks/StableConstDerived::read()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -3552,7 +3627,7 @@
 
 		} // end of class Scope_read
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_6FDF1CC2_StableConstDerived
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -3572,9 +3647,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/FunctionObject_ClassConstructor_6FDF1CC2_StableConstDerived::_transitionalScopes
+				IL_0008: stfld object[] Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_6FDF1CC2_StableConstDerived::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3585,7 +3660,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_6FDF1CC2_StableConstDerived::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3596,80 +3671,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_6FDF1CC2_StableConstDerived::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_6FDF1CC2_StableConstDerived
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_7C6EEB13_StableConstDerived_read
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/FunctionObject_ClassMethod_7C6EEB13_StableConstDerived_read::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_7C6EEB13_StableConstDerived_read::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_7C6EEB13_StableConstDerived_read::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_7C6EEB13_StableConstDerived_read::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Function_StableConstCallable_Fallbacks/StableConstDerived
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/FunctionObject_ClassMethod_7C6EEB13_StableConstDerived_read::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Function_StableConstCallable_Fallbacks/StableConstDerived
-				IL_001d: call instance object Modules.Function_StableConstCallable_Fallbacks/StableConstDerived::read()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_7C6EEB13_StableConstDerived_read::CallCore
-
-		} // end of class FunctionObject_ClassMethod_7C6EEB13_StableConstDerived_read
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -3835,8 +3839,8 @@
 			[24] class Modules.Function_StableConstCallable_Fallbacks/ownIdentity/FunctionObject,
 			[25] class [System.Runtime]System.Type,
 			[26] object,
-			[27] class Modules.Function_StableConstCallable_Fallbacks/StableConstBase/FunctionObject_ClassConstructor_FF86048C_StableConstBase,
-			[28] class Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/FunctionObject_ClassConstructor_6FDF1CC2_StableConstDerived,
+			[27] class Modules.Function_StableConstCallable_Fallbacks/StableConstBase/FunctionObject,
+			[28] class Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/FunctionObject,
 			[29] object,
 			[30] object,
 			[31] object,
@@ -4148,14 +4152,14 @@
 		IL_031e: stloc.s 13
 		IL_0320: ldloc.s 26
 		IL_0322: ldstr "read"
-		IL_0327: newobj instance void Modules.Function_StableConstCallable_Fallbacks/StableConstBase/FunctionObject_ClassMethod_D5ADD173_StableConstBase_read::.ctor()
+		IL_0327: newobj instance void Modules.Function_StableConstCallable_Fallbacks/StableConstBase/Scope_read/FunctionObject::.ctor()
 		IL_032c: ldc.i4.0
 		IL_032d: conv.r8
 		IL_032e: ldstr "read"
 		IL_0333: ldc.i4.0
 		IL_0334: ldc.i4.1
-		IL_0335: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/StableConstBase/FunctionObject_ClassMethod_D5ADD173_StableConstBase_read>(!!0, float64, string, bool, bool)
-		IL_033a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_StableConstCallable_Fallbacks/StableConstBase/FunctionObject_ClassMethod_D5ADD173_StableConstBase_read>(!!0)
+		IL_0335: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/StableConstBase/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_033a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_StableConstCallable_Fallbacks/StableConstBase/Scope_read/FunctionObject>(!!0)
 		IL_033f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0344: pop
 		IL_0345: ldc.i4.1
@@ -4166,14 +4170,14 @@
 		IL_034e: stelem.ref
 		IL_034f: stloc.s 13
 		IL_0351: ldloc.s 13
-		IL_0353: newobj instance void Modules.Function_StableConstCallable_Fallbacks/StableConstBase/FunctionObject_ClassConstructor_FF86048C_StableConstBase::.ctor(object[])
+		IL_0353: newobj instance void Modules.Function_StableConstCallable_Fallbacks/StableConstBase/FunctionObject::.ctor(object[])
 		IL_0358: ldloc.s 25
 		IL_035a: ldloc.s 13
 		IL_035c: ldc.i4.0
 		IL_035d: conv.r8
 		IL_035e: ldc.i4.0
 		IL_035f: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0364: castclass Modules.Function_StableConstCallable_Fallbacks/StableConstBase/FunctionObject_ClassConstructor_FF86048C_StableConstBase
+		IL_0364: castclass Modules.Function_StableConstCallable_Fallbacks/StableConstBase/FunctionObject
 		IL_0369: stloc.s 27
 		IL_036b: ldloc.0
 		IL_036c: ldloc.s 27
@@ -4192,14 +4196,14 @@
 		IL_039e: ldloc.s 26
 		IL_03a0: ldstr "read"
 		IL_03a5: ldloc.s 13
-		IL_03a7: newobj instance void Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/FunctionObject_ClassMethod_7C6EEB13_StableConstDerived_read::.ctor(object[])
+		IL_03a7: newobj instance void Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/Scope_read/FunctionObject::.ctor(object[])
 		IL_03ac: ldc.i4.0
 		IL_03ad: conv.r8
 		IL_03ae: ldstr "read"
 		IL_03b3: ldc.i4.0
 		IL_03b4: ldc.i4.1
-		IL_03b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/FunctionObject_ClassMethod_7C6EEB13_StableConstDerived_read>(!!0, float64, string, bool, bool)
-		IL_03ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/FunctionObject_ClassMethod_7C6EEB13_StableConstDerived_read>(!!0)
+		IL_03b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/Scope_read/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/Scope_read/FunctionObject>(!!0)
 		IL_03bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_03c4: pop
 		IL_03c5: ldc.i4.1
@@ -4210,14 +4214,14 @@
 		IL_03ce: stelem.ref
 		IL_03cf: stloc.s 13
 		IL_03d1: ldloc.s 13
-		IL_03d3: newobj instance void Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/FunctionObject_ClassConstructor_6FDF1CC2_StableConstDerived::.ctor(object[])
+		IL_03d3: newobj instance void Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/FunctionObject::.ctor(object[])
 		IL_03d8: ldloc.s 25
 		IL_03da: ldloc.s 13
 		IL_03dc: ldc.i4.0
 		IL_03dd: conv.r8
 		IL_03de: ldc.i4.0
 		IL_03df: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_03e4: castclass Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/FunctionObject_ClassConstructor_6FDF1CC2_StableConstDerived
+		IL_03e4: castclass Modules.Function_StableConstCallable_Fallbacks/StableConstDerived/FunctionObject
 		IL_03e9: stloc.s 28
 		IL_03eb: ldloc.s 28
 		IL_03ed: ldloc.s 27

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_SimpleYield.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_SimpleYield.verified.txt
@@ -33,6 +33,84 @@
 		.class nested public auto ansi beforefieldinit Scope_values
 			extends [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Generator_ClassMethod_SimpleYield/Gen/Scope_values/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 48 (0x30)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Generator_ClassMethod_SimpleYield/Gen
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Generator_ClassMethod_SimpleYield/Gen/Scope_values/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Generator_ClassMethod_SimpleYield/Gen
+					IL_001d: ldarg.0
+					IL_001e: ldfld object[] Modules.Generator_ClassMethod_SimpleYield/Gen/Scope_values/FunctionObject::_transitionalScopes
+					IL_0023: ldnull
+					IL_0024: call instance object Modules.Generator_ClassMethod_SimpleYield/Gen::values(object[], object)
+					IL_0029: ldarg.0
+					IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
+					IL_002f: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +127,7 @@
 
 		} // end of class Scope_values
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_55505B9D_Gen
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -69,9 +147,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_ClassMethod_SimpleYield/Gen/FunctionObject_ClassConstructor_55505B9D_Gen::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_ClassMethod_SimpleYield/Gen/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_55505B9D_Gen::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -82,7 +160,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_55505B9D_Gen::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -93,85 +171,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_55505B9D_Gen::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_55505B9D_Gen
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_8A90F746_Gen_values
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_ClassMethod_SimpleYield/Gen/FunctionObject_ClassMethod_8A90F746_Gen_values::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_8A90F746_Gen_values::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_8A90F746_Gen_values::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_8A90F746_Gen_values::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 48 (0x30)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Generator_ClassMethod_SimpleYield/Gen
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Generator_ClassMethod_SimpleYield/Gen/FunctionObject_ClassMethod_8A90F746_Gen_values::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Generator_ClassMethod_SimpleYield/Gen
-				IL_001d: ldarg.0
-				IL_001e: ldfld object[] Modules.Generator_ClassMethod_SimpleYield/Gen/FunctionObject_ClassMethod_8A90F746_Gen_values::_transitionalScopes
-				IL_0023: ldnull
-				IL_0024: call instance object Modules.Generator_ClassMethod_SimpleYield/Gen::values(object[], object)
-				IL_0029: ldarg.0
-				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
-				IL_002f: ret
-			} // end of method FunctionObject_ClassMethod_8A90F746_Gen_values::CallCore
-
-		} // end of class FunctionObject_ClassMethod_8A90F746_Gen_values
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -226,7 +228,7 @@
 			IL_001f: ldftn instance object Modules.Generator_ClassMethod_SimpleYield/Gen::values(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.1
-			IL_002b: ldtoken Modules.Generator_ClassMethod_SimpleYield/Gen/FunctionObject_ClassMethod_8A90F746_Gen_values
+			IL_002b: ldtoken Modules.Generator_ClassMethod_SimpleYield/Gen/Scope_values/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -437,7 +439,7 @@
 			[5] class [System.Runtime]System.Type,
 			[6] object,
 			[7] object[],
-			[8] class Modules.Generator_ClassMethod_SimpleYield/Gen/FunctionObject_ClassConstructor_55505B9D_Gen,
+			[8] class Modules.Generator_ClassMethod_SimpleYield/Gen/FunctionObject,
 			[9] class Modules.Generator_ClassMethod_SimpleYield/Gen,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[11] object
@@ -460,15 +462,15 @@
 		IL_0032: ldloc.s 6
 		IL_0034: ldstr "values"
 		IL_0039: ldloc.s 7
-		IL_003b: newobj instance void Modules.Generator_ClassMethod_SimpleYield/Gen/FunctionObject_ClassMethod_8A90F746_Gen_values::.ctor(object[])
+		IL_003b: newobj instance void Modules.Generator_ClassMethod_SimpleYield/Gen/Scope_values/FunctionObject::.ctor(object[])
 		IL_0040: ldc.i4.0
 		IL_0041: conv.r8
 		IL_0042: ldstr "values"
 		IL_0047: ldc.i4.1
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_ClassMethod_SimpleYield/Gen/FunctionObject_ClassMethod_8A90F746_Gen_values>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_ClassMethod_SimpleYield/Gen/Scope_values/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_0053: castclass Modules.Generator_ClassMethod_SimpleYield/Gen/FunctionObject_ClassMethod_8A90F746_Gen_values
+		IL_0053: castclass Modules.Generator_ClassMethod_SimpleYield/Gen/Scope_values/FunctionObject
 		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_005d: pop
 		IL_005e: ldc.i4.1
@@ -479,14 +481,14 @@
 		IL_0067: stelem.ref
 		IL_0068: stloc.s 7
 		IL_006a: ldloc.s 7
-		IL_006c: newobj instance void Modules.Generator_ClassMethod_SimpleYield/Gen/FunctionObject_ClassConstructor_55505B9D_Gen::.ctor(object[])
+		IL_006c: newobj instance void Modules.Generator_ClassMethod_SimpleYield/Gen/FunctionObject::.ctor(object[])
 		IL_0071: ldloc.s 5
 		IL_0073: ldloc.s 7
 		IL_0075: ldc.i4.0
 		IL_0076: conv.r8
 		IL_0077: ldc.i4.0
 		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_007d: castclass Modules.Generator_ClassMethod_SimpleYield/Gen/FunctionObject_ClassConstructor_55505B9D_Gen
+		IL_007d: castclass Modules.Generator_ClassMethod_SimpleYield/Gen/FunctionObject
 		IL_0082: stloc.s 8
 		IL_0084: ldloc.s 8
 		IL_0086: stloc.1

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_WithThis.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_WithThis.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Generator_ClassMethod_WithThis/Counter/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +102,84 @@
 		.class nested public auto ansi beforefieldinit Scope_getCountLater
 			extends [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Generator_ClassMethod_WithThis/Counter/Scope_getCountLater/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 48 (0x30)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Generator_ClassMethod_WithThis/Counter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Generator_ClassMethod_WithThis/Counter/Scope_getCountLater/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Generator_ClassMethod_WithThis/Counter
+					IL_001d: ldarg.0
+					IL_001e: ldfld object[] Modules.Generator_ClassMethod_WithThis/Counter/Scope_getCountLater/FunctionObject::_transitionalScopes
+					IL_0023: ldnull
+					IL_0024: call instance object Modules.Generator_ClassMethod_WithThis/Counter::getCountLater(object[], object)
+					IL_0029: ldarg.0
+					IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
+					IL_002f: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -67,130 +195,6 @@
 			} // end of method Scope_getCountLater::.ctor
 
 		} // end of class Scope_getCountLater
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_3DEBA3B4_Counter
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_ClassMethod_WithThis/Counter/FunctionObject_ClassConstructor_3DEBA3B4_Counter::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_3DEBA3B4_Counter::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_3DEBA3B4_Counter::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_3DEBA3B4_Counter::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_3DEBA3B4_Counter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_ClassMethod_WithThis/Counter/FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 48 (0x30)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Generator_ClassMethod_WithThis/Counter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Generator_ClassMethod_WithThis/Counter/FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Generator_ClassMethod_WithThis/Counter
-				IL_001d: ldarg.0
-				IL_001e: ldfld object[] Modules.Generator_ClassMethod_WithThis/Counter/FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater::_transitionalScopes
-				IL_0023: ldnull
-				IL_0024: call instance object Modules.Generator_ClassMethod_WithThis/Counter::getCountLater(object[], object)
-				IL_0029: ldarg.0
-				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
-				IL_002f: ret
-			} // end of method FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater::CallCore
-
-		} // end of class FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater
 
 
 		// Fields
@@ -251,7 +255,7 @@
 			IL_001f: ldftn instance object Modules.Generator_ClassMethod_WithThis/Counter::getCountLater(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.1
-			IL_002b: ldtoken Modules.Generator_ClassMethod_WithThis/Counter/FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater
+			IL_002b: ldtoken Modules.Generator_ClassMethod_WithThis/Counter/Scope_getCountLater/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -416,7 +420,7 @@
 			[5] class [System.Runtime]System.Type,
 			[6] object,
 			[7] object[],
-			[8] class Modules.Generator_ClassMethod_WithThis/Counter/FunctionObject_ClassConstructor_3DEBA3B4_Counter,
+			[8] class Modules.Generator_ClassMethod_WithThis/Counter/Scope_ctor/FunctionObject,
 			[9] class Modules.Generator_ClassMethod_WithThis/Counter,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[11] object
@@ -439,15 +443,15 @@
 		IL_0032: ldloc.s 6
 		IL_0034: ldstr "getCountLater"
 		IL_0039: ldloc.s 7
-		IL_003b: newobj instance void Modules.Generator_ClassMethod_WithThis/Counter/FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater::.ctor(object[])
+		IL_003b: newobj instance void Modules.Generator_ClassMethod_WithThis/Counter/Scope_getCountLater/FunctionObject::.ctor(object[])
 		IL_0040: ldc.i4.0
 		IL_0041: conv.r8
 		IL_0042: ldstr "getCountLater"
 		IL_0047: ldc.i4.1
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_ClassMethod_WithThis/Counter/FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_ClassMethod_WithThis/Counter/Scope_getCountLater/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_0053: castclass Modules.Generator_ClassMethod_WithThis/Counter/FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater
+		IL_0053: castclass Modules.Generator_ClassMethod_WithThis/Counter/Scope_getCountLater/FunctionObject
 		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_005d: pop
 		IL_005e: ldc.i4.1
@@ -458,14 +462,14 @@
 		IL_0067: stelem.ref
 		IL_0068: stloc.s 7
 		IL_006a: ldloc.s 7
-		IL_006c: newobj instance void Modules.Generator_ClassMethod_WithThis/Counter/FunctionObject_ClassConstructor_3DEBA3B4_Counter::.ctor(object[])
+		IL_006c: newobj instance void Modules.Generator_ClassMethod_WithThis/Counter/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_0071: ldloc.s 5
 		IL_0073: ldloc.s 7
 		IL_0075: ldc.i4.0
 		IL_0076: conv.r8
 		IL_0077: ldc.i4.0
 		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_007d: castclass Modules.Generator_ClassMethod_WithThis/Counter/FunctionObject_ClassConstructor_3DEBA3B4_Counter
+		IL_007d: castclass Modules.Generator_ClassMethod_WithThis/Counter/Scope_ctor/FunctionObject
 		IL_0082: stloc.s 8
 		IL_0084: ldloc.s 8
 		IL_0086: stloc.1

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_YieldAssign.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_YieldAssign.verified.txt
@@ -33,6 +33,84 @@
 		.class nested public auto ansi beforefieldinit Scope_values
 			extends [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Generator_ClassMethod_YieldAssign/Gen/Scope_values/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 48 (0x30)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Generator_ClassMethod_YieldAssign/Gen
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Generator_ClassMethod_YieldAssign/Gen/Scope_values/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Generator_ClassMethod_YieldAssign/Gen
+					IL_001d: ldarg.0
+					IL_001e: ldfld object[] Modules.Generator_ClassMethod_YieldAssign/Gen/Scope_values/FunctionObject::_transitionalScopes
+					IL_0023: ldnull
+					IL_0024: call instance object Modules.Generator_ClassMethod_YieldAssign/Gen::values(object[], object)
+					IL_0029: ldarg.0
+					IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
+					IL_002f: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +127,7 @@
 
 		} // end of class Scope_values
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_50C640BC_Gen
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -69,9 +147,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_ClassMethod_YieldAssign/Gen/FunctionObject_ClassConstructor_50C640BC_Gen::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_ClassMethod_YieldAssign/Gen/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_50C640BC_Gen::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -82,7 +160,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_50C640BC_Gen::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -93,85 +171,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_50C640BC_Gen::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_50C640BC_Gen
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_764EBF87_Gen_values
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_ClassMethod_YieldAssign/Gen/FunctionObject_ClassMethod_764EBF87_Gen_values::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_764EBF87_Gen_values::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_764EBF87_Gen_values::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_764EBF87_Gen_values::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 48 (0x30)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Generator_ClassMethod_YieldAssign/Gen
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Generator_ClassMethod_YieldAssign/Gen/FunctionObject_ClassMethod_764EBF87_Gen_values::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Generator_ClassMethod_YieldAssign/Gen
-				IL_001d: ldarg.0
-				IL_001e: ldfld object[] Modules.Generator_ClassMethod_YieldAssign/Gen/FunctionObject_ClassMethod_764EBF87_Gen_values::_transitionalScopes
-				IL_0023: ldnull
-				IL_0024: call instance object Modules.Generator_ClassMethod_YieldAssign/Gen::values(object[], object)
-				IL_0029: ldarg.0
-				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
-				IL_002f: ret
-			} // end of method FunctionObject_ClassMethod_764EBF87_Gen_values::CallCore
-
-		} // end of class FunctionObject_ClassMethod_764EBF87_Gen_values
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -227,7 +229,7 @@
 			IL_001f: ldftn instance object Modules.Generator_ClassMethod_YieldAssign/Gen::values(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.1
-			IL_002b: ldtoken Modules.Generator_ClassMethod_YieldAssign/Gen/FunctionObject_ClassMethod_764EBF87_Gen_values
+			IL_002b: ldtoken Modules.Generator_ClassMethod_YieldAssign/Gen/Scope_values/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -452,7 +454,7 @@
 			[5] class [System.Runtime]System.Type,
 			[6] object,
 			[7] object[],
-			[8] class Modules.Generator_ClassMethod_YieldAssign/Gen/FunctionObject_ClassConstructor_50C640BC_Gen,
+			[8] class Modules.Generator_ClassMethod_YieldAssign/Gen/FunctionObject,
 			[9] class Modules.Generator_ClassMethod_YieldAssign/Gen,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[11] object
@@ -475,15 +477,15 @@
 		IL_0032: ldloc.s 6
 		IL_0034: ldstr "values"
 		IL_0039: ldloc.s 7
-		IL_003b: newobj instance void Modules.Generator_ClassMethod_YieldAssign/Gen/FunctionObject_ClassMethod_764EBF87_Gen_values::.ctor(object[])
+		IL_003b: newobj instance void Modules.Generator_ClassMethod_YieldAssign/Gen/Scope_values/FunctionObject::.ctor(object[])
 		IL_0040: ldc.i4.0
 		IL_0041: conv.r8
 		IL_0042: ldstr "values"
 		IL_0047: ldc.i4.1
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_ClassMethod_YieldAssign/Gen/FunctionObject_ClassMethod_764EBF87_Gen_values>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_ClassMethod_YieldAssign/Gen/Scope_values/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_0053: castclass Modules.Generator_ClassMethod_YieldAssign/Gen/FunctionObject_ClassMethod_764EBF87_Gen_values
+		IL_0053: castclass Modules.Generator_ClassMethod_YieldAssign/Gen/Scope_values/FunctionObject
 		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_005d: pop
 		IL_005e: ldc.i4.1
@@ -494,14 +496,14 @@
 		IL_0067: stelem.ref
 		IL_0068: stloc.s 7
 		IL_006a: ldloc.s 7
-		IL_006c: newobj instance void Modules.Generator_ClassMethod_YieldAssign/Gen/FunctionObject_ClassConstructor_50C640BC_Gen::.ctor(object[])
+		IL_006c: newobj instance void Modules.Generator_ClassMethod_YieldAssign/Gen/FunctionObject::.ctor(object[])
 		IL_0071: ldloc.s 5
 		IL_0073: ldloc.s 7
 		IL_0075: ldc.i4.0
 		IL_0076: conv.r8
 		IL_0077: ldc.i4.0
 		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_007d: castclass Modules.Generator_ClassMethod_YieldAssign/Gen/FunctionObject_ClassConstructor_50C640BC_Gen
+		IL_007d: castclass Modules.Generator_ClassMethod_YieldAssign/Gen/FunctionObject
 		IL_0082: stloc.s 8
 		IL_0084: ldloc.s 8
 		IL_0086: stloc.1

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_GeneratedFunctionObject_Semantics.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_GeneratedFunctionObject_Semantics.verified.txt
@@ -2687,6 +2687,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -2706,6 +2756,87 @@
 		.class nested public auto ansi beforefieldinit Scope_run
 			extends [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_run/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 55 (0x37)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_run/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
+					IL_001d: ldarg.0
+					IL_001e: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_run/FunctionObject::_transitionalScopes
+					IL_0023: ldnull
+					IL_0024: ldarg.2
+					IL_0025: ldc.i4.0
+					IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_002b: call instance object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::run(object[], object, object)
+					IL_0030: ldarg.0
+					IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
+					IL_0036: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -2725,6 +2856,74 @@
 		.class nested public auto ansi beforefieldinit Scope_callRun
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::callRun(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -2744,6 +2943,78 @@
 		.class nested public auto ansi beforefieldinit Scope_twice
 			extends [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_twice/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 26 (0x1a)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_twice/FunctionObject::_transitionalScopes
+					IL_0006: ldnull
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::twice(object[], object, object)
+					IL_0013: ldarg.0
+					IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
+					IL_0019: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -2759,269 +3030,6 @@
 			} // end of method Scope_twice::.ctor
 
 		} // end of class Scope_twice
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_5AB5D10F_GeneratorClass
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassConstructor_5AB5D10F_GeneratorClass::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_5AB5D10F_GeneratorClass::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_5AB5D10F_GeneratorClass::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_5AB5D10F_GeneratorClass::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_5AB5D10F_GeneratorClass
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_2555843F_GeneratorClass_run
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassMethod_2555843F_GeneratorClass_run::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_2555843F_GeneratorClass_run::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_2555843F_GeneratorClass_run::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_2555843F_GeneratorClass_run::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 55 (0x37)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassMethod_2555843F_GeneratorClass_run::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
-				IL_001d: ldarg.0
-				IL_001e: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassMethod_2555843F_GeneratorClass_run::_transitionalScopes
-				IL_0023: ldnull
-				IL_0024: ldarg.2
-				IL_0025: ldc.i4.0
-				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_002b: call instance object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::run(object[], object, object)
-				IL_0030: ldarg.0
-				IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
-				IL_0036: ret
-			} // end of method FunctionObject_ClassMethod_2555843F_GeneratorClass_run::CallCore
-
-		} // end of class FunctionObject_ClassMethod_2555843F_GeneratorClass_run
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B1A67D8B_GeneratorClass_callRun
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_B1A67D8B_GeneratorClass_callRun::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B1A67D8B_GeneratorClass_callRun::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B1A67D8B_GeneratorClass_callRun::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::callRun(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_B1A67D8B_GeneratorClass_callRun::CallCore
-
-		} // end of class FunctionObject_ClassMethod_B1A67D8B_GeneratorClass_callRun
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 26 (0x1a)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice::_transitionalScopes
-				IL_0006: ldnull
-				IL_0007: ldarg.2
-				IL_0008: ldc.i4.0
-				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_000e: call object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::twice(object[], object, object)
-				IL_0013: ldarg.0
-				IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
-				IL_0019: ret
-			} // end of method FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice::CallCore
-
-		} // end of class FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice
 
 
 		// Fields
@@ -3086,7 +3094,7 @@
 			IL_001f: ldftn instance object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::run(object[], object, object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002a: ldarg.1
-			IL_002b: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassMethod_2555843F_GeneratorClass_run
+			IL_002b: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_run/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.1
 			IL_0036: newarr [System.Runtime]System.Object
@@ -3289,7 +3297,7 @@
 			IL_001f: ldftn object Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass::twice(object[], object, object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice
+			IL_002b: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_twice/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.1
 			IL_0036: newarr [System.Runtime]System.Object
@@ -3465,6 +3473,111 @@
 		.class nested public auto ansi beforefieldinit Scope_callSuper
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class [System.Runtime]System.Object Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/Scope_callSuper/FunctionObject::_homeObject
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/Scope_callSuper/FunctionObject::_lexicalSuperScopes
+					IL_0014: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/Scope_callSuper/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/Scope_callSuper/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass::callSuper(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -3481,7 +3594,7 @@
 
 		} // end of class Scope_callSuper
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_98E5520E_DerivedGeneratorClass
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -3501,9 +3614,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassConstructor_98E5520E_DerivedGeneratorClass::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_98E5520E_DerivedGeneratorClass::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3514,7 +3627,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_98E5520E_DerivedGeneratorClass::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3525,112 +3638,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_98E5520E_DerivedGeneratorClass::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_98E5520E_DerivedGeneratorClass
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class [System.Runtime]System.Object capture0,
-					object[] capture1
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 21 (0x15)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper::_homeObject
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper::_lexicalSuperScopes
-				IL_0014: ret
-			} // end of method FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper::GetLexicalSuperScopesCore
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass::callSuper(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper::CallCore
-
-		} // end of class FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -3895,8 +3905,8 @@
 			[41] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[42] class Modules.Generator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject,
 			[43] class [System.Runtime]System.Type,
-			[44] class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassConstructor_5AB5D10F_GeneratorClass,
-			[45] class Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassConstructor_98E5520E_DerivedGeneratorClass,
+			[44] class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_ctor/FunctionObject,
+			[45] class Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject,
 			[46] class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass
 		)
 
@@ -4475,29 +4485,29 @@
 		IL_065b: ldloc.s 34
 		IL_065d: ldstr "run"
 		IL_0662: ldloc.s 28
-		IL_0664: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassMethod_2555843F_GeneratorClass_run::.ctor(object[])
+		IL_0664: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_run/FunctionObject::.ctor(object[])
 		IL_0669: ldc.i4.1
 		IL_066a: conv.r8
 		IL_066b: ldstr "run"
 		IL_0670: ldc.i4.1
 		IL_0671: ldc.i4.1
-		IL_0672: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassMethod_2555843F_GeneratorClass_run>(!!0, float64, string, bool, bool)
+		IL_0672: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_run/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0677: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_067c: castclass Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassMethod_2555843F_GeneratorClass_run
+		IL_067c: castclass Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_run/FunctionObject
 		IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0686: pop
 		IL_0687: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_068c: stloc.s 28
 		IL_068e: ldloc.s 34
 		IL_0690: ldstr "callRun"
-		IL_0695: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassMethod_B1A67D8B_GeneratorClass_callRun::.ctor()
+		IL_0695: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_callRun/FunctionObject::.ctor()
 		IL_069a: ldc.i4.1
 		IL_069b: conv.r8
 		IL_069c: ldstr "callRun"
 		IL_06a1: ldc.i4.1
 		IL_06a2: ldc.i4.1
-		IL_06a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassMethod_B1A67D8B_GeneratorClass_callRun>(!!0, float64, string, bool, bool)
-		IL_06a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassMethod_B1A67D8B_GeneratorClass_callRun>(!!0)
+		IL_06a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_callRun/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_06a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_callRun/FunctionObject>(!!0)
 		IL_06ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_06b2: pop
 		IL_06b3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -4505,15 +4515,15 @@
 		IL_06ba: ldloc.s 43
 		IL_06bc: ldstr "twice"
 		IL_06c1: ldloc.s 28
-		IL_06c3: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice::.ctor(object[])
+		IL_06c3: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_twice/FunctionObject::.ctor(object[])
 		IL_06c8: ldc.i4.1
 		IL_06c9: conv.r8
 		IL_06ca: ldstr "twice"
 		IL_06cf: ldc.i4.1
 		IL_06d0: ldc.i4.1
-		IL_06d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice>(!!0, float64, string, bool, bool)
+		IL_06d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_twice/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_06d6: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_06db: castclass Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassStaticMethod_F339DE0C_GeneratorClass_twice
+		IL_06db: castclass Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_twice/FunctionObject
 		IL_06e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_06e5: pop
 		IL_06e6: ldc.i4.1
@@ -4524,14 +4534,14 @@
 		IL_06ef: stelem.ref
 		IL_06f0: stloc.s 28
 		IL_06f2: ldloc.s 28
-		IL_06f4: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassConstructor_5AB5D10F_GeneratorClass::.ctor(object[])
+		IL_06f4: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_06f9: ldloc.s 43
 		IL_06fb: ldloc.s 28
 		IL_06fd: ldc.i4.1
 		IL_06fe: conv.r8
 		IL_06ff: ldc.i4.0
 		IL_0700: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0705: castclass Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassConstructor_5AB5D10F_GeneratorClass
+		IL_0705: castclass Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/Scope_ctor/FunctionObject
 		IL_070a: stloc.s 44
 		IL_070c: ldloc.0
 		IL_070d: ldloc.s 44
@@ -4551,14 +4561,14 @@
 		IL_0741: ldstr "callSuper"
 		IL_0746: ldloc.s 34
 		IL_0748: ldloc.s 28
-		IL_074a: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper::.ctor(class [System.Runtime]System.Object, object[])
+		IL_074a: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/Scope_callSuper/FunctionObject::.ctor(class [System.Runtime]System.Object, object[])
 		IL_074f: ldc.i4.1
 		IL_0750: conv.r8
 		IL_0751: ldstr "callSuper"
 		IL_0756: ldc.i4.1
 		IL_0757: ldc.i4.1
-		IL_0758: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper>(!!0, float64, string, bool, bool)
-		IL_075d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassMethod_B0D1DEA2_DerivedGeneratorClass_callSuper>(!!0)
+		IL_0758: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/Scope_callSuper/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_075d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/Scope_callSuper/FunctionObject>(!!0)
 		IL_0762: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0767: pop
 		IL_0768: ldc.i4.1
@@ -4569,14 +4579,14 @@
 		IL_0771: stelem.ref
 		IL_0772: stloc.s 28
 		IL_0774: ldloc.s 28
-		IL_0776: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassConstructor_98E5520E_DerivedGeneratorClass::.ctor(object[])
+		IL_0776: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject::.ctor(object[])
 		IL_077b: ldloc.s 43
 		IL_077d: ldloc.s 28
 		IL_077f: ldc.i4.0
 		IL_0780: conv.r8
 		IL_0781: ldc.i4.0
 		IL_0782: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0787: castclass Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassConstructor_98E5520E_DerivedGeneratorClass
+		IL_0787: castclass Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject
 		IL_078c: stloc.s 45
 		IL_078e: ldloc.s 45
 		IL_0790: ldloc.s 44

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Inheritance_SuperIteratorMethod.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Inheritance_SuperIteratorMethod.verified.txt
@@ -33,6 +33,84 @@
 		.class nested public auto ansi beforefieldinit Scope_values
 			extends [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Generator_Inheritance_SuperIteratorMethod/Base/Scope_values/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 48 (0x30)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Base
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Generator_Inheritance_SuperIteratorMethod/Base/Scope_values/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Generator_Inheritance_SuperIteratorMethod/Base
+					IL_001d: ldarg.0
+					IL_001e: ldfld object[] Modules.Generator_Inheritance_SuperIteratorMethod/Base/Scope_values/FunctionObject::_transitionalScopes
+					IL_0023: ldnull
+					IL_0024: call instance object Modules.Generator_Inheritance_SuperIteratorMethod/Base::values(object[], object)
+					IL_0029: ldarg.0
+					IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
+					IL_002f: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +127,7 @@
 
 		} // end of class Scope_values
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_DA8A3036_Base
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -69,9 +147,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_Inheritance_SuperIteratorMethod/Base/FunctionObject_ClassConstructor_DA8A3036_Base::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_Inheritance_SuperIteratorMethod/Base/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_DA8A3036_Base::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -82,7 +160,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_DA8A3036_Base::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -93,85 +171,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_DA8A3036_Base::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_DA8A3036_Base
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C9EFEAA1_Base_values
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_Inheritance_SuperIteratorMethod/Base/FunctionObject_ClassMethod_C9EFEAA1_Base_values::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_C9EFEAA1_Base_values::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C9EFEAA1_Base_values::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_C9EFEAA1_Base_values::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 48 (0x30)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Base
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Generator_Inheritance_SuperIteratorMethod/Base/FunctionObject_ClassMethod_C9EFEAA1_Base_values::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Generator_Inheritance_SuperIteratorMethod/Base
-				IL_001d: ldarg.0
-				IL_001e: ldfld object[] Modules.Generator_Inheritance_SuperIteratorMethod/Base/FunctionObject_ClassMethod_C9EFEAA1_Base_values::_transitionalScopes
-				IL_0023: ldnull
-				IL_0024: call instance object Modules.Generator_Inheritance_SuperIteratorMethod/Base::values(object[], object)
-				IL_0029: ldarg.0
-				IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
-				IL_002f: ret
-			} // end of method FunctionObject_ClassMethod_C9EFEAA1_Base_values::CallCore
-
-		} // end of class FunctionObject_ClassMethod_C9EFEAA1_Base_values
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -226,7 +228,7 @@
 			IL_001f: ldftn instance object Modules.Generator_Inheritance_SuperIteratorMethod/Base::values(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.1
-			IL_002b: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Base/FunctionObject_ClassMethod_C9EFEAA1_Base_values
+			IL_002b: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Base/Scope_values/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -420,6 +422,108 @@
 		.class nested public auto ansi beforefieldinit Scope_run
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class [System.Runtime]System.Object capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class [System.Runtime]System.Object Modules.Generator_Inheritance_SuperIteratorMethod/Derived/Scope_run/FunctionObject::_homeObject
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Generator_Inheritance_SuperIteratorMethod/Derived/Scope_run/FunctionObject::_lexicalSuperScopes
+					IL_0014: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.Generator_Inheritance_SuperIteratorMethod/Derived/Scope_run/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Generator_Inheritance_SuperIteratorMethod/Derived/Scope_run/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Derived
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Generator_Inheritance_SuperIteratorMethod/Derived
+					IL_001d: call instance object Modules.Generator_Inheritance_SuperIteratorMethod/Derived::run()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -436,7 +540,7 @@
 
 		} // end of class Scope_run
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_C29E0300_Derived
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -456,9 +560,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassConstructor_C29E0300_Derived::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_C29E0300_Derived::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -469,7 +573,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_C29E0300_Derived::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -480,109 +584,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_C29E0300_Derived::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_C29E0300_Derived
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_E8608C04_Derived_run
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class [System.Runtime]System.Object capture0,
-					object[] capture1
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 21 (0x15)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run::_homeObject
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run::_lexicalSuperScopes
-				IL_0014: ret
-			} // end of method FunctionObject_ClassMethod_E8608C04_Derived_run::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_E8608C04_Derived_run::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_E8608C04_Derived_run::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_E8608C04_Derived_run::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_E8608C04_Derived_run::GetLexicalSuperScopesCore
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Generator_Inheritance_SuperIteratorMethod/Derived
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Generator_Inheritance_SuperIteratorMethod/Derived
-				IL_001d: call instance object Modules.Generator_Inheritance_SuperIteratorMethod/Derived::run()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_E8608C04_Derived_run::CallCore
-
-		} // end of class FunctionObject_ClassMethod_E8608C04_Derived_run
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -724,8 +728,8 @@
 			[2] class [System.Runtime]System.Type,
 			[3] object,
 			[4] object[],
-			[5] class Modules.Generator_Inheritance_SuperIteratorMethod/Base/FunctionObject_ClassConstructor_DA8A3036_Base,
-			[6] class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassConstructor_C29E0300_Derived
+			[5] class Modules.Generator_Inheritance_SuperIteratorMethod/Base/FunctionObject,
+			[6] class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Scope::.ctor()
@@ -745,15 +749,15 @@
 		IL_002f: ldloc.3
 		IL_0030: ldstr "values"
 		IL_0035: ldloc.s 4
-		IL_0037: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Base/FunctionObject_ClassMethod_C9EFEAA1_Base_values::.ctor(object[])
+		IL_0037: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Base/Scope_values/FunctionObject::.ctor(object[])
 		IL_003c: ldc.i4.0
 		IL_003d: conv.r8
 		IL_003e: ldstr "values"
 		IL_0043: ldc.i4.1
 		IL_0044: ldc.i4.1
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_Inheritance_SuperIteratorMethod/Base/FunctionObject_ClassMethod_C9EFEAA1_Base_values>(!!0, float64, string, bool, bool)
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_Inheritance_SuperIteratorMethod/Base/Scope_values/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_004f: castclass Modules.Generator_Inheritance_SuperIteratorMethod/Base/FunctionObject_ClassMethod_C9EFEAA1_Base_values
+		IL_004f: castclass Modules.Generator_Inheritance_SuperIteratorMethod/Base/Scope_values/FunctionObject
 		IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0059: pop
 		IL_005a: ldc.i4.1
@@ -764,14 +768,14 @@
 		IL_0063: stelem.ref
 		IL_0064: stloc.s 4
 		IL_0066: ldloc.s 4
-		IL_0068: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Base/FunctionObject_ClassConstructor_DA8A3036_Base::.ctor(object[])
+		IL_0068: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Base/FunctionObject::.ctor(object[])
 		IL_006d: ldloc.2
 		IL_006e: ldloc.s 4
 		IL_0070: ldc.i4.0
 		IL_0071: conv.r8
 		IL_0072: ldc.i4.0
 		IL_0073: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0078: castclass Modules.Generator_Inheritance_SuperIteratorMethod/Base/FunctionObject_ClassConstructor_DA8A3036_Base
+		IL_0078: castclass Modules.Generator_Inheritance_SuperIteratorMethod/Base/FunctionObject
 		IL_007d: stloc.s 5
 		IL_007f: ldloc.0
 		IL_0080: ldloc.s 5
@@ -791,14 +795,14 @@
 		IL_00b0: ldstr "run"
 		IL_00b5: ldloc.3
 		IL_00b6: ldloc.s 4
-		IL_00b8: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run::.ctor(class [System.Runtime]System.Object, object[])
+		IL_00b8: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Derived/Scope_run/FunctionObject::.ctor(class [System.Runtime]System.Object, object[])
 		IL_00bd: ldc.i4.0
 		IL_00be: conv.r8
 		IL_00bf: ldstr "run"
 		IL_00c4: ldc.i4.1
 		IL_00c5: ldc.i4.1
-		IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run>(!!0, float64, string, bool, bool)
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassMethod_E8608C04_Derived_run>(!!0)
+		IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/Scope_run/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Generator_Inheritance_SuperIteratorMethod/Derived/Scope_run/FunctionObject>(!!0)
 		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_00d5: pop
 		IL_00d6: ldc.i4.1
@@ -809,14 +813,14 @@
 		IL_00df: stelem.ref
 		IL_00e0: stloc.s 4
 		IL_00e2: ldloc.s 4
-		IL_00e4: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassConstructor_C29E0300_Derived::.ctor(object[])
+		IL_00e4: newobj instance void Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject::.ctor(object[])
 		IL_00e9: ldloc.2
 		IL_00ea: ldloc.s 4
 		IL_00ec: ldc.i4.0
 		IL_00ed: conv.r8
 		IL_00ee: ldc.i4.0
 		IL_00ef: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_00f4: castclass Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassConstructor_C29E0300_Derived
+		IL_00f4: castclass Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject
 		IL_00f9: stloc.s 6
 		IL_00fb: ldloc.s 6
 		IL_00fd: ldloc.s 5

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_StaticMethod_SimpleYield.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_StaticMethod_SimpleYield.verified.txt
@@ -33,6 +33,75 @@
 		.class nested public auto ansi beforefieldinit Scope_values
 			extends [JavaScriptRuntime]JavaScriptRuntime.GeneratorScope
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Generator_StaticMethod_SimpleYield/Gen/Scope_values/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 19 (0x13)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Generator_StaticMethod_SimpleYield/Gen/Scope_values/FunctionObject::_transitionalScopes
+					IL_0006: ldnull
+					IL_0007: call object Modules.Generator_StaticMethod_SimpleYield/Gen::values(object[], object)
+					IL_000c: ldarg.0
+					IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
+					IL_0012: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -49,7 +118,7 @@
 
 		} // end of class Scope_values
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_03FB2AC1_Gen
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -69,9 +138,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_StaticMethod_SimpleYield/Gen/FunctionObject_ClassConstructor_03FB2AC1_Gen::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_StaticMethod_SimpleYield/Gen/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_03FB2AC1_Gen::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -82,7 +151,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_03FB2AC1_Gen::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -93,76 +162,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_03FB2AC1_Gen::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_03FB2AC1_Gen
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_58F13DA0_Gen_values
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_StaticMethod_SimpleYield/Gen/FunctionObject_ClassStaticMethod_58F13DA0_Gen_values::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassStaticMethod_58F13DA0_Gen_values::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_58F13DA0_Gen_values::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassStaticMethod_58F13DA0_Gen_values::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 19 (0x13)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_StaticMethod_SimpleYield/Gen/FunctionObject_ClassStaticMethod_58F13DA0_Gen_values::_transitionalScopes
-				IL_0006: ldnull
-				IL_0007: call object Modules.Generator_StaticMethod_SimpleYield/Gen::values(object[], object)
-				IL_000c: ldarg.0
-				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
-				IL_0012: ret
-			} // end of method FunctionObject_ClassStaticMethod_58F13DA0_Gen_values::CallCore
-
-		} // end of class FunctionObject_ClassStaticMethod_58F13DA0_Gen_values
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -217,7 +219,7 @@
 			IL_001f: ldftn object Modules.Generator_StaticMethod_SimpleYield/Gen::values(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_StaticMethod_SimpleYield/Gen/FunctionObject_ClassStaticMethod_58F13DA0_Gen_values
+			IL_002b: ldtoken Modules.Generator_StaticMethod_SimpleYield/Gen/Scope_values/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -379,7 +381,7 @@
 			[3] object,
 			[4] class [System.Runtime]System.Type,
 			[5] object[],
-			[6] class Modules.Generator_StaticMethod_SimpleYield/Gen/FunctionObject_ClassConstructor_03FB2AC1_Gen,
+			[6] class Modules.Generator_StaticMethod_SimpleYield/Gen/FunctionObject,
 			[7] object,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[9] object
@@ -402,15 +404,15 @@
 		IL_0031: ldloc.s 4
 		IL_0033: ldstr "values"
 		IL_0038: ldloc.s 5
-		IL_003a: newobj instance void Modules.Generator_StaticMethod_SimpleYield/Gen/FunctionObject_ClassStaticMethod_58F13DA0_Gen_values::.ctor(object[])
+		IL_003a: newobj instance void Modules.Generator_StaticMethod_SimpleYield/Gen/Scope_values/FunctionObject::.ctor(object[])
 		IL_003f: ldc.i4.0
 		IL_0040: conv.r8
 		IL_0041: ldstr "values"
 		IL_0046: ldc.i4.1
 		IL_0047: ldc.i4.1
-		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_StaticMethod_SimpleYield/Gen/FunctionObject_ClassStaticMethod_58F13DA0_Gen_values>(!!0, float64, string, bool, bool)
+		IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_StaticMethod_SimpleYield/Gen/Scope_values/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_0052: castclass Modules.Generator_StaticMethod_SimpleYield/Gen/FunctionObject_ClassStaticMethod_58F13DA0_Gen_values
+		IL_0052: castclass Modules.Generator_StaticMethod_SimpleYield/Gen/Scope_values/FunctionObject
 		IL_0057: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_005c: pop
 		IL_005d: ldc.i4.1
@@ -421,14 +423,14 @@
 		IL_0066: stelem.ref
 		IL_0067: stloc.s 5
 		IL_0069: ldloc.s 5
-		IL_006b: newobj instance void Modules.Generator_StaticMethod_SimpleYield/Gen/FunctionObject_ClassConstructor_03FB2AC1_Gen::.ctor(object[])
+		IL_006b: newobj instance void Modules.Generator_StaticMethod_SimpleYield/Gen/FunctionObject::.ctor(object[])
 		IL_0070: ldloc.s 4
 		IL_0072: ldloc.s 5
 		IL_0074: ldc.i4.0
 		IL_0075: conv.r8
 		IL_0076: ldc.i4.0
 		IL_0077: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_007c: castclass Modules.Generator_StaticMethod_SimpleYield/Gen/FunctionObject_ClassConstructor_03FB2AC1_Gen
+		IL_007c: castclass Modules.Generator_StaticMethod_SimpleYield/Gen/FunctionObject
 		IL_0081: stloc.s 6
 		IL_0083: ldloc.s 6
 		IL_0085: stloc.1

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DefaultAnonClass.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DefaultAnonClass.verified.txt
@@ -162,6 +162,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Import_DefaultAnonClass_Lib/Class1/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -181,6 +231,71 @@
 		.class nested public auto ansi beforefieldinit Scope_greet
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Import_DefaultAnonClass_Lib/Class1
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Import_DefaultAnonClass_Lib/Class1
+					IL_001d: call instance object Modules.Import_DefaultAnonClass_Lib/Class1::greet()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -196,117 +311,6 @@
 			} // end of method Scope_greet::.ctor
 
 		} // end of class Scope_greet
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_1C37C2FE_Class1
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Import_DefaultAnonClass_Lib/Class1/FunctionObject_ClassConstructor_1C37C2FE_Class1::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_1C37C2FE_Class1::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_1C37C2FE_Class1::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_1C37C2FE_Class1::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_1C37C2FE_Class1
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_BD5B1290_Class1_greet
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_BD5B1290_Class1_greet::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_BD5B1290_Class1_greet::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_BD5B1290_Class1_greet::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Import_DefaultAnonClass_Lib/Class1
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Import_DefaultAnonClass_Lib/Class1
-				IL_001d: call instance object Modules.Import_DefaultAnonClass_Lib/Class1::greet()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_BD5B1290_Class1_greet::CallCore
-
-		} // end of class FunctionObject_ClassMethod_BD5B1290_Class1_greet
 
 
 		// Fields
@@ -389,7 +393,7 @@
 			[2] class [System.Runtime]System.Type,
 			[3] object,
 			[4] object[],
-			[5] class Modules.Import_DefaultAnonClass_Lib/Class1/FunctionObject_ClassConstructor_1C37C2FE_Class1
+			[5] class Modules.Import_DefaultAnonClass_Lib/Class1/Scope_ctor/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_DefaultAnonClass_Lib/Scope::.ctor()
@@ -414,14 +418,14 @@
 		IL_0043: stloc.s 4
 		IL_0045: ldloc.3
 		IL_0046: ldstr "greet"
-		IL_004b: newobj instance void Modules.Import_DefaultAnonClass_Lib/Class1/FunctionObject_ClassMethod_BD5B1290_Class1_greet::.ctor()
+		IL_004b: newobj instance void Modules.Import_DefaultAnonClass_Lib/Class1/Scope_greet/FunctionObject::.ctor()
 		IL_0050: ldc.i4.0
 		IL_0051: conv.r8
 		IL_0052: ldstr "greet"
 		IL_0057: ldc.i4.1
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DefaultAnonClass_Lib/Class1/FunctionObject_ClassMethod_BD5B1290_Class1_greet>(!!0, float64, string, bool, bool)
-		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_DefaultAnonClass_Lib/Class1/FunctionObject_ClassMethod_BD5B1290_Class1_greet>(!!0)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DefaultAnonClass_Lib/Class1/Scope_greet/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_DefaultAnonClass_Lib/Class1/Scope_greet/FunctionObject>(!!0)
 		IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0068: pop
 		IL_0069: ldc.i4.1
@@ -432,14 +436,14 @@
 		IL_0072: stelem.ref
 		IL_0073: stloc.s 4
 		IL_0075: ldloc.s 4
-		IL_0077: newobj instance void Modules.Import_DefaultAnonClass_Lib/Class1/FunctionObject_ClassConstructor_1C37C2FE_Class1::.ctor(object[])
+		IL_0077: newobj instance void Modules.Import_DefaultAnonClass_Lib/Class1/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_007c: ldloc.2
 		IL_007d: ldloc.s 4
 		IL_007f: ldc.i4.0
 		IL_0080: conv.r8
 		IL_0081: ldc.i4.0
 		IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0087: castclass Modules.Import_DefaultAnonClass_Lib/Class1/FunctionObject_ClassConstructor_1C37C2FE_Class1
+		IL_0087: castclass Modules.Import_DefaultAnonClass_Lib/Class1/Scope_ctor/FunctionObject
 		IL_008c: stloc.s 5
 		IL_008e: ldloc.s 5
 		IL_0090: stloc.1

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DefaultNamedClass.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DefaultNamedClass.verified.txt
@@ -162,6 +162,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Import_DefaultNamedClass_Lib/Widget/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -181,6 +231,71 @@
 		.class nested public auto ansi beforefieldinit Scope_describe
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Import_DefaultNamedClass_Lib/Widget
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Import_DefaultNamedClass_Lib/Widget
+					IL_001d: call instance object Modules.Import_DefaultNamedClass_Lib/Widget::describe()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -196,117 +311,6 @@
 			} // end of method Scope_describe::.ctor
 
 		} // end of class Scope_describe
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_FF8C96D4_Widget
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Import_DefaultNamedClass_Lib/Widget/FunctionObject_ClassConstructor_FF8C96D4_Widget::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_FF8C96D4_Widget::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_FF8C96D4_Widget::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_FF8C96D4_Widget::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_FF8C96D4_Widget
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_A3A87C9E_Widget_describe
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_A3A87C9E_Widget_describe::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_A3A87C9E_Widget_describe::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_A3A87C9E_Widget_describe::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Import_DefaultNamedClass_Lib/Widget
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Import_DefaultNamedClass_Lib/Widget
-				IL_001d: call instance object Modules.Import_DefaultNamedClass_Lib/Widget::describe()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_A3A87C9E_Widget_describe::CallCore
-
-		} // end of class FunctionObject_ClassMethod_A3A87C9E_Widget_describe
 
 
 		// Fields
@@ -388,7 +392,7 @@
 			[1] object,
 			[2] object[],
 			[3] class [System.Runtime]System.Type,
-			[4] class Modules.Import_DefaultNamedClass_Lib/Widget/FunctionObject_ClassConstructor_FF8C96D4_Widget
+			[4] class Modules.Import_DefaultNamedClass_Lib/Widget/Scope_ctor/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_DefaultNamedClass_Lib/Scope::.ctor()
@@ -413,14 +417,14 @@
 		IL_0037: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		IL_003c: stloc.3
 		IL_003d: ldloc.2
-		IL_003e: newobj instance void Modules.Import_DefaultNamedClass_Lib/Widget/FunctionObject_ClassConstructor_FF8C96D4_Widget::.ctor(object[])
+		IL_003e: newobj instance void Modules.Import_DefaultNamedClass_Lib/Widget/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_0043: ldloc.3
 		IL_0044: ldloc.2
 		IL_0045: ldc.i4.0
 		IL_0046: conv.r8
 		IL_0047: ldc.i4.0
 		IL_0048: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_004d: castclass Modules.Import_DefaultNamedClass_Lib/Widget/FunctionObject_ClassConstructor_FF8C96D4_Widget
+		IL_004d: castclass Modules.Import_DefaultNamedClass_Lib/Widget/Scope_ctor/FunctionObject
 		IL_0052: stloc.s 4
 		IL_0054: ldloc.s 4
 		IL_0056: stloc.1

--- a/tests/Jroc.Tests/Integration/GeneratedFunctionObjectEmissionTests.cs
+++ b/tests/Jroc.Tests/Integration/GeneratedFunctionObjectEmissionTests.cs
@@ -271,9 +271,9 @@ public sealed class GeneratedFunctionObjectEmissionTests
 
         var methodFunctionType = Assert.Single(
             GetFunctionObjectTypes(compiled.Assembly),
-            type => type.Name.Contains("ClassMethod", StringComparison.Ordinal)
-                && type.Name.EndsWith("_Echo_method", StringComparison.Ordinal));
-        Assert.Equal("Echo", methodFunctionType.DeclaringType!.Name);
+            type => type.Name == GeneratedFunctionObjectNaming.WrapperTypeName
+                && type.DeclaringType?.Name == "Scope_method"
+                && type.DeclaringType.DeclaringType?.Name == "Echo");
         var methodFunction = Assert.IsAssignableFrom<JsFunctionObject>(
             Activator.CreateInstance(methodFunctionType));
         var echoType = compiled.Assembly.GetTypes().Single(type => type.Name == "Echo");
@@ -293,13 +293,13 @@ public sealed class GeneratedFunctionObjectEmissionTests
             type => typeof(JsAsyncFunctionObject).IsAssignableFrom(type));
         Assert.Contains(
             functionObjectTypes,
-            type => type.Name.Contains("ClassMethod", StringComparison.Ordinal));
+            type => IsClassMemberFunctionObject(type, "Scope_method"));
         Assert.Contains(
             functionObjectTypes,
-            type => type.Name.Contains("ClassGetter", StringComparison.Ordinal));
+            type => IsClassMemberFunctionObject(type, "Scope_get_accessor"));
         Assert.Contains(
             functionObjectTypes,
-            type => type.Name.Contains("ClassSetter", StringComparison.Ordinal));
+            type => IsClassMemberFunctionObject(type, "Scope_set_accessor"));
         Assert.Contains(
             functionObjectTypes,
             type => typeof(JsClassConstructorObject).IsAssignableFrom(type));
@@ -345,9 +345,7 @@ public sealed class GeneratedFunctionObjectEmissionTests
         using var compiled = CompileAndLoad(Source);
         var constructorObjectType = Assert.Single(
             GetFunctionObjectTypes(compiled.Assembly),
-            type => type.Name.Contains(
-                "ClassConstructor",
-                StringComparison.Ordinal)
+            type => type.Name == GeneratedFunctionObjectNaming.WrapperTypeName
                 && type.DeclaringType?.Name == "Echo");
         Assert.Equal(
             typeof(JsClassConstructorObject),
@@ -400,6 +398,11 @@ public sealed class GeneratedFunctionObjectEmissionTests
             constructorObject,
             ObjectRuntime.GetProperty(prototype!, "constructor"));
     }
+
+    private static bool IsClassMemberFunctionObject(Type type, string ownerScopeName)
+        => type.Name == GeneratedFunctionObjectNaming.WrapperTypeName
+            && type.DeclaringType?.Name == ownerScopeName
+            && type.DeclaringType.DeclaringType?.Name == "Example";
 
     [Fact]
     public void CommonArityAdaptersDoNotAllocateArgumentArrays()

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -624,6 +624,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -643,6 +693,75 @@
 		.class nested public auto ansi beforefieldinit Scope_setBitTrue
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 47 (0x2f)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0029: call instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitTrue(float64)
+					IL_002e: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -844,6 +963,89 @@
 
 			} // end of class Block_L83C29
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 12
+					// Code size: 71 (0x47)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0029: ldarg.2
+					IL_002a: ldc.i4.1
+					IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0035: ldarg.2
+					IL_0036: ldc.i4.2
+					IL_0037: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0041: call instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitsTrue(float64, float64, float64)
+					IL_0046: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -864,6 +1066,76 @@
 		.class nested public auto ansi beforefieldinit Scope_testBitTrue
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 52 (0x34)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0029: call instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::testBitTrue(float64)
+					IL_002e: box [System.Runtime]System.Double
+					IL_0033: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -903,6 +1175,74 @@
 
 			} // end of class Block_L107C34
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 52 (0x34)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0029: call instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::searchBitFalse(float64)
+					IL_002e: box [System.Runtime]System.Double
+					IL_0033: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -919,340 +1259,6 @@
 			} // end of method Scope_searchBitFalse::.ctor
 
 		} // end of class Scope_searchBitFalse
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_29DE0AB5_BitArray
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassConstructor_29DE0AB5_BitArray::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_29DE0AB5_BitArray::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_29DE0AB5_BitArray::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_29DE0AB5_BitArray::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_29DE0AB5_BitArray
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_64943931_BitArray_setBitTrue
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 47 (0x2f)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0029: call instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitTrue(float64)
-				IL_002e: ret
-			} // end of method FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::CallCore
-
-		} // end of class FunctionObject_ClassMethod_64943931_BitArray_setBitTrue
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 12
-				// Code size: 71 (0x47)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0029: ldarg.2
-				IL_002a: ldc.i4.1
-				IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0035: ldarg.2
-				IL_0036: ldc.i4.2
-				IL_0037: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0041: call instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitsTrue(float64, float64, float64)
-				IL_0046: ret
-			} // end of method FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::CallCore
-
-		} // end of class FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 52 (0x34)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0029: call instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::testBitTrue(float64)
-				IL_002e: box [System.Runtime]System.Double
-				IL_0033: ret
-			} // end of method FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::CallCore
-
-		} // end of class FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 52 (0x34)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0029: call instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::searchBitFalse(float64)
-				IL_002e: box [System.Runtime]System.Double
-				IL_0033: ret
-			} // end of method FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::CallCore
-
-		} // end of class FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse
 
 
 		// Fields
@@ -1760,6 +1766,61 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly class Modules.Compile_Performance_PrimeJavaScript/Scope _environment0_Compile_Performance_PrimeJavaScript
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Compile_Performance_PrimeJavaScript/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Compile_Performance_PrimeJavaScript/Scope Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_ctor/FunctionObject::_environment0_Compile_Performance_PrimeJavaScript
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1799,6 +1860,77 @@
 
 			} // end of class Block_L133C2
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_runSieve/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_runSieve/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+					IL_001d: call instance class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::runSieve()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -1819,6 +1951,80 @@
 		.class nested public auto ansi beforefieldinit Scope_countPrimes
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_countPrimes/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_countPrimes/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+					IL_001d: call instance float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::countPrimes()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1959,6 +2165,80 @@
 
 			} // end of class Scope_For_L159C7
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_getPrimes/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_getPrimes/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::getPrimes(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -1999,6 +2279,81 @@
 
 			} // end of class Block_L187C2
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_validatePrimeCount/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 47 (0x2f)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/Scope_validatePrimeCount/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance bool Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::validatePrimeCount(object)
+					IL_0029: box [System.Runtime]System.Boolean
+					IL_002e: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -2015,351 +2370,6 @@
 			} // end of method Scope_validatePrimeCount::.ctor
 
 		} // end of class Scope_validatePrimeCount
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_CC015EE2_PrimeSieve
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly class Modules.Compile_Performance_PrimeJavaScript/Scope _environment0_Compile_Performance_PrimeJavaScript
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class Modules.Compile_Performance_PrimeJavaScript/Scope capture0,
-					object[] capture1
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 21 (0x15)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_PrimeJavaScript/Scope Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::_environment0_Compile_Performance_PrimeJavaScript
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::_transitionalScopes
-				IL_0014: ret
-			} // end of method FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_CC015EE2_PrimeSieve
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-				IL_001d: call instance class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::runSieve()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve::CallCore
-
-		} // end of class FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-				IL_001d: call instance float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::countPrimes()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes::CallCore
-
-		} // end of class FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::getPrimes(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes::CallCore
-
-		} // end of class FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 47 (0x2f)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance bool Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::validatePrimeCount(object)
-				IL_0029: box [System.Runtime]System.Boolean
-				IL_002e: ret
-			} // end of method FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount::CallCore
-
-		} // end of class FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount
 
 
 		// Fields
@@ -3107,7 +3117,7 @@
 			[7] float64,
 			[8] class [System.Runtime]System.Type,
 			[9] object[],
-			[10] class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassConstructor_29DE0AB5_BitArray,
+			[10] class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_ctor/FunctionObject,
 			[11] class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject
 		)
 
@@ -3217,14 +3227,14 @@
 		IL_016b: stloc.s 9
 		IL_016d: ldloc.s 5
 		IL_016f: ldstr "setBitTrue"
-		IL_0174: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::.ctor()
+		IL_0174: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject::.ctor()
 		IL_0179: ldc.i4.1
 		IL_017a: conv.r8
 		IL_017b: ldstr "setBitTrue"
 		IL_0180: ldc.i4.1
 		IL_0181: ldc.i4.1
-		IL_0182: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
-		IL_0187: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_64943931_BitArray_setBitTrue>(!!0)
+		IL_0182: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0187: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject>(!!0)
 		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0191: pop
 		IL_0192: ldc.i4.1
@@ -3237,42 +3247,42 @@
 		IL_019e: ldloc.s 5
 		IL_01a0: ldstr "setBitsTrue"
 		IL_01a5: ldloc.s 9
-		IL_01a7: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::.ctor(object[])
+		IL_01a7: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject::.ctor(object[])
 		IL_01ac: ldc.i4.3
 		IL_01ad: conv.r8
 		IL_01ae: ldstr "setBitsTrue"
 		IL_01b3: ldc.i4.1
 		IL_01b4: ldc.i4.1
-		IL_01b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
-		IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue>(!!0)
+		IL_01b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject>(!!0)
 		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_01c4: pop
 		IL_01c5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_01ca: stloc.s 9
 		IL_01cc: ldloc.s 5
 		IL_01ce: ldstr "testBitTrue"
-		IL_01d3: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::.ctor()
+		IL_01d3: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject::.ctor()
 		IL_01d8: ldc.i4.1
 		IL_01d9: conv.r8
 		IL_01da: ldstr "testBitTrue"
 		IL_01df: ldc.i4.1
 		IL_01e0: ldc.i4.1
-		IL_01e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
-		IL_01e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue>(!!0)
+		IL_01e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject>(!!0)
 		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_01f0: pop
 		IL_01f1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_01f6: stloc.s 9
 		IL_01f8: ldloc.s 5
 		IL_01fa: ldstr "searchBitFalse"
-		IL_01ff: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::.ctor()
+		IL_01ff: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject::.ctor()
 		IL_0204: ldc.i4.1
 		IL_0205: conv.r8
 		IL_0206: ldstr "searchBitFalse"
 		IL_020b: ldc.i4.1
 		IL_020c: ldc.i4.1
-		IL_020d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse>(!!0, float64, string, bool, bool)
-		IL_0212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse>(!!0)
+		IL_020d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject>(!!0)
 		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_021c: pop
 		IL_021d: ldc.i4.1
@@ -3283,14 +3293,14 @@
 		IL_0226: stelem.ref
 		IL_0227: stloc.s 9
 		IL_0229: ldloc.s 9
-		IL_022b: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassConstructor_29DE0AB5_BitArray::.ctor(object[])
+		IL_022b: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_0230: ldloc.s 8
 		IL_0232: ldloc.s 9
 		IL_0234: ldc.i4.1
 		IL_0235: conv.r8
 		IL_0236: ldc.i4.0
 		IL_0237: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_023c: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassConstructor_29DE0AB5_BitArray
+		IL_023c: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_ctor/FunctionObject
 		IL_0241: stloc.s 10
 		IL_0243: ldloc.0
 		IL_0244: ldloc.s 10

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -573,6 +573,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -592,6 +642,75 @@
 		.class nested public auto ansi beforefieldinit Scope_setBitTrue
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 47 (0x2f)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0029: call instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitTrue(float64)
+					IL_002e: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -793,6 +912,89 @@
 
 			} // end of class Block_L86C29
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 12
+					// Code size: 71 (0x47)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0029: ldarg.2
+					IL_002a: ldc.i4.1
+					IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0035: ldarg.2
+					IL_0036: ldc.i4.2
+					IL_0037: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0041: call instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitsTrue(float64, float64, float64)
+					IL_0046: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -813,6 +1015,76 @@
 		.class nested public auto ansi beforefieldinit Scope_testBitTrue
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 52 (0x34)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0029: call instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::testBitTrue(float64)
+					IL_002e: box [System.Runtime]System.Double
+					IL_0033: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -852,6 +1124,74 @@
 
 			} // end of class Block_L110C34
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 52 (0x34)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0029: call instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::searchBitFalse(float64)
+					IL_002e: box [System.Runtime]System.Double
+					IL_0033: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -868,340 +1208,6 @@
 			} // end of method Scope_searchBitFalse::.ctor
 
 		} // end of class Scope_searchBitFalse
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_25D92CDA_BitArray
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassConstructor_25D92CDA_BitArray::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_25D92CDA_BitArray::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_25D92CDA_BitArray::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_25D92CDA_BitArray::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_25D92CDA_BitArray
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 47 (0x2f)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0029: call instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitTrue(float64)
-				IL_002e: ret
-			} // end of method FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::CallCore
-
-		} // end of class FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 12
-				// Code size: 71 (0x47)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0029: ldarg.2
-				IL_002a: ldc.i4.1
-				IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0035: ldarg.2
-				IL_0036: ldc.i4.2
-				IL_0037: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0041: call instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitsTrue(float64, float64, float64)
-				IL_0046: ret
-			} // end of method FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::CallCore
-
-		} // end of class FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 52 (0x34)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0029: call instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::testBitTrue(float64)
-				IL_002e: box [System.Runtime]System.Double
-				IL_0033: ret
-			} // end of method FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::CallCore
-
-		} // end of class FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 52 (0x34)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0029: call instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::searchBitFalse(float64)
-				IL_002e: box [System.Runtime]System.Double
-				IL_0033: ret
-			} // end of method FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::CallCore
-
-		} // end of class FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse
 
 
 		// Fields
@@ -1709,6 +1715,61 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope _environment0_Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject::_environment0_Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1748,6 +1809,77 @@
 
 			} // end of class Block_L136C2
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+					IL_001d: call instance class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::runSieve()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -1768,6 +1900,80 @@
 		.class nested public auto ansi beforefieldinit Scope_countPrimes
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+					IL_001d: call instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::countPrimes()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1908,6 +2114,80 @@
 
 			} // end of class Scope_For_L162C7
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::getPrimes(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -1948,6 +2228,81 @@
 
 			} // end of class Block_L190C2
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 47 (0x2f)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance bool Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::validatePrimeCount(object)
+					IL_0029: box [System.Runtime]System.Boolean
+					IL_002e: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -1964,351 +2319,6 @@
 			} // end of method Scope_validatePrimeCount::.ctor
 
 		} // end of class Scope_validatePrimeCount
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_89EFC421_PrimeSieve
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope _environment0_Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope capture0,
-					object[] capture1
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 21 (0x15)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassConstructor_89EFC421_PrimeSieve::_environment0_Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassConstructor_89EFC421_PrimeSieve::_transitionalScopes
-				IL_0014: ret
-			} // end of method FunctionObject_ClassConstructor_89EFC421_PrimeSieve::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_89EFC421_PrimeSieve::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_89EFC421_PrimeSieve::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_89EFC421_PrimeSieve
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-				IL_001d: call instance class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::runSieve()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::CallCore
-
-		} // end of class FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-				IL_001d: call instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::countPrimes()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::CallCore
-
-		} // end of class FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::getPrimes(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::CallCore
-
-		} // end of class FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 47 (0x2f)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance bool Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::validatePrimeCount(object)
-				IL_0029: box [System.Runtime]System.Boolean
-				IL_002e: ret
-			} // end of method FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::CallCore
-
-		} // end of class FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount
 
 
 		// Fields
@@ -3054,8 +3064,8 @@
 			[7] float64,
 			[8] class [System.Runtime]System.Type,
 			[9] object[],
-			[10] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassConstructor_25D92CDA_BitArray,
-			[11] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassConstructor_89EFC421_PrimeSieve
+			[10] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_ctor/FunctionObject,
+			[11] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::.ctor()
@@ -3164,14 +3174,14 @@
 		IL_016b: stloc.s 9
 		IL_016d: ldloc.s 5
 		IL_016f: ldstr "setBitTrue"
-		IL_0174: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::.ctor()
+		IL_0174: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject::.ctor()
 		IL_0179: ldc.i4.1
 		IL_017a: conv.r8
 		IL_017b: ldstr "setBitTrue"
 		IL_0180: ldc.i4.1
 		IL_0181: ldc.i4.1
-		IL_0182: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
-		IL_0187: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue>(!!0)
+		IL_0182: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0187: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject>(!!0)
 		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0191: pop
 		IL_0192: ldc.i4.1
@@ -3184,42 +3194,42 @@
 		IL_019e: ldloc.s 5
 		IL_01a0: ldstr "setBitsTrue"
 		IL_01a5: ldloc.s 9
-		IL_01a7: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::.ctor(object[])
+		IL_01a7: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject::.ctor(object[])
 		IL_01ac: ldc.i4.3
 		IL_01ad: conv.r8
 		IL_01ae: ldstr "setBitsTrue"
 		IL_01b3: ldc.i4.1
 		IL_01b4: ldc.i4.1
-		IL_01b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
-		IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue>(!!0)
+		IL_01b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject>(!!0)
 		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_01c4: pop
 		IL_01c5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_01ca: stloc.s 9
 		IL_01cc: ldloc.s 5
 		IL_01ce: ldstr "testBitTrue"
-		IL_01d3: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::.ctor()
+		IL_01d3: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject::.ctor()
 		IL_01d8: ldc.i4.1
 		IL_01d9: conv.r8
 		IL_01da: ldstr "testBitTrue"
 		IL_01df: ldc.i4.1
 		IL_01e0: ldc.i4.1
-		IL_01e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
-		IL_01e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue>(!!0)
+		IL_01e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject>(!!0)
 		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_01f0: pop
 		IL_01f1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_01f6: stloc.s 9
 		IL_01f8: ldloc.s 5
 		IL_01fa: ldstr "searchBitFalse"
-		IL_01ff: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::.ctor()
+		IL_01ff: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject::.ctor()
 		IL_0204: ldc.i4.1
 		IL_0205: conv.r8
 		IL_0206: ldstr "searchBitFalse"
 		IL_020b: ldc.i4.1
 		IL_020c: ldc.i4.1
-		IL_020d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse>(!!0, float64, string, bool, bool)
-		IL_0212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse>(!!0)
+		IL_020d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject>(!!0)
 		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_021c: pop
 		IL_021d: ldc.i4.1
@@ -3230,14 +3240,14 @@
 		IL_0226: stelem.ref
 		IL_0227: stloc.s 9
 		IL_0229: ldloc.s 9
-		IL_022b: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassConstructor_25D92CDA_BitArray::.ctor(object[])
+		IL_022b: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_0230: ldloc.s 8
 		IL_0232: ldloc.s 9
 		IL_0234: ldc.i4.1
 		IL_0235: conv.r8
 		IL_0236: ldc.i4.0
 		IL_0237: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_023c: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassConstructor_25D92CDA_BitArray
+		IL_023c: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_ctor/FunctionObject
 		IL_0241: stloc.s 10
 		IL_0243: ldloc.0
 		IL_0244: ldloc.s 10
@@ -3261,14 +3271,14 @@
 		IL_027b: ldloc.s 5
 		IL_027d: ldstr "runSieve"
 		IL_0282: ldloc.s 9
-		IL_0284: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::.ctor(object[])
+		IL_0284: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject::.ctor(object[])
 		IL_0289: ldc.i4.0
 		IL_028a: conv.r8
 		IL_028b: ldstr "runSieve"
 		IL_0290: ldc.i4.1
 		IL_0291: ldc.i4.1
-		IL_0292: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve>(!!0, float64, string, bool, bool)
-		IL_0297: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve>(!!0)
+		IL_0292: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0297: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject>(!!0)
 		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_02a1: pop
 		IL_02a2: ldc.i4.1
@@ -3281,14 +3291,14 @@
 		IL_02ae: ldloc.s 5
 		IL_02b0: ldstr "countPrimes"
 		IL_02b5: ldloc.s 9
-		IL_02b7: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::.ctor(object[])
+		IL_02b7: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject::.ctor(object[])
 		IL_02bc: ldc.i4.0
 		IL_02bd: conv.r8
 		IL_02be: ldstr "countPrimes"
 		IL_02c3: ldc.i4.1
 		IL_02c4: ldc.i4.1
-		IL_02c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes>(!!0, float64, string, bool, bool)
-		IL_02ca: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes>(!!0)
+		IL_02c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02ca: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject>(!!0)
 		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_02d4: pop
 		IL_02d5: ldc.i4.1
@@ -3301,14 +3311,14 @@
 		IL_02e1: ldloc.s 5
 		IL_02e3: ldstr "getPrimes"
 		IL_02e8: ldloc.s 9
-		IL_02ea: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::.ctor(object[])
+		IL_02ea: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject::.ctor(object[])
 		IL_02ef: ldc.i4.0
 		IL_02f0: conv.r8
 		IL_02f1: ldstr "getPrimes"
 		IL_02f6: ldc.i4.1
 		IL_02f7: ldc.i4.1
-		IL_02f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes>(!!0, float64, string, bool, bool)
-		IL_02fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes>(!!0)
+		IL_02f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject>(!!0)
 		IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0307: pop
 		IL_0308: ldc.i4.1
@@ -3321,14 +3331,14 @@
 		IL_0314: ldloc.s 5
 		IL_0316: ldstr "validatePrimeCount"
 		IL_031b: ldloc.s 9
-		IL_031d: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::.ctor(object[])
+		IL_031d: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject::.ctor(object[])
 		IL_0322: ldc.i4.1
 		IL_0323: conv.r8
 		IL_0324: ldstr "validatePrimeCount"
 		IL_0329: ldc.i4.1
 		IL_032a: ldc.i4.1
-		IL_032b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount>(!!0, float64, string, bool, bool)
-		IL_0330: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount>(!!0)
+		IL_032b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0330: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject>(!!0)
 		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_033a: pop
 		IL_033b: ldc.i4.1
@@ -3343,14 +3353,14 @@
 		IL_034a: ldelem.ref
 		IL_034b: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
 		IL_0350: ldloc.s 9
-		IL_0352: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassConstructor_89EFC421_PrimeSieve::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object[])
+		IL_0352: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object[])
 		IL_0357: ldloc.s 8
 		IL_0359: ldloc.s 9
 		IL_035b: ldc.i4.1
 		IL_035c: conv.r8
 		IL_035d: ldc.i4.0
 		IL_035e: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0363: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassConstructor_89EFC421_PrimeSieve
+		IL_0363: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject
 		IL_0368: stloc.s 11
 		IL_036a: ldloc.0
 		IL_036b: ldloc.s 11

--- a/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_AsyncResource_Subclass.verified.txt
+++ b/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_AsyncResource_Subclass.verified.txt
@@ -231,6 +231,90 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+				.field private initonly class [System.Runtime]System.Object _homeObject
+				.field private initonly object[] _lexicalSuperScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0,
+						class [System.Runtime]System.Object capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class [System.Runtime]System.Object Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/Scope_ctor/FunctionObject::_homeObject
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_001b: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object GetLexicalSuperReceiverCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld class [System.Runtime]System.Object Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/Scope_ctor/FunctionObject::_homeObject
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperReceiverCore
+
+				.method family hidebysig virtual 
+					instance object[] GetLexicalSuperScopesCore () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/Scope_ctor/FunctionObject::_lexicalSuperScopes
+					IL_0006: ret
+				} // end of method FunctionObject::GetLexicalSuperScopesCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -250,6 +334,77 @@
 		.class nested public auto ansi beforefieldinit Scope_deliver
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 49 (0x31)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: ldarg.2
+					IL_0025: ldc.i4.1
+					IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_002b: call instance object Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler::deliver(object, object)
+					IL_0030: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -265,157 +420,6 @@
 			} // end of method Scope_deliver::.ctor
 
 		} // end of class Scope_deliver
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_56E834DB_UndiciStyleHandler
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-			.field private initonly class [System.Runtime]System.Object _homeObject
-			.field private initonly object[] _lexicalSuperScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0,
-					class [System.Runtime]System.Object capture1,
-					object[] capture2
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 28 (0x1c)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/FunctionObject_ClassConstructor_56E834DB_UndiciStyleHandler::_transitionalScopes
-				IL_000d: ldarg.0
-				IL_000e: ldarg.2
-				IL_000f: stfld class [System.Runtime]System.Object Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/FunctionObject_ClassConstructor_56E834DB_UndiciStyleHandler::_homeObject
-				IL_0014: ldarg.0
-				IL_0015: ldarg.3
-				IL_0016: stfld object[] Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/FunctionObject_ClassConstructor_56E834DB_UndiciStyleHandler::_lexicalSuperScopes
-				IL_001b: ret
-			} // end of method FunctionObject_ClassConstructor_56E834DB_UndiciStyleHandler::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_56E834DB_UndiciStyleHandler::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_56E834DB_UndiciStyleHandler::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object GetLexicalSuperReceiverCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/FunctionObject_ClassConstructor_56E834DB_UndiciStyleHandler::_homeObject
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_56E834DB_UndiciStyleHandler::GetLexicalSuperReceiverCore
-
-			.method family hidebysig virtual 
-				instance object[] GetLexicalSuperScopesCore () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/FunctionObject_ClassConstructor_56E834DB_UndiciStyleHandler::_lexicalSuperScopes
-				IL_0006: ret
-			} // end of method FunctionObject_ClassConstructor_56E834DB_UndiciStyleHandler::GetLexicalSuperScopesCore
-
-		} // end of class FunctionObject_ClassConstructor_56E834DB_UndiciStyleHandler
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_4E00F3BF_UndiciStyleHandler_deliver
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_4E00F3BF_UndiciStyleHandler_deliver::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_4E00F3BF_UndiciStyleHandler_deliver::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_4E00F3BF_UndiciStyleHandler_deliver::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 49 (0x31)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: ldarg.2
-				IL_0025: ldc.i4.1
-				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_002b: call instance object Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler::deliver(object, object)
-				IL_0030: ret
-			} // end of method FunctionObject_ClassMethod_4E00F3BF_UndiciStyleHandler_deliver::CallCore
-
-		} // end of class FunctionObject_ClassMethod_4E00F3BF_UndiciStyleHandler_deliver
 
 
 		// Fields
@@ -564,7 +568,7 @@
 			[3] object,
 			[4] class [System.Runtime]System.Type,
 			[5] object[],
-			[6] class Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/FunctionObject_ClassConstructor_56E834DB_UndiciStyleHandler,
+			[6] class Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/Scope_ctor/FunctionObject,
 			[7] object[],
 			[8] class Modules.Require_AsyncHooks_AsyncResource_Subclass/FunctionExpression_handler/FunctionObject,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -613,14 +617,14 @@
 		IL_006f: stloc.s 5
 		IL_0071: ldloc.3
 		IL_0072: ldstr "deliver"
-		IL_0077: newobj instance void Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/FunctionObject_ClassMethod_4E00F3BF_UndiciStyleHandler_deliver::.ctor()
+		IL_0077: newobj instance void Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/Scope_deliver/FunctionObject::.ctor()
 		IL_007c: ldc.i4.2
 		IL_007d: conv.r8
 		IL_007e: ldstr "deliver"
 		IL_0083: ldc.i4.1
 		IL_0084: ldc.i4.1
-		IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/FunctionObject_ClassMethod_4E00F3BF_UndiciStyleHandler_deliver>(!!0, float64, string, bool, bool)
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/FunctionObject_ClassMethod_4E00F3BF_UndiciStyleHandler_deliver>(!!0)
+		IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/Scope_deliver/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/Scope_deliver/FunctionObject>(!!0)
 		IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0094: pop
 		IL_0095: ldc.i4.1
@@ -638,14 +642,14 @@
 		IL_00af: ldc.i4.0
 		IL_00b0: ldloc.0
 		IL_00b1: stelem.ref
-		IL_00b2: newobj instance void Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/FunctionObject_ClassConstructor_56E834DB_UndiciStyleHandler::.ctor(object[], class [System.Runtime]System.Object, object[])
+		IL_00b2: newobj instance void Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/Scope_ctor/FunctionObject::.ctor(object[], class [System.Runtime]System.Object, object[])
 		IL_00b7: ldloc.s 4
 		IL_00b9: ldloc.s 5
 		IL_00bb: ldc.i4.1
 		IL_00bc: conv.r8
 		IL_00bd: ldc.i4.0
 		IL_00be: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_00c3: castclass Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/FunctionObject_ClassConstructor_56E834DB_UndiciStyleHandler
+		IL_00c3: castclass Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/Scope_ctor/FunctionObject
 		IL_00c8: stloc.s 6
 		IL_00ca: ldloc.0
 		IL_00cb: ldfld object Modules.Require_AsyncHooks_AsyncResource_Subclass/Scope::AsyncResource

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.BeanCounter_Class_Index_Assign.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.BeanCounter_Class_Index_Assign.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.BeanCounter_Class_Index_Assign/BeanCounter/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +102,77 @@
 		.class nested public auto ansi beforefieldinit Scope_setBeanCount
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 49 (0x31)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.BeanCounter_Class_Index_Assign/BeanCounter
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.BeanCounter_Class_Index_Assign/BeanCounter
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: ldarg.2
+					IL_0025: ldc.i4.1
+					IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_002b: call instance object Modules.BeanCounter_Class_Index_Assign/BeanCounter::setBeanCount(object, object)
+					IL_0030: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -67,123 +188,6 @@
 			} // end of method Scope_setBeanCount::.ctor
 
 		} // end of class Scope_setBeanCount
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 49 (0x31)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.BeanCounter_Class_Index_Assign/BeanCounter
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.BeanCounter_Class_Index_Assign/BeanCounter
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: ldarg.2
-				IL_0025: ldc.i4.1
-				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_002b: call instance object Modules.BeanCounter_Class_Index_Assign/BeanCounter::setBeanCount(object, object)
-				IL_0030: ret
-			} // end of method FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::CallCore
-
-		} // end of class FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount
 
 
 		// Fields
@@ -279,7 +283,7 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter,
+			[6] class Modules.BeanCounter_Class_Index_Assign/BeanCounter/Scope_ctor/FunctionObject,
 			[7] class Modules.BeanCounter_Class_Index_Assign/BeanCounter,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -300,14 +304,14 @@
 		IL_002e: stloc.s 5
 		IL_0030: ldloc.s 4
 		IL_0032: ldstr "setBeanCount"
-		IL_0037: newobj instance void Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::.ctor()
+		IL_0037: newobj instance void Modules.BeanCounter_Class_Index_Assign/BeanCounter/Scope_setBeanCount/FunctionObject::.ctor()
 		IL_003c: ldc.i4.2
 		IL_003d: conv.r8
 		IL_003e: ldstr "setBeanCount"
 		IL_0043: ldc.i4.1
 		IL_0044: ldc.i4.1
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount>(!!0, float64, string, bool, bool)
-		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount>(!!0)
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BeanCounter_Class_Index_Assign/BeanCounter/Scope_setBeanCount/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.BeanCounter_Class_Index_Assign/BeanCounter/Scope_setBeanCount/FunctionObject>(!!0)
 		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0054: pop
 		IL_0055: ldc.i4.1
@@ -318,14 +322,14 @@
 		IL_005e: stelem.ref
 		IL_005f: stloc.s 5
 		IL_0061: ldloc.s 5
-		IL_0063: newobj instance void Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::.ctor(object[])
+		IL_0063: newobj instance void Modules.BeanCounter_Class_Index_Assign/BeanCounter/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_0068: ldloc.3
 		IL_0069: ldloc.s 5
 		IL_006b: ldc.i4.0
 		IL_006c: conv.r8
 		IL_006d: ldc.i4.0
 		IL_006e: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0073: castclass Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter
+		IL_0073: castclass Modules.BeanCounter_Class_Index_Assign/BeanCounter/Scope_ctor/FunctionObject
 		IL_0078: stloc.s 6
 		IL_007a: ldloc.s 6
 		IL_007c: stloc.1

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -71,6 +121,73 @@
 				} // end of method Block_L13C19::.ctor
 
 			} // end of class Block_L13C19
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 47 (0x2f)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+					IL_0029: call instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
+					IL_002e: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -234,6 +351,86 @@
 
 			} // end of class Scope_For_L30C8
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 56 (0x38)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: ldarg.2
+					IL_0025: ldc.i4.1
+					IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_002b: ldarg.2
+					IL_002c: ldc.i4.2
+					IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0032: call instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
+					IL_0037: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -294,6 +491,88 @@
 		.class nested public auto ansi beforefieldinit Scope_setBitsTrue_Naive
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue_Naive/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 56 (0x38)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue_Naive/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: ldarg.2
+					IL_0025: ldc.i4.1
+					IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_002b: ldarg.2
+					IL_002c: ldc.i4.2
+					IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0032: call instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
+					IL_0037: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -349,281 +628,6 @@
 			} // end of method Scope_For_L50C7::.ctor
 
 		} // end of class Scope_For_L50C7
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_CF24C66C_BitArray
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassConstructor_CF24C66C_BitArray::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_CF24C66C_BitArray::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_CF24C66C_BitArray::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_CF24C66C_BitArray::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_CF24C66C_BitArray
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 47 (0x2f)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0029: call instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
-				IL_002e: ret
-			} // end of method FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::CallCore
-
-		} // end of class FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 56 (0x38)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: ldarg.2
-				IL_0025: ldc.i4.1
-				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_002b: ldarg.2
-				IL_002c: ldc.i4.2
-				IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0032: call instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
-				IL_0037: ret
-			} // end of method FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::CallCore
-
-		} // end of class FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 56 (0x38)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: ldarg.2
-				IL_0025: ldc.i4.1
-				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_002b: ldarg.2
-				IL_002c: ldc.i4.2
-				IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0032: call instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
-				IL_0037: ret
-			} // end of method FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::CallCore
-
-		} // end of class FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive
 
 
 		// Fields
@@ -1218,7 +1222,7 @@
 			[7] class [System.Runtime]System.Type,
 			[8] object,
 			[9] object[],
-			[10] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassConstructor_CF24C66C_BitArray,
+			[10] class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_ctor/FunctionObject,
 			[11] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[12] string,
 			[13] string,
@@ -1248,14 +1252,14 @@
 		IL_0030: stloc.s 9
 		IL_0032: ldloc.s 8
 		IL_0034: ldstr "setBitTrue"
-		IL_0039: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::.ctor()
+		IL_0039: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitTrue/FunctionObject::.ctor()
 		IL_003e: ldc.i4.1
 		IL_003f: conv.r8
 		IL_0040: ldstr "setBitTrue"
 		IL_0045: ldc.i4.1
 		IL_0046: ldc.i4.1
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
-		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue>(!!0)
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitTrue/FunctionObject>(!!0)
 		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0056: pop
 		IL_0057: ldc.i4.1
@@ -1268,14 +1272,14 @@
 		IL_0063: ldloc.s 8
 		IL_0065: ldstr "setBitsTrue"
 		IL_006a: ldloc.s 9
-		IL_006c: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::.ctor(object[])
+		IL_006c: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/FunctionObject::.ctor(object[])
 		IL_0071: ldc.i4.3
 		IL_0072: conv.r8
 		IL_0073: ldstr "setBitsTrue"
 		IL_0078: ldc.i4.1
 		IL_0079: ldc.i4.1
-		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
-		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue>(!!0)
+		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue/FunctionObject>(!!0)
 		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0089: pop
 		IL_008a: ldc.i4.1
@@ -1288,14 +1292,14 @@
 		IL_0096: ldloc.s 8
 		IL_0098: ldstr "setBitsTrue_Naive"
 		IL_009d: ldloc.s 9
-		IL_009f: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::.ctor(object[])
+		IL_009f: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue_Naive/FunctionObject::.ctor(object[])
 		IL_00a4: ldc.i4.3
 		IL_00a5: conv.r8
 		IL_00a6: ldstr "setBitsTrue_Naive"
 		IL_00ab: ldc.i4.1
 		IL_00ac: ldc.i4.1
-		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive>(!!0, float64, string, bool, bool)
-		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive>(!!0)
+		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue_Naive/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_setBitsTrue_Naive/FunctionObject>(!!0)
 		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_00bc: pop
 		IL_00bd: ldc.i4.1
@@ -1306,14 +1310,14 @@
 		IL_00c6: stelem.ref
 		IL_00c7: stloc.s 9
 		IL_00c9: ldloc.s 9
-		IL_00cb: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassConstructor_CF24C66C_BitArray::.ctor(object[])
+		IL_00cb: newobj instance void Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_00d0: ldloc.s 7
 		IL_00d2: ldloc.s 9
 		IL_00d4: ldc.i4.1
 		IL_00d5: conv.r8
 		IL_00d6: ldc.i4.0
 		IL_00d7: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_00dc: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassConstructor_CF24C66C_BitArray
+		IL_00dc: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/Scope_ctor/FunctionObject
 		IL_00e1: stloc.s 10
 		IL_00e3: ldloc.s 10
 		IL_00e5: stloc.1

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
@@ -33,6 +33,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +102,74 @@
 		.class nested public auto ansi beforefieldinit Scope_setBitTrue
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 42 (0x2a)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitTrue(object)
+					IL_0029: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -150,6 +268,86 @@
 
 			} // end of class Block_L28C29
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 56 (0x38)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: ldarg.2
+					IL_0025: ldc.i4.1
+					IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_002b: ldarg.2
+					IL_002c: ldc.i4.2
+					IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0032: call instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
+					IL_0037: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -170,6 +368,75 @@
 		.class nested public auto ansi beforefieldinit Scope_testBitTrue
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 47 (0x2f)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+					IL_001d: ldarg.2
+					IL_001e: ldc.i4.0
+					IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0024: call instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+					IL_0029: box [System.Runtime]System.Double
+					IL_002e: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -185,267 +452,6 @@
 			} // end of method Scope_testBitTrue::.ctor
 
 		} // end of class Scope_testBitTrue
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_4DDDF0E6_BitArray
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassConstructor_4DDDF0E6_BitArray::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_4DDDF0E6_BitArray::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_4DDDF0E6_BitArray::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_4DDDF0E6_BitArray::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_4DDDF0E6_BitArray
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 42 (0x2a)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitTrue(object)
-				IL_0029: ret
-			} // end of method FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::CallCore
-
-		} // end of class FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 56 (0x38)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: ldarg.2
-				IL_0025: ldc.i4.1
-				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_002b: ldarg.2
-				IL_002c: ldc.i4.2
-				IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0032: call instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
-				IL_0037: ret
-			} // end of method FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::CallCore
-
-		} // end of class FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 47 (0x2f)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-				IL_001d: ldarg.2
-				IL_001e: ldc.i4.0
-				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0024: call instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-				IL_0029: box [System.Runtime]System.Double
-				IL_002e: ret
-			} // end of method FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::CallCore
-
-		} // end of class FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue
 
 
 		// Fields
@@ -1055,7 +1061,7 @@
 			[9] class [System.Runtime]System.Type,
 			[10] object,
 			[11] object[],
-			[12] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassConstructor_4DDDF0E6_BitArray,
+			[12] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_ctor/FunctionObject,
 			[13] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[14] object,
 			[15] class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray,
@@ -1079,14 +1085,14 @@
 		IL_0030: stloc.s 11
 		IL_0032: ldloc.s 10
 		IL_0034: ldstr "setBitTrue"
-		IL_0039: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::.ctor()
+		IL_0039: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitTrue/FunctionObject::.ctor()
 		IL_003e: ldc.i4.1
 		IL_003f: conv.r8
 		IL_0040: ldstr "setBitTrue"
 		IL_0045: ldc.i4.1
 		IL_0046: ldc.i4.1
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue>(!!0, float64, string, bool, bool)
-		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue>(!!0)
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitTrue/FunctionObject>(!!0)
 		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0056: pop
 		IL_0057: ldc.i4.1
@@ -1099,28 +1105,28 @@
 		IL_0063: ldloc.s 10
 		IL_0065: ldstr "setBitsTrue"
 		IL_006a: ldloc.s 11
-		IL_006c: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::.ctor(object[])
+		IL_006c: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/FunctionObject::.ctor(object[])
 		IL_0071: ldc.i4.3
 		IL_0072: conv.r8
 		IL_0073: ldstr "setBitsTrue"
 		IL_0078: ldc.i4.1
 		IL_0079: ldc.i4.1
-		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue>(!!0, float64, string, bool, bool)
-		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue>(!!0)
+		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_setBitsTrue/FunctionObject>(!!0)
 		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0089: pop
 		IL_008a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_008f: stloc.s 11
 		IL_0091: ldloc.s 10
 		IL_0093: ldstr "testBitTrue"
-		IL_0098: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::.ctor()
+		IL_0098: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_testBitTrue/FunctionObject::.ctor()
 		IL_009d: ldc.i4.1
 		IL_009e: conv.r8
 		IL_009f: ldstr "testBitTrue"
 		IL_00a4: ldc.i4.1
 		IL_00a5: ldc.i4.1
-		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue>(!!0, float64, string, bool, bool)
-		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue>(!!0)
+		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_testBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_testBitTrue/FunctionObject>(!!0)
 		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_00b5: pop
 		IL_00b6: ldc.i4.1
@@ -1131,14 +1137,14 @@
 		IL_00bf: stelem.ref
 		IL_00c0: stloc.s 11
 		IL_00c2: ldloc.s 11
-		IL_00c4: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassConstructor_4DDDF0E6_BitArray::.ctor(object[])
+		IL_00c4: newobj instance void Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
 		IL_00c9: ldloc.s 9
 		IL_00cb: ldloc.s 11
 		IL_00cd: ldc.i4.1
 		IL_00ce: conv.r8
 		IL_00cf: ldc.i4.0
 		IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_00d5: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassConstructor_4DDDF0E6_BitArray
+		IL_00d5: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/Scope_ctor/FunctionObject
 		IL_00da: stloc.s 12
 		IL_00dc: ldloc.s 12
 		IL_00de: stloc.1

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_DoubleNot_NaNTruthiness.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_DoubleNot_NaNTruthiness.verified.txt
@@ -33,6 +33,72 @@
 		.class nested public auto ansi beforefieldinit Scope_returnNaN
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.UnaryOperator_DoubleNot_NaNTruthiness/C
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.UnaryOperator_DoubleNot_NaNTruthiness/C
+					IL_001d: call instance float64 Modules.UnaryOperator_DoubleNot_NaNTruthiness/C::returnNaN()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -52,6 +118,72 @@
 		.class nested public auto ansi beforefieldinit Scope_returnNumber
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.UnaryOperator_DoubleNot_NaNTruthiness/C
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.UnaryOperator_DoubleNot_NaNTruthiness/C
+					IL_001d: call instance float64 Modules.UnaryOperator_DoubleNot_NaNTruthiness/C::returnNumber()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -71,6 +203,56 @@
 		.class nested public auto ansi beforefieldinit Scope_ctor
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.UnaryOperator_DoubleNot_NaNTruthiness/C/Scope_ctor/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -86,182 +268,6 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_8999139A_C
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.UnaryOperator_DoubleNot_NaNTruthiness/C/FunctionObject_ClassConstructor_8999139A_C::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_8999139A_C::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_8999139A_C::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.1
-				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_8999139A_C::get_RequiresInvocationContext
-
-		} // end of class FunctionObject_ClassConstructor_8999139A_C
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_1A72E20C_C_returnNaN
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_1A72E20C_C_returnNaN::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_1A72E20C_C_returnNaN::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_1A72E20C_C_returnNaN::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.UnaryOperator_DoubleNot_NaNTruthiness/C
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.UnaryOperator_DoubleNot_NaNTruthiness/C
-				IL_001d: call instance float64 Modules.UnaryOperator_DoubleNot_NaNTruthiness/C::returnNaN()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_1A72E20C_C_returnNaN::CallCore
-
-		} // end of class FunctionObject_ClassMethod_1A72E20C_C_returnNaN
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_F42D957A_C_returnNumber
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_F42D957A_C_returnNumber::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_F42D957A_C_returnNumber::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_F42D957A_C_returnNumber::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.UnaryOperator_DoubleNot_NaNTruthiness/C
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.UnaryOperator_DoubleNot_NaNTruthiness/C
-				IL_001d: call instance float64 Modules.UnaryOperator_DoubleNot_NaNTruthiness/C::returnNumber()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_F42D957A_C_returnNumber::CallCore
-
-		} // end of class FunctionObject_ClassMethod_F42D957A_C_returnNumber
 
 
 		// Methods

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation.verified.txt
@@ -732,6 +732,79 @@
 		.class nested public auto ansi beforefieldinit Scope_read
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/Reader/Scope_read/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Variable_ConstPrimitivePropagation/Reader
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Variable_ConstPrimitivePropagation/Reader/Scope_read/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Variable_ConstPrimitivePropagation/Reader
+					IL_001d: call instance object Modules.Variable_ConstPrimitivePropagation/Reader::read()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -751,6 +824,71 @@
 		.class nested public auto ansi beforefieldinit Scope_shadow
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Variable_ConstPrimitivePropagation/Reader
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldc.i4.1
+					IL_000c: newarr [System.Runtime]System.Object
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Variable_ConstPrimitivePropagation/Reader
+					IL_001d: call instance object Modules.Variable_ConstPrimitivePropagation/Reader::shadow()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -767,7 +905,7 @@
 
 		} // end of class Scope_shadow
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_684D8BC2_Reader
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -787,9 +925,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/Reader/FunctionObject_ClassConstructor_684D8BC2_Reader::_transitionalScopes
+				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/Reader/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_684D8BC2_Reader::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -800,7 +938,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_684D8BC2_Reader::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -811,143 +949,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_684D8BC2_Reader::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_684D8BC2_Reader
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_3DE6B5BB_Reader_read
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/Reader/FunctionObject_ClassMethod_3DE6B5BB_Reader_read::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_3DE6B5BB_Reader_read::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_3DE6B5BB_Reader_read::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_3DE6B5BB_Reader_read::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Variable_ConstPrimitivePropagation/Reader
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Variable_ConstPrimitivePropagation/Reader/FunctionObject_ClassMethod_3DE6B5BB_Reader_read::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Variable_ConstPrimitivePropagation/Reader
-				IL_001d: call instance object Modules.Variable_ConstPrimitivePropagation/Reader::read()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_3DE6B5BB_Reader_read::CallCore
-
-		} // end of class FunctionObject_ClassMethod_3DE6B5BB_Reader_read
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_53B63CFF_Reader_shadow
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 7 (0x7)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ret
-			} // end of method FunctionObject_ClassMethod_53B63CFF_Reader_shadow::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_53B63CFF_Reader_shadow::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_53B63CFF_Reader_shadow::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Variable_ConstPrimitivePropagation/Reader
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldc.i4.1
-				IL_000c: newarr [System.Runtime]System.Object
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Variable_ConstPrimitivePropagation/Reader
-				IL_001d: call instance object Modules.Variable_ConstPrimitivePropagation/Reader::shadow()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_53B63CFF_Reader_shadow::CallCore
-
-		} // end of class FunctionObject_ClassMethod_53B63CFF_Reader_shadow
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -1081,6 +1085,80 @@
 		.class nested public auto ansi beforefieldinit Scope_read
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/WrittenReader/Scope_read/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Variable_ConstPrimitivePropagation/WrittenReader
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Variable_ConstPrimitivePropagation/WrittenReader/Scope_read/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Variable_ConstPrimitivePropagation/WrittenReader
+					IL_001d: call instance float64 Modules.Variable_ConstPrimitivePropagation/WrittenReader::read()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1097,7 +1175,7 @@
 
 		} // end of class Scope_read
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_C9CF370F_WrittenReader
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -1117,9 +1195,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/WrittenReader/FunctionObject_ClassConstructor_C9CF370F_WrittenReader::_transitionalScopes
+				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/WrittenReader/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_C9CF370F_WrittenReader::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1130,7 +1208,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_C9CF370F_WrittenReader::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1141,81 +1219,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_C9CF370F_WrittenReader::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_C9CF370F_WrittenReader
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_F21E7C12_WrittenReader_read
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/WrittenReader/FunctionObject_ClassMethod_F21E7C12_WrittenReader_read::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_F21E7C12_WrittenReader_read::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_F21E7C12_WrittenReader_read::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_F21E7C12_WrittenReader_read::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Variable_ConstPrimitivePropagation/WrittenReader
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Variable_ConstPrimitivePropagation/WrittenReader/FunctionObject_ClassMethod_F21E7C12_WrittenReader_read::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Variable_ConstPrimitivePropagation/WrittenReader
-				IL_001d: call instance float64 Modules.Variable_ConstPrimitivePropagation/WrittenReader::read()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_F21E7C12_WrittenReader_read::CallCore
-
-		} // end of class FunctionObject_ClassMethod_F21E7C12_WrittenReader_read
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -1294,6 +1300,80 @@
 		.class nested public auto ansi beforefieldinit Scope_read
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/PatternReader/Scope_read/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Variable_ConstPrimitivePropagation/PatternReader
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Variable_ConstPrimitivePropagation/PatternReader/Scope_read/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Variable_ConstPrimitivePropagation/PatternReader
+					IL_001d: call instance float64 Modules.Variable_ConstPrimitivePropagation/PatternReader::read()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1310,7 +1390,7 @@
 
 		} // end of class Scope_read
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_9780F786_PatternReader
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -1330,9 +1410,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/PatternReader/FunctionObject_ClassConstructor_9780F786_PatternReader::_transitionalScopes
+				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/PatternReader/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_9780F786_PatternReader::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1343,7 +1423,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_9780F786_PatternReader::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1354,81 +1434,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_9780F786_PatternReader::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_9780F786_PatternReader
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_1232A1A1_PatternReader_read
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/PatternReader/FunctionObject_ClassMethod_1232A1A1_PatternReader_read::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_1232A1A1_PatternReader_read::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_1232A1A1_PatternReader_read::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_1232A1A1_PatternReader_read::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Variable_ConstPrimitivePropagation/PatternReader
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Variable_ConstPrimitivePropagation/PatternReader/FunctionObject_ClassMethod_1232A1A1_PatternReader_read::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Variable_ConstPrimitivePropagation/PatternReader
-				IL_001d: call instance float64 Modules.Variable_ConstPrimitivePropagation/PatternReader::read()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_1232A1A1_PatternReader_read::CallCore
-
-		} // end of class FunctionObject_ClassMethod_1232A1A1_PatternReader_read
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -1507,6 +1515,80 @@
 		.class nested public auto ansi beforefieldinit Scope_read
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/LoopReader/Scope_read/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 40 (0x28)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Variable_ConstPrimitivePropagation/LoopReader
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Variable_ConstPrimitivePropagation/LoopReader/Scope_read/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Variable_ConstPrimitivePropagation/LoopReader
+					IL_001d: call instance float64 Modules.Variable_ConstPrimitivePropagation/LoopReader::read()
+					IL_0022: box [System.Runtime]System.Double
+					IL_0027: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1523,7 +1605,7 @@
 
 		} // end of class Scope_read
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7E4AB268_LoopReader
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -1543,9 +1625,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/LoopReader/FunctionObject_ClassConstructor_7E4AB268_LoopReader::_transitionalScopes
+				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/LoopReader/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_7E4AB268_LoopReader::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1556,7 +1638,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7E4AB268_LoopReader::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1567,81 +1649,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_7E4AB268_LoopReader::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_7E4AB268_LoopReader
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_30F34DFD_LoopReader_read
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/LoopReader/FunctionObject_ClassMethod_30F34DFD_LoopReader_read::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_30F34DFD_LoopReader_read::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_30F34DFD_LoopReader_read::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_30F34DFD_LoopReader_read::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 40 (0x28)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Variable_ConstPrimitivePropagation/LoopReader
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Variable_ConstPrimitivePropagation/LoopReader/FunctionObject_ClassMethod_30F34DFD_LoopReader_read::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Variable_ConstPrimitivePropagation/LoopReader
-				IL_001d: call instance float64 Modules.Variable_ConstPrimitivePropagation/LoopReader::read()
-				IL_0022: box [System.Runtime]System.Double
-				IL_0027: ret
-			} // end of method FunctionObject_ClassMethod_30F34DFD_LoopReader_read::CallCore
-
-		} // end of class FunctionObject_ClassMethod_30F34DFD_LoopReader_read
+		} // end of class FunctionObject
 
 
 		// Fields
@@ -1720,6 +1730,79 @@
 		.class nested public auto ansi beforefieldinit Scope_read
 			extends [System.Runtime]System.Object
 		{
+			// Nested Types
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/DestructuredReader/Scope_read/FunctionObject::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 35 (0x23)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: ldtoken Modules.Variable_ConstPrimitivePropagation/DestructuredReader
+					IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+					IL_000b: ldarg.0
+					IL_000c: ldfld object[] Modules.Variable_ConstPrimitivePropagation/DestructuredReader/Scope_read/FunctionObject::_transitionalScopes
+					IL_0011: ldnull
+					IL_0012: ldarg.0
+					IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
+					IL_0018: castclass Modules.Variable_ConstPrimitivePropagation/DestructuredReader
+					IL_001d: call instance object Modules.Variable_ConstPrimitivePropagation/DestructuredReader::read()
+					IL_0022: ret
+				} // end of method FunctionObject::CallCore
+
+			} // end of class FunctionObject
+
+
 			// Methods
 			.method public hidebysig specialname rtspecialname 
 				instance void .ctor () cil managed 
@@ -1736,7 +1819,7 @@
 
 		} // end of class Scope_read
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
 		{
 			// Fields
@@ -1756,9 +1839,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/DestructuredReader/FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader::_transitionalScopes
+				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/DestructuredReader/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1769,7 +1852,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1780,80 +1863,9 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
-		} // end of class FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader
-
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read
-			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-		{
-			// Fields
-			.field private initonly object[] _transitionalScopes
-
-			// Methods
-			.method public hidebysig specialname rtspecialname 
-				instance void .ctor (
-					object[] capture0
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 14 (0xe)
-				.maxstack 8
-
-				IL_0000: ldarg.0
-				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-				IL_0006: ldarg.0
-				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/DestructuredReader/FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read::_transitionalScopes
-				IL_000d: ret
-			} // end of method FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read::.ctor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_IsConstructor () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read::get_IsConstructor
-
-			.method public hidebysig specialname virtual 
-				instance bool get_RequiresInvocationContext () cil managed 
-			{
-				// Header size: 1
-				// Code size: 2 (0x2)
-				.maxstack 8
-
-				IL_0000: ldc.i4.0
-				IL_0001: ret
-			} // end of method FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read::get_RequiresInvocationContext
-
-			.method family hidebysig virtual 
-				instance object CallCore (
-					object thisArgument,
-					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-				) cil managed 
-			{
-				// Header size: 1
-				// Code size: 35 (0x23)
-				.maxstack 8
-
-				IL_0000: ldarg.1
-				IL_0001: ldtoken Modules.Variable_ConstPrimitivePropagation/DestructuredReader
-				IL_0006: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-				IL_000b: ldarg.0
-				IL_000c: ldfld object[] Modules.Variable_ConstPrimitivePropagation/DestructuredReader/FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read::_transitionalScopes
-				IL_0011: ldnull
-				IL_0012: ldarg.0
-				IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveGeneratedClassMethodReceiver(object, class [System.Runtime]System.Type, object[], object, class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject)
-				IL_0018: castclass Modules.Variable_ConstPrimitivePropagation/DestructuredReader
-				IL_001d: call instance object Modules.Variable_ConstPrimitivePropagation/DestructuredReader::read()
-				IL_0022: ret
-			} // end of method FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read::CallCore
-
-		} // end of class FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read
+		} // end of class FunctionObject
 
 
 		// Fields


### PR DESCRIPTION
## Summary
- Nest generated class function objects under their method scope with the concise `FunctionObject` name.
- Keep the class type as the runtime owner while giving getter and setter scopes distinct registry/type identities.
- Update generated IL baselines and function-object emission coverage.

## Validation
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-build --no-restore --verbosity:minimal`
