### PR TITLE
perf(runtime): add realm-owned intrinsic prototype epochs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- perf(runtime): add a realm-owned String prototype mutation epoch for guarded
+  compiler specialization (issue #1892). Assignment, descriptor definition and
+  deletion, accessors, default-callable replacement, and prototype-link changes
+  on `String.prototype` or `Object.prototype` invalidate only the owning realm;
+  reads and validation allocate zero bytes.
 - perf(runtime/docs): evaluate a reusable thread-static compatibility frame
   (issue #1890). The benchmark control reaches 0 B/call, but production retains
   the 200 B/call immutable `AsyncLocal` fallback because residual state must

--- a/docs/runtime/IntrinsicPrototypeMutationEpochs.md
+++ b/docs/runtime/IntrinsicPrototypeMutationEpochs.md
@@ -1,0 +1,109 @@
+# Intrinsic prototype mutation epochs
+
+Generated specialization must never bypass observable JavaScript property
+lookup based only on a receiver's static type. Issue #1892 adds realm-owned
+mutation epochs that generated code can use to validate assumptions about an
+intrinsic prototype chain before taking a direct helper path.
+
+## Design
+
+Epochs are per realm and per intrinsic family. The first family is
+`IntrinsicPrototypeFamily.String`.
+
+```csharp
+if (IntrinsicPrototypeEpochs.IsPristine(
+        IntrinsicPrototypeFamily.String))
+{
+    // Guarded specialization.
+}
+else
+{
+    // Full JavaScript property lookup.
+}
+```
+
+Reads perform one ambient realm lookup and one volatile counter read. They
+allocate no memory and are marked for aggressive inlining.
+
+Each epoch is monotonic. Restoring a default descriptor does not make an old
+assumption valid again; generated code must continue using its exact fallback
+after any relevant mutation.
+
+Only `PristineEpoch` (`0`) proves that the realm still has its default
+intrinsic chain. `Read` and `IsCurrent` support diagnostics and future hoisting
+work, but generated code must not capture an already-mutated epoch and treat it
+as permission to specialize.
+
+## Invalidation
+
+The String family increments when user code mutates:
+
+- any own property or descriptor on `String.prototype`;
+- any own property or descriptor on `Object.prototype`, the default ancestor;
+- the `[[Prototype]]` link of either intrinsic prototype.
+
+This covers assignment, `Object.defineProperty`, descriptor reconfiguration,
+accessor installation, deletion, default callable replacement,
+`Object.setPrototypeOf`, `Reflect.setPrototypeOf`, and legacy `__proto__`
+mutation because those operations converge on `PropertyDescriptorStore` or
+`PrototypeChain`.
+
+Intrinsic bootstrap runs under initialization suppression, so constructing the
+default descriptor graph and prototype links leaves the initial epoch stable.
+Unrelated object and intrinsic mutations do not invalidate the String family.
+
+`Object.prototype` is a shared ancestor, so its mutations fan out to every
+family that depends on it. The current implementation has only the String
+family; future families can add their own counters and ancestor dependencies
+without introducing a process-wide coarse invalidation token.
+
+## Realm ownership
+
+Counters live directly on `RuntimeIntrinsics`, alongside the realm's intrinsic
+objects. No static table retains a realm or prototype. Mutation hooks compare
+the target against already-published intrinsic slots and never materialize a
+new intrinsic graph merely because an ordinary object changed.
+
+A mutation in one realm therefore cannot change another realm's epoch.
+Disposing the realm releases both its intrinsic objects and counters.
+
+## Array tracking
+
+Array's existing process-wide prototype mutation version remains separate.
+It drives a thread-local dense-write rescan cache and also reacts to descriptor
+store switches; it is not a compiler assumption token. Compiler specialization
+should use the realm-owned epoch API when an Array family is added rather than
+depending on that legacy cache version.
+
+## Validation
+
+`IntrinsicPrototypeEpochTests` covers:
+
+- stable initialization and unrelated mutations;
+- assignment and default callable replacement;
+- property definition and descriptor reconfiguration;
+- accessor installation and deletion;
+- intrinsic and ancestor prototype-link changes;
+- cross-realm isolation;
+- failed guard validation after mutation;
+- zero-allocation epoch reads and validation.
+
+Run the focused microbenchmark with:
+
+```bash
+dotnet run -c Release \
+  --project tests/performance/Benchmarks/Benchmarks.csproj -- \
+  --intrinsic-epochs --filter "*"
+```
+
+The 2026-08-19 .NET 10 ShortRun measured:
+
+| Operation | Mean | Allocated |
+| --- | ---: | ---: |
+| Validate pristine String epoch | 5.623 ns | 0 B |
+| Read String epoch | 5.776 ns | 0 B |
+| Invalidate String epoch | 9.820 ns | 0 B |
+
+The read and invalidation costs support per-family counters: ordinary guarded
+reads remain single-digit nanoseconds, while unrelated intrinsic families avoid
+coarse invalidation and unnecessary fallback.

--- a/docs/runtime/JsFunctionObjectInvocationAbi.md
+++ b/docs/runtime/JsFunctionObjectInvocationAbi.md
@@ -102,6 +102,11 @@ Runtime-owned built-ins that still use CLR delegates are isolated behind
 materialize arguments when their explicit host ABI requires an array, but
 compiled JavaScript functions never enter this path.
 
+Generated built-in specialization must retain an exact generic fallback.
+Realm-owned assumption tokens are exposed through
+[`IntrinsicPrototypeEpochs`](IntrinsicPrototypeMutationEpochs.md); receiver
+type alone is never sufficient to skip dynamic prototype lookup.
+
 The public .NET hosting boundary projects callable values as runtime-owned
 `Jroc.Runtime.JsCallable` wrappers. Calls, receiver-aware calls, construction,
 and alternate `newTarget` construction marshal to the owning script thread and

--- a/src/JavaScriptRuntime/IntrinsicPrototypeEpochs.cs
+++ b/src/JavaScriptRuntime/IntrinsicPrototypeEpochs.cs
@@ -1,0 +1,35 @@
+using System.Runtime.CompilerServices;
+
+namespace JavaScriptRuntime;
+
+/// <summary>
+/// Identifies an intrinsic prototype family whose default lookup chain can be
+/// guarded by generated code.
+/// </summary>
+public enum IntrinsicPrototypeFamily
+{
+    String = 0
+}
+
+/// <summary>
+/// Allocation-free access to realm-owned intrinsic prototype mutation epochs.
+/// </summary>
+public static class IntrinsicPrototypeEpochs
+{
+    public const long PristineEpoch = 0;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static long Read(IntrinsicPrototypeFamily family)
+        => RuntimeIntrinsics.Current.ReadPrototypeMutationEpoch(family);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsPristine(
+        IntrinsicPrototypeFamily family)
+        => IsCurrent(family, PristineEpoch);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsCurrent(
+        IntrinsicPrototypeFamily family,
+        long expectedEpoch)
+        => Read(family) == expectedEpoch;
+}

--- a/src/JavaScriptRuntime/PropertyDescriptorStore.cs
+++ b/src/JavaScriptRuntime/PropertyDescriptorStore.cs
@@ -476,12 +476,14 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
             }
 
             NotifyCanonicalIndexMutation(GetLookupStore(target), key);
+            RuntimeIntrinsics.NotifyPrototypeMutation(target);
             return;
         }
 
         var store = CurrentStore;
         store.DefineOrUpdate(target, key, descriptor);
         NotifyCanonicalIndexMutation(store, key);
+        RuntimeIntrinsics.NotifyPrototypeMutation(target);
     }
 
     internal static void CopyOwnProperties(object source, object target)
@@ -542,12 +544,20 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
             }
 
             NotifyCanonicalIndexMutation(GetLookupStore(target), key);
+            if (inlineDeleted)
+            {
+                RuntimeIntrinsics.NotifyPrototypeMutation(target);
+            }
             return inlineDeleted;
         }
 
         var store = CurrentStore;
         var deleted = store.Delete(target, key);
         NotifyCanonicalIndexMutation(store, key);
+        if (deleted)
+        {
+            RuntimeIntrinsics.NotifyPrototypeMutation(target);
+        }
         return deleted;
     }
 
@@ -572,6 +582,7 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
         }
 
         Array.NotifyPrototypeMutation();
+        RuntimeIntrinsics.NotifyPrototypeMutation(target);
     }
 
     internal static bool HasExternalDescriptorStateForTests(object target)

--- a/src/JavaScriptRuntime/PrototypeChain.cs
+++ b/src/JavaScriptRuntime/PrototypeChain.cs
@@ -85,6 +85,7 @@ public static class PrototypeChain
             array.DisableDenseGrowthFastPath();
         }
         Array.NotifyPrototypeMutation();
+        RuntimeIntrinsics.NotifyPrototypeMutation(obj);
     }
 
     internal static void InitializePrototype(object obj, object? prototype)

--- a/src/JavaScriptRuntime/RuntimeIntrinsics.cs
+++ b/src/JavaScriptRuntime/RuntimeIntrinsics.cs
@@ -139,6 +139,7 @@ internal enum RuntimeIntrinsicSlot
 internal sealed class RuntimeIntrinsics
 {
     private const int MaxWaitChainLength = 64;
+    private const int PrototypeFamilyCount = 1;
 
     private static readonly TimeSpan WaitSlice = TimeSpan.FromMilliseconds(20);
 
@@ -158,6 +159,8 @@ internal sealed class RuntimeIntrinsics
 
     private readonly object _slotTableGate = new();
     private readonly SlotEntry?[] _slots = new SlotEntry?[(int)RuntimeIntrinsicSlot.Count];
+    private readonly long[] _prototypeMutationEpochs =
+        new long[PrototypeFamilyCount];
 
     /// <summary>
     /// Fully initialized slot values. Only written after the slot's initializer has
@@ -175,6 +178,53 @@ internal sealed class RuntimeIntrinsics
     /// not keep the intrinsic graph alive (see <c>Array</c>'s cached prototype-chain state).
     /// </summary>
     internal long Id { get; }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal long ReadPrototypeMutationEpoch(
+        IntrinsicPrototypeFamily family)
+    {
+        var index = (int)family;
+        if ((uint)index >= PrototypeFamilyCount)
+        {
+            throw new ArgumentOutOfRangeException(nameof(family));
+        }
+
+        return Volatile.Read(ref _prototypeMutationEpochs[index]);
+    }
+
+    internal static void NotifyPrototypeMutation(object target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        if (PropertyDescriptorStore.IsIntrinsicInitialization
+            || IsInitializingOnCurrentThread)
+        {
+            return;
+        }
+
+        var intrinsics = RuntimeExecutionContext.Current?.Realm.Intrinsics
+            ?? Volatile.Read(ref _processDefault);
+        intrinsics?.NotifyOwnedPrototypeMutation(
+            BuiltinDelegateFunctionAdapter.NormalizeJavaScriptObject(target));
+    }
+
+    private void NotifyOwnedPrototypeMutation(object target)
+    {
+        if (ReferenceEquals(
+                target,
+                Volatile.Read(
+                    ref _published[
+                        (int)RuntimeIntrinsicSlot.StringPrototype]))
+            || ReferenceEquals(
+                target,
+                Volatile.Read(
+                    ref _published[
+                        (int)RuntimeIntrinsicSlot.ObjectPrototype])))
+        {
+            Interlocked.Increment(
+                ref _prototypeMutationEpochs[
+                    (int)IntrinsicPrototypeFamily.String]);
+        }
+    }
 
     /// <summary>
     /// Per-realm stable adapter identities for runtime-owned built-in delegates.

--- a/tests/Jroc.Tests/IntrinsicPrototypeEpochTests.cs
+++ b/tests/Jroc.Tests/IntrinsicPrototypeEpochTests.cs
@@ -1,0 +1,267 @@
+using JavaScriptRuntime;
+using JsString = JavaScriptRuntime.String;
+
+namespace Jroc.Tests;
+
+public sealed class IntrinsicPrototypeEpochTests
+{
+    [Fact]
+    public void StringEpochRemainsStableDuringInitializationAndUnrelatedMutation()
+    {
+        WithRealm(
+            () =>
+            {
+                var initial =
+                    IntrinsicPrototypeEpochs.Read(
+                        IntrinsicPrototypeFamily.String);
+                Assert.Equal(
+                    IntrinsicPrototypeEpochs.PristineEpoch,
+                    initial);
+                Assert.True(
+                    IntrinsicPrototypeEpochs.IsPristine(
+                        IntrinsicPrototypeFamily.String));
+
+                _ = GlobalThis.globalThis;
+                _ = ObjectRuntime.GetProperty(
+                    JsString.Prototype,
+                    "charAt");
+                ObjectRuntime.SetProperty(
+                    new JsObject(),
+                    "unrelated",
+                    true);
+                ObjectRuntime.SetProperty(
+                    JavaScriptRuntime.Array.Prototype,
+                    "unrelatedFamilyMutation",
+                    true);
+
+                Assert.Equal(
+                    initial,
+                    IntrinsicPrototypeEpochs.Read(
+                        IntrinsicPrototypeFamily.String));
+                Assert.True(
+                    IntrinsicPrototypeEpochs.IsCurrent(
+                        IntrinsicPrototypeFamily.String,
+                        initial));
+            });
+    }
+
+    [Fact]
+    public void StringEpochInvalidatesForEveryRelevantMutationShape()
+    {
+        WithRealm(
+            () =>
+            {
+                _ = GlobalThis.globalThis;
+                var stringPrototype = JsString.Prototype;
+                var objectPrototype =
+                    GlobalThis.ObjectPrototypeValue;
+
+                AssertAdvances(
+                    () => ObjectRuntime.SetProperty(
+                        stringPrototype,
+                        "charAt",
+                        new EpochFunction()));
+                AssertAdvances(
+                    () => JavaScriptRuntime.Object.defineProperty(
+                        stringPrototype,
+                        "epochData",
+                        DataDescriptor(
+                            "defined",
+                            enumerable: true)));
+                AssertAdvances(
+                    () => JavaScriptRuntime.Object.defineProperty(
+                        stringPrototype,
+                        "epochData",
+                        DataDescriptor(
+                            "reconfigured",
+                            enumerable: false)));
+                AssertAdvances(
+                    () => JavaScriptRuntime.Object.defineProperty(
+                        stringPrototype,
+                        "epochAccessor",
+                        AccessorDescriptor(new EpochFunction())));
+                AssertAdvances(
+                    () => Assert.True(
+                        ObjectRuntime.DeleteProperty(
+                            stringPrototype,
+                            "epochAccessor")));
+                AssertAdvances(
+                    () => ObjectRuntime.SetProperty(
+                        objectPrototype,
+                        "stringAncestorMutation",
+                        true));
+                AssertAdvances(
+                    () => JavaScriptRuntime.Object.setPrototypeOf(
+                        objectPrototype,
+                        new JsObject()));
+                AssertAdvances(
+                    () => JavaScriptRuntime.Object.setPrototypeOf(
+                        stringPrototype,
+                        new JsObject()));
+            });
+    }
+
+    [Fact]
+    public void StringEpochIsIsolatedPerRealm()
+    {
+        var firstServices = RuntimeServices.BuildServiceProvider();
+        var secondServices = RuntimeServices.BuildServiceProvider();
+        var firstContext =
+            RuntimeExecutionContext.GetOrCreate(firstServices);
+        var secondContext =
+            RuntimeExecutionContext.GetOrCreate(secondServices);
+        long firstMutatedEpoch;
+
+        try
+        {
+            using (firstContext.EnterAsRoot())
+            {
+                _ = GlobalThis.globalThis;
+                var initial = IntrinsicPrototypeEpochs.Read(
+                    IntrinsicPrototypeFamily.String);
+                ObjectRuntime.SetProperty(
+                    JsString.Prototype,
+                    "realmMutation",
+                    "first");
+                firstMutatedEpoch = IntrinsicPrototypeEpochs.Read(
+                    IntrinsicPrototypeFamily.String);
+                Assert.True(firstMutatedEpoch > initial);
+            }
+
+            using (secondContext.EnterAsRoot())
+            {
+                _ = GlobalThis.globalThis;
+                Assert.Equal(
+                    0,
+                    IntrinsicPrototypeEpochs.Read(
+                        IntrinsicPrototypeFamily.String));
+                Assert.Null(
+                    ObjectRuntime.GetProperty(
+                        JsString.Prototype,
+                        "realmMutation"));
+            }
+
+            using (firstContext.EnterAsRoot())
+            {
+                Assert.Equal(
+                    firstMutatedEpoch,
+                    IntrinsicPrototypeEpochs.Read(
+                        IntrinsicPrototypeFamily.String));
+                Assert.Equal(
+                    "first",
+                    ObjectRuntime.GetProperty(
+                        JsString.Prototype,
+                        "realmMutation"));
+            }
+        }
+        finally
+        {
+            firstServices.OwningRealm!.Agent.Cluster.Dispose();
+            secondServices.OwningRealm!.Agent.Cluster.Dispose();
+        }
+    }
+
+    [Fact]
+    public void EpochReadAndValidationAllocateNothing()
+    {
+        WithRealm(
+            () =>
+            {
+                _ = GlobalThis.globalThis;
+                var expected = IntrinsicPrototypeEpochs.Read(
+                    IntrinsicPrototypeFamily.String);
+
+                for (var index = 0; index < 1_000; index++)
+                {
+                    _ = IntrinsicPrototypeEpochs.IsCurrent(
+                        IntrinsicPrototypeFamily.String,
+                        expected);
+                    _ = IntrinsicPrototypeEpochs.IsPristine(
+                        IntrinsicPrototypeFamily.String);
+                }
+
+                var before =
+                    GC.GetAllocatedBytesForCurrentThread();
+                var valid = true;
+                long observed = 0;
+                for (var index = 0; index < 100_000; index++)
+                {
+                    observed ^= IntrinsicPrototypeEpochs.Read(
+                        IntrinsicPrototypeFamily.String);
+                    valid &= IntrinsicPrototypeEpochs.IsCurrent(
+                        IntrinsicPrototypeFamily.String,
+                        expected);
+                    valid &= IntrinsicPrototypeEpochs.IsPristine(
+                        IntrinsicPrototypeFamily.String);
+                }
+                var allocated =
+                    GC.GetAllocatedBytesForCurrentThread() - before;
+
+                GC.KeepAlive(observed);
+                Assert.True(valid);
+                Assert.Equal(0, allocated);
+            });
+    }
+
+    private static void AssertAdvances(Action mutation)
+    {
+        var before = IntrinsicPrototypeEpochs.Read(
+            IntrinsicPrototypeFamily.String);
+
+        mutation();
+
+        var after = IntrinsicPrototypeEpochs.Read(
+            IntrinsicPrototypeFamily.String);
+        Assert.True(after > before);
+        Assert.False(
+            IntrinsicPrototypeEpochs.IsCurrent(
+                IntrinsicPrototypeFamily.String,
+                before));
+        Assert.False(
+            IntrinsicPrototypeEpochs.IsPristine(
+                IntrinsicPrototypeFamily.String));
+    }
+
+    private static JsObject DataDescriptor(
+        object? value,
+        bool enumerable)
+        => new()
+        {
+            ["value"] = value,
+            ["writable"] = true,
+            ["enumerable"] = enumerable,
+            ["configurable"] = true
+        };
+
+    private static JsObject AccessorDescriptor(
+        JsFunctionObject getter)
+        => new()
+        {
+            ["get"] = getter,
+            ["enumerable"] = false,
+            ["configurable"] = true
+        };
+
+    private static void WithRealm(Action body)
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        var context = RuntimeExecutionContext.GetOrCreate(services);
+        try
+        {
+            using var scope = context.EnterAsRoot();
+            body();
+        }
+        finally
+        {
+            services.OwningRealm!.Agent.Cluster.Dispose();
+        }
+    }
+
+    private sealed class EpochFunction : JsFunctionObject
+    {
+        protected override object? CallCore(
+            object? thisArgument,
+            in JsCallArguments arguments)
+            => null;
+    }
+}

--- a/tests/performance/Benchmarks/IntrinsicPrototypeEpochBenchmarks.cs
+++ b/tests/performance/Benchmarks/IntrinsicPrototypeEpochBenchmarks.cs
@@ -1,0 +1,52 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Order;
+using JavaScriptRuntime;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[HideColumns("Error", "StdDev")]
+public class IntrinsicPrototypeEpochBenchmarks
+{
+    private RuntimeAgentCluster? _cluster;
+    private IDisposable? _scope;
+    private object _stringPrototype = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        _cluster = services.OwningRealm!.Agent.Cluster;
+        var context = RuntimeExecutionContext.GetOrCreate(services);
+        _scope = context.EnterAsRoot();
+        _ = GlobalThis.globalThis;
+        _stringPrototype = JavaScriptRuntime.String.Prototype;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _scope?.Dispose();
+        _cluster?.Dispose();
+    }
+
+    [Benchmark(Baseline = true, Description = "Read String prototype epoch")]
+    public long ReadStringEpoch()
+        => IntrinsicPrototypeEpochs.Read(
+            IntrinsicPrototypeFamily.String);
+
+    [Benchmark(Description = "Validate pristine String prototype epoch")]
+    public bool ValidatePristineStringEpoch()
+        => IntrinsicPrototypeEpochs.IsPristine(
+            IntrinsicPrototypeFamily.String);
+
+    [Benchmark(Description = "Invalidate String prototype epoch")]
+    public void InvalidateStringEpoch()
+        => RuntimeIntrinsics.NotifyPrototypeMutation(
+            _stringPrototype);
+}

--- a/tests/performance/Benchmarks/Program.cs
+++ b/tests/performance/Benchmarks/Program.cs
@@ -64,6 +64,12 @@ else
         var summary = BenchmarkRunner.Run<AsyncContextBenchmarks>(args: programArgs.Skip(1).ToArray());
         SetExitCodeFromSummaries([summary]);
     }
+    else if (programArgs.Length > 0 && programArgs[0] == "--intrinsic-epochs")
+    {
+        var summary = BenchmarkRunner.Run<IntrinsicPrototypeEpochBenchmarks>(
+            args: programArgs.Skip(1).ToArray());
+        SetExitCodeFromSummaries([summary]);
+    }
 #if SOURCE_JROC_PROJECTS
     else if (programArgs.Length > 0 && programArgs[0] == "--shape-storage")
     {
@@ -144,6 +150,7 @@ Console.WriteLine("  dotnet run -c Release --callable-baselines # Run callable m
 Console.WriteLine("  dotnet run -c Release --callable-abi # Compare function-object and legacy invocation ABIs");
 Console.WriteLine("  dotnet run -c Release --builtin-invocation # Measure representative runtime-owned built-in adapters");
 Console.WriteLine("  dotnet run -c Release --async-context # Compare disabled and enabled async-context overhead");
+Console.WriteLine("  dotnet run -c Release --intrinsic-epochs # Measure realm-owned intrinsic epoch guards");
 Console.WriteLine("  dotnet run -c Release --callable-arity-analysis # Measure benchmark/runtime call-site arities");
 Console.WriteLine("  dotnet run -c Release -- --dromaeo # Run Dromaeo execution benchmarks");
 Console.WriteLine("  dotnet run -c Release -- --kracken --scenario audio-oscillator # Run one Kraken scenario");


### PR DESCRIPTION
## Summary

- add realm-owned intrinsic prototype mutation epochs with a public allocation-free guard API
- invalidate the String intrinsic family for descriptor, deletion, and prototype-link mutations on `String.prototype` or its default `Object.prototype` ancestor
- preserve pristine epochs during intrinsic graph initialization and isolate counters across realms
- document the specialization contract and add focused correctness, isolation, allocation, and benchmark coverage

## Design

`IntrinsicPrototypeEpochs.IsPristine(IntrinsicPrototypeFamily.String)` is the safe compiler guard. The pristine epoch is `0`; intrinsic mutations advance a monotonic per-realm counter, and restoring default descriptors does not restore pristine status. This prevents a compiler from treating a post-mutation epoch snapshot as authorization for a fast intrinsic path.

Array's existing process-wide prototype version remains unchanged because it serves the dense-write rescan cache rather than compiler specialization guards.

## Benchmarks

| Operation | Mean | Allocated |
| --- | ---: | ---: |
| Pristine validation | 5.623 ns | 0 B |
| Epoch read | 5.776 ns | 0 B |
| Invalidation | 9.820 ns | 0 B |

## Validation

- `dotnet build --no-restore`
- 123 focused prototype, descriptor, String, realm-isolation, ownership, weak-retention, and static-state tests

Closes #1892
