### PR TITLE
perf(runtime): evaluate zero-allocation invocation transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- perf(runtime/docs): evaluate a reusable thread-static compatibility frame
+  (issue #1890). The benchmark control reaches 0 B/call, but production retains
+  the 200 B/call immutable `AsyncLocal` fallback because residual state must
+  preserve point-in-time snapshots across arbitrary task/thread hops.
 - perf(runtime): collapse residual ambient invocation state into one immutable
   `AsyncLocal` frame (issue #1887). Compatibility calls now publish and restore
   `this`, arguments, callee, `new.target`, and lexical-super state with one

--- a/docs/runtime/JsFunctionObjectInvocationAbi.md
+++ b/docs/runtime/JsFunctionObjectInvocationAbi.md
@@ -52,9 +52,11 @@ explicit context, install no `AsyncLocal` values. Compatibility paths for
 named-function identity, non-strict `arguments.callee`, bound `with`
 environments, lexical `super`, and resumable state machines retain ambient
 transport. `CallableOperations` and generated array adapters publish only the
-individual values selected by `InvocationContextRequirements`, then restore
-only those values in a `finally` block. Inline arguments remain lazy and
-stable for the duration of an invocation.
+values selected by `InvocationContextRequirements` in one immutable
+`AsyncLocal` frame, then restore the previous frame in a `finally` block.
+Inline arguments remain lazy and stable for the duration of an invocation.
+See [Residual invocation-state transport](ResidualInvocationState.md) for the
+thread-hop audit and issue #1890 decision.
 
 Known spread/rest/`arguments` calls still end in the canonical typed MethodDef.
 Their generated static array adapter receives the actual `JsFunctionObject`
@@ -163,15 +165,22 @@ dotnet run -c Release \
   --callable-abi --filter "*"
 ```
 
-The local .NET 10 ShortRun on 2026-08-05 produced:
+The local .NET 10 ShortRun on 2026-08-19 produced:
 
 | Path | Mean | Allocated |
 | --- | ---: | ---: |
-| `JsFunctionObject` fixed arity 3 | 1.537 ns | 0 B |
-| `JsFunctionObject` pre-materialized arbitrary arguments | 1.572 ns | 0 B |
-| `JsFunctionObject` spread materialization | 12.161 ns | 48 B |
-| legacy `Closure.InvokeWithArgs3` | 18.774 ns | 48 B |
-| `JsFunctionObject` ambient-context fixed arity 3 | 325.786 ns | 304 B |
+| `JsFunctionObject` pre-materialized arbitrary arguments | 1.179 ns | 0 B |
+| `JsFunctionObject` fixed arity 3 | 1.397 ns | 0 B |
+| receiver-aware built-in adapter fixed arity 3 | 6.388 ns | 0 B |
+| built-in delegate adapter fixed arity 3 | 8.633 ns | 0 B |
+| `JsFunctionObject` spread materialization | 10.409 ns | 48 B |
+| thread-static compatibility-frame prototype | 17.358 ns | 0 B |
+| `JsFunctionObject` ambient-context fixed arity 3 | 70.840 ns | 200 B |
+
+Issue #1890 also retains a benchmark-only reusable thread-static frame control.
+It measures 0 B/call but is not used in production because it cannot preserve
+point-in-time compatibility state across arbitrary CLR `ExecutionContext`
+captures without reintroducing copy-on-write publication.
 
 These microbenchmarks guard the ABI shape; end-to-end benchmark results remain
 the authority for application performance. The ambient-context result also

--- a/docs/runtime/ResidualInvocationState.md
+++ b/docs/runtime/ResidualInvocationState.md
@@ -1,0 +1,84 @@
+# Residual invocation-state transport
+
+Issue #1890 evaluated replacing the residual `RuntimeServices` invocation
+frame with a reusable `[ThreadStatic]` stack. The production design remains
+the single immutable `AsyncLocal` frame introduced by issue #1887.
+
+## Boundary inventory
+
+Most calls carry invocation data explicitly:
+
+- receiver-aware built-ins receive `this` and fixed-arity arguments directly;
+- synchronous generated callables receive `GeneratedInvocationContext` when
+  their ABI supports it;
+- generated constructors receive `new.target` explicitly;
+- async and generator scopes retain state that must survive suspension,
+  including their captured `this` value and compiler-generated locals.
+
+The ambient compatibility frame remains for:
+
+- named-function identity, `arguments.callee`, bound `with` environments, and
+  lexical `super`;
+- generated array adapters that cannot use the explicit-context ABI;
+- generator and async-generator entry before their scope captures resumable
+  state;
+- legacy constructors and accessors that still read `this`, arguments, or
+  `new.target` through `RuntimeServices`.
+
+State crosses the following boundaries:
+
+| Boundary | Transport and isolation |
+| --- | --- |
+| Nested and reentrant calls | `CallableOperations` pushes one immutable frame and restores it in `finally`. |
+| Exceptions | The same `finally` restoration prevents state leaks. |
+| Synchronous generators | `GeneratorScope.ThisValue` is captured at creation and reinstalled around every resume. |
+| Async functions | `AsyncScope` captures `this`; compiler-generated scope fields retain locals needed after `await`. |
+| Async generators | `AsyncGeneratorScope` retains resumable state and reinstalls captured `this` around `MoveNext`. |
+| Promise reactions and jobs | Callbacks re-enter through `CallableOperations` on the owning runtime scheduler. |
+| Root realm/agent entry | `RuntimeExecutionContext.EnterAsRoot()` captures, clears, and restores the complete compatibility state. |
+| Arbitrary task/thread hops | `AsyncLocal` snapshots the immutable frame with the CLR `ExecutionContext`. |
+| Concurrent tasks | Copy-on-write frame replacement prevents one continuation from mutating another continuation's snapshot. |
+
+## Measured alternatives
+
+Run the focused comparison:
+
+```bash
+dotnet run -c Release \
+  --project tests/performance/Benchmarks/Benchmarks.csproj -- \
+  --callable-abi --filter "*"
+```
+
+The relevant designs are:
+
+| Design | Steady-state allocation | Status |
+| --- | ---: | --- |
+| Explicit generated/built-in context | 0 B/call | Preferred and used whenever supported |
+| Single immutable `AsyncLocal` frame | 200 B/call | Residual compatibility fallback |
+| Reusable `[ThreadStatic]` frame prototype | 0 B/call | Rejected for production |
+
+The `AsyncLocal` result is a 70.9% reduction from the 688 B/call multi-slot
+control measured by issue #1885.
+
+## Decision
+
+A thread-static stack is safe only while execution stays on one CLR thread or
+passes through a boundary that JROC explicitly instruments. That is not the
+complete runtime contract. Active compatibility state currently flows through
+arbitrary `Task.Run` and CLR `ExecutionContext` captures; hosted lifecycle
+suppression must then clear the inherited state for a child runtime and restore
+it afterward.
+
+JROC cannot intercept every task, host callback, or third-party
+`ExecutionContext` capture. Attaching a mutable thread-static snapshot to the
+existing runtime `AsyncLocal` would also be incorrect: captured continuations
+would share the same mutable object instead of receiving point-in-time state.
+Making that snapshot copy-on-write would require an `AsyncLocal` publication
+at each call boundary and recreate the allocation cost the thread-static design
+was intended to remove.
+
+Therefore the zero-allocation stack remains a benchmark control, not runtime
+architecture. Future work should continue shrinking the residual set through
+explicit parameters and state-machine fields. The single immutable
+`AsyncLocal` frame is the safer fallback for the compatibility paths that
+remain.

--- a/docs/runtime/RuntimeExecutionFrames.md
+++ b/docs/runtime/RuntimeExecutionFrames.md
@@ -24,10 +24,11 @@ realm is rejected.
 and the engine's test/bootstrap service override all resolve through this
 frame. Thread identity is not a runtime identity boundary.
 
-The existing invocation-state fields remain separate for now. The
-continuation-scoped values preserve per-continuation snapshots without
-allocating a new execution frame on hot JavaScript call paths. Root frame
-entry explicitly captures, clears, and restores those values and the
+Residual invocation values use one immutable `AsyncLocal` frame. Copy-on-write
+replacement preserves point-in-time snapshots across task/thread hops, while
+root frame entry explicitly captures, clears, and restores that frame plus the
 thread-affine direct-call stacks so a new agent cannot inherit its creator's
 call state. Root engine and hosted entry scopes remain synchronous and
-thread-affine while those stacks use thread-static storage.
+thread-affine while those stacks use thread-static storage. The rejected
+thread-static invocation-frame evaluation is documented in
+[Residual invocation-state transport](ResidualInvocationState.md).

--- a/docs/runtime/RuntimeStaticState.md
+++ b/docs/runtime/RuntimeStaticState.md
@@ -55,13 +55,7 @@ another thread must not observe itself as reentrant.
 | `PropertyDescriptorStore._intrinsicInitializationDepth` | CLR thread | Reentrant intrinsic bootstrap state |
 | `RuntimeExecutionContext.Ambient` | Async flow | The sole ambient realm/agent pointer |
 | `RuntimeIntrinsics._blockedThreads` | Process coordination | Transient wait graph; entries are removed when waits end |
-| `RuntimeServices._currentArguments` | Async flow | Invocation state captured/restored by root frames |
-| `RuntimeServices._currentCallArguments` | Async flow | Invocation state captured/restored by root frames |
-| `RuntimeServices._currentCallee` | Async flow | Invocation state captured/restored by root frames |
-| `RuntimeServices._currentLexicalSuperReceiver` | Async flow | Invocation state captured/restored by root frames |
-| `RuntimeServices._currentLexicalSuperScopes` | Async flow | Invocation state captured/restored by root frames |
-| `RuntimeServices._currentNewTarget` | Async flow | Invocation state captured/restored by root frames |
-| `RuntimeServices._currentThis` | Async flow | Invocation state captured/restored by root frames |
+| `RuntimeServices._currentInvocation` | Async flow | Immutable residual invocation frame captured/restored by root frames |
 | `JsReturnConverter.ResultConversions` | Process metadata | Weak-keyed constructed generic methods |
 
 A weak-keyed table is approved only when the key has the semantic lifetime of

--- a/tests/Jroc.Tests/Function/JsFunctionObjectRuntimeTests.cs
+++ b/tests/Jroc.Tests/Function/JsFunctionObjectRuntimeTests.cs
@@ -149,6 +149,29 @@ public sealed class JsFunctionObjectRuntimeTests
     }
 
     [Fact]
+    public void CompatibilityInvocationFrameFlowsAcrossTaskThreadHop()
+    {
+        var callerThreadId = Environment.CurrentManagedThreadId;
+        var function = new ThreadHopFunction();
+
+        var result = Assert.IsType<ThreadHopSnapshot>(
+            CallableOperations.Call1(
+                function,
+                "thread-hop-this",
+                "thread-hop-argument"));
+
+        Assert.NotEqual(callerThreadId, result.ThreadId);
+        Assert.Equal("thread-hop-this", result.ThisArgument);
+        Assert.Equal("thread-hop-argument", result.Argument);
+        Assert.Same(function, result.Callee);
+        Assert.Null(result.NewTarget);
+        Assert.Null(RuntimeServices.GetCurrentThis());
+        Assert.Null(RuntimeServices.GetCurrentArguments());
+        Assert.Null(RuntimeServices.GetCurrentCallee());
+        Assert.Null(RuntimeServices.GetCurrentNewTarget());
+    }
+
+    [Fact]
     public void CallableOperations_ConstructsOnlyConstructableFunctionObjects()
     {
         var constructor = new ConstructableFunction();
@@ -1084,6 +1107,25 @@ public sealed class JsFunctionObjectRuntimeTests
         }
     }
 
+    private sealed class ThreadHopFunction : JsFunctionObject
+    {
+        protected override object? CallCore(
+            object? thisArgument,
+            in JsCallArguments arguments)
+            => Task.Factory.StartNew(
+                    () => new ThreadHopSnapshot(
+                        Environment.CurrentManagedThreadId,
+                        RuntimeServices.GetCurrentThis(),
+                        RuntimeServices.GetCurrentArguments()?[0],
+                        RuntimeServices.GetCurrentCallee(),
+                        RuntimeServices.GetCurrentNewTarget()),
+                    CancellationToken.None,
+                    TaskCreationOptions.LongRunning,
+                    TaskScheduler.Default)
+                .GetAwaiter()
+                .GetResult();
+    }
+
     private sealed class ConstructableFunction : JsFunctionObject
     {
         public override bool IsConstructor => true;
@@ -1178,6 +1220,13 @@ public sealed class JsFunctionObjectRuntimeTests
             RuntimeServices.GetCurrentNewTarget());
 
     private sealed record CallSnapshot(
+        object? ThisArgument,
+        object? Argument,
+        object? Callee,
+        object? NewTarget);
+
+    private sealed record ThreadHopSnapshot(
+        int ThreadId,
         object? ThisArgument,
         object? Argument,
         object? Callee,

--- a/tests/performance/Benchmarks/JsFunctionObjectInvocationBenchmarks.cs
+++ b/tests/performance/Benchmarks/JsFunctionObjectInvocationBenchmarks.cs
@@ -21,6 +21,9 @@ public class JsFunctionObjectInvocationBenchmarks
     private static readonly object Argument1 = new();
     private static readonly object Argument2 = new();
     private static readonly object?[] ArbitraryArguments = [Argument0, Argument1, Argument2];
+    private static readonly object[] LexicalSuperScopes = [new object()];
+    private static readonly JsCallArguments PackedArguments =
+        JsCallArguments.From(Argument0, Argument1, Argument2);
 
     private readonly BenchmarkFunction _functionObject = new();
     private readonly ContextualBenchmarkFunction _contextualFunctionObject = new();
@@ -85,6 +88,28 @@ public class JsFunctionObjectInvocationBenchmarks
             Argument1,
             Argument2)!;
 
+    [Benchmark(Description = "Thread-static compatibility frame prototype")]
+    public object ThreadStaticCompatibilityFramePrototype()
+    {
+        var previousDepth =
+            ThreadStaticInvocationFramePrototype.Push(
+                Argument0,
+                Argument1,
+                LexicalSuperScopes,
+                currentArguments: null,
+                currentCallArguments: PackedArguments,
+                callee: _contextualFunctionObject,
+                newTarget: null);
+        try
+        {
+            return ThreadStaticInvocationFramePrototype.CurrentCallee!;
+        }
+        finally
+        {
+            ThreadStaticInvocationFramePrototype.Pop(previousDepth);
+        }
+    }
+
     [Benchmark(Description = "JsFunctionObject spread materialization")]
     public object FunctionObjectSpreadMaterialization()
         => CallableOperations.Call(
@@ -108,5 +133,88 @@ public class JsFunctionObjectInvocationBenchmarks
             object? thisArgument,
             in JsCallArguments arguments)
             => arguments.GetArgument(2);
+    }
+
+    private static class ThreadStaticInvocationFramePrototype
+    {
+        [ThreadStatic]
+        private static FrameStack? _stack;
+
+        internal static object? CurrentCallee
+            => _stack?.Current.Callee;
+
+        internal static int Push(
+            object? currentThis,
+            object? lexicalSuperReceiver,
+            object[] lexicalSuperScopes,
+            object?[]? currentArguments,
+            in JsCallArguments currentCallArguments,
+            object? callee,
+            object? newTarget)
+            => (_stack ??= new FrameStack()).Push(
+                currentThis,
+                lexicalSuperReceiver,
+                lexicalSuperScopes,
+                currentArguments,
+                currentCallArguments,
+                callee,
+                newTarget);
+
+        internal static void Pop(int previousDepth)
+            => _stack!.Pop(previousDepth);
+
+        private sealed class FrameStack
+        {
+            private PrototypeFrame[] _frames = new PrototypeFrame[8];
+            private int _depth;
+
+            internal ref readonly PrototypeFrame Current
+                => ref _frames[_depth];
+
+            internal int Push(
+                object? currentThis,
+                object? lexicalSuperReceiver,
+                object[] lexicalSuperScopes,
+                object?[]? currentArguments,
+                in JsCallArguments currentCallArguments,
+                object? callee,
+                object? newTarget)
+            {
+                var previousDepth = _depth;
+                var nextDepth = previousDepth + 1;
+                if (nextDepth == _frames.Length)
+                {
+                    System.Array.Resize(
+                        ref _frames,
+                        _frames.Length * 2);
+                }
+
+                _frames[nextDepth] = new PrototypeFrame(
+                    currentThis,
+                    lexicalSuperReceiver,
+                    lexicalSuperScopes,
+                    currentArguments,
+                    currentCallArguments,
+                    callee,
+                    newTarget);
+                _depth = nextDepth;
+                return previousDepth;
+            }
+
+            internal void Pop(int previousDepth)
+            {
+                _frames[_depth] = default;
+                _depth = previousDepth;
+            }
+        }
+
+        private readonly record struct PrototypeFrame(
+            object? CurrentThis,
+            object? LexicalSuperReceiver,
+            object[]? LexicalSuperScopes,
+            object?[]? CurrentArguments,
+            JsCallArguments? CurrentCallArguments,
+            object? Callee,
+            object? NewTarget);
     }
 }


### PR DESCRIPTION
## Summary

- audit residual invocation state across calls, constructors, generators, async resumptions, promise jobs, realms, exceptions, concurrent tasks, and physical thread hops
- add a benchmark-only reusable `[ThreadStatic]` frame-stack prototype
- prove compatibility state must retain immutable `ExecutionContext` snapshots across arbitrary task/thread hops
- document the decision to keep the single `AsyncLocal` frame from #1887 while continuing to prefer explicit transport

## Decision

The thread-static prototype reaches zero steady-state allocation, but it is not safe as the production fallback. JROC cannot intercept every CLR task or host `ExecutionContext` capture, and a mutable snapshot attached to the realm `AsyncLocal` would leak state between captured continuations. Making it copy-on-write would recreate the publication cost the prototype is intended to remove.

## Benchmark

| Design | Mean | Allocated |
| --- | ---: | ---: |
| Explicit `JsFunctionObject` fixed arity 3 | 1.397 ns | 0 B |
| Thread-static compatibility-frame prototype | 17.358 ns | 0 B |
| Immutable `AsyncLocal` compatibility frame | 70.840 ns | 200 B |

## Validation

- `dotnet build --no-restore`
- 52 invocation-frame, lifecycle, execution-context, and static-state tests
- 232 class/function/generator/async-generator semantic tests
- 19 generated-function planning, emission, and integration tests
- BenchmarkDotNet callable ABI suite

Closes #1890
