### PR TITLE
perf(compiler): emit guarded String intrinsic calls with fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- perf(compiler): emit realm-epoch-guarded fixed-arity String intrinsic calls
+  with exact `CallMember0..5` fallbacks (issue #1891). Proven receivers skip
+  the type test, uncertain receivers use `isinst string`, and the guarded
+  `String.trim` microbenchmark improves 193.275 ns / 88 B to 7.835 ns / 0 B.
 - perf(runtime): add a realm-owned String prototype mutation epoch for guarded
   compiler specialization (issue #1892). Assignment, descriptor definition and
   deletion, accessors, default-callable replacement, and prototype-link changes

--- a/docs/compiler/GuardedStringIntrinsicCalls.md
+++ b/docs/compiler/GuardedStringIntrinsicCalls.md
@@ -1,0 +1,93 @@
+# Guarded String intrinsic calls
+
+Issue #1891 restores direct AOT calls for common primitive String operations
+without bypassing JavaScript prototype semantics. Receiver type alone is not a
+valid specialization assumption because user code can replace, delete, or
+reconfigure methods on `String.prototype` or its `Object.prototype` ancestor.
+
+## LIR contract
+
+`LIRCallGuardedStringIntrinsic` records:
+
+- the original receiver, member name, arguments, and result;
+- the exact fixed-arity `JavaScriptRuntime.String` helper signature;
+- whether static analysis already proves a primitive-string receiver;
+- any result conversion that both branches must perform.
+
+The instruction is a scheduling boundary because its IL contains internal
+control flow.
+
+## Emitted paths
+
+The generated fast path:
+
+1. validates
+   `IntrinsicPrototypeEpochs.IsPristine(IntrinsicPrototypeFamily.String)`;
+2. performs `isinst string` when the receiver type is uncertain;
+3. calls the exact fixed-arity String helper.
+
+The cold path executes the original `ObjectRuntime.CallMember0..5` operation
+with the original receiver and arguments. Argument expressions are evaluated
+before the guard, so both branches preserve JavaScript evaluation order and
+coercion behavior.
+
+The compiler keeps result storage as `object` when an override can return an
+arbitrary value. The `charCodeAt` plus `ToNumber` fusion is the current
+exception: both branches produce the same numeric result because the fallback
+performs ordinary member dispatch and then applies `ToNumber`, so the result
+can remain an unboxed `double`.
+
+Stable `substring` calls now pass through this guarded instruction instead of
+using their former unconditional HIR-level direct call. The previous
+unguarded `charCodeAt` numeric fusion is guarded as well.
+
+## Current specialization surface
+
+The initial allowlist matches the previously supported String early-binding
+surface:
+
+- arity 0: `charAt`, `charCodeAt`, trim aliases, and case conversion;
+- arity 1: character access, substring/slice operations, searches, and prefix
+  or suffix checks;
+- arity 2: substring/slice operations, searches, and prefix or suffix checks.
+
+A call is specialized only when a fixed-arity helper preserves each argument's
+existing representation. Otherwise the original generic call remains.
+
+## Performance
+
+Run the focused benchmark with:
+
+```bash
+dotnet run -c Release \
+  --project tests/performance/Benchmarks/Benchmarks.csproj -- \
+  --guarded-string-intrinsics
+```
+
+The 2026-08-19 .NET 10 ShortRun measured the post-#1889 residual lookup cost:
+
+| Path | Mean | Allocated |
+| --- | ---: | ---: |
+| Guarded proven `String.trim` | 7.835 ns | 0 B |
+| Guarded uncertain `String.trim` | 8.069 ns | 0 B |
+| Generic `CallMember0` `String.trim` | 193.275 ns | 88 B |
+
+The guard removes about 96% of the generic dispatch time in this focused case
+and eliminates its steady-state allocation. The uncertain receiver type test
+adds about 0.2 ns while retaining the complete generic fallback.
+
+## Validation
+
+Coverage includes:
+
+- direct-helper and exact-fallback generator snapshots;
+- replacement, accessor, deletion, inherited override, and aliased-call
+  behavior;
+- uncertain receivers that alternate between strings and ordinary objects;
+- cross-realm prototype isolation using one compiled module loaded twice;
+- guarded numeric fallback conversion;
+- zero-allocation guard plus `String.trim` fast-path execution;
+- targeted `built-ins/String/prototype/**` test262 tests.
+
+The realm-owned invalidation contract is documented in
+[Intrinsic prototype mutation epochs](../runtime/IntrinsicPrototypeMutationEpochs.md).

--- a/docs/compiler/Index.md
+++ b/docs/compiler/Index.md
@@ -15,6 +15,7 @@ These design documents describe the JROC compiler pipeline, including callable p
 
 - [Async/await lowering specification](AsyncAwait_LoweringSpec.md)
 - [Async/await three-way comparison](AsyncAwait_ThreeWay_Comparison.md)
+- [Guarded String intrinsic calls](GuardedStringIntrinsicCalls.md)
 - [Instruction chaining](InstructionChaining.md)
 - [LIR rematerialization](LIRRematerialization.md)
 - [LIR stack scheduler](LIRStackScheduler.md)

--- a/docs/runtime/Index.md
+++ b/docs/runtime/Index.md
@@ -23,4 +23,5 @@ These documents describe the JavaScriptRuntime hosting model and its internal ex
 
 ## Performance
 
+- [Intrinsic prototype mutation epochs](IntrinsicPrototypeMutationEpochs.md)
 - [RegExp and string hot-path performance optimizations](RegExpStringPerformanceOptimizations.md)

--- a/docs/runtime/IntrinsicPrototypeMutationEpochs.md
+++ b/docs/runtime/IntrinsicPrototypeMutationEpochs.md
@@ -107,3 +107,6 @@ The 2026-08-19 .NET 10 ShortRun measured:
 The read and invalidation costs support per-family counters: ordinary guarded
 reads remain single-digit nanoseconds, while unrelated intrinsic families avoid
 coarse invalidation and unnecessary fallback.
+
+The compiler consumer and exact generic fallback are documented in
+[Guarded String intrinsic calls](../compiler/GuardedStringIntrinsicCalls.md).

--- a/src/Compiler/IL/LIRInstructionInfo.cs
+++ b/src/Compiler/IL/LIRInstructionInfo.cs
@@ -132,6 +132,7 @@ internal static partial class LIRInstructionInfo
         typeof(LIRCallMember3),
         typeof(LIRCallMember4),
         typeof(LIRCallMember5),
+        typeof(LIRCallGuardedStringIntrinsic),
         typeof(LIRCallNodeModuleContractMember),
         typeof(LIRCallRequire),
         typeof(LIRCallRuntimeServicesStatic),
@@ -281,6 +282,7 @@ internal static partial class LIRInstructionInfo
         typeof(LIRAsyncStateSwitch),
         typeof(LIRAsyncStoreAwaitedResult),
         typeof(LIRAsyncLoadAwaitedResult),
+        typeof(LIRCallGuardedStringIntrinsic),
         typeof(LIRCallNodeModuleContractMember),
         typeof(LIRCreateLeafScopeInstance),
         typeof(LIRCreateScopeInstance)
@@ -506,6 +508,10 @@ internal static partial class LIRInstructionInfo
                 or LIRAsyncStateSwitch
                 or LIRAsyncStoreAwaitedResult
                 or LIRAsyncLoadAwaitedResult
+                => LIRInstructionEffects.EmitsInternalControlFlow
+                    | CallEffects,
+
+            LIRCallGuardedStringIntrinsic
                 => LIRInstructionEffects.EmitsInternalControlFlow
                     | CallEffects,
 

--- a/src/Compiler/IL/LIRStackScheduler.cs
+++ b/src/Compiler/IL/LIRStackScheduler.cs
@@ -1866,6 +1866,9 @@ internal static class LIRStackScheduler
             LIRCallMember3 call => call.Receiver.Equals(result),
             LIRCallMember4 call => call.Receiver.Equals(result),
             LIRCallMember5 call => call.Receiver.Equals(result),
+            LIRCallGuardedStringIntrinsic call =>
+                call.ReceiverIsProvenString
+                && call.Receiver.Equals(result),
             LIRCallComputedMemberFixed call =>
                 call.Receiver.Equals(result),
             LIRCallFunctionValue call =>

--- a/src/Compiler/IL/LIRToILCompiler.GuardedIntrinsics.cs
+++ b/src/Compiler/IL/LIRToILCompiler.GuardedIntrinsics.cs
@@ -1,0 +1,210 @@
+using Jroc.IR;
+using Jroc.Services.ILGenerators;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace Jroc.IL;
+
+internal sealed partial class LIRToILCompiler
+{
+    private void EmitGuardedStringIntrinsicCall(
+        LIRCallGuardedStringIntrinsic instruction,
+        InstructionEncoder ilEncoder,
+        TempLocalAllocation allocation,
+        MethodDescriptor methodDescriptor)
+    {
+        if (instruction.Arguments.Count > 5
+            || instruction.IntrinsicParameterTypes.Count
+                != instruction.Arguments.Count + 1
+            || instruction.IntrinsicParameterTypes[0] != typeof(string)
+            || instruction.IntrinsicReturnClrType == typeof(void)
+            || (instruction.FallbackResultConversion
+                    == LIRGuardedStringFallbackResultConversion.ToNumber
+                && instruction.IntrinsicReturnClrType != typeof(double)))
+        {
+            throw new InvalidOperationException(
+                $"Invalid guarded String intrinsic call shape for '{instruction.MemberName}'.");
+        }
+
+        var fallbackLabel = ilEncoder.DefineLabel();
+        var typeFallbackLabel = instruction.ReceiverIsProvenString
+            ? default
+            : ilEncoder.DefineLabel();
+        var doneLabel = ilEncoder.DefineLabel();
+
+        ilEncoder.LoadConstantI4(
+            (int)JavaScriptRuntime.IntrinsicPrototypeFamily.String);
+        var isPristine = _memberRefRegistry.GetOrAddMethod(
+            typeof(JavaScriptRuntime.IntrinsicPrototypeEpochs),
+            nameof(JavaScriptRuntime.IntrinsicPrototypeEpochs.IsPristine),
+            new[]
+            {
+                typeof(JavaScriptRuntime.IntrinsicPrototypeFamily)
+            });
+        ilEncoder.OpCode(ILOpCode.Call);
+        ilEncoder.Token(isPristine);
+        ilEncoder.Branch(ILOpCode.Brfalse, fallbackLabel);
+
+        if (instruction.ReceiverIsProvenString)
+        {
+            EmitLoadTempAsString(
+                instruction.Receiver,
+                ilEncoder,
+                allocation,
+                methodDescriptor);
+        }
+        else
+        {
+            EmitLoadTempAsObject(
+                instruction.Receiver,
+                ilEncoder,
+                allocation,
+                methodDescriptor);
+            ilEncoder.OpCode(ILOpCode.Isinst);
+            ilEncoder.Token(_bclReferences.StringType);
+            ilEncoder.OpCode(ILOpCode.Dup);
+            ilEncoder.Branch(ILOpCode.Brfalse, typeFallbackLabel);
+        }
+
+        for (var i = 0; i < instruction.Arguments.Count; i++)
+        {
+            EmitLoadTempForParameter(
+                instruction.Arguments[i],
+                instruction.IntrinsicParameterTypes[i + 1],
+                ilEncoder,
+                allocation,
+                methodDescriptor);
+        }
+
+        var intrinsicMethod = _memberRefRegistry.GetOrAddMethod(
+            typeof(JavaScriptRuntime.String),
+            instruction.IntrinsicMethodName,
+            instruction.IntrinsicParameterTypes.ToArray());
+        ilEncoder.OpCode(ILOpCode.Call);
+        ilEncoder.Token(intrinsicMethod);
+        EmitStoreGuardedStringFastResult(
+            instruction,
+            ilEncoder,
+            allocation);
+        ilEncoder.Branch(ILOpCode.Br, doneLabel);
+
+        if (!instruction.ReceiverIsProvenString)
+        {
+            ilEncoder.MarkLabel(typeFallbackLabel);
+            ilEncoder.OpCode(ILOpCode.Pop);
+        }
+
+        ilEncoder.MarkLabel(fallbackLabel);
+        EmitGuardedStringFallbackCall(
+            instruction,
+            ilEncoder,
+            allocation,
+            methodDescriptor);
+        EmitStoreGuardedStringFallbackResult(
+            instruction,
+            ilEncoder,
+            allocation);
+
+        ilEncoder.MarkLabel(doneLabel);
+    }
+
+    private void EmitStoreGuardedStringFastResult(
+        LIRCallGuardedStringIntrinsic instruction,
+        InstructionEncoder ilEncoder,
+        TempLocalAllocation allocation)
+    {
+        if (!IsMaterialized(instruction.Result, allocation))
+        {
+            if (instruction.IntrinsicReturnClrType != typeof(void))
+            {
+                ilEncoder.OpCode(ILOpCode.Pop);
+            }
+
+            return;
+        }
+
+        var resultStorage = GetMaterializedTempStorage(
+            instruction.Result,
+            allocation);
+        if (resultStorage.Kind == ValueStorageKind.Reference
+            && resultStorage.ClrType == typeof(object)
+            && instruction.IntrinsicReturnClrType.IsValueType)
+        {
+            ilEncoder.OpCode(ILOpCode.Box);
+            ilEncoder.Token(
+                _memberRefRegistry.GetOrAddTypeHandle(
+                    instruction.IntrinsicReturnClrType));
+        }
+
+        EmitStoreTemp(
+            instruction.Result,
+            ilEncoder,
+            allocation);
+    }
+
+    private void EmitGuardedStringFallbackCall(
+        LIRCallGuardedStringIntrinsic instruction,
+        InstructionEncoder ilEncoder,
+        TempLocalAllocation allocation,
+        MethodDescriptor methodDescriptor)
+    {
+        EmitLoadTempAsObject(
+            instruction.Receiver,
+            ilEncoder,
+            allocation,
+            methodDescriptor);
+        ilEncoder.Ldstr(_metadataBuilder, instruction.MemberName);
+        foreach (var argument in instruction.Arguments)
+        {
+            EmitLoadTempAsObject(
+                argument,
+                ilEncoder,
+                allocation,
+                methodDescriptor);
+        }
+
+        var parameterTypes = new Type[instruction.Arguments.Count + 2];
+        parameterTypes[0] = typeof(object);
+        parameterTypes[1] = typeof(string);
+        global::System.Array.Fill(
+            parameterTypes,
+            typeof(object),
+            startIndex: 2,
+            count: instruction.Arguments.Count);
+        var callMember = _memberRefRegistry.GetOrAddMethod(
+            typeof(JavaScriptRuntime.ObjectRuntime),
+            $"CallMember{instruction.Arguments.Count}",
+            parameterTypes);
+        ilEncoder.OpCode(ILOpCode.Call);
+        ilEncoder.Token(callMember);
+
+        if (instruction.FallbackResultConversion
+            == LIRGuardedStringFallbackResultConversion.ToNumber)
+        {
+            var toNumber = _memberRefRegistry.GetOrAddMethod(
+                typeof(JavaScriptRuntime.TypeUtilities),
+                nameof(JavaScriptRuntime.TypeUtilities.ToNumber),
+                new[] { typeof(object) });
+            ilEncoder.OpCode(ILOpCode.Call);
+            ilEncoder.Token(toNumber);
+        }
+    }
+
+    private void EmitStoreGuardedStringFallbackResult(
+        LIRCallGuardedStringIntrinsic instruction,
+        InstructionEncoder ilEncoder,
+        TempLocalAllocation allocation)
+    {
+        if (IsMaterialized(instruction.Result, allocation))
+        {
+            EmitStoreTemp(
+                instruction.Result,
+                ilEncoder,
+                allocation);
+        }
+        else
+        {
+            ilEncoder.OpCode(ILOpCode.Pop);
+        }
+    }
+}

--- a/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Calls.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Calls.cs
@@ -1311,6 +1311,16 @@ internal sealed partial class LIRToILCompiler
                     break;
                 }
 
+            case LIRCallGuardedStringIntrinsic guardedString:
+                {
+                    EmitGuardedStringIntrinsicCall(
+                        guardedString,
+                        ilEncoder,
+                        allocation,
+                        methodDescriptor);
+                    break;
+                }
+
             case LIRCallComputedMemberFixed callComputedMember:
                 {
                     EmitLoadTempAsObject(

--- a/src/Compiler/IL/LIRToILCompiler.MethodBodyCompilation.cs
+++ b/src/Compiler/IL/LIRToILCompiler.MethodBodyCompilation.cs
@@ -912,6 +912,8 @@ internal sealed partial class LIRToILCompiler
                     6 + EstimateTempLoadPeak(callMember5.A4),
                     7
                 }.Max(),
+                LIRCallGuardedStringIntrinsic guardedString =>
+                    Math.Max(3, 2 + guardedString.Arguments.Count),
 
                 // Known CLR instance method calls: receiver + args (no padding)
                 LIRCallInstanceMethod callInstance => 1 + callInstance.Arguments.Count,

--- a/src/Compiler/IL/TempLocalAllocator.cs
+++ b/src/Compiler/IL/TempLocalAllocator.cs
@@ -505,6 +505,8 @@ internal static partial class LIRInstructionInfo
                 visitor.Visit(value.Receiver); visitor.Visit(value.A0); visitor.Visit(value.A1); visitor.Visit(value.A2); visitor.Visit(value.A3); break;
             case LIRCallMember5 value:
                 visitor.Visit(value.Receiver); visitor.Visit(value.A0); visitor.Visit(value.A1); visitor.Visit(value.A2); visitor.Visit(value.A3); visitor.Visit(value.A4); break;
+            case LIRCallGuardedStringIntrinsic value:
+                visitor.Visit(value.Receiver); VisitList(value.Arguments, ref visitor); break;
             case LIRCallComputedMemberFixed value:
                 visitor.Visit(value.Receiver); visitor.Visit(value.PropertyKey); VisitList(value.Arguments, ref visitor); break;
             case LIRCallNodeModuleContractMember value:
@@ -1007,6 +1009,9 @@ internal static partial class LIRInstructionInfo
                 return true;
             case LIRCallMember5 callMember5:
                 defined = callMember5.Result;
+                return true;
+            case LIRCallGuardedStringIntrinsic guardedString:
+                defined = guardedString.Result;
                 return true;
             case LIRCallComputedMemberFixed callComputedMember:
                 defined = callComputedMember.Result;

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
@@ -1248,45 +1248,6 @@ public sealed partial class HIRToLIRLowerer
             return true;
         }
 
-        // Case 2a.0: Stable string local/member receiver for substring(...) calls.
-        // This avoids late-bound ObjectRuntime.CallMember* dispatch in hot loops (e.g., dromaeo generateTestStrings).
-        if (!hasSpreadArgs
-            && callExpr.Arguments.Length <= 2
-            && string.Equals(calleePropAccess.PropertyName, "substring", StringComparison.Ordinal)
-            && calleePropAccess.Object is HIRVariableExpression receiverVarExpr
-            && receiverVarExpr.Name.BindingInfo.IsStableType
-            && receiverVarExpr.Name.BindingInfo.ClrType == typeof(string))
-        {
-            // Ensure the receiver temp is strongly typed as string for the intrinsic static call signature.
-            if (GetTempStorage(receiverTempVar).Kind != ValueStorageKind.Reference
-                || GetTempStorage(receiverTempVar).ClrType != typeof(string))
-            {
-                var receiverAsString = CreateTempVariable();
-                _methodBodyIR.Instructions.Add(new LIRConvertToString(EnsureObject(receiverTempVar), receiverAsString));
-                DefineTempStorage(receiverAsString, new ValueStorage(ValueStorageKind.Reference, typeof(string)));
-                receiverTempVar = receiverAsString;
-            }
-
-            var substringArgs = new List<TempVariable>(1 + callExpr.Arguments.Length) { receiverTempVar };
-            foreach (var argExpr in callExpr.Arguments)
-            {
-                if (!TryLowerExpression(argExpr, out var argTemp))
-                {
-                    return false;
-                }
-
-                substringArgs.Add(EnsureObject(argTemp));
-            }
-
-            _methodBodyIR.Instructions.Add(new LIRCallIntrinsicStatic(
-                "String",
-                "substring",
-                substringArgs,
-                resultTempVar));
-            DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(string)));
-            return true;
-        }
-
         // Case 2a: Typed Array instance method calls (e.g., arr.join(), arr.push(...)).
         // If the receiver CLR type is known to be JavaScriptRuntime.Array, emit a typed instance call.
         {

--- a/src/Compiler/IR/LIR/LIRInstructions.cs
+++ b/src/Compiler/IR/LIR/LIRInstructions.cs
@@ -253,6 +253,29 @@ public record LIRCallMember5(
     TempVariable A4,
     TempVariable Result) : LIRInstruction;
 
+public enum LIRGuardedStringFallbackResultConversion
+{
+    None,
+    ToNumber
+}
+
+/// <summary>
+/// Calls a fixed-arity String intrinsic helper while the current realm's
+/// String prototype chain is pristine, with exact ordinary member dispatch as
+/// the fallback.
+/// </summary>
+public record LIRCallGuardedStringIntrinsic(
+    TempVariable Receiver,
+    string MemberName,
+    string IntrinsicMethodName,
+    IReadOnlyList<Type> IntrinsicParameterTypes,
+    Type IntrinsicReturnClrType,
+    bool ReceiverIsProvenString,
+    IReadOnlyList<TempVariable> Arguments,
+    TempVariable Result,
+    LIRGuardedStringFallbackResultConversion FallbackResultConversion =
+        LIRGuardedStringFallbackResultConversion.None) : LIRInstruction;
+
 /// <summary>
 /// Calls a computed member with inline common-arity arguments.
 /// </summary>

--- a/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
+++ b/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
@@ -141,6 +141,10 @@ internal static class LIRIntrinsicNormalization
             }
         }
 
+        FuseCharCodeAtWithConvertToNumber(
+            methodBody,
+            knownSpecializedReceiverClrTypes);
+
         for (int i = 0; i < methodBody.Instructions.Count; i++)
         {
             var instruction = methodBody.Instructions[i];
@@ -356,6 +360,18 @@ internal static class LIRIntrinsicNormalization
                     continue;
                 }
 
+                if (TryNormalizeGuardedStringMemberCall(
+                        methodBody,
+                        i,
+                        callMember0.Receiver,
+                        callMember0.MethodName,
+                        Array.Empty<TempVariable>(),
+                        callMember0.Result,
+                        knownSpecializedReceiverClrTypes))
+                {
+                    continue;
+                }
+
             }
 
             if (instruction is LIRCallMember1 callMember1)
@@ -373,6 +389,18 @@ internal static class LIRIntrinsicNormalization
                 }
 
                 if (TryNormalizeArrayMemberCall(
+                        methodBody,
+                        i,
+                        callMember1.Receiver,
+                        callMember1.MethodName,
+                        new[] { callMember1.A0 },
+                        callMember1.Result,
+                        knownSpecializedReceiverClrTypes))
+                {
+                    continue;
+                }
+
+                if (TryNormalizeGuardedStringMemberCall(
                         methodBody,
                         i,
                         callMember1.Receiver,
@@ -427,11 +455,35 @@ internal static class LIRIntrinsicNormalization
                     continue;
                 }
 
+                if (TryNormalizeGuardedStringMemberCall(
+                        methodBody,
+                        i,
+                        callMember2.Receiver,
+                        callMember2.MethodName,
+                        new[] { callMember2.A0, callMember2.A1 },
+                        callMember2.Result,
+                        knownSpecializedReceiverClrTypes))
+                {
+                    continue;
+                }
+
             }
 
             if (instruction is LIRCallMember3 callMember3)
             {
-                TryNormalizeArrayMemberCall(
+                if (TryNormalizeArrayMemberCall(
+                    methodBody,
+                    i,
+                    callMember3.Receiver,
+                    callMember3.MethodName,
+                    new[] { callMember3.A0, callMember3.A1, callMember3.A2 },
+                    callMember3.Result,
+                    knownSpecializedReceiverClrTypes))
+                {
+                    continue;
+                }
+
+                TryNormalizeGuardedStringMemberCall(
                     methodBody,
                     i,
                     callMember3.Receiver,
@@ -443,7 +495,25 @@ internal static class LIRIntrinsicNormalization
 
             if (instruction is LIRCallMember4 callMember4)
             {
-                TryNormalizeArrayMemberCall(
+                if (TryNormalizeArrayMemberCall(
+                    methodBody,
+                    i,
+                    callMember4.Receiver,
+                    callMember4.MethodName,
+                    new[]
+                    {
+                        callMember4.A0,
+                        callMember4.A1,
+                        callMember4.A2,
+                        callMember4.A3
+                    },
+                    callMember4.Result,
+                    knownSpecializedReceiverClrTypes))
+                {
+                    continue;
+                }
+
+                TryNormalizeGuardedStringMemberCall(
                     methodBody,
                     i,
                     callMember4.Receiver,
@@ -461,7 +531,26 @@ internal static class LIRIntrinsicNormalization
 
             if (instruction is LIRCallMember5 callMember5)
             {
-                TryNormalizeArrayMemberCall(
+                if (TryNormalizeArrayMemberCall(
+                    methodBody,
+                    i,
+                    callMember5.Receiver,
+                    callMember5.MethodName,
+                    new[]
+                    {
+                        callMember5.A0,
+                        callMember5.A1,
+                        callMember5.A2,
+                        callMember5.A3,
+                        callMember5.A4
+                    },
+                    callMember5.Result,
+                    knownSpecializedReceiverClrTypes))
+                {
+                    continue;
+                }
+
+                TryNormalizeGuardedStringMemberCall(
                     methodBody,
                     i,
                     callMember5.Receiver,
@@ -479,13 +568,243 @@ internal static class LIRIntrinsicNormalization
             }
         }
 
-        FuseCharCodeAtWithConvertToNumber(methodBody);
         FuseGetItemWithConvertToNumber(methodBody);
     }
 
     public static void NormalizeLateNumericMemberCalls(MethodBodyIR methodBody)
     {
-        FuseCharCodeAtWithConvertToNumber(methodBody);
+        FuseCharCodeAtWithConvertToNumber(
+            methodBody,
+            knownSpecializedReceiverClrTypes: null);
+    }
+
+    private static bool TryNormalizeGuardedStringMemberCall(
+        MethodBodyIR methodBody,
+        int instructionIndex,
+        TempVariable receiver,
+        string methodName,
+        IReadOnlyList<TempVariable> arguments,
+        TempVariable result,
+        IReadOnlyDictionary<int, Type> knownSpecializedReceiverClrTypes)
+    {
+        if (!TryResolveSafeStringIntrinsicMethod(
+                methodBody,
+                methodName,
+                arguments,
+                out var intrinsicMethod))
+        {
+            return false;
+        }
+
+        if (!TryClassifyGuardedStringReceiver(
+                methodBody,
+                receiver,
+                knownSpecializedReceiverClrTypes,
+                out var receiverIsProvenString))
+        {
+            return false;
+        }
+
+        methodBody.Instructions[instructionIndex] =
+            new LIRCallGuardedStringIntrinsic(
+                receiver,
+                methodName,
+                intrinsicMethod.Name,
+                intrinsicMethod
+                    .GetParameters()
+                    .Select(static parameter => parameter.ParameterType)
+                    .ToArray(),
+                intrinsicMethod.ReturnType,
+                receiverIsProvenString,
+                arguments,
+                result);
+        ApplyGuardedStringResultStorage(
+            methodBody,
+            result,
+            LIRGuardedStringFallbackResultConversion.None);
+        return true;
+    }
+
+    private static bool TryClassifyGuardedStringReceiver(
+        MethodBodyIR methodBody,
+        TempVariable receiver,
+        IReadOnlyDictionary<int, Type>?
+            knownSpecializedReceiverClrTypes,
+        out bool receiverIsProvenString)
+    {
+        receiverIsProvenString = false;
+        if (knownSpecializedReceiverClrTypes?.TryGetValue(
+                receiver.Index,
+                out var knownReceiverType) == true)
+        {
+            receiverIsProvenString =
+                knownReceiverType == typeof(string);
+            return receiverIsProvenString;
+        }
+
+        if (receiver.Index < 0
+            || receiver.Index >= methodBody.TempStorages.Count)
+        {
+            return true;
+        }
+
+        var storage = methodBody.TempStorages[receiver.Index];
+        if (storage.Kind == ValueStorageKind.Reference
+            && storage.ClrType == typeof(string))
+        {
+            receiverIsProvenString = true;
+            return true;
+        }
+
+        if (!storage.TypeHandle.IsNil)
+        {
+            return false;
+        }
+
+        return storage.Kind == ValueStorageKind.Unknown
+            || storage.ClrType == null
+            || (storage.Kind == ValueStorageKind.Reference
+                && storage.ClrType == typeof(object));
+    }
+
+    private static bool TryResolveSafeStringIntrinsicMethod(
+        MethodBodyIR methodBody,
+        string methodName,
+        IReadOnlyList<TempVariable> arguments,
+        out System.Reflection.MethodInfo intrinsicMethod)
+    {
+        intrinsicMethod = null!;
+        if (!IsStringMethodEligibleForEarlyBind(
+                methodName,
+                arguments.Count))
+        {
+            return false;
+        }
+
+        intrinsicMethod = typeof(JavaScriptRuntime.String)
+            .GetMethods(
+                System.Reflection.BindingFlags.Public
+                | System.Reflection.BindingFlags.Static)
+            .Where(method => string.Equals(
+                method.Name,
+                methodName,
+                StringComparison.OrdinalIgnoreCase))
+            .Where(method =>
+            {
+                var parameters = method.GetParameters();
+                if (parameters.Length != arguments.Count + 1
+                    || parameters[0].ParameterType != typeof(string))
+                {
+                    return false;
+                }
+
+                for (var i = 1; i < parameters.Length; i++)
+                {
+                    var parameterType = parameters[i].ParameterType;
+                    if (parameterType == typeof(object))
+                    {
+                        continue;
+                    }
+
+                    if (parameterType == typeof(string)
+                        && IsTempStringReference(
+                            methodBody,
+                            arguments[i - 1]))
+                    {
+                        continue;
+                    }
+
+                    if (parameterType == typeof(bool)
+                        && IsUnboxedBool(
+                            methodBody,
+                            arguments[i - 1]))
+                    {
+                        continue;
+                    }
+
+                    if (parameterType == typeof(double)
+                        && IsUnboxedDouble(
+                            methodBody,
+                            arguments[i - 1]))
+                    {
+                        continue;
+                    }
+
+                    return false;
+                }
+
+                return true;
+            })
+            .OrderBy(
+                static method => method.ToString(),
+                StringComparer.Ordinal)
+            .FirstOrDefault()!;
+        return intrinsicMethod != null;
+    }
+
+    private static bool IsStringMethodEligibleForEarlyBind(
+        string methodName,
+        int argumentCount)
+        => argumentCount switch
+        {
+            0 => methodName is
+                "charAt"
+                or "charCodeAt"
+                or "trim"
+                or "trimStart"
+                or "trimLeft"
+                or "trimEnd"
+                or "trimRight"
+                or "toLowerCase"
+                or "toUpperCase",
+            1 => methodName is
+                "charAt"
+                or "charCodeAt"
+                or "substring"
+                or "substr"
+                or "slice"
+                or "indexOf"
+                or "lastIndexOf"
+                or "startsWith"
+                or "endsWith"
+                or "includes",
+            2 => methodName is
+                "substring"
+                or "substr"
+                or "slice"
+                or "indexOf"
+                or "lastIndexOf"
+                or "startsWith"
+                or "endsWith"
+                or "includes",
+            _ => false
+        };
+
+    private static void ApplyGuardedStringResultStorage(
+        MethodBodyIR methodBody,
+        TempVariable result,
+        LIRGuardedStringFallbackResultConversion fallbackResultConversion)
+    {
+        if (result.Index < 0
+            || result.Index >= methodBody.TempStorages.Count)
+        {
+            return;
+        }
+
+        var storage = fallbackResultConversion
+            == LIRGuardedStringFallbackResultConversion.ToNumber
+            ? new ValueStorage(
+                ValueStorageKind.UnboxedValue,
+                typeof(double))
+            : new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object));
+        methodBody.TempStorages[result.Index] = storage;
+        ApplySingleAssignmentSlotStorage(
+            methodBody,
+            result,
+            storage,
+            replaceReferenceStorage: true);
     }
 
     private static bool TryNormalizePromiseMemberCall(
@@ -768,7 +1087,10 @@ internal static class LIRIntrinsicNormalization
         methodBody.Instructions.AddRange(newInstructions);
     }
 
-    private static void FuseCharCodeAtWithConvertToNumber(MethodBodyIR methodBody)
+    private static void FuseCharCodeAtWithConvertToNumber(
+        MethodBodyIR methodBody,
+        IReadOnlyDictionary<int, Type>?
+            knownSpecializedReceiverClrTypes)
     {
         var singleConvertToNumberConsumerByTempIndex = new Dictionary<int, int>();
         var ineligibleTempIndices = new HashSet<int>();
@@ -821,17 +1143,44 @@ internal static class LIRIntrinsicNormalization
             }
 
             var conv = (LIRConvertToNumber)methodBody.Instructions[convIdx];
-            methodBody.Instructions[i] = new LIRCallIntrinsicStatic(
-                IntrinsicName: "String",
-                MethodName: nameof(JavaScriptRuntime.String.CharCodeAtAsNumber),
-                Arguments: new[] { callMember.Receiver, callMember.A0 },
-                Result: conv.Result);
-            indicesToRemove.Add(convIdx);
-
-            if (conv.Result.Index >= 0 && conv.Result.Index < methodBody.TempStorages.Count)
+            var arguments = new[] { callMember.A0 };
+            if (!TryResolveSafeStringIntrinsicMethod(
+                    methodBody,
+                    callMember.MethodName,
+                    arguments,
+                    out var intrinsicMethod))
             {
-                methodBody.TempStorages[conv.Result.Index] = new ValueStorage(ValueStorageKind.UnboxedValue, typeof(double));
+                continue;
             }
+
+            if (!TryClassifyGuardedStringReceiver(
+                    methodBody,
+                    callMember.Receiver,
+                    knownSpecializedReceiverClrTypes,
+                    out var receiverIsProvenString))
+            {
+                continue;
+            }
+
+            methodBody.Instructions[i] =
+                new LIRCallGuardedStringIntrinsic(
+                    callMember.Receiver,
+                    callMember.MethodName,
+                    intrinsicMethod.Name,
+                    intrinsicMethod
+                        .GetParameters()
+                        .Select(static parameter => parameter.ParameterType)
+                        .ToArray(),
+                    intrinsicMethod.ReturnType,
+                    receiverIsProvenString,
+                    arguments,
+                    conv.Result,
+                    LIRGuardedStringFallbackResultConversion.ToNumber);
+            indicesToRemove.Add(convIdx);
+            ApplyGuardedStringResultStorage(
+                methodBody,
+                conv.Result,
+                LIRGuardedStringFallbackResultConversion.ToNumber);
         }
 
         if (indicesToRemove.Count == 0)
@@ -885,7 +1234,11 @@ internal static class LIRIntrinsicNormalization
         ApplySingleAssignmentSlotStorage(methodBody, result, storage);
     }
 
-    private static void ApplySingleAssignmentSlotStorage(MethodBodyIR methodBody, TempVariable result, ValueStorage storage)
+    private static void ApplySingleAssignmentSlotStorage(
+        MethodBodyIR methodBody,
+        TempVariable result,
+        ValueStorage storage,
+        bool replaceReferenceStorage = false)
     {
         if (result.Index < 0 || result.Index >= methodBody.TempVariableSlots.Count)
         {
@@ -901,7 +1254,9 @@ internal static class LIRIntrinsicNormalization
         }
 
         var current = methodBody.VariableStorages[slot];
-        if (current.Kind == ValueStorageKind.Reference && current.ClrType == typeof(object))
+        if (current.Kind == ValueStorageKind.Reference
+            && (current.ClrType == typeof(object)
+                || replaceReferenceStorage))
         {
             methodBody.VariableStorages[slot] = storage;
         }

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -1768,7 +1768,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 163 (0xa3)
+			// Code size: 204 (0xcc)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Error,
@@ -1795,59 +1795,77 @@
 			IL_001b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0020: stloc.2
 			IL_0021: ldloc.2
-			IL_0022: brtrue IL_0057
+			IL_0022: brtrue IL_0080
 
 			IL_0027: ldarg.1
 			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_002d: ldstr "trim"
-			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0037: stloc.s 4
-			IL_0039: ldloc.s 4
-			IL_003b: ldstr ""
-			IL_0040: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0045: stloc.2
-			IL_0046: ldloc.2
-			IL_0047: box [System.Runtime]System.Boolean
-			IL_004c: stloc.s 5
-			IL_004e: ldloc.s 5
-			IL_0050: stloc.s 7
-			IL_0052: br IL_005a
+			IL_002d: stloc.s 4
+			IL_002f: ldc.i4.0
+			IL_0030: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0035: brfalse IL_0054
 
-			IL_0057: ldloc.3
-			IL_0058: stloc.s 7
+			IL_003a: ldloc.s 4
+			IL_003c: isinst [System.Runtime]System.String
+			IL_0041: dup
+			IL_0042: brfalse IL_0053
 
-			IL_005a: ldloc.s 7
-			IL_005c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0061: stloc.2
-			IL_0062: ldloc.2
-			IL_0063: brfalse IL_00a1
+			IL_0047: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_004c: stloc.s 4
+			IL_004e: br IL_0062
 
-			IL_0068: ldarg.2
-			IL_0069: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_006e: stloc.1
-			IL_006f: ldstr "Invalid pin file: expected non-empty string for '"
-			IL_0074: ldloc.1
-			IL_0075: call string [System.Runtime]System.String::Concat(string, string)
-			IL_007a: ldstr "'."
-			IL_007f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0084: stloc.1
-			IL_0085: ldloc.1
-			IL_0086: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_008b: stloc.0
-			IL_008c: ldloc.0
-			IL_008d: isinst [System.Runtime]System.Exception
-			IL_0092: dup
-			IL_0093: brtrue IL_00a0
+			IL_0053: pop
 
-			IL_0098: pop
-			IL_0099: ldloc.0
-			IL_009a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_009f: throw
+			IL_0054: ldloc.s 4
+			IL_0056: ldstr "trim"
+			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0060: stloc.s 4
 
-			IL_00a0: throw
+			IL_0062: ldloc.s 4
+			IL_0064: ldstr ""
+			IL_0069: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_006e: stloc.2
+			IL_006f: ldloc.2
+			IL_0070: box [System.Runtime]System.Boolean
+			IL_0075: stloc.s 5
+			IL_0077: ldloc.s 5
+			IL_0079: stloc.s 7
+			IL_007b: br IL_0083
 
-			IL_00a1: ldnull
-			IL_00a2: ret
+			IL_0080: ldloc.3
+			IL_0081: stloc.s 7
+
+			IL_0083: ldloc.s 7
+			IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_008a: stloc.2
+			IL_008b: ldloc.2
+			IL_008c: brfalse IL_00ca
+
+			IL_0091: ldarg.2
+			IL_0092: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0097: stloc.1
+			IL_0098: ldstr "Invalid pin file: expected non-empty string for '"
+			IL_009d: ldloc.1
+			IL_009e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00a3: ldstr "'."
+			IL_00a8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00ad: stloc.1
+			IL_00ae: ldloc.1
+			IL_00af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00b4: stloc.0
+			IL_00b5: ldloc.0
+			IL_00b6: isinst [System.Runtime]System.Exception
+			IL_00bb: dup
+			IL_00bc: brtrue IL_00c9
+
+			IL_00c1: pop
+			IL_00c2: ldloc.0
+			IL_00c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00c8: throw
+
+			IL_00c9: throw
+
+			IL_00ca: ldnull
+			IL_00cb: ret
 		} // end of method ensureString::__js_call__
 
 	} // end of class ensureString
@@ -2073,7 +2091,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 456 (0x1c8)
+			// Code size: 497 (0x1f1)
 			.maxstack 10
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Error,
@@ -2176,7 +2194,7 @@
 					IL_00c6: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
 					IL_00cb: stloc.s 6
 					IL_00cd: ldloc.s 6
-					IL_00cf: brtrue IL_01ac
+					IL_00cf: brtrue IL_01d5
 
 					IL_00d4: ldloc.s 8
 					IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
@@ -2199,85 +2217,103 @@
 					IL_0105: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_010a: stloc.s 6
 					IL_010c: ldloc.s 6
-					IL_010e: brtrue IL_0146
+					IL_010e: brtrue IL_016f
 
 					IL_0113: ldloc.s 4
 					IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_011a: ldstr "trim"
-					IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_0124: stloc.s 8
-					IL_0126: ldloc.s 8
-					IL_0128: ldstr ""
-					IL_012d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-					IL_0132: stloc.s 6
-					IL_0134: ldloc.s 6
-					IL_0136: box [System.Runtime]System.Boolean
-					IL_013b: stloc.s 9
-					IL_013d: ldloc.s 9
-					IL_013f: stloc.s 13
-					IL_0141: br IL_014a
+					IL_011a: stloc.s 8
+					IL_011c: ldc.i4.0
+					IL_011d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+					IL_0122: brfalse IL_0141
 
-					IL_0146: ldloc.s 7
-					IL_0148: stloc.s 13
+					IL_0127: ldloc.s 8
+					IL_0129: isinst [System.Runtime]System.String
+					IL_012e: dup
+					IL_012f: brfalse IL_0140
 
-					IL_014a: ldloc.s 13
-					IL_014c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0151: stloc.s 6
-					IL_0153: ldloc.s 6
-					IL_0155: brfalse IL_019a
+					IL_0134: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+					IL_0139: stloc.s 8
+					IL_013b: br IL_014f
 
-					IL_015a: ldarg.2
-					IL_015b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0160: stloc.s 12
-					IL_0162: ldstr "Invalid pin file: '"
-					IL_0167: ldloc.s 12
-					IL_0169: call string [System.Runtime]System.String::Concat(string, string)
-					IL_016e: ldstr "' entries must be non-empty strings."
-					IL_0173: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0178: stloc.s 12
-					IL_017a: ldloc.s 12
-					IL_017c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0181: stloc.s 5
-					IL_0183: ldloc.s 5
-					IL_0185: isinst [System.Runtime]System.Exception
-					IL_018a: dup
-					IL_018b: brtrue IL_0199
+					IL_0140: pop
 
-					IL_0190: pop
-					IL_0191: ldloc.s 5
-					IL_0193: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-					IL_0198: throw
+					IL_0141: ldloc.s 8
+					IL_0143: ldstr "trim"
+					IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_014d: stloc.s 8
 
-					IL_0199: throw
+					IL_014f: ldloc.s 8
+					IL_0151: ldstr ""
+					IL_0156: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+					IL_015b: stloc.s 6
+					IL_015d: ldloc.s 6
+					IL_015f: box [System.Runtime]System.Boolean
+					IL_0164: stloc.s 9
+					IL_0166: ldloc.s 9
+					IL_0168: stloc.s 13
+					IL_016a: br IL_0173
 
-					IL_019a: br IL_00ba
+					IL_016f: ldloc.s 7
+					IL_0171: stloc.s 13
+
+					IL_0173: ldloc.s 13
+					IL_0175: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_017a: stloc.s 6
+					IL_017c: ldloc.s 6
+					IL_017e: brfalse IL_01c3
+
+					IL_0183: ldarg.2
+					IL_0184: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0189: stloc.s 12
+					IL_018b: ldstr "Invalid pin file: '"
+					IL_0190: ldloc.s 12
+					IL_0192: call string [System.Runtime]System.String::Concat(string, string)
+					IL_0197: ldstr "' entries must be non-empty strings."
+					IL_019c: call string [System.Runtime]System.String::Concat(string, string)
+					IL_01a1: stloc.s 12
+					IL_01a3: ldloc.s 12
+					IL_01a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_01aa: stloc.s 5
+					IL_01ac: ldloc.s 5
+					IL_01ae: isinst [System.Runtime]System.Exception
+					IL_01b3: dup
+					IL_01b4: brtrue IL_01c2
+
+					IL_01b9: pop
+					IL_01ba: ldloc.s 5
+					IL_01bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+					IL_01c1: throw
+
+					IL_01c2: throw
+
+					IL_01c3: br IL_00ba
 				// end loop
-				IL_019f: ldloc.1
-				IL_01a0: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_01a5: ldc.i4.1
-				IL_01a6: stloc.3
-				IL_01a7: leave IL_01c6
+				IL_01c8: ldloc.1
+				IL_01c9: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_01ce: ldc.i4.1
+				IL_01cf: stloc.3
+				IL_01d0: leave IL_01ef
 
-				IL_01ac: ldc.i4.1
-				IL_01ad: stloc.2
-				IL_01ae: leave IL_01c6
+				IL_01d5: ldc.i4.1
+				IL_01d6: stloc.2
+				IL_01d7: leave IL_01ef
 			} // end .try
 			finally
 			{
-				IL_01b3: ldloc.2
-				IL_01b4: brtrue IL_01c5
+				IL_01dc: ldloc.2
+				IL_01dd: brtrue IL_01ee
 
-				IL_01b9: ldloc.3
-				IL_01ba: brtrue IL_01c5
+				IL_01e2: ldloc.3
+				IL_01e3: brtrue IL_01ee
 
-				IL_01bf: ldloc.1
-				IL_01c0: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_01e8: ldloc.1
+				IL_01e9: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_01c5: endfinally
+				IL_01ee: endfinally
 			} // end handler
 
-			IL_01c6: ldnull
-			IL_01c7: ret
+			IL_01ef: ldnull
+			IL_01f0: ret
 		} // end of method ensureStringArray::__js_call__
 
 	} // end of class ensureStringArray
@@ -2488,7 +2524,7 @@
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 207 (0xcf)
+			// Code size: 258 (0x102)
 			.maxstack 10
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
@@ -2536,7 +2572,7 @@
 					IL_003b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
 					IL_0040: stloc.s 7
 					IL_0042: ldloc.s 7
-					IL_0044: brtrue IL_00b3
+					IL_0044: brtrue IL_00e6
 
 					IL_0049: ldloc.s 5
 					IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
@@ -2547,59 +2583,79 @@
 					IL_0056: stloc.3
 					IL_0057: ldloc.3
 					IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_005d: ldstr "startsWith"
-					IL_0062: ldstr "frontmatter:"
-					IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_006c: stloc.s 5
-					IL_006e: ldloc.s 5
-					IL_0070: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_0075: stloc.s 7
-					IL_0077: ldloc.s 7
-					IL_0079: brfalse IL_00a1
+					IL_005d: stloc.s 5
+					IL_005f: ldc.i4.0
+					IL_0060: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+					IL_0065: brfalse IL_008e
 
-					IL_007e: ldstr "Invalid pin file: 'excludedFromMvp' now accepts only path-based exclusions; frontmatter rules belong in metadata-driven unsupported classification."
-					IL_0083: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_0088: stloc.s 4
-					IL_008a: ldloc.s 4
-					IL_008c: isinst [System.Runtime]System.Exception
-					IL_0091: dup
-					IL_0092: brtrue IL_00a0
+					IL_006a: ldloc.s 5
+					IL_006c: isinst [System.Runtime]System.String
+					IL_0071: dup
+					IL_0072: brfalse IL_008d
 
-					IL_0097: pop
-					IL_0098: ldloc.s 4
-					IL_009a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-					IL_009f: throw
+					IL_0077: ldstr "frontmatter:"
+					IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+					IL_0081: box [System.Runtime]System.Boolean
+					IL_0086: stloc.s 5
+					IL_0088: br IL_00a1
 
-					IL_00a0: throw
+					IL_008d: pop
 
-					IL_00a1: br IL_002f
+					IL_008e: ldloc.s 5
+					IL_0090: ldstr "startsWith"
+					IL_0095: ldstr "frontmatter:"
+					IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_009f: stloc.s 5
+
+					IL_00a1: ldloc.s 5
+					IL_00a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00a8: stloc.s 7
+					IL_00aa: ldloc.s 7
+					IL_00ac: brfalse IL_00d4
+
+					IL_00b1: ldstr "Invalid pin file: 'excludedFromMvp' now accepts only path-based exclusions; frontmatter rules belong in metadata-driven unsupported classification."
+					IL_00b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_00bb: stloc.s 4
+					IL_00bd: ldloc.s 4
+					IL_00bf: isinst [System.Runtime]System.Exception
+					IL_00c4: dup
+					IL_00c5: brtrue IL_00d3
+
+					IL_00ca: pop
+					IL_00cb: ldloc.s 4
+					IL_00cd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+					IL_00d2: throw
+
+					IL_00d3: throw
+
+					IL_00d4: br IL_002f
 				// end loop
-				IL_00a6: ldloc.0
-				IL_00a7: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_00ac: ldc.i4.1
-				IL_00ad: stloc.2
-				IL_00ae: leave IL_00cd
+				IL_00d9: ldloc.0
+				IL_00da: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_00df: ldc.i4.1
+				IL_00e0: stloc.2
+				IL_00e1: leave IL_0100
 
-				IL_00b3: ldc.i4.1
-				IL_00b4: stloc.1
-				IL_00b5: leave IL_00cd
+				IL_00e6: ldc.i4.1
+				IL_00e7: stloc.1
+				IL_00e8: leave IL_0100
 			} // end .try
 			finally
 			{
-				IL_00ba: ldloc.1
-				IL_00bb: brtrue IL_00cc
+				IL_00ed: ldloc.1
+				IL_00ee: brtrue IL_00ff
 
-				IL_00c0: ldloc.2
-				IL_00c1: brtrue IL_00cc
+				IL_00f3: ldloc.2
+				IL_00f4: brtrue IL_00ff
 
-				IL_00c6: ldloc.0
-				IL_00c7: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_00f9: ldloc.0
+				IL_00fa: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_00cc: endfinally
+				IL_00ff: endfinally
 			} // end handler
 
-			IL_00cd: ldnull
-			IL_00ce: ret
+			IL_0100: ldnull
+			IL_0101: ret
 		} // end of method validateExcludedFromMvp::__js_call__
 
 	} // end of class validateExcludedFromMvp
@@ -5495,7 +5551,7 @@
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 678 (0x2a6)
+			// Code size: 744 (0x2e8)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5610,7 +5666,7 @@
 			IL_0104: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
 			IL_0109: stloc.s 10
 			IL_010b: ldloc.s 10
-			IL_010d: brfalse IL_0280
+			IL_010d: brfalse IL_02c2
 
 			IL_0112: ldloc.0
 			IL_0113: ldstr "stderr"
@@ -5631,133 +5687,159 @@
 
 			IL_013f: ldloc.s 12
 			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0146: ldstr "trim"
-			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0150: stloc.2
-			IL_0151: ldloc.0
-			IL_0152: ldstr "stdout"
-			IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_015c: stloc.s 9
-			IL_015e: ldloc.s 9
-			IL_0160: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0165: stloc.s 10
-			IL_0167: ldloc.s 10
-			IL_0169: brtrue IL_017a
+			IL_0146: stloc.s 9
+			IL_0148: ldc.i4.0
+			IL_0149: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_014e: brfalse IL_0165
 
-			IL_016e: ldstr ""
-			IL_0173: stloc.s 13
-			IL_0175: br IL_017e
+			IL_0153: ldloc.s 9
+			IL_0155: castclass [System.Runtime]System.String
+			IL_015a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_015f: stloc.2
+			IL_0160: br IL_0172
 
-			IL_017a: ldloc.s 9
-			IL_017c: stloc.s 13
+			IL_0165: ldloc.s 9
+			IL_0167: ldstr "trim"
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0171: stloc.2
 
-			IL_017e: ldloc.s 13
-			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0185: ldstr "trim"
-			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_018f: stloc.3
-			IL_0190: ldc.i4.2
-			IL_0191: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0196: dup
-			IL_0197: ldloc.2
-			IL_0198: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_019d: dup
-			IL_019e: ldloc.3
-			IL_019f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01a4: stloc.s 14
-			IL_01a6: ldstr "Boolean"
-			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01b0: stloc.s 9
-			IL_01b2: ldloc.s 14
-			IL_01b4: ldc.i4.1
-			IL_01b5: newarr [System.Runtime]System.Object
-			IL_01ba: dup
-			IL_01bb: ldc.i4.0
-			IL_01bc: ldloc.s 9
-			IL_01be: stelem.ref
-			IL_01bf: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::'filter'(object[])
-			IL_01c4: stloc.s 14
-			IL_01c6: ldloc.s 14
-			IL_01c8: ldc.i4.1
-			IL_01c9: newarr [System.Runtime]System.Object
-			IL_01ce: dup
-			IL_01cf: ldc.i4.0
-			IL_01d0: ldstr "\n"
-			IL_01d5: stelem.ref
-			IL_01d6: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_01db: stloc.s 4
-			IL_01dd: ldarg.2
-			IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01e3: ldstr "join"
-			IL_01e8: ldstr " "
-			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0172: ldloc.0
+			IL_0173: ldstr "stdout"
+			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017d: stloc.s 9
+			IL_017f: ldloc.s 9
+			IL_0181: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0186: stloc.s 10
+			IL_0188: ldloc.s 10
+			IL_018a: brtrue IL_019b
+
+			IL_018f: ldstr ""
+			IL_0194: stloc.s 13
+			IL_0196: br IL_019f
+
+			IL_019b: ldloc.s 9
+			IL_019d: stloc.s 13
+
+			IL_019f: ldloc.s 13
+			IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a6: stloc.s 9
+			IL_01a8: ldc.i4.0
+			IL_01a9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01ae: brfalse IL_01c5
+
+			IL_01b3: ldloc.s 9
+			IL_01b5: castclass [System.Runtime]System.String
+			IL_01ba: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_01bf: stloc.3
+			IL_01c0: br IL_01d2
+
+			IL_01c5: ldloc.s 9
+			IL_01c7: ldstr "trim"
+			IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_01d1: stloc.3
+
+			IL_01d2: ldc.i4.2
+			IL_01d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_01d8: dup
+			IL_01d9: ldloc.2
+			IL_01da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01df: dup
+			IL_01e0: ldloc.3
+			IL_01e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01e6: stloc.s 14
+			IL_01e8: ldstr "Boolean"
+			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_01f2: stloc.s 9
-			IL_01f4: ldloc.s 9
-			IL_01f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01fb: stloc.s 15
-			IL_01fd: ldstr "git "
-			IL_0202: ldloc.s 15
-			IL_0204: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0209: ldstr " failed"
-			IL_020e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0213: stloc.s 15
-			IL_0215: ldloc.s 4
-			IL_0217: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_021c: stloc.s 10
-			IL_021e: ldloc.s 10
-			IL_0220: brfalse IL_0245
+			IL_01f4: ldloc.s 14
+			IL_01f6: ldc.i4.1
+			IL_01f7: newarr [System.Runtime]System.Object
+			IL_01fc: dup
+			IL_01fd: ldc.i4.0
+			IL_01fe: ldloc.s 9
+			IL_0200: stelem.ref
+			IL_0201: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::'filter'(object[])
+			IL_0206: stloc.s 14
+			IL_0208: ldloc.s 14
+			IL_020a: ldc.i4.1
+			IL_020b: newarr [System.Runtime]System.Object
+			IL_0210: dup
+			IL_0211: ldc.i4.0
+			IL_0212: ldstr "\n"
+			IL_0217: stelem.ref
+			IL_0218: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_021d: stloc.s 4
+			IL_021f: ldarg.2
+			IL_0220: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0225: ldstr "join"
+			IL_022a: ldstr " "
+			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0234: stloc.s 9
+			IL_0236: ldloc.s 9
+			IL_0238: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_023d: stloc.s 15
+			IL_023f: ldstr "git "
+			IL_0244: ldloc.s 15
+			IL_0246: call string [System.Runtime]System.String::Concat(string, string)
+			IL_024b: ldstr " failed"
+			IL_0250: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0255: stloc.s 15
+			IL_0257: ldloc.s 4
+			IL_0259: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_025e: stloc.s 10
+			IL_0260: ldloc.s 10
+			IL_0262: brfalse IL_0287
 
-			IL_0225: ldloc.s 4
-			IL_0227: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_022c: stloc.s 16
-			IL_022e: ldstr ":\n"
-			IL_0233: ldloc.s 16
-			IL_0235: call string [System.Runtime]System.String::Concat(string, string)
-			IL_023a: stloc.s 16
-			IL_023c: ldloc.s 16
-			IL_023e: stloc.s 5
-			IL_0240: br IL_024c
+			IL_0267: ldloc.s 4
+			IL_0269: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_026e: stloc.s 16
+			IL_0270: ldstr ":\n"
+			IL_0275: ldloc.s 16
+			IL_0277: call string [System.Runtime]System.String::Concat(string, string)
+			IL_027c: stloc.s 16
+			IL_027e: ldloc.s 16
+			IL_0280: stloc.s 5
+			IL_0282: br IL_028e
 
-			IL_0245: ldstr "."
-			IL_024a: stloc.s 5
+			IL_0287: ldstr "."
+			IL_028c: stloc.s 5
 
-			IL_024c: ldloc.s 5
-			IL_024e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0253: stloc.s 16
-			IL_0255: ldloc.s 15
-			IL_0257: ldloc.s 16
-			IL_0259: call string [System.Runtime]System.String::Concat(string, string)
-			IL_025e: stloc.s 16
-			IL_0260: ldloc.s 16
-			IL_0262: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0267: stloc.s 6
-			IL_0269: ldloc.s 6
-			IL_026b: isinst [System.Runtime]System.Exception
-			IL_0270: dup
-			IL_0271: brtrue IL_027f
+			IL_028e: ldloc.s 5
+			IL_0290: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0295: stloc.s 16
+			IL_0297: ldloc.s 15
+			IL_0299: ldloc.s 16
+			IL_029b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02a0: stloc.s 16
+			IL_02a2: ldloc.s 16
+			IL_02a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_02a9: stloc.s 6
+			IL_02ab: ldloc.s 6
+			IL_02ad: isinst [System.Runtime]System.Exception
+			IL_02b2: dup
+			IL_02b3: brtrue IL_02c1
 
-			IL_0276: pop
-			IL_0277: ldloc.s 6
-			IL_0279: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_027e: throw
+			IL_02b8: pop
+			IL_02b9: ldloc.s 6
+			IL_02bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_02c0: throw
 
-			IL_027f: throw
+			IL_02c1: throw
 
-			IL_0280: ldloc.0
-			IL_0281: ldstr "stdout"
-			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_028b: stloc.s 9
-			IL_028d: ldloc.s 9
-			IL_028f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0294: stloc.s 10
-			IL_0296: ldloc.s 10
-			IL_0298: brtrue IL_02a3
+			IL_02c2: ldloc.0
+			IL_02c3: ldstr "stdout"
+			IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_02cd: stloc.s 9
+			IL_02cf: ldloc.s 9
+			IL_02d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02d6: stloc.s 10
+			IL_02d8: ldloc.s 10
+			IL_02da: brtrue IL_02e5
 
-			IL_029d: ldstr ""
-			IL_02a2: ret
+			IL_02df: ldstr ""
+			IL_02e4: ret
 
-			IL_02a3: ldloc.s 9
-			IL_02a5: ret
+			IL_02e5: ldloc.s 9
+			IL_02e7: ret
 		} // end of method runGit::__js_call__
 
 	} // end of class runGit
@@ -8833,18 +8915,18 @@
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 433 (0x1b1)
-			.maxstack 9
+			// Code size: 492 (0x1ec)
+			.maxstack 8
 			.locals init (
 				[0] object,
 				[1] object,
 				[2] object,
 				[3] object,
 				[4] object,
-				[5] object[],
-				[6] object,
-				[7] bool,
-				[8] object,
+				[5] object,
+				[6] object[],
+				[7] object,
+				[8] bool,
 				[9] object,
 				[10] object,
 				[11] object,
@@ -8853,186 +8935,208 @@
 
 			IL_0000: ldarg.0
 			IL_0001: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::parseArgs
-			IL_0006: ldc.i4.1
-			IL_0007: newarr [System.Runtime]System.Object
-			IL_000c: dup
-			IL_000d: ldc.i4.0
-			IL_000e: ldarg.0
-			IL_000f: stelem.ref
-			IL_0010: stloc.s 5
-			IL_0012: ldstr "process"
-			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_001c: ldstr "argv"
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0026: stloc.s 6
-			IL_0028: ldloc.s 6
-			IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_002f: ldstr "slice"
-			IL_0034: ldc.r8 2
-			IL_003d: box [System.Runtime]System.Double
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0047: stloc.s 6
-			IL_0049: ldloc.s 5
-			IL_004b: ldloc.s 6
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0052: stloc.0
-			IL_0053: ldloc.0
-			IL_0054: ldstr "help"
-			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005e: stloc.s 6
-			IL_0060: ldloc.s 6
-			IL_0062: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0067: stloc.s 7
-			IL_0069: ldloc.s 7
-			IL_006b: brfalse IL_008c
+			IL_0006: stloc.s 5
+			IL_0008: ldc.i4.1
+			IL_0009: newarr [System.Runtime]System.Object
+			IL_000e: dup
+			IL_000f: ldc.i4.0
+			IL_0010: ldarg.0
+			IL_0011: stelem.ref
+			IL_0012: stloc.s 6
+			IL_0014: ldstr "process"
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_001e: ldstr "argv"
+			IL_0023: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0028: stloc.s 7
+			IL_002a: ldloc.s 7
+			IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0031: stloc.s 7
+			IL_0033: ldc.i4.0
+			IL_0034: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0039: brfalse IL_0066
 
-			IL_0070: ldarg.0
-			IL_0071: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printHelp
-			IL_0076: stloc.s 6
-			IL_0078: ldloc.s 6
-			IL_007a: ldc.i4.1
-			IL_007b: newarr [System.Runtime]System.Object
-			IL_0080: dup
-			IL_0081: ldc.i4.0
-			IL_0082: ldarg.0
-			IL_0083: stelem.ref
-			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_0089: pop
-			IL_008a: ldnull
-			IL_008b: ret
+			IL_003e: ldloc.s 7
+			IL_0040: isinst [System.Runtime]System.String
+			IL_0045: dup
+			IL_0046: brfalse IL_0065
 
-			IL_008c: ldarg.0
-			IL_008d: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolvePathFromCwd
-			IL_0092: stloc.s 6
-			IL_0094: ldc.i4.1
-			IL_0095: newarr [System.Runtime]System.Object
-			IL_009a: dup
-			IL_009b: ldc.i4.0
-			IL_009c: ldarg.0
-			IL_009d: stelem.ref
-			IL_009e: stloc.s 5
-			IL_00a0: ldloc.0
-			IL_00a1: ldstr "pin"
-			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00ab: stloc.s 8
-			IL_00ad: ldloc.s 8
-			IL_00af: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00b4: stloc.s 7
-			IL_00b6: ldloc.s 7
-			IL_00b8: brtrue IL_00dd
+			IL_004b: ldc.r8 2
+			IL_0054: box [System.Runtime]System.Double
+			IL_0059: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
+			IL_005e: stloc.s 7
+			IL_0060: br IL_0082
 
+			IL_0065: pop
+
+			IL_0066: ldloc.s 7
+			IL_0068: ldstr "slice"
+			IL_006d: ldc.r8 2
+			IL_0076: box [System.Runtime]System.Double
+			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0080: stloc.s 7
+
+			IL_0082: ldloc.s 5
+			IL_0084: ldloc.s 6
+			IL_0086: ldloc.s 7
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_008d: stloc.0
+			IL_008e: ldloc.0
+			IL_008f: ldstr "help"
+			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0099: stloc.s 7
+			IL_009b: ldloc.s 7
+			IL_009d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00a2: stloc.s 8
+			IL_00a4: ldloc.s 8
+			IL_00a6: brfalse IL_00c7
+
+			IL_00ab: ldarg.0
+			IL_00ac: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printHelp
+			IL_00b1: stloc.s 7
+			IL_00b3: ldloc.s 7
+			IL_00b5: ldc.i4.1
+			IL_00b6: newarr [System.Runtime]System.Object
+			IL_00bb: dup
+			IL_00bc: ldc.i4.0
 			IL_00bd: ldarg.0
-			IL_00be: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::defaultPinPath
-			IL_00c3: ldc.i4.1
-			IL_00c4: newarr [System.Runtime]System.Object
-			IL_00c9: dup
-			IL_00ca: ldc.i4.0
-			IL_00cb: ldarg.0
-			IL_00cc: stelem.ref
-			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_00d2: stloc.s 9
-			IL_00d4: ldloc.s 9
-			IL_00d6: stloc.s 11
-			IL_00d8: br IL_00e1
+			IL_00be: stelem.ref
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00c4: pop
+			IL_00c5: ldnull
+			IL_00c6: ret
 
-			IL_00dd: ldloc.s 8
-			IL_00df: stloc.s 11
+			IL_00c7: ldarg.0
+			IL_00c8: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolvePathFromCwd
+			IL_00cd: stloc.s 7
+			IL_00cf: ldc.i4.1
+			IL_00d0: newarr [System.Runtime]System.Object
+			IL_00d5: dup
+			IL_00d6: ldc.i4.0
+			IL_00d7: ldarg.0
+			IL_00d8: stelem.ref
+			IL_00d9: stloc.s 6
+			IL_00db: ldloc.0
+			IL_00dc: ldstr "pin"
+			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e6: stloc.s 5
+			IL_00e8: ldloc.s 5
+			IL_00ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00ef: stloc.s 8
+			IL_00f1: ldloc.s 8
+			IL_00f3: brtrue IL_0118
 
-			IL_00e1: ldloc.s 6
-			IL_00e3: ldloc.s 5
-			IL_00e5: ldloc.s 11
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00ec: stloc.1
-			IL_00ed: ldarg.0
-			IL_00ee: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::loadPin
-			IL_00f3: ldc.i4.1
-			IL_00f4: newarr [System.Runtime]System.Object
-			IL_00f9: dup
-			IL_00fa: ldc.i4.0
-			IL_00fb: ldarg.0
-			IL_00fc: stelem.ref
-			IL_00fd: ldloc.1
-			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0103: stloc.2
-			IL_0104: ldarg.0
-			IL_0105: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
-			IL_010a: ldc.i4.1
-			IL_010b: newarr [System.Runtime]System.Object
-			IL_0110: dup
-			IL_0111: ldc.i4.0
-			IL_0112: ldarg.0
-			IL_0113: stelem.ref
-			IL_0114: ldloc.0
-			IL_0115: ldloc.2
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_011b: stloc.3
-			IL_011c: ldloc.0
-			IL_011d: ldstr "describe"
-			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0127: stloc.s 6
-			IL_0129: ldloc.s 6
-			IL_012b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0130: stloc.s 7
-			IL_0132: ldloc.s 7
-			IL_0134: brfalse IL_0165
+			IL_00f8: ldarg.0
+			IL_00f9: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::defaultPinPath
+			IL_00fe: ldc.i4.1
+			IL_00ff: newarr [System.Runtime]System.Object
+			IL_0104: dup
+			IL_0105: ldc.i4.0
+			IL_0106: ldarg.0
+			IL_0107: stelem.ref
+			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_010d: stloc.s 9
+			IL_010f: ldloc.s 9
+			IL_0111: stloc.s 11
+			IL_0113: br IL_011c
 
-			IL_0139: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_013e: stloc.s 12
-			IL_0140: ldarg.0
-			IL_0141: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::describePlan
-			IL_0146: ldc.i4.1
-			IL_0147: newarr [System.Runtime]System.Object
-			IL_014c: dup
-			IL_014d: ldc.i4.0
-			IL_014e: ldarg.0
-			IL_014f: stelem.ref
+			IL_0118: ldloc.s 5
+			IL_011a: stloc.s 11
+
+			IL_011c: ldloc.s 7
+			IL_011e: ldloc.s 6
+			IL_0120: ldloc.s 11
+			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0127: stloc.1
+			IL_0128: ldarg.0
+			IL_0129: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::loadPin
+			IL_012e: ldc.i4.1
+			IL_012f: newarr [System.Runtime]System.Object
+			IL_0134: dup
+			IL_0135: ldc.i4.0
+			IL_0136: ldarg.0
+			IL_0137: stelem.ref
+			IL_0138: ldloc.1
+			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_013e: stloc.2
+			IL_013f: ldarg.0
+			IL_0140: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
+			IL_0145: ldc.i4.1
+			IL_0146: newarr [System.Runtime]System.Object
+			IL_014b: dup
+			IL_014c: ldc.i4.0
+			IL_014d: ldarg.0
+			IL_014e: stelem.ref
+			IL_014f: ldloc.0
 			IL_0150: ldloc.2
-			IL_0151: ldloc.3
-			IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0157: stloc.s 6
-			IL_0159: ldloc.s 12
-			IL_015b: ldloc.s 6
-			IL_015d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0162: pop
-			IL_0163: ldnull
-			IL_0164: ret
+			IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0156: stloc.3
+			IL_0157: ldloc.0
+			IL_0158: ldstr "describe"
+			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0162: stloc.s 7
+			IL_0164: ldloc.s 7
+			IL_0166: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_016b: stloc.s 8
+			IL_016d: ldloc.s 8
+			IL_016f: brfalse IL_01a0
 
-			IL_0165: ldarg.0
-			IL_0166: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveBootstrapRoot
-			IL_016b: ldc.i4.1
-			IL_016c: newarr [System.Runtime]System.Object
-			IL_0171: dup
-			IL_0172: ldc.i4.0
-			IL_0173: ldarg.0
-			IL_0174: stelem.ref
-			IL_0175: ldloc.1
-			IL_0176: ldloc.2
-			IL_0177: ldloc.0
-			IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_017d: stloc.s 4
-			IL_017f: ldarg.0
-			IL_0180: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printResolvedRoot
-			IL_0185: stloc.s 6
-			IL_0187: ldc.i4.1
-			IL_0188: newarr [System.Runtime]System.Object
-			IL_018d: dup
-			IL_018e: ldc.i4.0
-			IL_018f: ldarg.0
-			IL_0190: stelem.ref
-			IL_0191: stloc.s 5
-			IL_0193: ldloc.0
-			IL_0194: ldstr "printRoot"
-			IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_019e: stloc.s 8
-			IL_01a0: ldloc.s 6
-			IL_01a2: ldloc.s 5
-			IL_01a4: ldloc.s 4
-			IL_01a6: ldloc.2
-			IL_01a7: ldloc.s 8
-			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_01ae: pop
-			IL_01af: ldnull
-			IL_01b0: ret
+			IL_0174: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0179: stloc.s 12
+			IL_017b: ldarg.0
+			IL_017c: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::describePlan
+			IL_0181: ldc.i4.1
+			IL_0182: newarr [System.Runtime]System.Object
+			IL_0187: dup
+			IL_0188: ldc.i4.0
+			IL_0189: ldarg.0
+			IL_018a: stelem.ref
+			IL_018b: ldloc.2
+			IL_018c: ldloc.3
+			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0192: stloc.s 7
+			IL_0194: ldloc.s 12
+			IL_0196: ldloc.s 7
+			IL_0198: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_019d: pop
+			IL_019e: ldnull
+			IL_019f: ret
+
+			IL_01a0: ldarg.0
+			IL_01a1: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveBootstrapRoot
+			IL_01a6: ldc.i4.1
+			IL_01a7: newarr [System.Runtime]System.Object
+			IL_01ac: dup
+			IL_01ad: ldc.i4.0
+			IL_01ae: ldarg.0
+			IL_01af: stelem.ref
+			IL_01b0: ldloc.1
+			IL_01b1: ldloc.2
+			IL_01b2: ldloc.0
+			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_01b8: stloc.s 4
+			IL_01ba: ldarg.0
+			IL_01bb: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printResolvedRoot
+			IL_01c0: stloc.s 7
+			IL_01c2: ldc.i4.1
+			IL_01c3: newarr [System.Runtime]System.Object
+			IL_01c8: dup
+			IL_01c9: ldc.i4.0
+			IL_01ca: ldarg.0
+			IL_01cb: stelem.ref
+			IL_01cc: stloc.s 6
+			IL_01ce: ldloc.0
+			IL_01cf: ldstr "printRoot"
+			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01d9: stloc.s 5
+			IL_01db: ldloc.s 7
+			IL_01dd: ldloc.s 6
+			IL_01df: ldloc.s 4
+			IL_01e1: ldloc.2
+			IL_01e2: ldloc.s 5
+			IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_01e9: pop
+			IL_01ea: ldnull
+			IL_01eb: ret
 		} // end of method main::__js_call__
 
 	} // end of class main

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -3763,7 +3763,7 @@
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 355 (0x163)
+			// Code size: 406 (0x196)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3791,7 +3791,7 @@
 			IL_001b: clt
 			IL_001d: ldc.i4.0
 			IL_001e: ceq
-			IL_0020: brfalse IL_0161
+			IL_0020: brfalse IL_0194
 
 			IL_0025: ldarg.2
 			IL_0026: ldc.r8 0.0
@@ -3878,7 +3878,7 @@
 			IL_0107: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_010c: stloc.s 4
 			IL_010e: ldloc.s 4
-			IL_0110: brfalse IL_0161
+			IL_0110: brfalse IL_0194
 
 			IL_0115: ldarg.2
 			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
@@ -3895,18 +3895,37 @@
 			IL_013b: ldloc.3
 			IL_013c: box [System.Runtime]System.Double
 			IL_0141: stloc.s 12
-			IL_0143: ldloc.2
-			IL_0144: ldstr "substring"
-			IL_0149: ldc.r8 1
-			IL_0152: box [System.Runtime]System.Double
-			IL_0157: ldloc.s 12
-			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_015e: stloc.2
-			IL_015f: ldloc.2
-			IL_0160: ret
+			IL_0143: ldc.i4.0
+			IL_0144: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0149: brfalse IL_0176
 
-			IL_0161: ldarg.2
-			IL_0162: ret
+			IL_014e: ldloc.2
+			IL_014f: isinst [System.Runtime]System.String
+			IL_0154: dup
+			IL_0155: brfalse IL_0175
+
+			IL_015a: ldc.r8 1
+			IL_0163: box [System.Runtime]System.Double
+			IL_0168: ldloc.s 12
+			IL_016a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_016f: stloc.2
+			IL_0170: br IL_0192
+
+			IL_0175: pop
+
+			IL_0176: ldloc.2
+			IL_0177: ldstr "substring"
+			IL_017c: ldc.r8 1
+			IL_0185: box [System.Runtime]System.Double
+			IL_018a: ldloc.s 12
+			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0191: stloc.2
+
+			IL_0192: ldloc.2
+			IL_0193: ret
+
+			IL_0194: ldarg.2
+			IL_0195: ret
 		} // end of method unquote::__js_call__
 
 	} // end of class unquote
@@ -4138,7 +4157,7 @@
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 296 (0x128)
+			// Code size: 430 (0x1ae)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -4170,95 +4189,150 @@
 			IL_0028: ldloc.s 7
 			IL_002a: box [System.Runtime]System.Double
 			IL_002f: stloc.s 8
-			IL_0031: ldloc.s 5
-			IL_0033: ldstr "substring"
-			IL_0038: ldc.r8 1
-			IL_0041: box [System.Runtime]System.Double
-			IL_0046: ldloc.s 8
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_004d: stloc.s 5
-			IL_004f: ldloc.s 5
-			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0056: ldstr "trim"
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0060: stloc.0
-			IL_0061: ldloc.0
-			IL_0062: ldstr ""
-			IL_0067: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_006c: stloc.s 9
-			IL_006e: ldloc.s 9
-			IL_0070: brfalse IL_0080
+			IL_0031: ldc.i4.0
+			IL_0032: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0037: brfalse IL_0066
 
-			IL_0075: ldc.i4.0
-			IL_0076: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_007b: stloc.s 10
-			IL_007d: ldloc.s 10
-			IL_007f: ret
+			IL_003c: ldloc.s 5
+			IL_003e: isinst [System.Runtime]System.String
+			IL_0043: dup
+			IL_0044: brfalse IL_0065
 
-			IL_0080: ldloc.0
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0086: ldstr "split"
-			IL_008b: ldstr ","
-			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0095: stloc.1
-			IL_0096: ldc.i4.0
-			IL_0097: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_009c: stloc.2
-			IL_009d: ldc.r8 0.0
-			IL_00a6: stloc.3
-			// loop start (head: IL_00a7)
-				IL_00a7: ldloc.3
-				IL_00a8: stloc.s 7
-				IL_00aa: ldloc.1
-				IL_00ab: ldstr "length"
-				IL_00b0: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_00b5: stloc.s 11
-				IL_00b7: ldloc.s 7
-				IL_00b9: ldloc.s 11
-				IL_00bb: clt
-				IL_00bd: brfalse IL_0126
+			IL_0049: ldc.r8 1
+			IL_0052: box [System.Runtime]System.Double
+			IL_0057: ldloc.s 8
+			IL_0059: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_005e: stloc.s 5
+			IL_0060: br IL_0084
 
-				IL_00c2: ldloc.1
-				IL_00c3: ldloc.3
-				IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00c9: stloc.s 5
-				IL_00cb: ldloc.s 5
-				IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00d2: ldstr "trim"
-				IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_00dc: stloc.s 4
-				IL_00de: ldloc.s 4
-				IL_00e0: ldstr ""
-				IL_00e5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_00ea: stloc.s 9
-				IL_00ec: ldloc.s 9
-				IL_00ee: brfalse IL_0115
+			IL_0065: pop
 
-				IL_00f3: ldarg.0
-				IL_00f4: ldfld object Modules.test262_metadataParser/Scope::unquote
-				IL_00f9: ldc.i4.1
-				IL_00fa: newarr [System.Runtime]System.Object
-				IL_00ff: dup
-				IL_0100: ldc.i4.0
-				IL_0101: ldarg.0
-				IL_0102: stelem.ref
-				IL_0103: ldloc.s 4
-				IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_010a: stloc.s 5
-				IL_010c: ldloc.2
-				IL_010d: ldloc.s 5
-				IL_010f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0114: pop
+			IL_0066: ldloc.s 5
+			IL_0068: ldstr "substring"
+			IL_006d: ldc.r8 1
+			IL_0076: box [System.Runtime]System.Double
+			IL_007b: ldloc.s 8
+			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0082: stloc.s 5
 
-				IL_0115: ldloc.3
-				IL_0116: ldc.r8 1
-				IL_011f: add
-				IL_0120: stloc.3
-				IL_0121: br IL_00a7
+			IL_0084: ldloc.s 5
+			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_008b: stloc.s 5
+			IL_008d: ldc.i4.0
+			IL_008e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0093: brfalse IL_00b1
+
+			IL_0098: ldloc.s 5
+			IL_009a: isinst [System.Runtime]System.String
+			IL_009f: dup
+			IL_00a0: brfalse IL_00b0
+
+			IL_00a5: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_00aa: stloc.0
+			IL_00ab: br IL_00be
+
+			IL_00b0: pop
+
+			IL_00b1: ldloc.s 5
+			IL_00b3: ldstr "trim"
+			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_00bd: stloc.0
+
+			IL_00be: ldloc.0
+			IL_00bf: ldstr ""
+			IL_00c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00c9: stloc.s 9
+			IL_00cb: ldloc.s 9
+			IL_00cd: brfalse IL_00dd
+
+			IL_00d2: ldc.i4.0
+			IL_00d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00d8: stloc.s 10
+			IL_00da: ldloc.s 10
+			IL_00dc: ret
+
+			IL_00dd: ldloc.0
+			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00e3: ldstr "split"
+			IL_00e8: ldstr ","
+			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00f2: stloc.1
+			IL_00f3: ldc.i4.0
+			IL_00f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00f9: stloc.2
+			IL_00fa: ldc.r8 0.0
+			IL_0103: stloc.3
+			// loop start (head: IL_0104)
+				IL_0104: ldloc.3
+				IL_0105: stloc.s 7
+				IL_0107: ldloc.1
+				IL_0108: ldstr "length"
+				IL_010d: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0112: stloc.s 11
+				IL_0114: ldloc.s 7
+				IL_0116: ldloc.s 11
+				IL_0118: clt
+				IL_011a: brfalse IL_01ac
+
+				IL_011f: ldloc.1
+				IL_0120: ldloc.3
+				IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0126: stloc.s 5
+				IL_0128: ldloc.s 5
+				IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_012f: stloc.s 5
+				IL_0131: ldc.i4.0
+				IL_0132: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0137: brfalse IL_0156
+
+				IL_013c: ldloc.s 5
+				IL_013e: isinst [System.Runtime]System.String
+				IL_0143: dup
+				IL_0144: brfalse IL_0155
+
+				IL_0149: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_014e: stloc.s 4
+				IL_0150: br IL_0164
+
+				IL_0155: pop
+
+				IL_0156: ldloc.s 5
+				IL_0158: ldstr "trim"
+				IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0162: stloc.s 4
+
+				IL_0164: ldloc.s 4
+				IL_0166: ldstr ""
+				IL_016b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_0170: stloc.s 9
+				IL_0172: ldloc.s 9
+				IL_0174: brfalse IL_019b
+
+				IL_0179: ldarg.0
+				IL_017a: ldfld object Modules.test262_metadataParser/Scope::unquote
+				IL_017f: ldc.i4.1
+				IL_0180: newarr [System.Runtime]System.Object
+				IL_0185: dup
+				IL_0186: ldc.i4.0
+				IL_0187: ldarg.0
+				IL_0188: stelem.ref
+				IL_0189: ldloc.s 4
+				IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0190: stloc.s 5
+				IL_0192: ldloc.2
+				IL_0193: ldloc.s 5
+				IL_0195: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_019a: pop
+
+				IL_019b: ldloc.3
+				IL_019c: ldc.r8 1
+				IL_01a5: add
+				IL_01a6: stloc.3
+				IL_01a7: br IL_0104
 			// end loop
 
-			IL_0126: ldloc.2
-			IL_0127: ret
+			IL_01ac: ldloc.2
+			IL_01ad: ret
 		} // end of method parseInlineList::__js_call__
 
 	} // end of class parseInlineList
@@ -4429,7 +4503,7 @@
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 163 (0xa3)
+			// Code size: 294 (0x126)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -4443,76 +4517,134 @@
 
 			IL_0000: ldarg.2
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0006: ldstr "trim"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0017: ldstr "startsWith"
-			IL_001c: ldstr "["
-			IL_0021: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0026: stloc.1
-			IL_0027: ldloc.1
-			IL_0028: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_002d: stloc.2
-			IL_002e: ldloc.2
-			IL_002f: brfalse IL_0052
+			IL_0006: stloc.1
+			IL_0007: ldc.i4.0
+			IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_000d: brfalse IL_002a
 
-			IL_0034: ldloc.0
-			IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_003a: ldstr "endsWith"
-			IL_003f: ldstr "]"
-			IL_0044: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0049: stloc.3
-			IL_004a: ldloc.3
-			IL_004b: stloc.s 5
-			IL_004d: br IL_0055
+			IL_0012: ldloc.1
+			IL_0013: isinst [System.Runtime]System.String
+			IL_0018: dup
+			IL_0019: brfalse IL_0029
 
-			IL_0052: ldloc.1
-			IL_0053: stloc.s 5
+			IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0023: stloc.0
+			IL_0024: br IL_0036
 
-			IL_0055: ldloc.s 5
-			IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_005c: stloc.2
-			IL_005d: ldloc.2
-			IL_005e: brfalse IL_0082
+			IL_0029: pop
 
-			IL_0063: ldc.i4.1
-			IL_0064: newarr [System.Runtime]System.Object
-			IL_0069: dup
-			IL_006a: ldc.i4.0
-			IL_006b: ldarg.0
-			IL_006c: stelem.ref
-			IL_006d: stloc.s 6
-			IL_006f: ldloc.s 6
-			IL_0071: ldc.i4.0
-			IL_0072: ldelem.ref
-			IL_0073: castclass Modules.test262_metadataParser/Scope
-			IL_0078: ldnull
-			IL_0079: ldloc.0
-			IL_007a: tail.
-			IL_007c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/parseInlineList::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-			IL_0081: ret
+			IL_002a: ldloc.1
+			IL_002b: ldstr "trim"
+			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0035: stloc.0
 
-			IL_0082: ldc.i4.1
-			IL_0083: newarr [System.Runtime]System.Object
-			IL_0088: dup
-			IL_0089: ldc.i4.0
-			IL_008a: ldarg.0
-			IL_008b: stelem.ref
-			IL_008c: stloc.s 6
-			IL_008e: ldloc.s 6
-			IL_0090: ldc.i4.0
-			IL_0091: ldelem.ref
-			IL_0092: castclass Modules.test262_metadataParser/Scope
-			IL_0097: ldnull
-			IL_0098: ldloc.0
-			IL_0099: tail.
-			IL_009b: call object Modules.test262_metadataParser/unquote::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-			IL_00a0: ret
+			IL_0036: ldloc.0
+			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_003c: stloc.1
+			IL_003d: ldc.i4.0
+			IL_003e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0043: brfalse IL_006a
 
-			IL_00a1: ldnull
-			IL_00a2: ret
+			IL_0048: ldloc.1
+			IL_0049: isinst [System.Runtime]System.String
+			IL_004e: dup
+			IL_004f: brfalse IL_0069
+
+			IL_0054: ldstr "["
+			IL_0059: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+			IL_005e: box [System.Runtime]System.Boolean
+			IL_0063: stloc.1
+			IL_0064: br IL_007b
+
+			IL_0069: pop
+
+			IL_006a: ldloc.1
+			IL_006b: ldstr "startsWith"
+			IL_0070: ldstr "["
+			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_007a: stloc.1
+
+			IL_007b: ldloc.1
+			IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0081: stloc.2
+			IL_0082: ldloc.2
+			IL_0083: brfalse IL_00d5
+
+			IL_0088: ldloc.0
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_008e: stloc.3
+			IL_008f: ldc.i4.0
+			IL_0090: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0095: brfalse IL_00bc
+
+			IL_009a: ldloc.3
+			IL_009b: isinst [System.Runtime]System.String
+			IL_00a0: dup
+			IL_00a1: brfalse IL_00bb
+
+			IL_00a6: ldstr "]"
+			IL_00ab: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
+			IL_00b0: box [System.Runtime]System.Boolean
+			IL_00b5: stloc.3
+			IL_00b6: br IL_00cd
+
+			IL_00bb: pop
+
+			IL_00bc: ldloc.3
+			IL_00bd: ldstr "endsWith"
+			IL_00c2: ldstr "]"
+			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00cc: stloc.3
+
+			IL_00cd: ldloc.3
+			IL_00ce: stloc.s 5
+			IL_00d0: br IL_00d8
+
+			IL_00d5: ldloc.1
+			IL_00d6: stloc.s 5
+
+			IL_00d8: ldloc.s 5
+			IL_00da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00df: stloc.2
+			IL_00e0: ldloc.2
+			IL_00e1: brfalse IL_0105
+
+			IL_00e6: ldc.i4.1
+			IL_00e7: newarr [System.Runtime]System.Object
+			IL_00ec: dup
+			IL_00ed: ldc.i4.0
+			IL_00ee: ldarg.0
+			IL_00ef: stelem.ref
+			IL_00f0: stloc.s 6
+			IL_00f2: ldloc.s 6
+			IL_00f4: ldc.i4.0
+			IL_00f5: ldelem.ref
+			IL_00f6: castclass Modules.test262_metadataParser/Scope
+			IL_00fb: ldnull
+			IL_00fc: ldloc.0
+			IL_00fd: tail.
+			IL_00ff: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/parseInlineList::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+			IL_0104: ret
+
+			IL_0105: ldc.i4.1
+			IL_0106: newarr [System.Runtime]System.Object
+			IL_010b: dup
+			IL_010c: ldc.i4.0
+			IL_010d: ldarg.0
+			IL_010e: stelem.ref
+			IL_010f: stloc.s 6
+			IL_0111: ldloc.s 6
+			IL_0113: ldc.i4.0
+			IL_0114: ldelem.ref
+			IL_0115: castclass Modules.test262_metadataParser/Scope
+			IL_011a: ldnull
+			IL_011b: ldloc.0
+			IL_011c: tail.
+			IL_011e: call object Modules.test262_metadataParser/unquote::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+			IL_0123: ret
+
+			IL_0124: ldnull
+			IL_0125: ret
 		} // end of method parseInlineValue::__js_call__
 
 	} // end of class parseInlineValue
@@ -5158,7 +5290,7 @@
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 438 (0x1b6)
+			// Code size: 521 (0x209)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -5197,7 +5329,7 @@
 				IL_003c: ldloc.s 6
 				IL_003e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0043: clt
-				IL_0045: brfalse IL_0164
+				IL_0045: brfalse IL_01b7
 
 				IL_004a: ldarg.3
 				IL_004b: ldstr "index"
@@ -5209,136 +5341,173 @@
 				IL_005f: stloc.2
 				IL_0060: ldloc.2
 				IL_0061: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0066: ldstr "trim"
-				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_0070: stloc.s 6
-				IL_0072: ldloc.s 6
-				IL_0074: ldstr ""
-				IL_0079: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_007e: stloc.s 7
-				IL_0080: ldloc.s 7
-				IL_0082: brfalse IL_00c2
+				IL_0066: stloc.s 6
+				IL_0068: ldc.i4.0
+				IL_0069: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_006e: brfalse IL_008d
 
-				IL_0087: ldloc.0
-				IL_0088: ldstr ""
-				IL_008d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0092: pop
-				IL_0093: ldarg.3
-				IL_0094: ldstr "index"
-				IL_0099: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_009e: stloc.s 4
-				IL_00a0: ldloc.s 4
-				IL_00a2: ldc.r8 1
-				IL_00ab: add
-				IL_00ac: stloc.s 4
-				IL_00ae: ldarg.3
-				IL_00af: ldstr "index"
-				IL_00b4: ldloc.s 4
-				IL_00b6: ldc.i4.1
-				IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_00bc: pop
-				IL_00bd: br IL_001b
+				IL_0073: ldloc.s 6
+				IL_0075: isinst [System.Runtime]System.String
+				IL_007a: dup
+				IL_007b: brfalse IL_008c
 
-				IL_00c2: ldarg.0
-				IL_00c3: ldfld object Modules.test262_metadataParser/Scope::countIndent
-				IL_00c8: ldc.i4.1
-				IL_00c9: newarr [System.Runtime]System.Object
-				IL_00ce: dup
-				IL_00cf: ldc.i4.0
-				IL_00d0: ldarg.0
-				IL_00d1: stelem.ref
-				IL_00d2: ldloc.2
-				IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_00d8: stloc.s 6
-				IL_00da: ldloc.s 6
-				IL_00dc: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00e1: stloc.3
-				IL_00e2: ldloc.3
-				IL_00e3: ldarg.s parentIndent
-				IL_00e5: cgt
-				IL_00e7: ldc.i4.0
-				IL_00e8: ceq
-				IL_00ea: brfalse IL_00f4
+				IL_0080: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_0085: stloc.s 6
+				IL_0087: br IL_009b
 
-				IL_00ef: br IL_0164
+				IL_008c: pop
 
-				IL_00f4: ldloc.1
-				IL_00f5: stloc.s 8
-				IL_00f7: ldloc.s 8
-				IL_00f9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00fe: ldc.r8 0.0
-				IL_0107: clt
-				IL_0109: brfalse IL_0119
+				IL_008d: ldloc.s 6
+				IL_008f: ldstr "trim"
+				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0099: stloc.s 6
 
-				IL_010e: ldloc.3
-				IL_010f: box [System.Runtime]System.Double
-				IL_0114: stloc.s 8
-				IL_0116: ldloc.s 8
-				IL_0118: stloc.1
+				IL_009b: ldloc.s 6
+				IL_009d: ldstr ""
+				IL_00a2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00a7: stloc.s 7
+				IL_00a9: ldloc.s 7
+				IL_00ab: brfalse IL_00eb
 
-				IL_0119: ldloc.2
-				IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_011f: ldstr "substring"
-				IL_0124: ldloc.1
-				IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_012a: stloc.s 6
-				IL_012c: ldloc.0
-				IL_012d: ldloc.s 6
-				IL_012f: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0134: pop
-				IL_0135: ldarg.3
-				IL_0136: ldstr "index"
-				IL_013b: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0140: stloc.s 4
-				IL_0142: ldloc.s 4
-				IL_0144: ldc.r8 1
-				IL_014d: add
-				IL_014e: stloc.s 4
-				IL_0150: ldarg.3
-				IL_0151: ldstr "index"
-				IL_0156: ldloc.s 4
-				IL_0158: ldc.i4.1
-				IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_015e: pop
-				IL_015f: br IL_001b
+				IL_00b0: ldloc.0
+				IL_00b1: ldstr ""
+				IL_00b6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_00bb: pop
+				IL_00bc: ldarg.3
+				IL_00bd: ldstr "index"
+				IL_00c2: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_00c7: stloc.s 4
+				IL_00c9: ldloc.s 4
+				IL_00cb: ldc.r8 1
+				IL_00d4: add
+				IL_00d5: stloc.s 4
+				IL_00d7: ldarg.3
+				IL_00d8: ldstr "index"
+				IL_00dd: ldloc.s 4
+				IL_00df: ldc.i4.1
+				IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_00e5: pop
+				IL_00e6: br IL_001b
+
+				IL_00eb: ldarg.0
+				IL_00ec: ldfld object Modules.test262_metadataParser/Scope::countIndent
+				IL_00f1: ldc.i4.1
+				IL_00f2: newarr [System.Runtime]System.Object
+				IL_00f7: dup
+				IL_00f8: ldc.i4.0
+				IL_00f9: ldarg.0
+				IL_00fa: stelem.ref
+				IL_00fb: ldloc.2
+				IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0101: stloc.s 6
+				IL_0103: ldloc.s 6
+				IL_0105: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_010a: stloc.3
+				IL_010b: ldloc.3
+				IL_010c: ldarg.s parentIndent
+				IL_010e: cgt
+				IL_0110: ldc.i4.0
+				IL_0111: ceq
+				IL_0113: brfalse IL_011d
+
+				IL_0118: br IL_01b7
+
+				IL_011d: ldloc.1
+				IL_011e: stloc.s 8
+				IL_0120: ldloc.s 8
+				IL_0122: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0127: ldc.r8 0.0
+				IL_0130: clt
+				IL_0132: brfalse IL_0142
+
+				IL_0137: ldloc.3
+				IL_0138: box [System.Runtime]System.Double
+				IL_013d: stloc.s 8
+				IL_013f: ldloc.s 8
+				IL_0141: stloc.1
+
+				IL_0142: ldloc.2
+				IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0148: stloc.s 6
+				IL_014a: ldc.i4.0
+				IL_014b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0150: brfalse IL_0170
+
+				IL_0155: ldloc.s 6
+				IL_0157: isinst [System.Runtime]System.String
+				IL_015c: dup
+				IL_015d: brfalse IL_016f
+
+				IL_0162: ldloc.1
+				IL_0163: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+				IL_0168: stloc.s 6
+				IL_016a: br IL_017f
+
+				IL_016f: pop
+
+				IL_0170: ldloc.s 6
+				IL_0172: ldstr "substring"
+				IL_0177: ldloc.1
+				IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_017d: stloc.s 6
+
+				IL_017f: ldloc.0
+				IL_0180: ldloc.s 6
+				IL_0182: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0187: pop
+				IL_0188: ldarg.3
+				IL_0189: ldstr "index"
+				IL_018e: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0193: stloc.s 4
+				IL_0195: ldloc.s 4
+				IL_0197: ldc.r8 1
+				IL_01a0: add
+				IL_01a1: stloc.s 4
+				IL_01a3: ldarg.3
+				IL_01a4: ldstr "index"
+				IL_01a9: ldloc.s 4
+				IL_01ab: ldc.i4.1
+				IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_01b1: pop
+				IL_01b2: br IL_001b
 			// end loop
 
-			IL_0164: ldarg.s style
-			IL_0166: ldstr ">"
-			IL_016b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0170: stloc.s 7
-			IL_0172: ldloc.s 7
-			IL_0174: brfalse IL_019d
+			IL_01b7: ldarg.s style
+			IL_01b9: ldstr ">"
+			IL_01be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01c3: stloc.s 7
+			IL_01c5: ldloc.s 7
+			IL_01c7: brfalse IL_01f0
 
-			IL_0179: ldc.i4.1
-			IL_017a: newarr [System.Runtime]System.Object
-			IL_017f: dup
-			IL_0180: ldc.i4.0
-			IL_0181: ldarg.0
-			IL_0182: stelem.ref
-			IL_0183: stloc.s 9
-			IL_0185: ldloc.s 9
-			IL_0187: ldc.i4.0
-			IL_0188: ldelem.ref
-			IL_0189: castclass Modules.test262_metadataParser/Scope
-			IL_018e: ldnull
-			IL_018f: ldloc.0
-			IL_0190: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0195: tail.
-			IL_0197: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-			IL_019c: ret
+			IL_01cc: ldc.i4.1
+			IL_01cd: newarr [System.Runtime]System.Object
+			IL_01d2: dup
+			IL_01d3: ldc.i4.0
+			IL_01d4: ldarg.0
+			IL_01d5: stelem.ref
+			IL_01d6: stloc.s 9
+			IL_01d8: ldloc.s 9
+			IL_01da: ldc.i4.0
+			IL_01db: ldelem.ref
+			IL_01dc: castclass Modules.test262_metadataParser/Scope
+			IL_01e1: ldnull
+			IL_01e2: ldloc.0
+			IL_01e3: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01e8: tail.
+			IL_01ea: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_01ef: ret
 
-			IL_019d: ldloc.0
-			IL_019e: ldc.i4.1
-			IL_019f: newarr [System.Runtime]System.Object
-			IL_01a4: dup
-			IL_01a5: ldc.i4.0
-			IL_01a6: ldstr "\n"
-			IL_01ab: stelem.ref
-			IL_01ac: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_01b1: stloc.s 10
-			IL_01b3: ldloc.s 10
-			IL_01b5: ret
+			IL_01f0: ldloc.0
+			IL_01f1: ldc.i4.1
+			IL_01f2: newarr [System.Runtime]System.Object
+			IL_01f7: dup
+			IL_01f8: ldc.i4.0
+			IL_01f9: ldstr "\n"
+			IL_01fe: stelem.ref
+			IL_01ff: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0204: stloc.s 10
+			IL_0206: ldloc.s 10
+			IL_0208: ret
 		} // end of method parseBlockScalar::__js_call__
 
 	} // end of class parseBlockScalar
@@ -5563,7 +5732,7 @@
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 368 (0x170)
+			// Code size: 405 (0x195)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5604,7 +5773,7 @@
 				IL_0035: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_003a: stloc.s 4
 				IL_003c: ldloc.s 4
-				IL_003e: brfalse IL_007b
+				IL_003e: brfalse IL_00a0
 
 				IL_0043: ldarg.2
 				IL_0044: ldloc.0
@@ -5612,132 +5781,150 @@
 				IL_004a: stloc.3
 				IL_004b: ldloc.3
 				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0051: ldstr "trim"
-				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_005b: stloc.3
-				IL_005c: ldloc.3
-				IL_005d: ldstr ""
-				IL_0062: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0067: stloc.s 4
-				IL_0069: ldloc.s 4
-				IL_006b: box [System.Runtime]System.Boolean
-				IL_0070: stloc.s 6
-				IL_0072: ldloc.s 6
-				IL_0074: stloc.s 8
-				IL_0076: br IL_007f
+				IL_0051: stloc.3
+				IL_0052: ldc.i4.0
+				IL_0053: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0058: brfalse IL_0075
 
-				IL_007b: ldloc.s 5
-				IL_007d: stloc.s 8
+				IL_005d: ldloc.3
+				IL_005e: isinst [System.Runtime]System.String
+				IL_0063: dup
+				IL_0064: brfalse IL_0074
 
-				IL_007f: ldloc.s 8
-				IL_0081: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0086: stloc.s 4
-				IL_0088: ldloc.s 4
-				IL_008a: brfalse IL_00b2
+				IL_0069: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_006e: stloc.3
+				IL_006f: br IL_0081
 
-				IL_008f: ldloc.0
-				IL_0090: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0095: ldc.r8 1
-				IL_009e: add
-				IL_009f: stloc.s 9
-				IL_00a1: ldloc.s 9
-				IL_00a3: box [System.Runtime]System.Double
-				IL_00a8: stloc.s 10
-				IL_00aa: ldloc.s 10
-				IL_00ac: stloc.0
-				IL_00ad: br IL_000c
+				IL_0074: pop
+
+				IL_0075: ldloc.3
+				IL_0076: ldstr "trim"
+				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0080: stloc.3
+
+				IL_0081: ldloc.3
+				IL_0082: ldstr ""
+				IL_0087: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_008c: stloc.s 4
+				IL_008e: ldloc.s 4
+				IL_0090: box [System.Runtime]System.Boolean
+				IL_0095: stloc.s 6
+				IL_0097: ldloc.s 6
+				IL_0099: stloc.s 8
+				IL_009b: br IL_00a4
+
+				IL_00a0: ldloc.s 5
+				IL_00a2: stloc.s 8
+
+				IL_00a4: ldloc.s 8
+				IL_00a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00ab: stloc.s 4
+				IL_00ad: ldloc.s 4
+				IL_00af: brfalse IL_00d7
+
+				IL_00b4: ldloc.0
+				IL_00b5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00ba: ldc.r8 1
+				IL_00c3: add
+				IL_00c4: stloc.s 9
+				IL_00c6: ldloc.s 9
+				IL_00c8: box [System.Runtime]System.Double
+				IL_00cd: stloc.s 10
+				IL_00cf: ldloc.s 10
+				IL_00d1: stloc.0
+				IL_00d2: br IL_000c
 			// end loop
 
-			IL_00b2: ldloc.0
-			IL_00b3: stloc.s 10
-			IL_00b5: ldarg.2
-			IL_00b6: ldstr "length"
-			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00c0: stloc.3
-			IL_00c1: ldloc.s 10
-			IL_00c3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00c8: ldloc.3
-			IL_00c9: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00ce: clt
-			IL_00d0: ldc.i4.0
-			IL_00d1: ceq
-			IL_00d3: brfalse IL_00ec
+			IL_00d7: ldloc.0
+			IL_00d8: stloc.s 10
+			IL_00da: ldarg.2
+			IL_00db: ldstr "length"
+			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00e5: stloc.3
+			IL_00e6: ldloc.s 10
+			IL_00e8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00ed: ldloc.3
+			IL_00ee: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00f3: clt
+			IL_00f5: ldc.i4.0
+			IL_00f6: ceq
+			IL_00f8: brfalse IL_0111
 
-			IL_00d8: ldarg.3
-			IL_00d9: ldstr "index"
-			IL_00de: ldloc.0
-			IL_00df: ldc.i4.1
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_00e5: pop
-			IL_00e6: ldstr ""
-			IL_00eb: ret
+			IL_00fd: ldarg.3
+			IL_00fe: ldstr "index"
+			IL_0103: ldloc.0
+			IL_0104: ldc.i4.1
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_010a: pop
+			IL_010b: ldstr ""
+			IL_0110: ret
 
-			IL_00ec: ldarg.0
-			IL_00ed: ldfld object Modules.test262_metadataParser/Scope::countIndent
-			IL_00f2: ldc.i4.1
-			IL_00f3: newarr [System.Runtime]System.Object
-			IL_00f8: dup
-			IL_00f9: ldc.i4.0
-			IL_00fa: ldarg.0
-			IL_00fb: stelem.ref
-			IL_00fc: stloc.s 11
-			IL_00fe: ldarg.2
-			IL_00ff: ldloc.0
-			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_0105: stloc.3
-			IL_0106: ldloc.s 11
-			IL_0108: ldloc.3
-			IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_010e: stloc.3
-			IL_010f: ldloc.3
-			IL_0110: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0115: stloc.1
-			IL_0116: ldloc.1
-			IL_0117: ldarg.s parentIndent
-			IL_0119: cgt
-			IL_011b: ldc.i4.0
-			IL_011c: ceq
-			IL_011e: brfalse IL_0137
+			IL_0111: ldarg.0
+			IL_0112: ldfld object Modules.test262_metadataParser/Scope::countIndent
+			IL_0117: ldc.i4.1
+			IL_0118: newarr [System.Runtime]System.Object
+			IL_011d: dup
+			IL_011e: ldc.i4.0
+			IL_011f: ldarg.0
+			IL_0120: stelem.ref
+			IL_0121: stloc.s 11
+			IL_0123: ldarg.2
+			IL_0124: ldloc.0
+			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_012a: stloc.3
+			IL_012b: ldloc.s 11
+			IL_012d: ldloc.3
+			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0133: stloc.3
+			IL_0134: ldloc.3
+			IL_0135: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_013a: stloc.1
+			IL_013b: ldloc.1
+			IL_013c: ldarg.s parentIndent
+			IL_013e: cgt
+			IL_0140: ldc.i4.0
+			IL_0141: ceq
+			IL_0143: brfalse IL_015c
 
-			IL_0123: ldarg.3
-			IL_0124: ldstr "index"
-			IL_0129: ldloc.0
-			IL_012a: ldc.i4.1
-			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0130: pop
-			IL_0131: ldstr ""
-			IL_0136: ret
+			IL_0148: ldarg.3
+			IL_0149: ldstr "index"
+			IL_014e: ldloc.0
+			IL_014f: ldc.i4.1
+			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0155: pop
+			IL_0156: ldstr ""
+			IL_015b: ret
 
-			IL_0137: ldarg.3
-			IL_0138: ldstr "index"
-			IL_013d: ldloc.0
-			IL_013e: ldc.i4.1
-			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0144: pop
-			IL_0145: ldloc.1
-			IL_0146: box [System.Runtime]System.Double
-			IL_014b: stloc.s 10
-			IL_014d: ldc.i4.1
-			IL_014e: newarr [System.Runtime]System.Object
-			IL_0153: dup
-			IL_0154: ldc.i4.0
-			IL_0155: ldarg.0
-			IL_0156: stelem.ref
-			IL_0157: stloc.s 11
-			IL_0159: ldloc.s 11
-			IL_015b: ldc.i4.0
-			IL_015c: ldelem.ref
-			IL_015d: castclass Modules.test262_metadataParser/Scope
-			IL_0162: ldnull
-			IL_0163: ldarg.2
-			IL_0164: ldarg.3
-			IL_0165: ldloc.1
-			IL_0166: tail.
-			IL_0168: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
-			IL_016d: ret
+			IL_015c: ldarg.3
+			IL_015d: ldstr "index"
+			IL_0162: ldloc.0
+			IL_0163: ldc.i4.1
+			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0169: pop
+			IL_016a: ldloc.1
+			IL_016b: box [System.Runtime]System.Double
+			IL_0170: stloc.s 10
+			IL_0172: ldc.i4.1
+			IL_0173: newarr [System.Runtime]System.Object
+			IL_0178: dup
+			IL_0179: ldc.i4.0
+			IL_017a: ldarg.0
+			IL_017b: stelem.ref
+			IL_017c: stloc.s 11
+			IL_017e: ldloc.s 11
+			IL_0180: ldc.i4.0
+			IL_0181: ldelem.ref
+			IL_0182: castclass Modules.test262_metadataParser/Scope
+			IL_0187: ldnull
+			IL_0188: ldarg.2
+			IL_0189: ldarg.3
+			IL_018a: ldloc.1
+			IL_018b: tail.
+			IL_018d: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
+			IL_0192: ret
 
-			IL_016e: ldnull
-			IL_016f: ret
+			IL_0193: ldnull
+			IL_0194: ret
 		} // end of method parseIndentedValue::__js_call__
 
 	} // end of class parseIndentedValue
@@ -6059,7 +6246,7 @@
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 855 (0x357)
+			// Code size: 980 (0x3d4)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -6102,7 +6289,7 @@
 				IL_0027: ldloc.s 11
 				IL_0029: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_002e: clt
-				IL_0030: brfalse IL_0355
+				IL_0030: brfalse IL_03d2
 
 				IL_0035: ldarg.3
 				IL_0036: ldstr "index"
@@ -6114,288 +6301,343 @@
 				IL_004a: stloc.1
 				IL_004b: ldloc.1
 				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0051: ldstr "trim"
-				IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_005b: stloc.s 11
-				IL_005d: ldloc.s 11
-				IL_005f: ldstr ""
-				IL_0064: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0069: stloc.s 12
-				IL_006b: ldloc.s 12
-				IL_006d: brfalse IL_00a1
+				IL_0051: stloc.s 11
+				IL_0053: ldc.i4.0
+				IL_0054: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0059: brfalse IL_0078
 
-				IL_0072: ldarg.3
-				IL_0073: ldstr "index"
-				IL_0078: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_007d: stloc.s 13
-				IL_007f: ldloc.s 13
-				IL_0081: ldc.r8 1
-				IL_008a: add
-				IL_008b: stloc.s 13
-				IL_008d: ldarg.3
-				IL_008e: ldstr "index"
-				IL_0093: ldloc.s 13
-				IL_0095: ldc.i4.1
-				IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_009b: pop
-				IL_009c: br IL_0006
+				IL_005e: ldloc.s 11
+				IL_0060: isinst [System.Runtime]System.String
+				IL_0065: dup
+				IL_0066: brfalse IL_0077
 
-				IL_00a1: ldarg.0
-				IL_00a2: ldfld object Modules.test262_metadataParser/Scope::countIndent
-				IL_00a7: ldc.i4.1
-				IL_00a8: newarr [System.Runtime]System.Object
-				IL_00ad: dup
-				IL_00ae: ldc.i4.0
-				IL_00af: ldarg.0
-				IL_00b0: stelem.ref
-				IL_00b1: ldloc.1
-				IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_00b7: stloc.s 11
-				IL_00b9: ldloc.s 11
-				IL_00bb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00c0: stloc.2
-				IL_00c1: ldloc.2
-				IL_00c2: ldarg.s baseIndent
-				IL_00c4: clt
-				IL_00c6: brfalse IL_00d0
+				IL_006b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_0070: stloc.s 11
+				IL_0072: br IL_0086
 
-				IL_00cb: br IL_0355
+				IL_0077: pop
 
-				IL_00d0: ldloc.2
-				IL_00d1: ldarg.s baseIndent
-				IL_00d3: cgt
-				IL_00d5: brfalse IL_0137
+				IL_0078: ldloc.s 11
+				IL_007a: ldstr "trim"
+				IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0084: stloc.s 11
 
-				IL_00da: ldarg.3
-				IL_00db: ldstr "index"
-				IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00e5: stloc.s 11
-				IL_00e7: ldloc.s 11
-				IL_00e9: ldc.r8 1
-				IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_00f7: stloc.s 14
-				IL_00f9: ldloc.s 14
-				IL_00fb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0100: stloc.s 15
-				IL_0102: ldstr "Unexpected indentation at frontmatter line "
-				IL_0107: ldloc.s 15
-				IL_0109: call string [System.Runtime]System.String::Concat(string, string)
-				IL_010e: ldstr "."
-				IL_0113: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0118: stloc.s 15
-				IL_011a: ldloc.s 15
-				IL_011c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0121: stloc.3
-				IL_0122: ldloc.3
-				IL_0123: isinst [System.Runtime]System.Exception
-				IL_0128: dup
-				IL_0129: brtrue IL_0136
+				IL_0086: ldloc.s 11
+				IL_0088: ldstr ""
+				IL_008d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0092: stloc.s 12
+				IL_0094: ldloc.s 12
+				IL_0096: brfalse IL_00ca
 
-				IL_012e: pop
-				IL_012f: ldloc.3
-				IL_0130: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_0135: throw
+				IL_009b: ldarg.3
+				IL_009c: ldstr "index"
+				IL_00a1: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_00a6: stloc.s 13
+				IL_00a8: ldloc.s 13
+				IL_00aa: ldc.r8 1
+				IL_00b3: add
+				IL_00b4: stloc.s 13
+				IL_00b6: ldarg.3
+				IL_00b7: ldstr "index"
+				IL_00bc: ldloc.s 13
+				IL_00be: ldc.i4.1
+				IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_00c4: pop
+				IL_00c5: br IL_0006
 
-				IL_0136: throw
+				IL_00ca: ldarg.0
+				IL_00cb: ldfld object Modules.test262_metadataParser/Scope::countIndent
+				IL_00d0: ldc.i4.1
+				IL_00d1: newarr [System.Runtime]System.Object
+				IL_00d6: dup
+				IL_00d7: ldc.i4.0
+				IL_00d8: ldarg.0
+				IL_00d9: stelem.ref
+				IL_00da: ldloc.1
+				IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_00e0: stloc.s 11
+				IL_00e2: ldloc.s 11
+				IL_00e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00e9: stloc.2
+				IL_00ea: ldloc.2
+				IL_00eb: ldarg.s baseIndent
+				IL_00ed: clt
+				IL_00ef: brfalse IL_00f9
 
-				IL_0137: ldloc.1
-				IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_013d: ldloc.2
-				IL_013e: box [System.Runtime]System.Double
-				IL_0143: stloc.s 16
-				IL_0145: ldstr "substring"
-				IL_014a: ldloc.s 16
-				IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0151: stloc.s 4
-				IL_0153: ldstr "^([A-Za-z0-9_-]+):(.*)$"
-				IL_0158: ldstr ""
-				IL_015d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0162: stloc.s 17
-				IL_0164: ldloc.s 17
-				IL_0166: ldstr "exec"
-				IL_016b: ldloc.s 4
-				IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0172: stloc.s 5
-				IL_0174: ldloc.s 5
-				IL_0176: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_017b: ldc.i4.0
-				IL_017c: ceq
-				IL_017e: stloc.s 12
-				IL_0180: ldloc.s 12
-				IL_0182: brfalse IL_01f7
+				IL_00f4: br IL_03d2
 
-				IL_0187: ldarg.3
-				IL_0188: ldstr "index"
-				IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0192: stloc.s 11
-				IL_0194: ldloc.s 11
-				IL_0196: ldc.r8 1
-				IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_01a4: stloc.s 14
-				IL_01a6: ldloc.s 14
-				IL_01a8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01ad: stloc.s 15
-				IL_01af: ldstr "Invalid frontmatter line "
-				IL_01b4: ldloc.s 15
-				IL_01b6: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01bb: ldstr ": "
-				IL_01c0: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01c5: ldloc.s 4
-				IL_01c7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01cc: stloc.s 15
-				IL_01ce: ldloc.s 15
-				IL_01d0: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01d5: stloc.s 15
-				IL_01d7: ldloc.s 15
-				IL_01d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_01de: stloc.s 6
-				IL_01e0: ldloc.s 6
-				IL_01e2: isinst [System.Runtime]System.Exception
-				IL_01e7: dup
-				IL_01e8: brtrue IL_01f6
+				IL_00f9: ldloc.2
+				IL_00fa: ldarg.s baseIndent
+				IL_00fc: cgt
+				IL_00fe: brfalse IL_0160
 
-				IL_01ed: pop
-				IL_01ee: ldloc.s 6
-				IL_01f0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_01f5: throw
+				IL_0103: ldarg.3
+				IL_0104: ldstr "index"
+				IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_010e: stloc.s 11
+				IL_0110: ldloc.s 11
+				IL_0112: ldc.r8 1
+				IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_0120: stloc.s 14
+				IL_0122: ldloc.s 14
+				IL_0124: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0129: stloc.s 15
+				IL_012b: ldstr "Unexpected indentation at frontmatter line "
+				IL_0130: ldloc.s 15
+				IL_0132: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0137: ldstr "."
+				IL_013c: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0141: stloc.s 15
+				IL_0143: ldloc.s 15
+				IL_0145: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_014a: stloc.3
+				IL_014b: ldloc.3
+				IL_014c: isinst [System.Runtime]System.Exception
+				IL_0151: dup
+				IL_0152: brtrue IL_015f
 
-				IL_01f6: throw
+				IL_0157: pop
+				IL_0158: ldloc.3
+				IL_0159: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_015e: throw
 
-				IL_01f7: ldloc.s 5
-				IL_01f9: ldc.r8 1
-				IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0207: stloc.s 7
-				IL_0209: ldloc.s 5
-				IL_020b: ldc.r8 2
-				IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0219: stloc.s 11
-				IL_021b: ldloc.s 11
-				IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0222: ldstr "trim"
-				IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_022c: stloc.s 8
-				IL_022e: ldarg.3
-				IL_022f: ldstr "index"
-				IL_0234: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0239: stloc.s 13
-				IL_023b: ldloc.s 13
-				IL_023d: ldc.r8 1
-				IL_0246: add
-				IL_0247: stloc.s 13
-				IL_0249: ldarg.3
-				IL_024a: ldstr "index"
-				IL_024f: ldloc.s 13
-				IL_0251: ldc.i4.1
-				IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_0257: pop
-				IL_0258: ldnull
-				IL_0259: stloc.s 9
-				IL_025b: ldloc.s 8
-				IL_025d: ldstr "|"
-				IL_0262: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0267: stloc.s 12
-				IL_0269: ldloc.s 12
-				IL_026b: box [System.Runtime]System.Boolean
-				IL_0270: stloc.s 18
-				IL_0272: ldloc.s 18
-				IL_0274: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0279: stloc.s 12
-				IL_027b: ldloc.s 12
-				IL_027d: brtrue IL_02a2
+				IL_015f: throw
 
-				IL_0282: ldloc.s 8
-				IL_0284: ldstr ">"
-				IL_0289: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_028e: stloc.s 12
-				IL_0290: ldloc.s 12
-				IL_0292: box [System.Runtime]System.Boolean
-				IL_0297: stloc.s 19
-				IL_0299: ldloc.s 19
-				IL_029b: stloc.s 20
-				IL_029d: br IL_02a6
+				IL_0160: ldloc.1
+				IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0166: stloc.s 11
+				IL_0168: ldloc.2
+				IL_0169: box [System.Runtime]System.Double
+				IL_016e: stloc.s 16
+				IL_0170: ldc.i4.0
+				IL_0171: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0176: brfalse IL_0197
 
-				IL_02a2: ldloc.s 18
-				IL_02a4: stloc.s 20
+				IL_017b: ldloc.s 11
+				IL_017d: isinst [System.Runtime]System.String
+				IL_0182: dup
+				IL_0183: brfalse IL_0196
 
-				IL_02a6: ldloc.s 20
-				IL_02a8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02ad: stloc.s 12
-				IL_02af: ldloc.s 12
-				IL_02b1: brfalse IL_02e5
+				IL_0188: ldloc.s 16
+				IL_018a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+				IL_018f: stloc.s 4
+				IL_0191: br IL_01a7
 
-				IL_02b6: ldarg.0
-				IL_02b7: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
-				IL_02bc: ldc.i4.1
-				IL_02bd: newarr [System.Runtime]System.Object
-				IL_02c2: dup
-				IL_02c3: ldc.i4.0
-				IL_02c4: ldarg.0
-				IL_02c5: stelem.ref
-				IL_02c6: stloc.s 21
-				IL_02c8: ldloc.s 21
-				IL_02ca: ldarg.2
-				IL_02cb: ldarg.3
-				IL_02cc: ldarg.s baseIndent
-				IL_02ce: box [System.Runtime]System.Double
-				IL_02d3: ldloc.s 8
-				IL_02d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-				IL_02da: stloc.s 11
-				IL_02dc: ldloc.s 11
-				IL_02de: stloc.s 9
-				IL_02e0: br IL_0344
+				IL_0196: pop
 
-				IL_02e5: ldloc.s 8
-				IL_02e7: ldstr ""
-				IL_02ec: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_02f1: stloc.s 12
-				IL_02f3: ldloc.s 12
-				IL_02f5: brfalse IL_0327
+				IL_0197: ldloc.s 11
+				IL_0199: ldstr "substring"
+				IL_019e: ldloc.s 16
+				IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01a5: stloc.s 4
 
-				IL_02fa: ldarg.0
-				IL_02fb: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
-				IL_0300: ldc.i4.1
-				IL_0301: newarr [System.Runtime]System.Object
-				IL_0306: dup
-				IL_0307: ldc.i4.0
-				IL_0308: ldarg.0
-				IL_0309: stelem.ref
-				IL_030a: stloc.s 21
-				IL_030c: ldloc.s 21
-				IL_030e: ldarg.2
-				IL_030f: ldarg.3
-				IL_0310: ldarg.s baseIndent
-				IL_0312: box [System.Runtime]System.Double
-				IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-				IL_031c: stloc.s 11
-				IL_031e: ldloc.s 11
-				IL_0320: stloc.s 9
-				IL_0322: br IL_0344
+				IL_01a7: ldstr "^([A-Za-z0-9_-]+):(.*)$"
+				IL_01ac: ldstr ""
+				IL_01b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_01b6: stloc.s 17
+				IL_01b8: ldloc.s 17
+				IL_01ba: ldstr "exec"
+				IL_01bf: ldloc.s 4
+				IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01c6: stloc.s 5
+				IL_01c8: ldloc.s 5
+				IL_01ca: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_01cf: ldc.i4.0
+				IL_01d0: ceq
+				IL_01d2: stloc.s 12
+				IL_01d4: ldloc.s 12
+				IL_01d6: brfalse IL_024b
 
-				IL_0327: ldarg.0
-				IL_0328: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
-				IL_032d: ldc.i4.1
-				IL_032e: newarr [System.Runtime]System.Object
-				IL_0333: dup
-				IL_0334: ldc.i4.0
-				IL_0335: ldarg.0
-				IL_0336: stelem.ref
-				IL_0337: ldloc.s 8
-				IL_0339: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_033e: stloc.s 11
-				IL_0340: ldloc.s 11
-				IL_0342: stloc.s 9
+				IL_01db: ldarg.3
+				IL_01dc: ldstr "index"
+				IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_01e6: stloc.s 11
+				IL_01e8: ldloc.s 11
+				IL_01ea: ldc.r8 1
+				IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_01f8: stloc.s 14
+				IL_01fa: ldloc.s 14
+				IL_01fc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0201: stloc.s 15
+				IL_0203: ldstr "Invalid frontmatter line "
+				IL_0208: ldloc.s 15
+				IL_020a: call string [System.Runtime]System.String::Concat(string, string)
+				IL_020f: ldstr ": "
+				IL_0214: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0219: ldloc.s 4
+				IL_021b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0220: stloc.s 15
+				IL_0222: ldloc.s 15
+				IL_0224: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0229: stloc.s 15
+				IL_022b: ldloc.s 15
+				IL_022d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_0232: stloc.s 6
+				IL_0234: ldloc.s 6
+				IL_0236: isinst [System.Runtime]System.Exception
+				IL_023b: dup
+				IL_023c: brtrue IL_024a
 
-				IL_0344: ldloc.0
-				IL_0345: ldloc.s 7
-				IL_0347: ldloc.s 9
-				IL_0349: ldc.i4.1
-				IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_034f: pop
-				IL_0350: br IL_0006
+				IL_0241: pop
+				IL_0242: ldloc.s 6
+				IL_0244: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0249: throw
+
+				IL_024a: throw
+
+				IL_024b: ldloc.s 5
+				IL_024d: ldc.r8 1
+				IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_025b: stloc.s 7
+				IL_025d: ldloc.s 5
+				IL_025f: ldc.r8 2
+				IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_026d: stloc.s 11
+				IL_026f: ldloc.s 11
+				IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0276: stloc.s 11
+				IL_0278: ldc.i4.0
+				IL_0279: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_027e: brfalse IL_029d
+
+				IL_0283: ldloc.s 11
+				IL_0285: isinst [System.Runtime]System.String
+				IL_028a: dup
+				IL_028b: brfalse IL_029c
+
+				IL_0290: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_0295: stloc.s 8
+				IL_0297: br IL_02ab
+
+				IL_029c: pop
+
+				IL_029d: ldloc.s 11
+				IL_029f: ldstr "trim"
+				IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_02a9: stloc.s 8
+
+				IL_02ab: ldarg.3
+				IL_02ac: ldstr "index"
+				IL_02b1: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_02b6: stloc.s 13
+				IL_02b8: ldloc.s 13
+				IL_02ba: ldc.r8 1
+				IL_02c3: add
+				IL_02c4: stloc.s 13
+				IL_02c6: ldarg.3
+				IL_02c7: ldstr "index"
+				IL_02cc: ldloc.s 13
+				IL_02ce: ldc.i4.1
+				IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_02d4: pop
+				IL_02d5: ldnull
+				IL_02d6: stloc.s 9
+				IL_02d8: ldloc.s 8
+				IL_02da: ldstr "|"
+				IL_02df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_02e4: stloc.s 12
+				IL_02e6: ldloc.s 12
+				IL_02e8: box [System.Runtime]System.Boolean
+				IL_02ed: stloc.s 18
+				IL_02ef: ldloc.s 18
+				IL_02f1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02f6: stloc.s 12
+				IL_02f8: ldloc.s 12
+				IL_02fa: brtrue IL_031f
+
+				IL_02ff: ldloc.s 8
+				IL_0301: ldstr ">"
+				IL_0306: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_030b: stloc.s 12
+				IL_030d: ldloc.s 12
+				IL_030f: box [System.Runtime]System.Boolean
+				IL_0314: stloc.s 19
+				IL_0316: ldloc.s 19
+				IL_0318: stloc.s 20
+				IL_031a: br IL_0323
+
+				IL_031f: ldloc.s 18
+				IL_0321: stloc.s 20
+
+				IL_0323: ldloc.s 20
+				IL_0325: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_032a: stloc.s 12
+				IL_032c: ldloc.s 12
+				IL_032e: brfalse IL_0362
+
+				IL_0333: ldarg.0
+				IL_0334: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
+				IL_0339: ldc.i4.1
+				IL_033a: newarr [System.Runtime]System.Object
+				IL_033f: dup
+				IL_0340: ldc.i4.0
+				IL_0341: ldarg.0
+				IL_0342: stelem.ref
+				IL_0343: stloc.s 21
+				IL_0345: ldloc.s 21
+				IL_0347: ldarg.2
+				IL_0348: ldarg.3
+				IL_0349: ldarg.s baseIndent
+				IL_034b: box [System.Runtime]System.Double
+				IL_0350: ldloc.s 8
+				IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
+				IL_0357: stloc.s 11
+				IL_0359: ldloc.s 11
+				IL_035b: stloc.s 9
+				IL_035d: br IL_03c1
+
+				IL_0362: ldloc.s 8
+				IL_0364: ldstr ""
+				IL_0369: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_036e: stloc.s 12
+				IL_0370: ldloc.s 12
+				IL_0372: brfalse IL_03a4
+
+				IL_0377: ldarg.0
+				IL_0378: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
+				IL_037d: ldc.i4.1
+				IL_037e: newarr [System.Runtime]System.Object
+				IL_0383: dup
+				IL_0384: ldc.i4.0
+				IL_0385: ldarg.0
+				IL_0386: stelem.ref
+				IL_0387: stloc.s 21
+				IL_0389: ldloc.s 21
+				IL_038b: ldarg.2
+				IL_038c: ldarg.3
+				IL_038d: ldarg.s baseIndent
+				IL_038f: box [System.Runtime]System.Double
+				IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+				IL_0399: stloc.s 11
+				IL_039b: ldloc.s 11
+				IL_039d: stloc.s 9
+				IL_039f: br IL_03c1
+
+				IL_03a4: ldarg.0
+				IL_03a5: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
+				IL_03aa: ldc.i4.1
+				IL_03ab: newarr [System.Runtime]System.Object
+				IL_03b0: dup
+				IL_03b1: ldc.i4.0
+				IL_03b2: ldarg.0
+				IL_03b3: stelem.ref
+				IL_03b4: ldloc.s 8
+				IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_03bb: stloc.s 11
+				IL_03bd: ldloc.s 11
+				IL_03bf: stloc.s 9
+
+				IL_03c1: ldloc.0
+				IL_03c2: ldloc.s 7
+				IL_03c4: ldloc.s 9
+				IL_03c6: ldc.i4.1
+				IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_03cc: pop
+				IL_03cd: br IL_0006
 			// end loop
 
-			IL_0355: ldloc.0
-			IL_0356: ret
+			IL_03d2: ldloc.0
+			IL_03d3: ret
 		} // end of method parseYamlSubsetLines::__js_call__
 
 	} // end of class parseYamlSubsetLines
@@ -6808,7 +7050,7 @@
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 299 (0x12b)
+			// Code size: 543 (0x21f)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -6837,91 +7079,188 @@
 			IL_001a: stloc.0
 			IL_001b: ldloc.0
 			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0021: ldstr "indexOf"
-			IL_0026: ldstr "/*---"
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0030: stloc.1
-			IL_0031: ldloc.1
-			IL_0032: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0037: ldc.r8 0.0
-			IL_0040: clt
-			IL_0042: brfalse IL_004e
+			IL_0021: stloc.s 6
+			IL_0023: ldc.i4.0
+			IL_0024: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0029: brfalse IL_0051
 
-			IL_0047: ldc.i4.0
-			IL_0048: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_004d: ret
+			IL_002e: ldloc.s 6
+			IL_0030: isinst [System.Runtime]System.String
+			IL_0035: dup
+			IL_0036: brfalse IL_0050
 
-			IL_004e: ldloc.0
-			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0054: stloc.s 6
-			IL_0056: ldloc.1
-			IL_0057: ldc.r8 5
-			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0065: stloc.s 7
-			IL_0067: ldloc.s 6
-			IL_0069: ldstr "indexOf"
-			IL_006e: ldstr "---*/"
-			IL_0073: ldloc.s 7
-			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_007a: stloc.2
-			IL_007b: ldloc.2
-			IL_007c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0081: ldc.r8 0.0
-			IL_008a: clt
-			IL_008c: brfalse IL_00b1
+			IL_003b: ldstr "/*---"
+			IL_0040: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0045: box [System.Runtime]System.Double
+			IL_004a: stloc.1
+			IL_004b: br IL_0063
 
-			IL_0091: ldstr "Unterminated test262 frontmatter block."
-			IL_0096: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_009b: stloc.3
-			IL_009c: ldloc.3
-			IL_009d: isinst [System.Runtime]System.Exception
-			IL_00a2: dup
-			IL_00a3: brtrue IL_00b0
+			IL_0050: pop
 
-			IL_00a8: pop
-			IL_00a9: ldloc.3
-			IL_00aa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00af: throw
+			IL_0051: ldloc.s 6
+			IL_0053: ldstr "indexOf"
+			IL_0058: ldstr "/*---"
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0062: stloc.1
 
-			IL_00b0: throw
+			IL_0063: ldloc.1
+			IL_0064: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0069: ldc.r8 0.0
+			IL_0072: clt
+			IL_0074: brfalse IL_0080
 
-			IL_00b1: ldloc.0
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00b7: stloc.s 6
-			IL_00b9: ldloc.1
-			IL_00ba: ldc.r8 5
-			IL_00c3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_00c8: stloc.s 7
-			IL_00ca: ldloc.s 6
-			IL_00cc: ldstr "substring"
-			IL_00d1: ldloc.s 7
-			IL_00d3: ldloc.2
-			IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00d9: stloc.s 4
-			IL_00db: ldloc.s 4
-			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e2: ldstr "startsWith"
-			IL_00e7: ldstr "\n"
-			IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00f1: stloc.s 6
-			IL_00f3: ldloc.s 6
-			IL_00f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00fa: stloc.s 8
-			IL_00fc: ldloc.s 8
-			IL_00fe: brfalse IL_0128
+			IL_0079: ldc.i4.0
+			IL_007a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_007f: ret
 
-			IL_0103: ldloc.s 4
-			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_010a: ldstr "substring"
-			IL_010f: ldc.r8 1
-			IL_0118: box [System.Runtime]System.Double
-			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0122: stloc.s 6
-			IL_0124: ldloc.s 6
-			IL_0126: stloc.s 4
+			IL_0080: ldloc.0
+			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0086: stloc.s 6
+			IL_0088: ldloc.1
+			IL_0089: ldc.r8 5
+			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0097: stloc.s 7
+			IL_0099: ldc.i4.0
+			IL_009a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_009f: brfalse IL_00c9
 
-			IL_0128: ldloc.s 4
-			IL_012a: ret
+			IL_00a4: ldloc.s 6
+			IL_00a6: isinst [System.Runtime]System.String
+			IL_00ab: dup
+			IL_00ac: brfalse IL_00c8
+
+			IL_00b1: ldstr "---*/"
+			IL_00b6: ldloc.s 7
+			IL_00b8: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string, object)
+			IL_00bd: box [System.Runtime]System.Double
+			IL_00c2: stloc.2
+			IL_00c3: br IL_00dd
+
+			IL_00c8: pop
+
+			IL_00c9: ldloc.s 6
+			IL_00cb: ldstr "indexOf"
+			IL_00d0: ldstr "---*/"
+			IL_00d5: ldloc.s 7
+			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00dc: stloc.2
+
+			IL_00dd: ldloc.2
+			IL_00de: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00e3: ldc.r8 0.0
+			IL_00ec: clt
+			IL_00ee: brfalse IL_0113
+
+			IL_00f3: ldstr "Unterminated test262 frontmatter block."
+			IL_00f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00fd: stloc.3
+			IL_00fe: ldloc.3
+			IL_00ff: isinst [System.Runtime]System.Exception
+			IL_0104: dup
+			IL_0105: brtrue IL_0112
+
+			IL_010a: pop
+			IL_010b: ldloc.3
+			IL_010c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0111: throw
+
+			IL_0112: throw
+
+			IL_0113: ldloc.0
+			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0119: stloc.s 6
+			IL_011b: ldloc.1
+			IL_011c: ldc.r8 5
+			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_012a: stloc.s 7
+			IL_012c: ldc.i4.0
+			IL_012d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0132: brfalse IL_0154
+
+			IL_0137: ldloc.s 6
+			IL_0139: isinst [System.Runtime]System.String
+			IL_013e: dup
+			IL_013f: brfalse IL_0153
+
+			IL_0144: ldloc.s 7
+			IL_0146: ldloc.2
+			IL_0147: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_014c: stloc.s 4
+			IL_014e: br IL_0165
+
+			IL_0153: pop
+
+			IL_0154: ldloc.s 6
+			IL_0156: ldstr "substring"
+			IL_015b: ldloc.s 7
+			IL_015d: ldloc.2
+			IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0163: stloc.s 4
+
+			IL_0165: ldloc.s 4
+			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_016c: stloc.s 6
+			IL_016e: ldc.i4.0
+			IL_016f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0174: brfalse IL_019d
+
+			IL_0179: ldloc.s 6
+			IL_017b: isinst [System.Runtime]System.String
+			IL_0180: dup
+			IL_0181: brfalse IL_019c
+
+			IL_0186: ldstr "\n"
+			IL_018b: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+			IL_0190: box [System.Runtime]System.Boolean
+			IL_0195: stloc.s 6
+			IL_0197: br IL_01b0
+
+			IL_019c: pop
+
+			IL_019d: ldloc.s 6
+			IL_019f: ldstr "startsWith"
+			IL_01a4: ldstr "\n"
+			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01ae: stloc.s 6
+
+			IL_01b0: ldloc.s 6
+			IL_01b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01b7: stloc.s 8
+			IL_01b9: ldloc.s 8
+			IL_01bb: brfalse IL_021c
+
+			IL_01c0: ldloc.s 4
+			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c7: stloc.s 6
+			IL_01c9: ldc.i4.0
+			IL_01ca: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01cf: brfalse IL_01fc
+
+			IL_01d4: ldloc.s 6
+			IL_01d6: isinst [System.Runtime]System.String
+			IL_01db: dup
+			IL_01dc: brfalse IL_01fb
+
+			IL_01e1: ldc.r8 1
+			IL_01ea: box [System.Runtime]System.Double
+			IL_01ef: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_01f4: stloc.s 6
+			IL_01f6: br IL_0218
+
+			IL_01fb: pop
+
+			IL_01fc: ldloc.s 6
+			IL_01fe: ldstr "substring"
+			IL_0203: ldc.r8 1
+			IL_020c: box [System.Runtime]System.Double
+			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0216: stloc.s 6
+
+			IL_0218: ldloc.s 6
+			IL_021a: stloc.s 4
+
+			IL_021c: ldloc.s 4
+			IL_021e: ret
 		} // end of method extractTest262Frontmatter::__js_call__
 
 	} // end of class extractTest262Frontmatter
@@ -7249,7 +7588,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 109 (0x6d)
+			// Code size: 192 (0xc0)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -7271,35 +7610,72 @@
 
 			IL_0016: ldarg.1
 			IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001c: ldstr "lastIndexOf"
-			IL_0021: ldstr "/"
-			IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_002b: stloc.0
-			IL_002c: ldloc.0
-			IL_002d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0032: ldc.r8 0.0
-			IL_003b: clt
-			IL_003d: ldc.i4.0
-			IL_003e: ceq
-			IL_0040: brfalse IL_006b
+			IL_001c: stloc.2
+			IL_001d: ldc.i4.0
+			IL_001e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0023: brfalse IL_004a
 
-			IL_0045: ldarg.1
-			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004b: stloc.2
-			IL_004c: ldloc.0
-			IL_004d: ldc.r8 1
-			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_005b: stloc.3
-			IL_005c: ldloc.2
-			IL_005d: ldstr "substring"
-			IL_0062: ldloc.3
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0068: stloc.2
-			IL_0069: ldloc.2
-			IL_006a: ret
+			IL_0028: ldloc.2
+			IL_0029: isinst [System.Runtime]System.String
+			IL_002e: dup
+			IL_002f: brfalse IL_0049
 
-			IL_006b: ldarg.1
-			IL_006c: ret
+			IL_0034: ldstr "/"
+			IL_0039: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+			IL_003e: box [System.Runtime]System.Double
+			IL_0043: stloc.0
+			IL_0044: br IL_005b
+
+			IL_0049: pop
+
+			IL_004a: ldloc.2
+			IL_004b: ldstr "lastIndexOf"
+			IL_0050: ldstr "/"
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_005a: stloc.0
+
+			IL_005b: ldloc.0
+			IL_005c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0061: ldc.r8 0.0
+			IL_006a: clt
+			IL_006c: ldc.i4.0
+			IL_006d: ceq
+			IL_006f: brfalse IL_00be
+
+			IL_0074: ldarg.1
+			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_007a: stloc.2
+			IL_007b: ldloc.0
+			IL_007c: ldc.r8 1
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_008a: stloc.3
+			IL_008b: ldc.i4.0
+			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0091: brfalse IL_00af
+
+			IL_0096: ldloc.2
+			IL_0097: isinst [System.Runtime]System.String
+			IL_009c: dup
+			IL_009d: brfalse IL_00ae
+
+			IL_00a2: ldloc.3
+			IL_00a3: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_00a8: stloc.2
+			IL_00a9: br IL_00bc
+
+			IL_00ae: pop
+
+			IL_00af: ldloc.2
+			IL_00b0: ldstr "substring"
+			IL_00b5: ldloc.3
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00bb: stloc.2
+
+			IL_00bc: ldloc.2
+			IL_00bd: ret
+
+			IL_00be: ldarg.1
+			IL_00bf: ret
 		} // end of method getFileName::__js_call__
 
 	} // end of class getFileName
@@ -9548,7 +9924,7 @@
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1583 (0x62f)
+			// Code size: 1634 (0x662)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -9664,528 +10040,548 @@
 			IL_009f: stloc.s 4
 			IL_00a1: ldarg.s fileName
 			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a8: ldstr "indexOf"
-			IL_00ad: ldstr "_FIXTURE"
-			IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00b7: stloc.s 22
-			IL_00b9: ldloc.s 22
-			IL_00bb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00c0: ldc.r8 0.0
-			IL_00c9: clt
-			IL_00cb: ldc.i4.0
-			IL_00cc: ceq
-			IL_00ce: stloc.s 5
-			IL_00d0: ldc.i4.0
-			IL_00d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00d6: stloc.s 6
-			IL_00d8: ldc.i4.4
-			IL_00d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00de: dup
-			IL_00df: ldstr "onlyStrict"
-			IL_00e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00e9: dup
-			IL_00ea: ldstr "noStrict"
-			IL_00ef: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00f4: dup
-			IL_00f5: ldstr "module"
-			IL_00fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_00ff: dup
-			IL_0100: ldstr "raw"
-			IL_0105: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_010a: stloc.s 7
-			IL_010c: ldc.r8 0.0
-			IL_0115: stloc.s 8
-			// loop start (head: IL_0117)
-				IL_0117: ldloc.s 8
-				IL_0119: stloc.s 23
-				IL_011b: ldloc.s 7
-				IL_011d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-				IL_0122: stloc.s 24
-				IL_0124: ldloc.s 23
-				IL_0126: ldloc.s 24
-				IL_0128: clt
-				IL_012a: brfalse IL_018a
+			IL_00a8: stloc.s 22
+			IL_00aa: ldc.i4.0
+			IL_00ab: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00b0: brfalse IL_00d9
 
-				IL_012f: ldloc.s 7
-				IL_0131: ldloc.s 8
-				IL_0133: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_0138: castclass [System.Runtime]System.String
-				IL_013d: stloc.s 9
-				IL_013f: ldarg.0
-				IL_0140: ldfld object Modules.test262_metadataParser/Scope::contains
-				IL_0145: ldc.i4.1
-				IL_0146: newarr [System.Runtime]System.Object
-				IL_014b: dup
-				IL_014c: ldc.i4.0
-				IL_014d: ldarg.0
-				IL_014e: stelem.ref
-				IL_014f: stloc.s 21
-				IL_0151: ldloc.s 21
-				IL_0153: ldarg.2
-				IL_0154: ldloc.s 9
-				IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_015b: stloc.s 22
-				IL_015d: ldloc.s 22
-				IL_015f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0164: stloc.s 25
-				IL_0166: ldloc.s 25
-				IL_0168: brfalse IL_0177
+			IL_00b5: ldloc.s 22
+			IL_00b7: isinst [System.Runtime]System.String
+			IL_00bc: dup
+			IL_00bd: brfalse IL_00d8
 
-				IL_016d: ldloc.s 6
-				IL_016f: ldloc.s 9
-				IL_0171: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0176: pop
+			IL_00c2: ldstr "_FIXTURE"
+			IL_00c7: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_00cc: box [System.Runtime]System.Double
+			IL_00d1: stloc.s 22
+			IL_00d3: br IL_00ec
 
-				IL_0177: ldloc.s 8
-				IL_0179: ldc.r8 1
-				IL_0182: add
-				IL_0183: stloc.s 8
-				IL_0185: br IL_0117
+			IL_00d8: pop
+
+			IL_00d9: ldloc.s 22
+			IL_00db: ldstr "indexOf"
+			IL_00e0: ldstr "_FIXTURE"
+			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00ea: stloc.s 22
+
+			IL_00ec: ldloc.s 22
+			IL_00ee: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00f3: ldc.r8 0.0
+			IL_00fc: clt
+			IL_00fe: ldc.i4.0
+			IL_00ff: ceq
+			IL_0101: stloc.s 5
+			IL_0103: ldc.i4.0
+			IL_0104: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0109: stloc.s 6
+			IL_010b: ldc.i4.4
+			IL_010c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0111: dup
+			IL_0112: ldstr "onlyStrict"
+			IL_0117: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_011c: dup
+			IL_011d: ldstr "noStrict"
+			IL_0122: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0127: dup
+			IL_0128: ldstr "module"
+			IL_012d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0132: dup
+			IL_0133: ldstr "raw"
+			IL_0138: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_013d: stloc.s 7
+			IL_013f: ldc.r8 0.0
+			IL_0148: stloc.s 8
+			// loop start (head: IL_014a)
+				IL_014a: ldloc.s 8
+				IL_014c: stloc.s 23
+				IL_014e: ldloc.s 7
+				IL_0150: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+				IL_0155: stloc.s 24
+				IL_0157: ldloc.s 23
+				IL_0159: ldloc.s 24
+				IL_015b: clt
+				IL_015d: brfalse IL_01bd
+
+				IL_0162: ldloc.s 7
+				IL_0164: ldloc.s 8
+				IL_0166: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_016b: castclass [System.Runtime]System.String
+				IL_0170: stloc.s 9
+				IL_0172: ldarg.0
+				IL_0173: ldfld object Modules.test262_metadataParser/Scope::contains
+				IL_0178: ldc.i4.1
+				IL_0179: newarr [System.Runtime]System.Object
+				IL_017e: dup
+				IL_017f: ldc.i4.0
+				IL_0180: ldarg.0
+				IL_0181: stelem.ref
+				IL_0182: stloc.s 21
+				IL_0184: ldloc.s 21
+				IL_0186: ldarg.2
+				IL_0187: ldloc.s 9
+				IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_018e: stloc.s 22
+				IL_0190: ldloc.s 22
+				IL_0192: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0197: stloc.s 25
+				IL_0199: ldloc.s 25
+				IL_019b: brfalse IL_01aa
+
+				IL_01a0: ldloc.s 6
+				IL_01a2: ldloc.s 9
+				IL_01a4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_01a9: pop
+
+				IL_01aa: ldloc.s 8
+				IL_01ac: ldc.r8 1
+				IL_01b5: add
+				IL_01b6: stloc.s 8
+				IL_01b8: br IL_014a
 			// end loop
 
-			IL_018a: ldstr "strict-and-non-strict"
-			IL_018f: stloc.s 10
-			IL_0191: ldloc.s 6
-			IL_0193: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_0198: ldc.r8 1
-			IL_01a1: ceq
-			IL_01a3: brfalse IL_0263
+			IL_01bd: ldstr "strict-and-non-strict"
+			IL_01c2: stloc.s 10
+			IL_01c4: ldloc.s 6
+			IL_01c6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_01cb: ldc.r8 1
+			IL_01d4: ceq
+			IL_01d6: brfalse IL_0296
 
-			IL_01a8: ldloc.s 6
-			IL_01aa: ldc.r8 0.0
-			IL_01b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_01b8: stloc.s 11
-			IL_01ba: ldloc.s 11
-			IL_01bc: ldstr "onlyStrict"
-			IL_01c1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01c6: stloc.s 25
-			IL_01c8: ldloc.s 25
-			IL_01ca: brfalse IL_01db
-
-			IL_01cf: ldstr "strict-only"
-			IL_01d4: stloc.s 10
-			IL_01d6: br IL_025e
-
-			IL_01db: ldloc.s 11
-			IL_01dd: ldstr "noStrict"
-			IL_01e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01e7: stloc.s 25
-			IL_01e9: ldloc.s 25
-			IL_01eb: box [System.Runtime]System.Boolean
-			IL_01f0: stloc.s 26
-			IL_01f2: ldloc.s 26
-			IL_01f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01db: ldloc.s 6
+			IL_01dd: ldc.r8 0.0
+			IL_01e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_01eb: stloc.s 11
+			IL_01ed: ldloc.s 11
+			IL_01ef: ldstr "onlyStrict"
+			IL_01f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 			IL_01f9: stloc.s 25
 			IL_01fb: ldloc.s 25
-			IL_01fd: brtrue IL_0222
+			IL_01fd: brfalse IL_020e
 
-			IL_0202: ldloc.s 11
-			IL_0204: ldstr "raw"
-			IL_0209: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_020e: stloc.s 25
-			IL_0210: ldloc.s 25
-			IL_0212: box [System.Runtime]System.Boolean
-			IL_0217: stloc.s 27
-			IL_0219: ldloc.s 27
-			IL_021b: stloc.s 29
-			IL_021d: br IL_0226
+			IL_0202: ldstr "strict-only"
+			IL_0207: stloc.s 10
+			IL_0209: br IL_0291
 
-			IL_0222: ldloc.s 26
-			IL_0224: stloc.s 29
+			IL_020e: ldloc.s 11
+			IL_0210: ldstr "noStrict"
+			IL_0215: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_021a: stloc.s 25
+			IL_021c: ldloc.s 25
+			IL_021e: box [System.Runtime]System.Boolean
+			IL_0223: stloc.s 26
+			IL_0225: ldloc.s 26
+			IL_0227: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_022c: stloc.s 25
+			IL_022e: ldloc.s 25
+			IL_0230: brtrue IL_0255
 
-			IL_0226: ldloc.s 29
-			IL_0228: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_022d: stloc.s 25
-			IL_022f: ldloc.s 25
-			IL_0231: brfalse IL_0242
+			IL_0235: ldloc.s 11
+			IL_0237: ldstr "raw"
+			IL_023c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0241: stloc.s 25
+			IL_0243: ldloc.s 25
+			IL_0245: box [System.Runtime]System.Boolean
+			IL_024a: stloc.s 27
+			IL_024c: ldloc.s 27
+			IL_024e: stloc.s 29
+			IL_0250: br IL_0259
 
-			IL_0236: ldstr "non-strict-only"
-			IL_023b: stloc.s 10
-			IL_023d: br IL_025e
+			IL_0255: ldloc.s 26
+			IL_0257: stloc.s 29
 
-			IL_0242: ldloc.s 11
-			IL_0244: ldstr "module"
-			IL_0249: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_024e: stloc.s 25
-			IL_0250: ldloc.s 25
-			IL_0252: brfalse IL_025e
+			IL_0259: ldloc.s 29
+			IL_025b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0260: stloc.s 25
+			IL_0262: ldloc.s 25
+			IL_0264: brfalse IL_0275
 
-			IL_0257: ldstr "module"
-			IL_025c: stloc.s 10
+			IL_0269: ldstr "non-strict-only"
+			IL_026e: stloc.s 10
+			IL_0270: br IL_0291
 
-			IL_025e: br IL_0281
+			IL_0275: ldloc.s 11
+			IL_0277: ldstr "module"
+			IL_027c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0281: stloc.s 25
+			IL_0283: ldloc.s 25
+			IL_0285: brfalse IL_0291
 
-			IL_0263: ldloc.s 6
-			IL_0265: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_026a: ldc.r8 1
-			IL_0273: cgt
-			IL_0275: brfalse IL_0281
+			IL_028a: ldstr "module"
+			IL_028f: stloc.s 10
 
-			IL_027a: ldstr "conflicting-flags"
-			IL_027f: stloc.s 10
+			IL_0291: br IL_02b4
 
-			IL_0281: ldloc.1
-			IL_0282: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0287: stloc.s 25
-			IL_0289: ldloc.s 25
-			IL_028b: brfalse IL_02a1
+			IL_0296: ldloc.s 6
+			IL_0298: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_029d: ldc.r8 1
+			IL_02a6: cgt
+			IL_02a8: brfalse IL_02b4
 
-			IL_0290: ldc.i4.0
-			IL_0291: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0296: stloc.s 30
-			IL_0298: ldloc.s 30
-			IL_029a: stloc.s 12
-			IL_029c: br IL_02b2
+			IL_02ad: ldstr "conflicting-flags"
+			IL_02b2: stloc.s 10
 
-			IL_02a1: ldarg.0
-			IL_02a2: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
-			IL_02a7: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
-			IL_02ac: stloc.s 30
-			IL_02ae: ldloc.s 30
-			IL_02b0: stloc.s 12
+			IL_02b4: ldloc.1
+			IL_02b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02ba: stloc.s 25
+			IL_02bc: ldloc.s 25
+			IL_02be: brfalse IL_02d4
 
-			IL_02b2: ldloc.s 12
-			IL_02b4: stloc.s 13
-			IL_02b6: ldloc.s 13
-			IL_02b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02bd: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_02c2: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
-			IL_02c7: stloc.s 30
-			IL_02c9: ldloc.s 30
-			IL_02cb: stloc.s 14
-			IL_02cd: ldloc.2
-			IL_02ce: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02d3: stloc.s 25
-			IL_02d5: ldloc.s 25
-			IL_02d7: brfalse IL_02f9
+			IL_02c3: ldc.i4.0
+			IL_02c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02c9: stloc.s 30
+			IL_02cb: ldloc.s 30
+			IL_02cd: stloc.s 12
+			IL_02cf: br IL_02e5
 
-			IL_02dc: ldloc.1
-			IL_02dd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_02e2: ldc.i4.0
-			IL_02e3: ceq
-			IL_02e5: stloc.s 25
-			IL_02e7: ldloc.s 25
-			IL_02e9: box [System.Runtime]System.Boolean
-			IL_02ee: stloc.s 26
-			IL_02f0: ldloc.s 26
-			IL_02f2: stloc.s 31
-			IL_02f4: br IL_02fc
+			IL_02d4: ldarg.0
+			IL_02d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
+			IL_02da: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
+			IL_02df: stloc.s 30
+			IL_02e1: ldloc.s 30
+			IL_02e3: stloc.s 12
 
-			IL_02f9: ldloc.2
-			IL_02fa: stloc.s 31
+			IL_02e5: ldloc.s 12
+			IL_02e7: stloc.s 13
+			IL_02e9: ldloc.s 13
+			IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02f0: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_02f5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
+			IL_02fa: stloc.s 30
+			IL_02fc: ldloc.s 30
+			IL_02fe: stloc.s 14
+			IL_0300: ldloc.2
+			IL_0301: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0306: stloc.s 25
+			IL_0308: ldloc.s 25
+			IL_030a: brfalse IL_032c
 
-			IL_02fc: ldloc.s 31
-			IL_02fe: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0303: stloc.s 25
-			IL_0305: ldloc.s 25
-			IL_0307: brfalse IL_0351
+			IL_030f: ldloc.1
+			IL_0310: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0315: ldc.i4.0
+			IL_0316: ceq
+			IL_0318: stloc.s 25
+			IL_031a: ldloc.s 25
+			IL_031c: box [System.Runtime]System.Boolean
+			IL_0321: stloc.s 26
+			IL_0323: ldloc.s 26
+			IL_0325: stloc.s 31
+			IL_0327: br IL_032f
 
-			IL_030c: ldarg.0
-			IL_030d: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0312: ldc.i4.1
-			IL_0313: newarr [System.Runtime]System.Object
-			IL_0318: dup
-			IL_0319: ldc.i4.0
-			IL_031a: ldarg.0
-			IL_031b: stelem.ref
-			IL_031c: stloc.s 21
-			IL_031e: ldarg.0
-			IL_031f: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_0324: stloc.s 32
-			IL_0326: ldloc.s 21
-			IL_0328: ldloc.s 14
-			IL_032a: ldloc.s 32
-			IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0331: stloc.s 22
-			IL_0333: ldloc.s 22
-			IL_0335: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_033a: ldc.i4.0
-			IL_033b: ceq
-			IL_033d: stloc.s 25
-			IL_033f: ldloc.s 25
-			IL_0341: box [System.Runtime]System.Boolean
-			IL_0346: stloc.s 26
-			IL_0348: ldloc.s 26
-			IL_034a: stloc.s 31
-			IL_034c: br IL_0351
+			IL_032c: ldloc.2
+			IL_032d: stloc.s 31
 
-			IL_0351: ldloc.s 31
-			IL_0353: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0358: stloc.s 25
-			IL_035a: ldloc.s 25
-			IL_035c: brfalse IL_0381
+			IL_032f: ldloc.s 31
+			IL_0331: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0336: stloc.s 25
+			IL_0338: ldloc.s 25
+			IL_033a: brfalse IL_0384
 
-			IL_0361: ldloc.s 14
-			IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0368: stloc.s 22
-			IL_036a: ldarg.0
-			IL_036b: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_0370: stloc.s 32
-			IL_0372: ldloc.s 22
-			IL_0374: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_0379: ldloc.s 32
-			IL_037b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_0380: pop
+			IL_033f: ldarg.0
+			IL_0340: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_0345: ldc.i4.1
+			IL_0346: newarr [System.Runtime]System.Object
+			IL_034b: dup
+			IL_034c: ldc.i4.0
+			IL_034d: ldarg.0
+			IL_034e: stelem.ref
+			IL_034f: stloc.s 21
+			IL_0351: ldarg.0
+			IL_0352: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_0357: stloc.s 32
+			IL_0359: ldloc.s 21
+			IL_035b: ldloc.s 14
+			IL_035d: ldloc.s 32
+			IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0364: stloc.s 22
+			IL_0366: ldloc.s 22
+			IL_0368: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_036d: ldc.i4.0
+			IL_036e: ceq
+			IL_0370: stloc.s 25
+			IL_0372: ldloc.s 25
+			IL_0374: box [System.Runtime]System.Boolean
+			IL_0379: stloc.s 26
+			IL_037b: ldloc.s 26
+			IL_037d: stloc.s 31
+			IL_037f: br IL_0384
 
-			IL_0381: ldc.r8 0.0
-			IL_038a: stloc.s 15
-			// loop start (head: IL_038c)
-				IL_038c: ldloc.s 15
-				IL_038e: stloc.s 24
-				IL_0390: ldarg.3
-				IL_0391: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-				IL_0396: stloc.s 23
-				IL_0398: ldloc.s 24
-				IL_039a: ldloc.s 23
-				IL_039c: clt
-				IL_039e: brfalse IL_0410
+			IL_0384: ldloc.s 31
+			IL_0386: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_038b: stloc.s 25
+			IL_038d: ldloc.s 25
+			IL_038f: brfalse IL_03b4
 
-				IL_03a3: ldarg.0
-				IL_03a4: ldfld object Modules.test262_metadataParser/Scope::contains
-				IL_03a9: ldc.i4.1
-				IL_03aa: newarr [System.Runtime]System.Object
-				IL_03af: dup
-				IL_03b0: ldc.i4.0
-				IL_03b1: ldarg.0
-				IL_03b2: stelem.ref
-				IL_03b3: stloc.s 21
-				IL_03b5: ldarg.3
-				IL_03b6: ldloc.s 15
-				IL_03b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_03bd: stloc.s 22
-				IL_03bf: ldloc.s 21
-				IL_03c1: ldloc.s 14
-				IL_03c3: ldloc.s 22
-				IL_03c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_03ca: stloc.s 22
-				IL_03cc: ldloc.s 22
-				IL_03ce: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_03d3: ldc.i4.0
-				IL_03d4: ceq
-				IL_03d6: stloc.s 25
-				IL_03d8: ldloc.s 25
-				IL_03da: brfalse IL_03fd
+			IL_0394: ldloc.s 14
+			IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_039b: stloc.s 22
+			IL_039d: ldarg.0
+			IL_039e: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_03a3: stloc.s 32
+			IL_03a5: ldloc.s 22
+			IL_03a7: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_03ac: ldloc.s 32
+			IL_03ae: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_03b3: pop
 
-				IL_03df: ldloc.s 14
-				IL_03e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_03e6: ldarg.3
-				IL_03e7: ldloc.s 15
-				IL_03e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_03ee: stloc.s 22
-				IL_03f0: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_03f5: ldloc.s 22
-				IL_03f7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_03fc: pop
+			IL_03b4: ldc.r8 0.0
+			IL_03bd: stloc.s 15
+			// loop start (head: IL_03bf)
+				IL_03bf: ldloc.s 15
+				IL_03c1: stloc.s 24
+				IL_03c3: ldarg.3
+				IL_03c4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+				IL_03c9: stloc.s 23
+				IL_03cb: ldloc.s 24
+				IL_03cd: ldloc.s 23
+				IL_03cf: clt
+				IL_03d1: brfalse IL_0443
 
-				IL_03fd: ldloc.s 15
-				IL_03ff: ldc.r8 1
-				IL_0408: add
-				IL_0409: stloc.s 15
-				IL_040b: br IL_038c
+				IL_03d6: ldarg.0
+				IL_03d7: ldfld object Modules.test262_metadataParser/Scope::contains
+				IL_03dc: ldc.i4.1
+				IL_03dd: newarr [System.Runtime]System.Object
+				IL_03e2: dup
+				IL_03e3: ldc.i4.0
+				IL_03e4: ldarg.0
+				IL_03e5: stelem.ref
+				IL_03e6: stloc.s 21
+				IL_03e8: ldarg.3
+				IL_03e9: ldloc.s 15
+				IL_03eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_03f0: stloc.s 22
+				IL_03f2: ldloc.s 21
+				IL_03f4: ldloc.s 14
+				IL_03f6: ldloc.s 22
+				IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_03fd: stloc.s 22
+				IL_03ff: ldloc.s 22
+				IL_0401: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0406: ldc.i4.0
+				IL_0407: ceq
+				IL_0409: stloc.s 25
+				IL_040b: ldloc.s 25
+				IL_040d: brfalse IL_0430
+
+				IL_0412: ldloc.s 14
+				IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0419: ldarg.3
+				IL_041a: ldloc.s 15
+				IL_041c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0421: stloc.s 22
+				IL_0423: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0428: ldloc.s 22
+				IL_042a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_042f: pop
+
+				IL_0430: ldloc.s 15
+				IL_0432: ldc.r8 1
+				IL_043b: add
+				IL_043c: stloc.s 15
+				IL_043e: br IL_03bf
 			// end loop
 
-			IL_0410: ldarg.0
-			IL_0411: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0416: ldc.i4.1
-			IL_0417: newarr [System.Runtime]System.Object
-			IL_041c: dup
-			IL_041d: ldc.i4.0
-			IL_041e: ldarg.0
-			IL_041f: stelem.ref
-			IL_0420: stloc.s 21
-			IL_0422: ldloc.s 21
-			IL_0424: ldarg.3
-			IL_0425: ldstr "agent.js"
-			IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_042f: stloc.s 16
-			IL_0431: ldarg.0
-			IL_0432: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0437: ldc.i4.1
-			IL_0438: newarr [System.Runtime]System.Object
-			IL_043d: dup
-			IL_043e: ldc.i4.0
-			IL_043f: ldarg.0
-			IL_0440: stelem.ref
-			IL_0441: stloc.s 21
-			IL_0443: ldloc.s 21
-			IL_0445: ldarg.2
-			IL_0446: ldstr "CanBlockIsFalse"
-			IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0450: stloc.s 22
-			IL_0452: ldloc.s 22
-			IL_0454: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0459: stloc.s 25
-			IL_045b: ldloc.s 25
-			IL_045d: brfalse IL_046e
+			IL_0443: ldarg.0
+			IL_0444: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_0449: ldc.i4.1
+			IL_044a: newarr [System.Runtime]System.Object
+			IL_044f: dup
+			IL_0450: ldc.i4.0
+			IL_0451: ldarg.0
+			IL_0452: stelem.ref
+			IL_0453: stloc.s 21
+			IL_0455: ldloc.s 21
+			IL_0457: ldarg.3
+			IL_0458: ldstr "agent.js"
+			IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0462: stloc.s 16
+			IL_0464: ldarg.0
+			IL_0465: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_046a: ldc.i4.1
+			IL_046b: newarr [System.Runtime]System.Object
+			IL_0470: dup
+			IL_0471: ldc.i4.0
+			IL_0472: ldarg.0
+			IL_0473: stelem.ref
+			IL_0474: stloc.s 21
+			IL_0476: ldloc.s 21
+			IL_0478: ldarg.2
+			IL_0479: ldstr "CanBlockIsFalse"
+			IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0483: stloc.s 22
+			IL_0485: ldloc.s 22
+			IL_0487: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_048c: stloc.s 25
+			IL_048e: ldloc.s 25
+			IL_0490: brfalse IL_04a1
 
-			IL_0462: ldstr "false"
-			IL_0467: stloc.s 17
-			IL_0469: br IL_04b6
+			IL_0495: ldstr "false"
+			IL_049a: stloc.s 17
+			IL_049c: br IL_04e9
 
-			IL_046e: ldarg.0
-			IL_046f: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0474: ldc.i4.1
-			IL_0475: newarr [System.Runtime]System.Object
-			IL_047a: dup
-			IL_047b: ldc.i4.0
-			IL_047c: ldarg.0
-			IL_047d: stelem.ref
-			IL_047e: stloc.s 21
-			IL_0480: ldloc.s 21
-			IL_0482: ldarg.2
-			IL_0483: ldstr "CanBlockIsTrue"
-			IL_0488: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_048d: stloc.s 22
-			IL_048f: ldloc.s 22
-			IL_0491: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0496: stloc.s 25
-			IL_0498: ldloc.s 25
-			IL_049a: brfalse IL_04ab
+			IL_04a1: ldarg.0
+			IL_04a2: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_04a7: ldc.i4.1
+			IL_04a8: newarr [System.Runtime]System.Object
+			IL_04ad: dup
+			IL_04ae: ldc.i4.0
+			IL_04af: ldarg.0
+			IL_04b0: stelem.ref
+			IL_04b1: stloc.s 21
+			IL_04b3: ldloc.s 21
+			IL_04b5: ldarg.2
+			IL_04b6: ldstr "CanBlockIsTrue"
+			IL_04bb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04c0: stloc.s 22
+			IL_04c2: ldloc.s 22
+			IL_04c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04c9: stloc.s 25
+			IL_04cb: ldloc.s 25
+			IL_04cd: brfalse IL_04de
 
-			IL_049f: ldstr "true"
-			IL_04a4: stloc.s 18
-			IL_04a6: br IL_04b2
+			IL_04d2: ldstr "true"
+			IL_04d7: stloc.s 18
+			IL_04d9: br IL_04e5
 
-			IL_04ab: ldstr "unspecified"
-			IL_04b0: stloc.s 18
+			IL_04de: ldstr "unspecified"
+			IL_04e3: stloc.s 18
 
-			IL_04b2: ldloc.s 18
-			IL_04b4: stloc.s 17
+			IL_04e5: ldloc.s 18
+			IL_04e7: stloc.s 17
 
-			IL_04b6: ldloc.s 17
-			IL_04b8: stloc.s 19
-			IL_04ba: ldloc.0
-			IL_04bb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04c0: stloc.s 25
-			IL_04c2: ldloc.s 25
-			IL_04c4: brfalse IL_04d5
+			IL_04e9: ldloc.s 17
+			IL_04eb: stloc.s 19
+			IL_04ed: ldloc.0
+			IL_04ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04f3: stloc.s 25
+			IL_04f5: ldloc.s 25
+			IL_04f7: brfalse IL_0508
 
-			IL_04c9: ldstr "module"
-			IL_04ce: stloc.s 20
-			IL_04d0: br IL_04dc
+			IL_04fc: ldstr "module"
+			IL_0501: stloc.s 20
+			IL_0503: br IL_050f
 
-			IL_04d5: ldstr "script"
-			IL_04da: stloc.s 20
+			IL_0508: ldstr "script"
+			IL_050d: stloc.s 20
 
-			IL_04dc: ldloc.s 13
-			IL_04de: ldstr "length"
-			IL_04e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04e8: stloc.s 22
-			IL_04ea: ldloc.s 22
-			IL_04ec: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_04f1: ldc.r8 0.0
-			IL_04fa: cgt
-			IL_04fc: stloc.s 25
-			IL_04fe: ldloc.2
-			IL_04ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0504: stloc.s 34
-			IL_0506: ldloc.s 34
-			IL_0508: brtrue IL_053c
+			IL_050f: ldloc.s 13
+			IL_0511: ldstr "length"
+			IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_051b: stloc.s 22
+			IL_051d: ldloc.s 22
+			IL_051f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0524: ldc.r8 0.0
+			IL_052d: cgt
+			IL_052f: stloc.s 25
+			IL_0531: ldloc.2
+			IL_0532: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0537: stloc.s 34
+			IL_0539: ldloc.s 34
+			IL_053b: brtrue IL_056f
 
-			IL_050d: ldarg.0
-			IL_050e: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0513: ldc.i4.1
-			IL_0514: newarr [System.Runtime]System.Object
-			IL_0519: dup
-			IL_051a: ldc.i4.0
-			IL_051b: ldarg.0
-			IL_051c: stelem.ref
-			IL_051d: stloc.s 21
-			IL_051f: ldarg.0
-			IL_0520: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_0525: stloc.s 32
-			IL_0527: ldloc.s 21
-			IL_0529: ldarg.3
-			IL_052a: ldloc.s 32
-			IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0531: stloc.s 22
-			IL_0533: ldloc.s 22
-			IL_0535: stloc.s 35
-			IL_0537: br IL_053f
+			IL_0540: ldarg.0
+			IL_0541: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_0546: ldc.i4.1
+			IL_0547: newarr [System.Runtime]System.Object
+			IL_054c: dup
+			IL_054d: ldc.i4.0
+			IL_054e: ldarg.0
+			IL_054f: stelem.ref
+			IL_0550: stloc.s 21
+			IL_0552: ldarg.0
+			IL_0553: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_0558: stloc.s 32
+			IL_055a: ldloc.s 21
+			IL_055c: ldarg.3
+			IL_055d: ldloc.s 32
+			IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0564: stloc.s 22
+			IL_0566: ldloc.s 22
+			IL_0568: stloc.s 35
+			IL_056a: br IL_0572
 
-			IL_053c: ldloc.2
-			IL_053d: stloc.s 35
+			IL_056f: ldloc.2
+			IL_0570: stloc.s 35
 
-			IL_053f: ldloc.s 16
-			IL_0541: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0546: stloc.s 34
-			IL_0548: ldloc.s 34
-			IL_054a: brtrue IL_056f
+			IL_0572: ldloc.s 16
+			IL_0574: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0579: stloc.s 34
+			IL_057b: ldloc.s 34
+			IL_057d: brtrue IL_05a2
 
-			IL_054f: ldloc.s 19
-			IL_0551: ldstr "unspecified"
-			IL_0556: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_055b: stloc.s 34
-			IL_055d: ldloc.s 34
-			IL_055f: box [System.Runtime]System.Boolean
-			IL_0564: stloc.s 26
-			IL_0566: ldloc.s 26
-			IL_0568: stloc.s 37
-			IL_056a: br IL_0573
+			IL_0582: ldloc.s 19
+			IL_0584: ldstr "unspecified"
+			IL_0589: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_058e: stloc.s 34
+			IL_0590: ldloc.s 34
+			IL_0592: box [System.Runtime]System.Boolean
+			IL_0597: stloc.s 26
+			IL_0599: ldloc.s 26
+			IL_059b: stloc.s 37
+			IL_059d: br IL_05a6
 
-			IL_056f: ldloc.s 16
-			IL_0571: stloc.s 37
+			IL_05a2: ldloc.s 16
+			IL_05a4: stloc.s 37
 
-			IL_0573: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0578: dup
-			IL_0579: ldstr "sourceType"
-			IL_057e: ldloc.s 20
-			IL_0580: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0585: dup
-			IL_0586: ldstr "strictMode"
-			IL_058b: ldloc.s 10
-			IL_058d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0592: dup
-			IL_0593: ldstr "defaultHarnessIncludes"
-			IL_0598: ldloc.s 13
-			IL_059a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_059f: dup
-			IL_05a0: ldstr "harnessIncludes"
-			IL_05a5: ldloc.s 14
-			IL_05a7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05ac: dup
-			IL_05ad: ldstr "requiresDefaultHarness"
-			IL_05b2: ldloc.s 25
-			IL_05b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_05b9: dup
-			IL_05ba: ldstr "requiresAsyncHarness"
-			IL_05bf: ldloc.s 35
-			IL_05c1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05c6: dup
-			IL_05c7: ldstr "requiresAgent"
-			IL_05cc: ldloc.s 37
-			IL_05ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05d3: dup
-			IL_05d4: ldstr "canBlock"
-			IL_05d9: ldloc.s 19
-			IL_05db: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05e0: dup
-			IL_05e1: ldstr "isModule"
-			IL_05e6: ldloc.0
-			IL_05e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05a6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05ab: dup
+			IL_05ac: ldstr "sourceType"
+			IL_05b1: ldloc.s 20
+			IL_05b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05b8: dup
+			IL_05b9: ldstr "strictMode"
+			IL_05be: ldloc.s 10
+			IL_05c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05c5: dup
+			IL_05c6: ldstr "defaultHarnessIncludes"
+			IL_05cb: ldloc.s 13
+			IL_05cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05d2: dup
+			IL_05d3: ldstr "harnessIncludes"
+			IL_05d8: ldloc.s 14
+			IL_05da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05df: dup
+			IL_05e0: ldstr "requiresDefaultHarness"
+			IL_05e5: ldloc.s 25
+			IL_05e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
 			IL_05ec: dup
-			IL_05ed: ldstr "isRaw"
-			IL_05f2: ldloc.1
-			IL_05f3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05f8: dup
-			IL_05f9: ldstr "isAsync"
-			IL_05fe: ldloc.2
-			IL_05ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0604: dup
-			IL_0605: ldstr "isGenerated"
-			IL_060a: ldloc.3
-			IL_060b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0610: dup
-			IL_0611: ldstr "isNonDeterministic"
-			IL_0616: ldloc.s 4
-			IL_0618: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_061d: dup
-			IL_061e: ldstr "isFixture"
-			IL_0623: ldloc.s 5
-			IL_0625: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_062a: stloc.s 38
-			IL_062c: ldloc.s 38
-			IL_062e: ret
+			IL_05ed: ldstr "requiresAsyncHarness"
+			IL_05f2: ldloc.s 35
+			IL_05f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05f9: dup
+			IL_05fa: ldstr "requiresAgent"
+			IL_05ff: ldloc.s 37
+			IL_0601: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0606: dup
+			IL_0607: ldstr "canBlock"
+			IL_060c: ldloc.s 19
+			IL_060e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0613: dup
+			IL_0614: ldstr "isModule"
+			IL_0619: ldloc.0
+			IL_061a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_061f: dup
+			IL_0620: ldstr "isRaw"
+			IL_0625: ldloc.1
+			IL_0626: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_062b: dup
+			IL_062c: ldstr "isAsync"
+			IL_0631: ldloc.2
+			IL_0632: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0637: dup
+			IL_0638: ldstr "isGenerated"
+			IL_063d: ldloc.3
+			IL_063e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0643: dup
+			IL_0644: ldstr "isNonDeterministic"
+			IL_0649: ldloc.s 4
+			IL_064b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0650: dup
+			IL_0651: ldstr "isFixture"
+			IL_0656: ldloc.s 5
+			IL_0658: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_065d: stloc.s 38
+			IL_065f: ldloc.s 38
+			IL_0661: ret
 		} // end of method buildExecutionMetadata::__js_call__
 
 	} // end of class buildExecutionMetadata

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_ExplicitReceiverAbi.verified.txt
@@ -137,7 +137,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 19 (0x13)
+			// Code size: 56 (0x38)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -145,11 +145,29 @@
 
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0006: ldstr "toUpperCase"
-			IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0010: stloc.0
-			IL_0011: ldloc.0
-			IL_0012: ret
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.0
+			IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_000d: brfalse IL_002a
+
+			IL_0012: ldloc.0
+			IL_0013: isinst [System.Runtime]System.String
+			IL_0018: dup
+			IL_0019: brfalse IL_0029
+
+			IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+			IL_0023: stloc.0
+			IL_0024: br IL_0036
+
+			IL_0029: pop
+
+			IL_002a: ldloc.0
+			IL_002b: ldstr "toUpperCase"
+			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0035: stloc.0
+
+			IL_0036: ldloc.0
+			IL_0037: ret
 		} // end of method FunctionExpression_L7C48::__js_call__
 
 	} // end of class FunctionExpression_L7C48

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
@@ -454,7 +454,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 263 (0x107)
+			// Code size: 298 (0x12a)
 			.maxstack 8
 			.locals init (
 				[0] class [System.Runtime]System.Exception,
@@ -483,7 +483,7 @@
 				IL_001f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
 				IL_0024: throw
 
-				IL_0025: leave IL_00bb
+				IL_0025: leave IL_00de
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -532,44 +532,56 @@
 				IL_0090: ldloc.s 5
 				IL_0092: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 				IL_0097: stloc.s 5
-				IL_0099: ldloc.s 5
-				IL_009b: ldstr "includes"
-				IL_00a0: ldstr "without a setter"
-				IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00aa: stloc.s 6
-				IL_00ac: ldloc.s 4
-				IL_00ae: ldloc.s 6
-				IL_00b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_00b5: pop
-				IL_00b6: leave IL_00bb
+				IL_0099: ldc.i4.0
+				IL_009a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_009f: brfalse IL_00bc
+
+				IL_00a4: ldloc.s 5
+				IL_00a6: ldstr "without a setter"
+				IL_00ab: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+				IL_00b0: box [System.Runtime]System.Boolean
+				IL_00b5: stloc.s 6
+				IL_00b7: br IL_00cf
+
+				IL_00bc: ldloc.s 5
+				IL_00be: ldstr "includes"
+				IL_00c3: ldstr "without a setter"
+				IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00cd: stloc.s 6
+
+				IL_00cf: ldloc.s 4
+				IL_00d1: ldloc.s 6
+				IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_00d8: pop
+				IL_00d9: leave IL_00de
 			} // end handler
 
-			IL_00bb: ldarg.0
-			IL_00bc: ldc.r8 7
-			IL_00c5: box [System.Runtime]System.Double
-			IL_00ca: callvirt instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_set_writeOnly(object)
-			IL_00cf: pop
-			IL_00d0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00d5: stloc.s 4
-			IL_00d7: ldloc.s 4
-			IL_00d9: ldarg.0
-			IL_00da: ldfld object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::saved
-			IL_00df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00e4: pop
-			IL_00e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00ea: stloc.s 4
-			IL_00ec: ldarg.0
-			IL_00ed: callvirt instance float64 Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_get_readOnly()
-			IL_00f2: box [System.Runtime]System.Double
-			IL_00f7: stloc.s 7
-			IL_00f9: ldloc.s 4
-			IL_00fb: ldloc.s 7
-			IL_00fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0102: pop
-			IL_0103: ldnull
-			IL_0104: stloc.3
-			IL_0105: ldloc.3
-			IL_0106: ret
+			IL_00de: ldarg.0
+			IL_00df: ldc.r8 7
+			IL_00e8: box [System.Runtime]System.Double
+			IL_00ed: callvirt instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_set_writeOnly(object)
+			IL_00f2: pop
+			IL_00f3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00f8: stloc.s 4
+			IL_00fa: ldloc.s 4
+			IL_00fc: ldarg.0
+			IL_00fd: ldfld object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::saved
+			IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0107: pop
+			IL_0108: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_010d: stloc.s 4
+			IL_010f: ldarg.0
+			IL_0110: callvirt instance float64 Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_get_readOnly()
+			IL_0115: box [System.Runtime]System.Double
+			IL_011a: stloc.s 7
+			IL_011c: ldloc.s 4
+			IL_011e: ldloc.s 7
+			IL_0120: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0125: pop
+			IL_0126: ldnull
+			IL_0127: stloc.3
+			IL_0128: ldloc.3
+			IL_0129: ret
 		} // end of method AccessorEdges::log
 
 	} // end of class AccessorEdges

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateMethodAndAccessor_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateMethodAndAccessor_Log.verified.txt
@@ -656,7 +656,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 472 (0x1d8)
+		// Code size: 574 (0x23e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Scope,
@@ -807,28 +807,68 @@
 		IL_0184: ldloc.2
 		IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
 		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_018f: ldstr "includes"
-		IL_0194: ldstr "#double"
-		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_019e: stloc.s 4
-		IL_01a0: ldloc.s 8
-		IL_01a2: ldloc.s 4
-		IL_01a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a9: pop
-		IL_01aa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01af: stloc.s 8
-		IL_01b1: ldloc.2
-		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01bc: ldstr "includes"
-		IL_01c1: ldstr "#secret"
-		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01cb: stloc.s 4
-		IL_01cd: ldloc.s 8
-		IL_01cf: ldloc.s 4
-		IL_01d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01d6: pop
-		IL_01d7: ret
+		IL_018f: stloc.s 4
+		IL_0191: ldc.i4.0
+		IL_0192: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0197: brfalse IL_01c0
+
+		IL_019c: ldloc.s 4
+		IL_019e: isinst [System.Runtime]System.String
+		IL_01a3: dup
+		IL_01a4: brfalse IL_01bf
+
+		IL_01a9: ldstr "#double"
+		IL_01ae: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_01b3: box [System.Runtime]System.Boolean
+		IL_01b8: stloc.s 4
+		IL_01ba: br IL_01d3
+
+		IL_01bf: pop
+
+		IL_01c0: ldloc.s 4
+		IL_01c2: ldstr "includes"
+		IL_01c7: ldstr "#double"
+		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d1: stloc.s 4
+
+		IL_01d3: ldloc.s 8
+		IL_01d5: ldloc.s 4
+		IL_01d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01dc: pop
+		IL_01dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01e2: stloc.s 8
+		IL_01e4: ldloc.2
+		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01ef: stloc.s 4
+		IL_01f1: ldc.i4.0
+		IL_01f2: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_01f7: brfalse IL_0220
+
+		IL_01fc: ldloc.s 4
+		IL_01fe: isinst [System.Runtime]System.String
+		IL_0203: dup
+		IL_0204: brfalse IL_021f
+
+		IL_0209: ldstr "#secret"
+		IL_020e: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_0213: box [System.Runtime]System.Boolean
+		IL_0218: stloc.s 4
+		IL_021a: br IL_0233
+
+		IL_021f: pop
+
+		IL_0220: ldloc.s 4
+		IL_0222: ldstr "includes"
+		IL_0227: ldstr "#secret"
+		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0231: stloc.s 4
+
+		IL_0233: ldloc.s 8
+		IL_0235: ldloc.s 4
+		IL_0237: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_023c: pop
+		IL_023d: ret
 	} // end of method Classes_ClassPrivateMethodAndAccessor_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateMethodAndAccessor_Log

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_ImportMeta_Basic.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_ImportMeta_Basic.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 398 (0x18e)
+		// Code size: 496 (0x1f0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_ImportMeta_Basic/Scope,
@@ -116,83 +116,123 @@
 		IL_00a6: stloc.s 5
 		IL_00a8: ldloc.s 5
 		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00af: ldstr "startsWith"
-		IL_00b4: ldstr "file://"
-		IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00be: stloc.s 5
-		IL_00c0: ldloc.2
-		IL_00c1: ldloc.s 5
-		IL_00c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c8: pop
-		IL_00c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ce: stloc.2
-		IL_00cf: ldarg.3
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
-		IL_00d5: stloc.s 5
-		IL_00d7: ldloc.s 5
-		IL_00d9: ldstr "url"
-		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00e3: stloc.s 5
-		IL_00e5: ldloc.1
-		IL_00e6: ldloc.s 5
-		IL_00e8: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
-		IL_00ed: stloc.s 5
-		IL_00ef: ldloc.s 5
-		IL_00f1: ldarg.3
-		IL_00f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00f7: stloc.s 6
-		IL_00f9: ldloc.s 6
-		IL_00fb: box [System.Runtime]System.Boolean
-		IL_0100: stloc.s 7
-		IL_0102: ldloc.2
-		IL_0103: ldloc.s 7
-		IL_0105: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_010a: pop
-		IL_010b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0110: stloc.2
-		IL_0111: ldloc.1
-		IL_0112: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URL()
-		IL_0117: stloc.s 5
-		IL_0119: ldarg.3
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
-		IL_011f: stloc.3
-		IL_0120: ldloc.3
-		IL_0121: ldstr "url"
-		IL_0126: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_012b: stloc.3
-		IL_012c: ldloc.s 5
-		IL_012e: dup
-		IL_012f: ldstr "./fixtures/demo.txt"
-		IL_0134: ldloc.3
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
-		IL_013a: stloc.3
-		IL_013b: ldloc.1
-		IL_013c: ldloc.3
-		IL_013d: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
-		IL_0142: stloc.3
-		IL_0143: ldloc.3
-		IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0149: ldstr "split"
-		IL_014e: ldstr "\\"
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0158: stloc.3
-		IL_0159: ldloc.3
-		IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_015f: ldstr "join"
-		IL_0164: ldstr "/"
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_016e: stloc.3
+		IL_00af: stloc.s 5
+		IL_00b1: ldc.i4.0
+		IL_00b2: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_00b7: brfalse IL_00e0
+
+		IL_00bc: ldloc.s 5
+		IL_00be: isinst [System.Runtime]System.String
+		IL_00c3: dup
+		IL_00c4: brfalse IL_00df
+
+		IL_00c9: ldstr "file://"
+		IL_00ce: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+		IL_00d3: box [System.Runtime]System.Boolean
+		IL_00d8: stloc.s 5
+		IL_00da: br IL_00f3
+
+		IL_00df: pop
+
+		IL_00e0: ldloc.s 5
+		IL_00e2: ldstr "startsWith"
+		IL_00e7: ldstr "file://"
+		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00f1: stloc.s 5
+
+		IL_00f3: ldloc.2
+		IL_00f4: ldloc.s 5
+		IL_00f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00fb: pop
+		IL_00fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0101: stloc.2
+		IL_0102: ldarg.3
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
+		IL_0108: stloc.s 5
+		IL_010a: ldloc.s 5
+		IL_010c: ldstr "url"
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0116: stloc.s 5
+		IL_0118: ldloc.1
+		IL_0119: ldloc.s 5
+		IL_011b: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
+		IL_0120: stloc.s 5
+		IL_0122: ldloc.s 5
+		IL_0124: ldarg.3
+		IL_0125: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_012a: stloc.s 6
+		IL_012c: ldloc.s 6
+		IL_012e: box [System.Runtime]System.Boolean
+		IL_0133: stloc.s 7
+		IL_0135: ldloc.2
+		IL_0136: ldloc.s 7
+		IL_0138: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_013d: pop
+		IL_013e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0143: stloc.2
+		IL_0144: ldloc.1
+		IL_0145: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URL()
+		IL_014a: stloc.s 5
+		IL_014c: ldarg.3
+		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
+		IL_0152: stloc.3
+		IL_0153: ldloc.3
+		IL_0154: ldstr "url"
+		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015e: stloc.3
+		IL_015f: ldloc.s 5
+		IL_0161: dup
+		IL_0162: ldstr "./fixtures/demo.txt"
+		IL_0167: ldloc.3
+		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
+		IL_016d: stloc.3
+		IL_016e: ldloc.1
 		IL_016f: ldloc.3
-		IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0175: ldstr "endsWith"
-		IL_017a: ldstr "/fixtures/demo.txt"
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0184: stloc.3
-		IL_0185: ldloc.2
-		IL_0186: ldloc.3
-		IL_0187: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_018c: pop
-		IL_018d: ret
+		IL_0170: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
+		IL_0175: stloc.3
+		IL_0176: ldloc.3
+		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017c: ldstr "split"
+		IL_0181: ldstr "\\"
+		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018b: stloc.3
+		IL_018c: ldloc.3
+		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0192: ldstr "join"
+		IL_0197: ldstr "/"
+		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01a1: stloc.3
+		IL_01a2: ldloc.3
+		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a8: stloc.3
+		IL_01a9: ldc.i4.0
+		IL_01aa: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_01af: brfalse IL_01d6
+
+		IL_01b4: ldloc.3
+		IL_01b5: isinst [System.Runtime]System.String
+		IL_01ba: dup
+		IL_01bb: brfalse IL_01d5
+
+		IL_01c0: ldstr "/fixtures/demo.txt"
+		IL_01c5: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
+		IL_01ca: box [System.Runtime]System.Boolean
+		IL_01cf: stloc.3
+		IL_01d0: br IL_01e7
+
+		IL_01d5: pop
+
+		IL_01d6: ldloc.3
+		IL_01d7: ldstr "endsWith"
+		IL_01dc: ldstr "/fixtures/demo.txt"
+		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e6: stloc.3
+
+		IL_01e7: ldloc.2
+		IL_01e8: ldloc.3
+		IL_01e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01ee: pop
+		IL_01ef: ret
 	} // end of method CommonJS_ImportMeta_Basic::__js_module_init__
 
 } // end of class Modules.CommonJS_ImportMeta_Basic

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_BoundFunctionObject_UnifiedTargets.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_BoundFunctionObject_UnifiedTargets.verified.txt
@@ -794,7 +794,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1706 (0x6aa)
+		// Code size: 1757 (0x6dd)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Function_BoundFunctionObject_UnifiedTargets/Scope,
@@ -1064,349 +1064,369 @@
 		IL_02c9: stloc.s 23
 		IL_02cb: ldloc.s 23
 		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d2: ldstr "includes"
-		IL_02d7: ldstr "bound add"
-		IL_02dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02e1: stloc.s 23
-		IL_02e3: ldloc.s 18
-		IL_02e5: ldstr "toString"
-		IL_02ea: ldloc.s 23
-		IL_02ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02f1: pop
-		IL_02f2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02f7: stloc.s 17
-		IL_02f9: ldloc.s 17
-		IL_02fb: ldstr "value"
-		IL_0300: ldc.r8 5
-		IL_0309: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, float64)
-		IL_030e: pop
-		IL_030f: ldc.i4.1
-		IL_0310: newarr [System.Runtime]System.Object
-		IL_0315: dup
-		IL_0316: ldc.i4.0
-		IL_0317: ldloc.0
-		IL_0318: stelem.ref
-		IL_0319: stloc.s 16
-		IL_031b: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject::.ctor()
-		IL_0320: ldc.i4.1
-		IL_0321: conv.r8
-		IL_0322: ldstr ""
-		IL_0327: ldc.i4.0
-		IL_0328: ldc.i4.1
-		IL_0329: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_032e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject>(!!0)
-		IL_0333: stloc.s 30
-		IL_0335: ldloc.s 17
-		IL_0337: ldstr "method"
-		IL_033c: ldloc.s 30
-		IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0343: pop
-		IL_0344: ldloc.s 17
-		IL_0346: stloc.s 4
-		IL_0348: ldloc.s 4
-		IL_034a: ldstr "method"
-		IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0354: stloc.s 23
-		IL_0356: ldloc.s 23
-		IL_0358: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_035d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0362: dup
-		IL_0363: ldstr "value"
-		IL_0368: ldc.r8 20
-		IL_0371: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0376: stloc.s 17
-		IL_0378: ldstr "bind"
-		IL_037d: ldloc.s 17
-		IL_037f: ldc.r8 2
-		IL_0388: box [System.Runtime]System.Double
-		IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0392: stloc.s 5
-		IL_0394: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0399: stloc.s 18
-		IL_039b: ldloc.s 5
-		IL_039d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_03a7: stloc.s 23
-		IL_03a9: ldloc.s 5
-		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03b0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03b5: dup
-		IL_03b6: ldstr "value"
-		IL_03bb: ldc.r8 100
-		IL_03c4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_03c9: stloc.s 17
-		IL_03cb: ldstr "call"
-		IL_03d0: ldloc.s 17
-		IL_03d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03d7: stloc.s 22
-		IL_03d9: ldloc.s 18
-		IL_03db: ldstr "method"
-		IL_03e0: ldloc.s 23
-		IL_03e2: ldloc.s 22
-		IL_03e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_03e9: pop
-		IL_03ea: ldc.i4.1
-		IL_03eb: newarr [System.Runtime]System.Object
-		IL_03f0: dup
-		IL_03f1: ldc.i4.0
-		IL_03f2: ldloc.0
-		IL_03f3: stelem.ref
-		IL_03f4: stloc.s 16
-		IL_03f6: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject::.ctor()
-		IL_03fb: ldc.i4.1
-		IL_03fc: conv.r8
-		IL_03fd: ldstr ""
-		IL_0402: ldc.i4.0
-		IL_0403: ldc.i4.0
-		IL_0404: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0409: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject>(!!0)
-		IL_040e: stloc.s 31
-		IL_0410: ldloc.s 31
-		IL_0412: ldstr "arrow"
-		IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_041c: stloc.s 6
-		IL_041e: ldloc.s 6
-		IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0425: ldstr "bind"
-		IL_042a: ldc.i4.0
-		IL_042b: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0430: ldc.r8 4
-		IL_0439: box [System.Runtime]System.Double
-		IL_043e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0443: stloc.s 7
-		IL_0445: ldc.i4.0
-		IL_0446: box [System.Runtime]System.Boolean
-		IL_044b: stloc.s 8
+		IL_02d2: stloc.s 23
+		IL_02d4: ldc.i4.0
+		IL_02d5: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_02da: brfalse IL_0303
+
+		IL_02df: ldloc.s 23
+		IL_02e1: isinst [System.Runtime]System.String
+		IL_02e6: dup
+		IL_02e7: brfalse IL_0302
+
+		IL_02ec: ldstr "bound add"
+		IL_02f1: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_02f6: box [System.Runtime]System.Boolean
+		IL_02fb: stloc.s 23
+		IL_02fd: br IL_0316
+
+		IL_0302: pop
+
+		IL_0303: ldloc.s 23
+		IL_0305: ldstr "includes"
+		IL_030a: ldstr "bound add"
+		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0314: stloc.s 23
+
+		IL_0316: ldloc.s 18
+		IL_0318: ldstr "toString"
+		IL_031d: ldloc.s 23
+		IL_031f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0324: pop
+		IL_0325: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_032a: stloc.s 17
+		IL_032c: ldloc.s 17
+		IL_032e: ldstr "value"
+		IL_0333: ldc.r8 5
+		IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, float64)
+		IL_0341: pop
+		IL_0342: ldc.i4.1
+		IL_0343: newarr [System.Runtime]System.Object
+		IL_0348: dup
+		IL_0349: ldc.i4.0
+		IL_034a: ldloc.0
+		IL_034b: stelem.ref
+		IL_034c: stloc.s 16
+		IL_034e: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject::.ctor()
+		IL_0353: ldc.i4.1
+		IL_0354: conv.r8
+		IL_0355: ldstr ""
+		IL_035a: ldc.i4.0
+		IL_035b: ldc.i4.1
+		IL_035c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0361: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject>(!!0)
+		IL_0366: stloc.s 30
+		IL_0368: ldloc.s 17
+		IL_036a: ldstr "method"
+		IL_036f: ldloc.s 30
+		IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0376: pop
+		IL_0377: ldloc.s 17
+		IL_0379: stloc.s 4
+		IL_037b: ldloc.s 4
+		IL_037d: ldstr "method"
+		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0387: stloc.s 23
+		IL_0389: ldloc.s 23
+		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0390: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0395: dup
+		IL_0396: ldstr "value"
+		IL_039b: ldc.r8 20
+		IL_03a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_03a9: stloc.s 17
+		IL_03ab: ldstr "bind"
+		IL_03b0: ldloc.s 17
+		IL_03b2: ldc.r8 2
+		IL_03bb: box [System.Runtime]System.Double
+		IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03c5: stloc.s 5
+		IL_03c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03cc: stloc.s 18
+		IL_03ce: ldloc.s 5
+		IL_03d0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_03da: stloc.s 23
+		IL_03dc: ldloc.s 5
+		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03e3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03e8: dup
+		IL_03e9: ldstr "value"
+		IL_03ee: ldc.r8 100
+		IL_03f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_03fc: stloc.s 17
+		IL_03fe: ldstr "call"
+		IL_0403: ldloc.s 17
+		IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_040a: stloc.s 22
+		IL_040c: ldloc.s 18
+		IL_040e: ldstr "method"
+		IL_0413: ldloc.s 23
+		IL_0415: ldloc.s 22
+		IL_0417: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_041c: pop
+		IL_041d: ldc.i4.1
+		IL_041e: newarr [System.Runtime]System.Object
+		IL_0423: dup
+		IL_0424: ldc.i4.0
+		IL_0425: ldloc.0
+		IL_0426: stelem.ref
+		IL_0427: stloc.s 16
+		IL_0429: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject::.ctor()
+		IL_042e: ldc.i4.1
+		IL_042f: conv.r8
+		IL_0430: ldstr ""
+		IL_0435: ldc.i4.0
+		IL_0436: ldc.i4.0
+		IL_0437: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_043c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject>(!!0)
+		IL_0441: stloc.s 31
+		IL_0443: ldloc.s 31
+		IL_0445: ldstr "arrow"
+		IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_044f: stloc.s 6
+		IL_0451: ldloc.s 6
+		IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0458: ldstr "bind"
+		IL_045d: ldc.i4.0
+		IL_045e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0463: ldc.r8 4
+		IL_046c: box [System.Runtime]System.Double
+		IL_0471: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0476: stloc.s 7
+		IL_0478: ldc.i4.0
+		IL_0479: box [System.Runtime]System.Boolean
+		IL_047e: stloc.s 8
 		.try
 		{
-			IL_044d: nop
-			IL_044e: ldstr "Reflect"
-			IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_045d: ldc.i4.0
-			IL_045e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0463: stloc.s 21
-			IL_0465: ldstr "construct"
-			IL_046a: ldloc.s 7
-			IL_046c: ldloc.s 21
-			IL_046e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0473: pop
-			IL_0474: leave IL_04d8
+			IL_0480: nop
+			IL_0481: ldstr "Reflect"
+			IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_048b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0490: ldc.i4.0
+			IL_0491: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0496: stloc.s 21
+			IL_0498: ldstr "construct"
+			IL_049d: ldloc.s 7
+			IL_049f: ldloc.s 21
+			IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_04a6: pop
+			IL_04a7: leave IL_050b
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0479: stloc.s 9
-			IL_047b: ldloc.s 9
-			IL_047d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0482: dup
-			IL_0483: brtrue IL_0499
+			IL_04ac: stloc.s 9
+			IL_04ae: ldloc.s 9
+			IL_04b0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_04b5: dup
+			IL_04b6: brtrue IL_04cc
 
-			IL_0488: pop
-			IL_0489: ldloc.s 9
-			IL_048b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0490: dup
-			IL_0491: brtrue IL_04a5
+			IL_04bb: pop
+			IL_04bc: ldloc.s 9
+			IL_04be: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_04c3: dup
+			IL_04c4: brtrue IL_04d8
 
-			IL_0496: pop
-			IL_0497: rethrow
+			IL_04c9: pop
+			IL_04ca: rethrow
 
-			IL_0499: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_049e: stloc.s 10
-			IL_04a0: br IL_04a7
+			IL_04cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_04d1: stloc.s 10
+			IL_04d3: br IL_04da
 
-			IL_04a5: stloc.s 10
+			IL_04d8: stloc.s 10
 
-			IL_04a7: ldloc.s 10
-			IL_04a9: stloc.s 11
-			IL_04ab: ldloc.s 11
-			IL_04ad: stloc.s 22
-			IL_04af: ldstr "TypeError"
-			IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04b9: stloc.s 23
-			IL_04bb: ldloc.s 22
-			IL_04bd: ldloc.s 23
-			IL_04bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_04c4: stloc.s 28
-			IL_04c6: ldloc.s 28
-			IL_04c8: box [System.Runtime]System.Boolean
-			IL_04cd: stloc.s 29
-			IL_04cf: ldloc.s 29
-			IL_04d1: stloc.s 8
-			IL_04d3: leave IL_04d8
+			IL_04da: ldloc.s 10
+			IL_04dc: stloc.s 11
+			IL_04de: ldloc.s 11
+			IL_04e0: stloc.s 22
+			IL_04e2: ldstr "TypeError"
+			IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04ec: stloc.s 23
+			IL_04ee: ldloc.s 22
+			IL_04f0: ldloc.s 23
+			IL_04f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_04f7: stloc.s 28
+			IL_04f9: ldloc.s 28
+			IL_04fb: box [System.Runtime]System.Boolean
+			IL_0500: stloc.s 29
+			IL_0502: ldloc.s 29
+			IL_0504: stloc.s 8
+			IL_0506: leave IL_050b
 		} // end handler
 
-		IL_04d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04dd: stloc.s 18
-		IL_04df: ldloc.s 7
-		IL_04e1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_04eb: stloc.s 23
-		IL_04ed: ldloc.s 18
-		IL_04ef: ldstr "arrow"
-		IL_04f4: ldloc.s 23
-		IL_04f6: ldloc.s 8
-		IL_04f8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_04fd: pop
-		IL_04fe: ldc.i4.1
-		IL_04ff: newarr [System.Runtime]System.Object
-		IL_0504: dup
-		IL_0505: ldc.i4.0
-		IL_0506: ldloc.0
-		IL_0507: stelem.ref
-		IL_0508: stloc.s 16
-		IL_050a: ldtoken Modules.Function_BoundFunctionObject_UnifiedTargets/Box
-		IL_050f: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0514: ldtoken Modules.Function_BoundFunctionObject_UnifiedTargets/Box
-		IL_0519: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_051e: stloc.s 32
-		IL_0520: ldloc.s 16
-		IL_0522: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/Box/Scope_ctor/FunctionObject::.ctor(object[])
-		IL_0527: ldloc.s 32
-		IL_0529: ldloc.s 16
-		IL_052b: ldc.i4.2
-		IL_052c: conv.r8
-		IL_052d: ldc.i4.0
-		IL_052e: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0533: castclass Modules.Function_BoundFunctionObject_UnifiedTargets/Box/Scope_ctor/FunctionObject
-		IL_0538: stloc.s 33
-		IL_053a: ldloc.s 33
-		IL_053c: stloc.s 12
-		IL_053e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0543: dup
-		IL_0544: ldstr "ignored"
-		IL_0549: ldc.i4.1
-		IL_054a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_054f: stloc.s 17
-		IL_0551: ldloc.s 12
-		IL_0553: ldstr "bind"
-		IL_0558: ldloc.s 17
-		IL_055a: ldc.r8 7
-		IL_0563: box [System.Runtime]System.Double
-		IL_0568: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_056d: stloc.s 13
-		IL_056f: ldloc.s 13
-		IL_0571: dup
-		IL_0572: ldc.r8 8
-		IL_057b: box [System.Runtime]System.Double
-		IL_0580: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_0585: stloc.s 14
-		IL_0587: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_058c: stloc.s 18
-		IL_058e: ldloc.s 14
-		IL_0590: ldstr "total"
-		IL_0595: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_059a: stloc.s 23
-		IL_059c: ldloc.s 14
-		IL_059e: ldstr "seenNewTarget"
-		IL_05a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05a8: stloc.s 22
-		IL_05aa: ldloc.s 22
-		IL_05ac: ldloc.s 12
-		IL_05ae: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_05b3: stloc.s 28
-		IL_05b5: ldloc.s 28
-		IL_05b7: box [System.Runtime]System.Boolean
-		IL_05bc: stloc.s 29
-		IL_05be: ldloc.s 14
-		IL_05c0: ldloc.s 12
-		IL_05c2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_05c7: stloc.s 28
-		IL_05c9: ldloc.s 28
-		IL_05cb: box [System.Runtime]System.Boolean
-		IL_05d0: stloc.s 27
-		IL_05d2: ldloc.s 14
-		IL_05d4: ldloc.s 13
-		IL_05d6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_05db: stloc.s 28
-		IL_05dd: ldloc.s 28
-		IL_05df: box [System.Runtime]System.Boolean
-		IL_05e4: stloc.s 26
-		IL_05e6: ldloc.s 13
-		IL_05e8: ldstr "name"
-		IL_05ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05f2: stloc.s 22
-		IL_05f4: ldloc.s 13
-		IL_05f6: ldstr "length"
-		IL_05fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0600: stloc.s 20
-		IL_0602: ldloc.s 13
-		IL_0604: ldstr "prototype"
-		IL_0609: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_060e: box [System.Runtime]System.Boolean
-		IL_0613: stloc.s 25
-		IL_0615: ldloc.s 18
-		IL_0617: ldc.i4.8
-		IL_0618: newarr [System.Runtime]System.Object
-		IL_061d: dup
-		IL_061e: ldc.i4.0
-		IL_061f: ldstr "class"
-		IL_0624: stelem.ref
-		IL_0625: dup
-		IL_0626: ldc.i4.1
-		IL_0627: ldloc.s 23
-		IL_0629: stelem.ref
-		IL_062a: dup
-		IL_062b: ldc.i4.2
-		IL_062c: ldloc.s 29
-		IL_062e: stelem.ref
-		IL_062f: dup
-		IL_0630: ldc.i4.3
-		IL_0631: ldloc.s 27
-		IL_0633: stelem.ref
-		IL_0634: dup
-		IL_0635: ldc.i4.4
-		IL_0636: ldloc.s 26
-		IL_0638: stelem.ref
-		IL_0639: dup
-		IL_063a: ldc.i4.5
-		IL_063b: ldloc.s 22
-		IL_063d: stelem.ref
-		IL_063e: dup
-		IL_063f: ldc.i4.6
-		IL_0640: ldloc.s 20
-		IL_0642: stelem.ref
-		IL_0643: dup
-		IL_0644: ldc.i4.7
-		IL_0645: ldloc.s 25
-		IL_0647: stelem.ref
-		IL_0648: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_064d: pop
-		IL_064e: ldc.i4.1
-		IL_064f: newarr [System.Runtime]System.Object
-		IL_0654: dup
-		IL_0655: ldc.i4.0
-		IL_0656: ldloc.0
+		IL_050b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0510: stloc.s 18
+		IL_0512: ldloc.s 7
+		IL_0514: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0519: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_051e: stloc.s 23
+		IL_0520: ldloc.s 18
+		IL_0522: ldstr "arrow"
+		IL_0527: ldloc.s 23
+		IL_0529: ldloc.s 8
+		IL_052b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0530: pop
+		IL_0531: ldc.i4.1
+		IL_0532: newarr [System.Runtime]System.Object
+		IL_0537: dup
+		IL_0538: ldc.i4.0
+		IL_0539: ldloc.0
+		IL_053a: stelem.ref
+		IL_053b: stloc.s 16
+		IL_053d: ldtoken Modules.Function_BoundFunctionObject_UnifiedTargets/Box
+		IL_0542: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0547: ldtoken Modules.Function_BoundFunctionObject_UnifiedTargets/Box
+		IL_054c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0551: stloc.s 32
+		IL_0553: ldloc.s 16
+		IL_0555: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/Box/Scope_ctor/FunctionObject::.ctor(object[])
+		IL_055a: ldloc.s 32
+		IL_055c: ldloc.s 16
+		IL_055e: ldc.i4.2
+		IL_055f: conv.r8
+		IL_0560: ldc.i4.0
+		IL_0561: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_0566: castclass Modules.Function_BoundFunctionObject_UnifiedTargets/Box/Scope_ctor/FunctionObject
+		IL_056b: stloc.s 33
+		IL_056d: ldloc.s 33
+		IL_056f: stloc.s 12
+		IL_0571: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0576: dup
+		IL_0577: ldstr "ignored"
+		IL_057c: ldc.i4.1
+		IL_057d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0582: stloc.s 17
+		IL_0584: ldloc.s 12
+		IL_0586: ldstr "bind"
+		IL_058b: ldloc.s 17
+		IL_058d: ldc.r8 7
+		IL_0596: box [System.Runtime]System.Double
+		IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_05a0: stloc.s 13
+		IL_05a2: ldloc.s 13
+		IL_05a4: dup
+		IL_05a5: ldc.r8 8
+		IL_05ae: box [System.Runtime]System.Double
+		IL_05b3: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_05b8: stloc.s 14
+		IL_05ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05bf: stloc.s 18
+		IL_05c1: ldloc.s 14
+		IL_05c3: ldstr "total"
+		IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05cd: stloc.s 23
+		IL_05cf: ldloc.s 14
+		IL_05d1: ldstr "seenNewTarget"
+		IL_05d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05db: stloc.s 22
+		IL_05dd: ldloc.s 22
+		IL_05df: ldloc.s 12
+		IL_05e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_05e6: stloc.s 28
+		IL_05e8: ldloc.s 28
+		IL_05ea: box [System.Runtime]System.Boolean
+		IL_05ef: stloc.s 29
+		IL_05f1: ldloc.s 14
+		IL_05f3: ldloc.s 12
+		IL_05f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_05fa: stloc.s 28
+		IL_05fc: ldloc.s 28
+		IL_05fe: box [System.Runtime]System.Boolean
+		IL_0603: stloc.s 27
+		IL_0605: ldloc.s 14
+		IL_0607: ldloc.s 13
+		IL_0609: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_060e: stloc.s 28
+		IL_0610: ldloc.s 28
+		IL_0612: box [System.Runtime]System.Boolean
+		IL_0617: stloc.s 26
+		IL_0619: ldloc.s 13
+		IL_061b: ldstr "name"
+		IL_0620: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0625: stloc.s 22
+		IL_0627: ldloc.s 13
+		IL_0629: ldstr "length"
+		IL_062e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0633: stloc.s 20
+		IL_0635: ldloc.s 13
+		IL_0637: ldstr "prototype"
+		IL_063c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0641: box [System.Runtime]System.Boolean
+		IL_0646: stloc.s 25
+		IL_0648: ldloc.s 18
+		IL_064a: ldc.i4.8
+		IL_064b: newarr [System.Runtime]System.Object
+		IL_0650: dup
+		IL_0651: ldc.i4.0
+		IL_0652: ldstr "class"
 		IL_0657: stelem.ref
-		IL_0658: stloc.s 16
-		IL_065a: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject::.ctor()
-		IL_065f: ldc.i4.0
-		IL_0660: conv.r8
-		IL_0661: ldstr ""
-		IL_0666: ldc.i4.0
-		IL_0667: ldc.i4.1
-		IL_0668: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_066d: stloc.s 34
-		IL_066f: ldloc.2
-		IL_0670: ldstr "call"
-		IL_0675: ldloc.s 34
-		IL_0677: ldc.i4.1
-		IL_0678: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_067d: pop
-		IL_067e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0683: stloc.s 18
-		IL_0685: ldloc.2
-		IL_0686: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_068b: ldstr "call"
-		IL_0690: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0695: stloc.s 20
-		IL_0697: ldloc.s 18
-		IL_0699: ldstr "override"
-		IL_069e: ldloc.s 20
-		IL_06a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_06a5: pop
-		IL_06a6: ldnull
-		IL_06a7: stloc.s 15
-		IL_06a9: ret
+		IL_0658: dup
+		IL_0659: ldc.i4.1
+		IL_065a: ldloc.s 23
+		IL_065c: stelem.ref
+		IL_065d: dup
+		IL_065e: ldc.i4.2
+		IL_065f: ldloc.s 29
+		IL_0661: stelem.ref
+		IL_0662: dup
+		IL_0663: ldc.i4.3
+		IL_0664: ldloc.s 27
+		IL_0666: stelem.ref
+		IL_0667: dup
+		IL_0668: ldc.i4.4
+		IL_0669: ldloc.s 26
+		IL_066b: stelem.ref
+		IL_066c: dup
+		IL_066d: ldc.i4.5
+		IL_066e: ldloc.s 22
+		IL_0670: stelem.ref
+		IL_0671: dup
+		IL_0672: ldc.i4.6
+		IL_0673: ldloc.s 20
+		IL_0675: stelem.ref
+		IL_0676: dup
+		IL_0677: ldc.i4.7
+		IL_0678: ldloc.s 25
+		IL_067a: stelem.ref
+		IL_067b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0680: pop
+		IL_0681: ldc.i4.1
+		IL_0682: newarr [System.Runtime]System.Object
+		IL_0687: dup
+		IL_0688: ldc.i4.0
+		IL_0689: ldloc.0
+		IL_068a: stelem.ref
+		IL_068b: stloc.s 16
+		IL_068d: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject::.ctor()
+		IL_0692: ldc.i4.0
+		IL_0693: conv.r8
+		IL_0694: ldstr ""
+		IL_0699: ldc.i4.0
+		IL_069a: ldc.i4.1
+		IL_069b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_06a0: stloc.s 34
+		IL_06a2: ldloc.2
+		IL_06a3: ldstr "call"
+		IL_06a8: ldloc.s 34
+		IL_06aa: ldc.i4.1
+		IL_06ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_06b0: pop
+		IL_06b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06b6: stloc.s 18
+		IL_06b8: ldloc.2
+		IL_06b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06be: ldstr "call"
+		IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_06c8: stloc.s 20
+		IL_06ca: ldloc.s 18
+		IL_06cc: ldstr "override"
+		IL_06d1: ldloc.s 20
+		IL_06d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_06d8: pop
+		IL_06d9: ldnull
+		IL_06da: stloc.s 15
+		IL_06dc: ret
 	} // end of method Function_BoundFunctionObject_UnifiedTargets::__js_module_init__
 
 } // end of class Modules.Function_BoundFunctionObject_UnifiedTargets

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableReflection_ProxyIntegration.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableReflection_ProxyIntegration.verified.txt
@@ -1782,7 +1782,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2900 (0xb54)
+		// Code size: 3002 (0xbba)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallableReflection_ProxyIntegration/Scope,
@@ -2126,815 +2126,855 @@
 		IL_02f1: stloc.s 42
 		IL_02f3: ldloc.s 42
 		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02fa: ldstr "includes"
-		IL_02ff: ldstr "name"
-		IL_0304: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0309: stloc.s 42
-		IL_030b: ldloc.0
-		IL_030c: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0311: stloc.s 36
-		IL_0313: ldloc.s 36
-		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_031a: stloc.s 36
-		IL_031c: ldloc.s 36
-		IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0323: ldstr "includes"
-		IL_0328: ldstr "length"
-		IL_032d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0332: stloc.s 36
-		IL_0334: ldloc.s 40
-		IL_0336: ldc.i4.4
-		IL_0337: newarr [System.Runtime]System.Object
-		IL_033c: dup
-		IL_033d: ldc.i4.0
-		IL_033e: ldstr "keys"
-		IL_0343: stelem.ref
-		IL_0344: dup
-		IL_0345: ldc.i4.1
-		IL_0346: ldloc.s 46
-		IL_0348: stelem.ref
-		IL_0349: dup
-		IL_034a: ldc.i4.2
-		IL_034b: ldloc.s 42
-		IL_034d: stelem.ref
-		IL_034e: dup
-		IL_034f: ldc.i4.3
-		IL_0350: ldloc.s 36
-		IL_0352: stelem.ref
-		IL_0353: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0358: pop
-		IL_0359: ldloc.0
-		IL_035a: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_035f: stloc.s 36
-		IL_0361: ldloc.s 36
-		IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-		IL_0368: pop
-		IL_0369: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_036e: stloc.s 40
-		IL_0370: ldloc.0
-		IL_0371: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0376: stloc.s 36
-		IL_0378: ldloc.s 36
-		IL_037a: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_037f: box [System.Runtime]System.Boolean
-		IL_0384: stloc.s 45
-		IL_0386: ldloc.2
-		IL_0387: ldstr "get"
-		IL_038c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0391: stloc.s 36
-		IL_0393: ldloc.s 36
-		IL_0395: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_039a: box [System.Runtime]System.Boolean
-		IL_039f: stloc.s 44
-		IL_03a1: ldloc.s 40
-		IL_03a3: ldstr "integrity"
-		IL_03a8: ldloc.s 45
-		IL_03aa: ldloc.s 44
-		IL_03ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_03b1: pop
-		IL_03b2: ldloc.2
-		IL_03b3: ldstr "get"
-		IL_03b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03bd: stloc.s 36
-		IL_03bf: ldloc.s 36
-		IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
-		IL_03c6: pop
-		IL_03c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03cc: stloc.s 40
-		IL_03ce: ldloc.2
-		IL_03cf: ldstr "get"
-		IL_03d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03d9: stloc.s 36
-		IL_03db: ldloc.s 36
-		IL_03dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
-		IL_03e2: box [System.Runtime]System.Boolean
-		IL_03e7: stloc.s 44
-		IL_03e9: ldloc.s 40
-		IL_03eb: ldstr "frozenFunction"
-		IL_03f0: ldloc.s 44
-		IL_03f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_03f7: pop
-		IL_03f8: nop
-		IL_03f9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03fe: dup
-		IL_03ff: ldstr "marker"
-		IL_0404: ldstr "custom-function-prototype"
-		IL_0409: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_040e: stloc.s 4
-		IL_0410: ldloc.1
-		IL_0411: ldloc.s 4
-		IL_0413: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_0418: pop
-		IL_0419: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_041e: stloc.s 40
-		IL_0420: ldloc.1
-		IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_0426: stloc.s 36
-		IL_0428: ldloc.s 36
-		IL_042a: ldloc.s 4
-		IL_042c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0431: stloc.s 43
-		IL_0433: ldloc.s 43
-		IL_0435: box [System.Runtime]System.Boolean
-		IL_043a: stloc.s 44
-		IL_043c: ldloc.1
-		IL_043d: ldstr "marker"
-		IL_0442: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0447: stloc.s 36
-		IL_0449: ldloc.s 40
-		IL_044b: ldstr "prototypeMutation"
-		IL_0450: ldloc.s 44
-		IL_0452: ldloc.s 36
-		IL_0454: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0459: pop
-		IL_045a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_045f: stloc.s 40
-		IL_0461: ldloc.0
-		IL_0462: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0467: stloc.s 36
-		IL_0469: ldloc.s 36
-		IL_046b: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_0470: stloc.s 36
-		IL_0472: ldloc.s 36
-		IL_0474: ldnull
-		IL_0475: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_047a: stloc.s 43
-		IL_047c: ldloc.s 43
-		IL_047e: box [System.Runtime]System.Boolean
-		IL_0483: stloc.s 44
-		IL_0485: ldloc.0
-		IL_0486: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_048b: stloc.s 36
-		IL_048d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0492: dup
-		IL_0493: ldstr "target"
-		IL_0498: ldloc.s 36
-		IL_049a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_049f: stloc.s 37
-		IL_04a1: ldloc.s 37
-		IL_04a3: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_04a8: stloc.s 36
-		IL_04aa: ldloc.s 36
-		IL_04ac: ldstr "{}"
-		IL_04b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_04b6: stloc.s 43
-		IL_04b8: ldloc.s 43
-		IL_04ba: box [System.Runtime]System.Boolean
-		IL_04bf: stloc.s 45
-		IL_04c1: ldloc.s 40
-		IL_04c3: ldstr "json"
-		IL_04c8: ldloc.s 44
-		IL_04ca: ldloc.s 45
-		IL_04cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_04d1: pop
-		IL_04d2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04d7: stloc.s 37
-		IL_04d9: ldc.i4.1
-		IL_04da: newarr [System.Runtime]System.Object
-		IL_04df: dup
-		IL_04e0: ldc.i4.0
-		IL_04e1: ldloc.0
-		IL_04e2: stelem.ref
-		IL_04e3: stloc.s 33
-		IL_04e5: ldloc.s 33
-		IL_04e7: ldc.i4.0
-		IL_04e8: ldelem.ref
-		IL_04e9: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
-		IL_04ee: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
-		IL_04f3: ldc.i4.3
-		IL_04f4: conv.r8
-		IL_04f5: ldstr ""
-		IL_04fa: ldc.i4.0
-		IL_04fb: ldc.i4.1
-		IL_04fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0501: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject>(!!0)
-		IL_0506: stloc.s 47
-		IL_0508: ldloc.s 37
-		IL_050a: ldstr "apply"
-		IL_050f: ldloc.s 47
-		IL_0511: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0516: pop
-		IL_0517: ldloc.0
-		IL_0518: ldloc.s 37
-		IL_051a: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::applyHandler
-		IL_051f: ldloc.0
-		IL_0520: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0525: stloc.s 36
-		IL_0527: ldloc.0
-		IL_0528: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::applyHandler
-		IL_052d: ldstr "Cannot access 'applyHandler' before initialization"
-		IL_0532: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_0537: stloc.s 42
-		IL_0539: ldloc.s 36
-		IL_053b: ldloc.s 42
-		IL_053d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0542: stloc.s 5
-		IL_0544: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0549: dup
-		IL_054a: ldstr "base"
-		IL_054f: ldc.r8 10
-		IL_0558: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_055d: dup
-		IL_055e: ldstr "method"
-		IL_0563: ldloc.s 5
-		IL_0565: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_056a: stloc.s 6
-		IL_056c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0571: stloc.s 40
-		IL_0573: ldloc.s 5
-		IL_0575: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_057a: stloc.s 41
-		IL_057c: ldloc.s 6
-		IL_057e: ldstr "method"
-		IL_0583: ldc.r8 5
-		IL_058c: box [System.Runtime]System.Double
-		IL_0591: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0596: stloc.s 42
-		IL_0598: ldloc.0
-		IL_0599: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_059e: stloc.s 36
-		IL_05a0: ldloc.s 5
-		IL_05a2: ldloc.s 36
-		IL_05a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_05a9: stloc.s 43
-		IL_05ab: ldloc.s 43
-		IL_05ad: box [System.Runtime]System.Boolean
-		IL_05b2: stloc.s 45
-		IL_05b4: ldloc.s 40
-		IL_05b6: ldc.i4.4
-		IL_05b7: newarr [System.Runtime]System.Object
-		IL_05bc: dup
-		IL_05bd: ldc.i4.0
-		IL_05be: ldstr "apply"
-		IL_05c3: stelem.ref
-		IL_05c4: dup
-		IL_05c5: ldc.i4.1
-		IL_05c6: ldloc.s 41
-		IL_05c8: stelem.ref
-		IL_05c9: dup
-		IL_05ca: ldc.i4.2
-		IL_05cb: ldloc.s 42
-		IL_05cd: stelem.ref
-		IL_05ce: dup
-		IL_05cf: ldc.i4.3
-		IL_05d0: ldloc.s 45
-		IL_05d2: stelem.ref
-		IL_05d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_05d8: pop
-		IL_05d9: ldloc.0
-		IL_05da: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_05df: stloc.s 42
-		IL_05e1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_05e6: stloc.s 37
-		IL_05e8: ldloc.s 42
-		IL_05ea: ldloc.s 37
-		IL_05ec: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_05f1: stloc.s 7
-		IL_05f3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05f8: stloc.s 40
-		IL_05fa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_05ff: dup
-		IL_0600: ldstr "base"
-		IL_0605: ldc.r8 20
-		IL_060e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0613: stloc.s 37
-		IL_0615: ldloc.s 7
-		IL_0617: ldstr "call"
-		IL_061c: ldloc.s 37
-		IL_061e: ldc.r8 2
-		IL_0627: box [System.Runtime]System.Double
-		IL_062c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0631: stloc.s 42
-		IL_0633: ldloc.s 40
-		IL_0635: ldstr "fallback"
-		IL_063a: ldloc.s 42
-		IL_063c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0641: pop
-		IL_0642: nop
-		IL_0643: ldloc.0
-		IL_0644: ldnull
-		IL_0645: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
-		IL_064a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_064f: stloc.s 37
-		IL_0651: ldc.i4.1
-		IL_0652: newarr [System.Runtime]System.Object
-		IL_0657: dup
-		IL_0658: ldc.i4.0
-		IL_0659: ldloc.0
-		IL_065a: stelem.ref
-		IL_065b: stloc.s 33
-		IL_065d: ldloc.s 33
-		IL_065f: ldc.i4.0
-		IL_0660: ldelem.ref
-		IL_0661: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
-		IL_0666: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
-		IL_066b: ldc.i4.3
-		IL_066c: conv.r8
-		IL_066d: ldstr ""
-		IL_0672: ldc.i4.0
-		IL_0673: ldc.i4.1
-		IL_0674: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0679: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject>(!!0)
-		IL_067e: stloc.s 48
-		IL_0680: ldloc.s 37
-		IL_0682: ldstr "construct"
-		IL_0687: ldloc.s 48
-		IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_068e: pop
-		IL_068f: ldloc.s 37
-		IL_0691: stloc.s 8
-		IL_0693: ldloc.0
-		IL_0694: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::Constructor
-		IL_0699: stloc.s 42
-		IL_069b: ldloc.s 42
-		IL_069d: ldloc.s 8
-		IL_069f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_06a4: stloc.s 49
-		IL_06a6: ldloc.0
-		IL_06a7: ldloc.s 49
-		IL_06a9: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
-		IL_06ae: ldloc.0
-		IL_06af: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
-		IL_06b4: castclass [JavaScriptRuntime]JavaScriptRuntime.Proxy
-		IL_06b9: stloc.s 49
-		IL_06bb: ldloc.s 49
+		IL_02fa: stloc.s 42
+		IL_02fc: ldc.i4.0
+		IL_02fd: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0302: brfalse IL_032b
+
+		IL_0307: ldloc.s 42
+		IL_0309: isinst [System.Runtime]System.String
+		IL_030e: dup
+		IL_030f: brfalse IL_032a
+
+		IL_0314: ldstr "name"
+		IL_0319: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_031e: box [System.Runtime]System.Boolean
+		IL_0323: stloc.s 42
+		IL_0325: br IL_033e
+
+		IL_032a: pop
+
+		IL_032b: ldloc.s 42
+		IL_032d: ldstr "includes"
+		IL_0332: ldstr "name"
+		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_033c: stloc.s 42
+
+		IL_033e: ldloc.0
+		IL_033f: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0344: stloc.s 36
+		IL_0346: ldloc.s 36
+		IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_034d: stloc.s 36
+		IL_034f: ldloc.s 36
+		IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0356: stloc.s 36
+		IL_0358: ldc.i4.0
+		IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_035e: brfalse IL_0387
+
+		IL_0363: ldloc.s 36
+		IL_0365: isinst [System.Runtime]System.String
+		IL_036a: dup
+		IL_036b: brfalse IL_0386
+
+		IL_0370: ldstr "length"
+		IL_0375: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_037a: box [System.Runtime]System.Boolean
+		IL_037f: stloc.s 36
+		IL_0381: br IL_039a
+
+		IL_0386: pop
+
+		IL_0387: ldloc.s 36
+		IL_0389: ldstr "includes"
+		IL_038e: ldstr "length"
+		IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0398: stloc.s 36
+
+		IL_039a: ldloc.s 40
+		IL_039c: ldc.i4.4
+		IL_039d: newarr [System.Runtime]System.Object
+		IL_03a2: dup
+		IL_03a3: ldc.i4.0
+		IL_03a4: ldstr "keys"
+		IL_03a9: stelem.ref
+		IL_03aa: dup
+		IL_03ab: ldc.i4.1
+		IL_03ac: ldloc.s 46
+		IL_03ae: stelem.ref
+		IL_03af: dup
+		IL_03b0: ldc.i4.2
+		IL_03b1: ldloc.s 42
+		IL_03b3: stelem.ref
+		IL_03b4: dup
+		IL_03b5: ldc.i4.3
+		IL_03b6: ldloc.s 36
+		IL_03b8: stelem.ref
+		IL_03b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_03be: pop
+		IL_03bf: ldloc.0
+		IL_03c0: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_03c5: stloc.s 36
+		IL_03c7: ldloc.s 36
+		IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+		IL_03ce: pop
+		IL_03cf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03d4: stloc.s 40
+		IL_03d6: ldloc.0
+		IL_03d7: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_03dc: stloc.s 36
+		IL_03de: ldloc.s 36
+		IL_03e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_03e5: box [System.Runtime]System.Boolean
+		IL_03ea: stloc.s 45
+		IL_03ec: ldloc.2
+		IL_03ed: ldstr "get"
+		IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03f7: stloc.s 36
+		IL_03f9: ldloc.s 36
+		IL_03fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_0400: box [System.Runtime]System.Boolean
+		IL_0405: stloc.s 44
+		IL_0407: ldloc.s 40
+		IL_0409: ldstr "integrity"
+		IL_040e: ldloc.s 45
+		IL_0410: ldloc.s 44
+		IL_0412: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0417: pop
+		IL_0418: ldloc.2
+		IL_0419: ldstr "get"
+		IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0423: stloc.s 36
+		IL_0425: ldloc.s 36
+		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
+		IL_042c: pop
+		IL_042d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0432: stloc.s 40
+		IL_0434: ldloc.2
+		IL_0435: ldstr "get"
+		IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_043f: stloc.s 36
+		IL_0441: ldloc.s 36
+		IL_0443: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
+		IL_0448: box [System.Runtime]System.Boolean
+		IL_044d: stloc.s 44
+		IL_044f: ldloc.s 40
+		IL_0451: ldstr "frozenFunction"
+		IL_0456: ldloc.s 44
+		IL_0458: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_045d: pop
+		IL_045e: nop
+		IL_045f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0464: dup
+		IL_0465: ldstr "marker"
+		IL_046a: ldstr "custom-function-prototype"
+		IL_046f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0474: stloc.s 4
+		IL_0476: ldloc.1
+		IL_0477: ldloc.s 4
+		IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_047e: pop
+		IL_047f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0484: stloc.s 40
+		IL_0486: ldloc.1
+		IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_048c: stloc.s 36
+		IL_048e: ldloc.s 36
+		IL_0490: ldloc.s 4
+		IL_0492: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0497: stloc.s 43
+		IL_0499: ldloc.s 43
+		IL_049b: box [System.Runtime]System.Boolean
+		IL_04a0: stloc.s 44
+		IL_04a2: ldloc.1
+		IL_04a3: ldstr "marker"
+		IL_04a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04ad: stloc.s 36
+		IL_04af: ldloc.s 40
+		IL_04b1: ldstr "prototypeMutation"
+		IL_04b6: ldloc.s 44
+		IL_04b8: ldloc.s 36
+		IL_04ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_04bf: pop
+		IL_04c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04c5: stloc.s 40
+		IL_04c7: ldloc.0
+		IL_04c8: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_04cd: stloc.s 36
+		IL_04cf: ldloc.s 36
+		IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_04d6: stloc.s 36
+		IL_04d8: ldloc.s 36
+		IL_04da: ldnull
+		IL_04db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_04e0: stloc.s 43
+		IL_04e2: ldloc.s 43
+		IL_04e4: box [System.Runtime]System.Boolean
+		IL_04e9: stloc.s 44
+		IL_04eb: ldloc.0
+		IL_04ec: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_04f1: stloc.s 36
+		IL_04f3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_04f8: dup
+		IL_04f9: ldstr "target"
+		IL_04fe: ldloc.s 36
+		IL_0500: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0505: stloc.s 37
+		IL_0507: ldloc.s 37
+		IL_0509: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_050e: stloc.s 36
+		IL_0510: ldloc.s 36
+		IL_0512: ldstr "{}"
+		IL_0517: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_051c: stloc.s 43
+		IL_051e: ldloc.s 43
+		IL_0520: box [System.Runtime]System.Boolean
+		IL_0525: stloc.s 45
+		IL_0527: ldloc.s 40
+		IL_0529: ldstr "json"
+		IL_052e: ldloc.s 44
+		IL_0530: ldloc.s 45
+		IL_0532: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0537: pop
+		IL_0538: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_053d: stloc.s 37
+		IL_053f: ldc.i4.1
+		IL_0540: newarr [System.Runtime]System.Object
+		IL_0545: dup
+		IL_0546: ldc.i4.0
+		IL_0547: ldloc.0
+		IL_0548: stelem.ref
+		IL_0549: stloc.s 33
+		IL_054b: ldloc.s 33
+		IL_054d: ldc.i4.0
+		IL_054e: ldelem.ref
+		IL_054f: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
+		IL_0554: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
+		IL_0559: ldc.i4.3
+		IL_055a: conv.r8
+		IL_055b: ldstr ""
+		IL_0560: ldc.i4.0
+		IL_0561: ldc.i4.1
+		IL_0562: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0567: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject>(!!0)
+		IL_056c: stloc.s 47
+		IL_056e: ldloc.s 37
+		IL_0570: ldstr "apply"
+		IL_0575: ldloc.s 47
+		IL_0577: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_057c: pop
+		IL_057d: ldloc.0
+		IL_057e: ldloc.s 37
+		IL_0580: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::applyHandler
+		IL_0585: ldloc.0
+		IL_0586: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_058b: stloc.s 36
+		IL_058d: ldloc.0
+		IL_058e: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::applyHandler
+		IL_0593: ldstr "Cannot access 'applyHandler' before initialization"
+		IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_059d: stloc.s 42
+		IL_059f: ldloc.s 36
+		IL_05a1: ldloc.s 42
+		IL_05a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_05a8: stloc.s 5
+		IL_05aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_05af: dup
+		IL_05b0: ldstr "base"
+		IL_05b5: ldc.r8 10
+		IL_05be: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_05c3: dup
+		IL_05c4: ldstr "method"
+		IL_05c9: ldloc.s 5
+		IL_05cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_05d0: stloc.s 6
+		IL_05d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05d7: stloc.s 40
+		IL_05d9: ldloc.s 5
+		IL_05db: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_05e0: stloc.s 41
+		IL_05e2: ldloc.s 6
+		IL_05e4: ldstr "method"
+		IL_05e9: ldc.r8 5
+		IL_05f2: box [System.Runtime]System.Double
+		IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_05fc: stloc.s 42
+		IL_05fe: ldloc.0
+		IL_05ff: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0604: stloc.s 36
+		IL_0606: ldloc.s 5
+		IL_0608: ldloc.s 36
+		IL_060a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_060f: stloc.s 43
+		IL_0611: ldloc.s 43
+		IL_0613: box [System.Runtime]System.Boolean
+		IL_0618: stloc.s 45
+		IL_061a: ldloc.s 40
+		IL_061c: ldc.i4.4
+		IL_061d: newarr [System.Runtime]System.Object
+		IL_0622: dup
+		IL_0623: ldc.i4.0
+		IL_0624: ldstr "apply"
+		IL_0629: stelem.ref
+		IL_062a: dup
+		IL_062b: ldc.i4.1
+		IL_062c: ldloc.s 41
+		IL_062e: stelem.ref
+		IL_062f: dup
+		IL_0630: ldc.i4.2
+		IL_0631: ldloc.s 42
+		IL_0633: stelem.ref
+		IL_0634: dup
+		IL_0635: ldc.i4.3
+		IL_0636: ldloc.s 45
+		IL_0638: stelem.ref
+		IL_0639: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_063e: pop
+		IL_063f: ldloc.0
+		IL_0640: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0645: stloc.s 42
+		IL_0647: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_064c: stloc.s 37
+		IL_064e: ldloc.s 42
+		IL_0650: ldloc.s 37
+		IL_0652: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0657: stloc.s 7
+		IL_0659: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_065e: stloc.s 40
+		IL_0660: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0665: dup
+		IL_0666: ldstr "base"
+		IL_066b: ldc.r8 20
+		IL_0674: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0679: stloc.s 37
+		IL_067b: ldloc.s 7
+		IL_067d: ldstr "call"
+		IL_0682: ldloc.s 37
+		IL_0684: ldc.r8 2
+		IL_068d: box [System.Runtime]System.Double
+		IL_0692: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0697: stloc.s 42
+		IL_0699: ldloc.s 40
+		IL_069b: ldstr "fallback"
+		IL_06a0: ldloc.s 42
+		IL_06a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_06a7: pop
+		IL_06a8: nop
+		IL_06a9: ldloc.0
+		IL_06aa: ldnull
+		IL_06ab: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
+		IL_06b0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_06b5: stloc.s 37
+		IL_06b7: ldc.i4.1
+		IL_06b8: newarr [System.Runtime]System.Object
 		IL_06bd: dup
-		IL_06be: ldc.r8 12
-		IL_06c7: box [System.Runtime]System.Double
-		IL_06cc: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_06d1: stloc.s 9
-		IL_06d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_06d8: stloc.s 40
-		IL_06da: ldloc.0
-		IL_06db: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
-		IL_06e0: castclass [JavaScriptRuntime]JavaScriptRuntime.Proxy
-		IL_06e5: stloc.s 49
-		IL_06e7: ldloc.s 49
-		IL_06e9: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_06ee: stloc.s 41
-		IL_06f0: ldloc.s 9
-		IL_06f2: ldstr "targetMatches"
-		IL_06f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_06fc: stloc.s 42
-		IL_06fe: ldloc.s 9
-		IL_0700: ldstr "argument"
-		IL_0705: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_070a: stloc.s 36
-		IL_070c: ldloc.s 9
-		IL_070e: ldstr "newTargetMatches"
-		IL_0713: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0718: stloc.s 46
-		IL_071a: ldloc.s 40
-		IL_071c: ldc.i4.5
-		IL_071d: newarr [System.Runtime]System.Object
-		IL_0722: dup
-		IL_0723: ldc.i4.0
-		IL_0724: ldstr "construct"
-		IL_0729: stelem.ref
-		IL_072a: dup
-		IL_072b: ldc.i4.1
-		IL_072c: ldloc.s 41
-		IL_072e: stelem.ref
-		IL_072f: dup
-		IL_0730: ldc.i4.2
-		IL_0731: ldloc.s 42
-		IL_0733: stelem.ref
-		IL_0734: dup
-		IL_0735: ldc.i4.3
-		IL_0736: ldloc.s 36
-		IL_0738: stelem.ref
-		IL_0739: dup
-		IL_073a: ldc.i4.4
-		IL_073b: ldloc.s 46
-		IL_073d: stelem.ref
-		IL_073e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0743: pop
-		IL_0744: ldloc.0
-		IL_0745: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::Constructor
-		IL_074a: stloc.s 46
-		IL_074c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0751: stloc.s 37
-		IL_0753: ldc.i4.1
-		IL_0754: newarr [System.Runtime]System.Object
-		IL_0759: dup
-		IL_075a: ldc.i4.0
-		IL_075b: ldloc.0
-		IL_075c: stelem.ref
-		IL_075d: stloc.s 33
-		IL_075f: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject::.ctor()
-		IL_0764: ldc.i4.0
-		IL_0765: conv.r8
-		IL_0766: ldstr ""
-		IL_076b: ldc.i4.0
-		IL_076c: ldc.i4.1
-		IL_076d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0772: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject>(!!0)
-		IL_0777: stloc.s 50
-		IL_0779: ldloc.s 37
-		IL_077b: ldstr "construct"
-		IL_0780: ldloc.s 50
-		IL_0782: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0787: pop
-		IL_0788: ldloc.s 46
-		IL_078a: ldloc.s 37
-		IL_078c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0791: stloc.s 10
-		IL_0793: ldc.i4.0
-		IL_0794: box [System.Runtime]System.Boolean
-		IL_0799: stloc.s 11
+		IL_06be: ldc.i4.0
+		IL_06bf: ldloc.0
+		IL_06c0: stelem.ref
+		IL_06c1: stloc.s 33
+		IL_06c3: ldloc.s 33
+		IL_06c5: ldc.i4.0
+		IL_06c6: ldelem.ref
+		IL_06c7: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
+		IL_06cc: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
+		IL_06d1: ldc.i4.3
+		IL_06d2: conv.r8
+		IL_06d3: ldstr ""
+		IL_06d8: ldc.i4.0
+		IL_06d9: ldc.i4.1
+		IL_06da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_06df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject>(!!0)
+		IL_06e4: stloc.s 48
+		IL_06e6: ldloc.s 37
+		IL_06e8: ldstr "construct"
+		IL_06ed: ldloc.s 48
+		IL_06ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_06f4: pop
+		IL_06f5: ldloc.s 37
+		IL_06f7: stloc.s 8
+		IL_06f9: ldloc.0
+		IL_06fa: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::Constructor
+		IL_06ff: stloc.s 42
+		IL_0701: ldloc.s 42
+		IL_0703: ldloc.s 8
+		IL_0705: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_070a: stloc.s 49
+		IL_070c: ldloc.0
+		IL_070d: ldloc.s 49
+		IL_070f: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
+		IL_0714: ldloc.0
+		IL_0715: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
+		IL_071a: castclass [JavaScriptRuntime]JavaScriptRuntime.Proxy
+		IL_071f: stloc.s 49
+		IL_0721: ldloc.s 49
+		IL_0723: dup
+		IL_0724: ldc.r8 12
+		IL_072d: box [System.Runtime]System.Double
+		IL_0732: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_0737: stloc.s 9
+		IL_0739: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_073e: stloc.s 40
+		IL_0740: ldloc.0
+		IL_0741: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
+		IL_0746: castclass [JavaScriptRuntime]JavaScriptRuntime.Proxy
+		IL_074b: stloc.s 49
+		IL_074d: ldloc.s 49
+		IL_074f: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0754: stloc.s 41
+		IL_0756: ldloc.s 9
+		IL_0758: ldstr "targetMatches"
+		IL_075d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0762: stloc.s 42
+		IL_0764: ldloc.s 9
+		IL_0766: ldstr "argument"
+		IL_076b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0770: stloc.s 36
+		IL_0772: ldloc.s 9
+		IL_0774: ldstr "newTargetMatches"
+		IL_0779: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_077e: stloc.s 46
+		IL_0780: ldloc.s 40
+		IL_0782: ldc.i4.5
+		IL_0783: newarr [System.Runtime]System.Object
+		IL_0788: dup
+		IL_0789: ldc.i4.0
+		IL_078a: ldstr "construct"
+		IL_078f: stelem.ref
+		IL_0790: dup
+		IL_0791: ldc.i4.1
+		IL_0792: ldloc.s 41
+		IL_0794: stelem.ref
+		IL_0795: dup
+		IL_0796: ldc.i4.2
+		IL_0797: ldloc.s 42
+		IL_0799: stelem.ref
+		IL_079a: dup
+		IL_079b: ldc.i4.3
+		IL_079c: ldloc.s 36
+		IL_079e: stelem.ref
+		IL_079f: dup
+		IL_07a0: ldc.i4.4
+		IL_07a1: ldloc.s 46
+		IL_07a3: stelem.ref
+		IL_07a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_07a9: pop
+		IL_07aa: ldloc.0
+		IL_07ab: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::Constructor
+		IL_07b0: stloc.s 46
+		IL_07b2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_07b7: stloc.s 37
+		IL_07b9: ldc.i4.1
+		IL_07ba: newarr [System.Runtime]System.Object
+		IL_07bf: dup
+		IL_07c0: ldc.i4.0
+		IL_07c1: ldloc.0
+		IL_07c2: stelem.ref
+		IL_07c3: stloc.s 33
+		IL_07c5: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject::.ctor()
+		IL_07ca: ldc.i4.0
+		IL_07cb: conv.r8
+		IL_07cc: ldstr ""
+		IL_07d1: ldc.i4.0
+		IL_07d2: ldc.i4.1
+		IL_07d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_07d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject>(!!0)
+		IL_07dd: stloc.s 50
+		IL_07df: ldloc.s 37
+		IL_07e1: ldstr "construct"
+		IL_07e6: ldloc.s 50
+		IL_07e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_07ed: pop
+		IL_07ee: ldloc.s 46
+		IL_07f0: ldloc.s 37
+		IL_07f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_07f7: stloc.s 10
+		IL_07f9: ldc.i4.0
+		IL_07fa: box [System.Runtime]System.Boolean
+		IL_07ff: stloc.s 11
 		.try
 		{
-			IL_079b: nop
-			IL_079c: ldloc.s 10
-			IL_079e: dup
-			IL_079f: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-			IL_07a4: pop
-			IL_07a5: leave IL_0809
+			IL_0801: nop
+			IL_0802: ldloc.s 10
+			IL_0804: dup
+			IL_0805: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+			IL_080a: pop
+			IL_080b: leave IL_086f
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_07aa: stloc.s 12
-			IL_07ac: ldloc.s 12
-			IL_07ae: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_07b3: dup
-			IL_07b4: brtrue IL_07ca
+			IL_0810: stloc.s 12
+			IL_0812: ldloc.s 12
+			IL_0814: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0819: dup
+			IL_081a: brtrue IL_0830
 
-			IL_07b9: pop
-			IL_07ba: ldloc.s 12
-			IL_07bc: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_07c1: dup
-			IL_07c2: brtrue IL_07d6
+			IL_081f: pop
+			IL_0820: ldloc.s 12
+			IL_0822: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0827: dup
+			IL_0828: brtrue IL_083c
 
-			IL_07c7: pop
-			IL_07c8: rethrow
+			IL_082d: pop
+			IL_082e: rethrow
 
-			IL_07ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_07cf: stloc.s 13
-			IL_07d1: br IL_07d8
+			IL_0830: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0835: stloc.s 13
+			IL_0837: br IL_083e
 
-			IL_07d6: stloc.s 13
+			IL_083c: stloc.s 13
 
-			IL_07d8: ldloc.s 13
-			IL_07da: stloc.s 14
-			IL_07dc: ldloc.s 14
-			IL_07de: stloc.s 46
-			IL_07e0: ldstr "TypeError"
-			IL_07e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07ea: stloc.s 36
-			IL_07ec: ldloc.s 46
-			IL_07ee: ldloc.s 36
-			IL_07f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_07f5: stloc.s 43
-			IL_07f7: ldloc.s 43
-			IL_07f9: box [System.Runtime]System.Boolean
-			IL_07fe: stloc.s 45
-			IL_0800: ldloc.s 45
-			IL_0802: stloc.s 11
-			IL_0804: leave IL_0809
+			IL_083e: ldloc.s 13
+			IL_0840: stloc.s 14
+			IL_0842: ldloc.s 14
+			IL_0844: stloc.s 46
+			IL_0846: ldstr "TypeError"
+			IL_084b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0850: stloc.s 36
+			IL_0852: ldloc.s 46
+			IL_0854: ldloc.s 36
+			IL_0856: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_085b: stloc.s 43
+			IL_085d: ldloc.s 43
+			IL_085f: box [System.Runtime]System.Boolean
+			IL_0864: stloc.s 45
+			IL_0866: ldloc.s 45
+			IL_0868: stloc.s 11
+			IL_086a: leave IL_086f
 		} // end handler
 
-		IL_0809: ldloc.0
-		IL_080a: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_080f: stloc.s 36
-		IL_0811: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0816: dup
-		IL_0817: ldstr "apply"
-		IL_081c: ldc.r8 1
-		IL_0825: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_082a: stloc.s 37
-		IL_082c: ldloc.s 36
-		IL_082e: ldloc.s 37
-		IL_0830: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0835: stloc.s 15
-		IL_0837: ldc.i4.0
-		IL_0838: box [System.Runtime]System.Boolean
-		IL_083d: stloc.s 16
+		IL_086f: ldloc.0
+		IL_0870: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0875: stloc.s 36
+		IL_0877: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_087c: dup
+		IL_087d: ldstr "apply"
+		IL_0882: ldc.r8 1
+		IL_088b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0890: stloc.s 37
+		IL_0892: ldloc.s 36
+		IL_0894: ldloc.s 37
+		IL_0896: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_089b: stloc.s 15
+		IL_089d: ldc.i4.0
+		IL_089e: box [System.Runtime]System.Boolean
+		IL_08a3: stloc.s 16
 		.try
 		{
-			IL_083f: nop
-			IL_0840: ldloc.s 15
-			IL_0842: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_0847: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_084c: pop
-			IL_084d: leave IL_08b1
+			IL_08a5: nop
+			IL_08a6: ldloc.s 15
+			IL_08a8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_08ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_08b2: pop
+			IL_08b3: leave IL_0917
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0852: stloc.s 17
-			IL_0854: ldloc.s 17
-			IL_0856: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_085b: dup
-			IL_085c: brtrue IL_0872
+			IL_08b8: stloc.s 17
+			IL_08ba: ldloc.s 17
+			IL_08bc: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_08c1: dup
+			IL_08c2: brtrue IL_08d8
 
-			IL_0861: pop
-			IL_0862: ldloc.s 17
-			IL_0864: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0869: dup
-			IL_086a: brtrue IL_087e
+			IL_08c7: pop
+			IL_08c8: ldloc.s 17
+			IL_08ca: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_08cf: dup
+			IL_08d0: brtrue IL_08e4
 
-			IL_086f: pop
-			IL_0870: rethrow
+			IL_08d5: pop
+			IL_08d6: rethrow
 
-			IL_0872: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0877: stloc.s 18
-			IL_0879: br IL_0880
+			IL_08d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_08dd: stloc.s 18
+			IL_08df: br IL_08e6
 
-			IL_087e: stloc.s 18
+			IL_08e4: stloc.s 18
 
-			IL_0880: ldloc.s 18
-			IL_0882: stloc.s 19
-			IL_0884: ldloc.s 19
-			IL_0886: stloc.s 36
-			IL_0888: ldstr "TypeError"
-			IL_088d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0892: stloc.s 46
-			IL_0894: ldloc.s 36
-			IL_0896: ldloc.s 46
-			IL_0898: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_089d: stloc.s 43
-			IL_089f: ldloc.s 43
-			IL_08a1: box [System.Runtime]System.Boolean
-			IL_08a6: stloc.s 45
-			IL_08a8: ldloc.s 45
-			IL_08aa: stloc.s 16
-			IL_08ac: leave IL_08b1
+			IL_08e6: ldloc.s 18
+			IL_08e8: stloc.s 19
+			IL_08ea: ldloc.s 19
+			IL_08ec: stloc.s 36
+			IL_08ee: ldstr "TypeError"
+			IL_08f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_08f8: stloc.s 46
+			IL_08fa: ldloc.s 36
+			IL_08fc: ldloc.s 46
+			IL_08fe: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0903: stloc.s 43
+			IL_0905: ldloc.s 43
+			IL_0907: box [System.Runtime]System.Boolean
+			IL_090c: stloc.s 45
+			IL_090e: ldloc.s 45
+			IL_0910: stloc.s 16
+			IL_0912: leave IL_0917
 		} // end handler
 
-		IL_08b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_08b6: stloc.s 40
-		IL_08b8: ldloc.s 40
-		IL_08ba: ldstr "invalidTraps"
-		IL_08bf: ldloc.s 11
-		IL_08c1: ldloc.s 16
-		IL_08c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_08c8: pop
-		IL_08c9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_08ce: stloc.s 20
-		IL_08d0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_08d5: stloc.s 37
-		IL_08d7: ldc.i4.1
-		IL_08d8: newarr [System.Runtime]System.Object
-		IL_08dd: dup
-		IL_08de: ldc.i4.0
-		IL_08df: ldloc.0
-		IL_08e0: stelem.ref
-		IL_08e1: stloc.s 33
-		IL_08e3: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject::.ctor()
-		IL_08e8: ldc.i4.1
-		IL_08e9: conv.r8
-		IL_08ea: ldstr ""
-		IL_08ef: ldc.i4.0
-		IL_08f0: ldc.i4.1
-		IL_08f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_08f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject>(!!0)
-		IL_08fb: stloc.s 51
-		IL_08fd: ldloc.s 37
-		IL_08ff: ldstr "isExtensible"
-		IL_0904: ldloc.s 51
-		IL_0906: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_090b: pop
-		IL_090c: ldc.i4.1
-		IL_090d: newarr [System.Runtime]System.Object
-		IL_0912: dup
-		IL_0913: ldc.i4.0
-		IL_0914: ldloc.0
-		IL_0915: stelem.ref
-		IL_0916: stloc.s 33
-		IL_0918: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject::.ctor()
-		IL_091d: ldc.i4.1
-		IL_091e: conv.r8
-		IL_091f: ldstr ""
-		IL_0924: ldc.i4.0
-		IL_0925: ldc.i4.1
-		IL_0926: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_092b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject>(!!0)
-		IL_0930: stloc.s 52
-		IL_0932: ldloc.s 37
-		IL_0934: ldstr "preventExtensions"
-		IL_0939: ldloc.s 52
-		IL_093b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0940: pop
-		IL_0941: ldloc.s 37
-		IL_0943: stloc.s 21
-		IL_0945: ldloc.s 20
-		IL_0947: ldloc.s 21
-		IL_0949: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_094e: stloc.s 22
-		IL_0950: ldloc.s 22
-		IL_0952: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_0957: stloc.s 23
-		IL_0959: ldloc.s 22
-		IL_095b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-		IL_0960: pop
-		IL_0961: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0966: stloc.s 40
-		IL_0968: ldloc.s 23
-		IL_096a: box [System.Runtime]System.Boolean
-		IL_096f: stloc.s 45
-		IL_0971: ldloc.s 22
-		IL_0973: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_0978: box [System.Runtime]System.Boolean
-		IL_097d: stloc.s 44
-		IL_097f: ldloc.s 20
-		IL_0981: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_0986: box [System.Runtime]System.Boolean
-		IL_098b: stloc.s 53
-		IL_098d: ldloc.s 40
-		IL_098f: ldc.i4.4
-		IL_0990: newarr [System.Runtime]System.Object
-		IL_0995: dup
-		IL_0996: ldc.i4.0
-		IL_0997: ldstr "proxyIntegrity"
-		IL_099c: stelem.ref
-		IL_099d: dup
-		IL_099e: ldc.i4.1
-		IL_099f: ldloc.s 45
-		IL_09a1: stelem.ref
-		IL_09a2: dup
-		IL_09a3: ldc.i4.2
-		IL_09a4: ldloc.s 44
-		IL_09a6: stelem.ref
-		IL_09a7: dup
-		IL_09a8: ldc.i4.3
-		IL_09a9: ldloc.s 53
-		IL_09ab: stelem.ref
-		IL_09ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_09b1: pop
-		IL_09b2: ldc.i4.0
-		IL_09b3: box [System.Runtime]System.Boolean
-		IL_09b8: stloc.s 24
+		IL_0917: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_091c: stloc.s 40
+		IL_091e: ldloc.s 40
+		IL_0920: ldstr "invalidTraps"
+		IL_0925: ldloc.s 11
+		IL_0927: ldloc.s 16
+		IL_0929: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_092e: pop
+		IL_092f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0934: stloc.s 20
+		IL_0936: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_093b: stloc.s 37
+		IL_093d: ldc.i4.1
+		IL_093e: newarr [System.Runtime]System.Object
+		IL_0943: dup
+		IL_0944: ldc.i4.0
+		IL_0945: ldloc.0
+		IL_0946: stelem.ref
+		IL_0947: stloc.s 33
+		IL_0949: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject::.ctor()
+		IL_094e: ldc.i4.1
+		IL_094f: conv.r8
+		IL_0950: ldstr ""
+		IL_0955: ldc.i4.0
+		IL_0956: ldc.i4.1
+		IL_0957: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_095c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject>(!!0)
+		IL_0961: stloc.s 51
+		IL_0963: ldloc.s 37
+		IL_0965: ldstr "isExtensible"
+		IL_096a: ldloc.s 51
+		IL_096c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0971: pop
+		IL_0972: ldc.i4.1
+		IL_0973: newarr [System.Runtime]System.Object
+		IL_0978: dup
+		IL_0979: ldc.i4.0
+		IL_097a: ldloc.0
+		IL_097b: stelem.ref
+		IL_097c: stloc.s 33
+		IL_097e: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject::.ctor()
+		IL_0983: ldc.i4.1
+		IL_0984: conv.r8
+		IL_0985: ldstr ""
+		IL_098a: ldc.i4.0
+		IL_098b: ldc.i4.1
+		IL_098c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0991: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject>(!!0)
+		IL_0996: stloc.s 52
+		IL_0998: ldloc.s 37
+		IL_099a: ldstr "preventExtensions"
+		IL_099f: ldloc.s 52
+		IL_09a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_09a6: pop
+		IL_09a7: ldloc.s 37
+		IL_09a9: stloc.s 21
+		IL_09ab: ldloc.s 20
+		IL_09ad: ldloc.s 21
+		IL_09af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_09b4: stloc.s 22
+		IL_09b6: ldloc.s 22
+		IL_09b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_09bd: stloc.s 23
+		IL_09bf: ldloc.s 22
+		IL_09c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+		IL_09c6: pop
+		IL_09c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_09cc: stloc.s 40
+		IL_09ce: ldloc.s 23
+		IL_09d0: box [System.Runtime]System.Boolean
+		IL_09d5: stloc.s 45
+		IL_09d7: ldloc.s 22
+		IL_09d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_09de: box [System.Runtime]System.Boolean
+		IL_09e3: stloc.s 44
+		IL_09e5: ldloc.s 20
+		IL_09e7: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_09ec: box [System.Runtime]System.Boolean
+		IL_09f1: stloc.s 53
+		IL_09f3: ldloc.s 40
+		IL_09f5: ldc.i4.4
+		IL_09f6: newarr [System.Runtime]System.Object
+		IL_09fb: dup
+		IL_09fc: ldc.i4.0
+		IL_09fd: ldstr "proxyIntegrity"
+		IL_0a02: stelem.ref
+		IL_0a03: dup
+		IL_0a04: ldc.i4.1
+		IL_0a05: ldloc.s 45
+		IL_0a07: stelem.ref
+		IL_0a08: dup
+		IL_0a09: ldc.i4.2
+		IL_0a0a: ldloc.s 44
+		IL_0a0c: stelem.ref
+		IL_0a0d: dup
+		IL_0a0e: ldc.i4.3
+		IL_0a0f: ldloc.s 53
+		IL_0a11: stelem.ref
+		IL_0a12: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0a17: pop
+		IL_0a18: ldc.i4.0
+		IL_0a19: box [System.Runtime]System.Boolean
+		IL_0a1e: stloc.s 24
 		.try
 		{
-			IL_09ba: nop
-			IL_09bb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_09c0: stloc.s 37
-			IL_09c2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_09c7: stloc.s 54
-			IL_09c9: ldc.i4.1
-			IL_09ca: newarr [System.Runtime]System.Object
-			IL_09cf: dup
-			IL_09d0: ldc.i4.0
-			IL_09d1: ldloc.0
-			IL_09d2: stelem.ref
-			IL_09d3: stloc.s 33
-			IL_09d5: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject::.ctor()
-			IL_09da: ldc.i4.0
-			IL_09db: conv.r8
-			IL_09dc: ldstr ""
-			IL_09e1: ldc.i4.0
-			IL_09e2: ldc.i4.1
-			IL_09e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_09e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject>(!!0)
-			IL_09ed: stloc.s 55
-			IL_09ef: ldloc.s 54
-			IL_09f1: ldstr "isExtensible"
-			IL_09f6: ldloc.s 55
-			IL_09f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_09fd: pop
-			IL_09fe: ldloc.s 37
-			IL_0a00: ldloc.s 54
-			IL_0a02: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-			IL_0a07: stloc.s 49
-			IL_0a09: ldloc.s 49
-			IL_0a0b: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-			IL_0a10: pop
-			IL_0a11: leave IL_0a75
+			IL_0a20: nop
+			IL_0a21: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0a26: stloc.s 37
+			IL_0a28: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0a2d: stloc.s 54
+			IL_0a2f: ldc.i4.1
+			IL_0a30: newarr [System.Runtime]System.Object
+			IL_0a35: dup
+			IL_0a36: ldc.i4.0
+			IL_0a37: ldloc.0
+			IL_0a38: stelem.ref
+			IL_0a39: stloc.s 33
+			IL_0a3b: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject::.ctor()
+			IL_0a40: ldc.i4.0
+			IL_0a41: conv.r8
+			IL_0a42: ldstr ""
+			IL_0a47: ldc.i4.0
+			IL_0a48: ldc.i4.1
+			IL_0a49: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0a4e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject>(!!0)
+			IL_0a53: stloc.s 55
+			IL_0a55: ldloc.s 54
+			IL_0a57: ldstr "isExtensible"
+			IL_0a5c: ldloc.s 55
+			IL_0a5e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0a63: pop
+			IL_0a64: ldloc.s 37
+			IL_0a66: ldloc.s 54
+			IL_0a68: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+			IL_0a6d: stloc.s 49
+			IL_0a6f: ldloc.s 49
+			IL_0a71: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+			IL_0a76: pop
+			IL_0a77: leave IL_0adb
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0a16: stloc.s 25
-			IL_0a18: ldloc.s 25
-			IL_0a1a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0a1f: dup
-			IL_0a20: brtrue IL_0a36
+			IL_0a7c: stloc.s 25
+			IL_0a7e: ldloc.s 25
+			IL_0a80: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0a85: dup
+			IL_0a86: brtrue IL_0a9c
 
-			IL_0a25: pop
-			IL_0a26: ldloc.s 25
-			IL_0a28: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0a2d: dup
-			IL_0a2e: brtrue IL_0a42
+			IL_0a8b: pop
+			IL_0a8c: ldloc.s 25
+			IL_0a8e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0a93: dup
+			IL_0a94: brtrue IL_0aa8
 
-			IL_0a33: pop
-			IL_0a34: rethrow
+			IL_0a99: pop
+			IL_0a9a: rethrow
 
-			IL_0a36: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0a3b: stloc.s 26
-			IL_0a3d: br IL_0a44
+			IL_0a9c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0aa1: stloc.s 26
+			IL_0aa3: br IL_0aaa
 
-			IL_0a42: stloc.s 26
+			IL_0aa8: stloc.s 26
 
-			IL_0a44: ldloc.s 26
-			IL_0a46: stloc.s 27
-			IL_0a48: ldloc.s 27
-			IL_0a4a: stloc.s 46
-			IL_0a4c: ldstr "TypeError"
-			IL_0a51: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a56: stloc.s 36
-			IL_0a58: ldloc.s 46
-			IL_0a5a: ldloc.s 36
-			IL_0a5c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0a61: stloc.s 43
-			IL_0a63: ldloc.s 43
-			IL_0a65: box [System.Runtime]System.Boolean
-			IL_0a6a: stloc.s 53
-			IL_0a6c: ldloc.s 53
-			IL_0a6e: stloc.s 24
-			IL_0a70: leave IL_0a75
+			IL_0aaa: ldloc.s 26
+			IL_0aac: stloc.s 27
+			IL_0aae: ldloc.s 27
+			IL_0ab0: stloc.s 46
+			IL_0ab2: ldstr "TypeError"
+			IL_0ab7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0abc: stloc.s 36
+			IL_0abe: ldloc.s 46
+			IL_0ac0: ldloc.s 36
+			IL_0ac2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0ac7: stloc.s 43
+			IL_0ac9: ldloc.s 43
+			IL_0acb: box [System.Runtime]System.Boolean
+			IL_0ad0: stloc.s 53
+			IL_0ad2: ldloc.s 53
+			IL_0ad4: stloc.s 24
+			IL_0ad6: leave IL_0adb
 		} // end handler
 
-		IL_0a75: ldc.i4.0
-		IL_0a76: box [System.Runtime]System.Boolean
-		IL_0a7b: stloc.s 28
+		IL_0adb: ldc.i4.0
+		IL_0adc: box [System.Runtime]System.Boolean
+		IL_0ae1: stloc.s 28
 		.try
 		{
-			IL_0a7d: nop
-			IL_0a7e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0a83: stloc.s 54
-			IL_0a85: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0a8a: stloc.s 37
-			IL_0a8c: ldc.i4.1
-			IL_0a8d: newarr [System.Runtime]System.Object
-			IL_0a92: dup
-			IL_0a93: ldc.i4.0
-			IL_0a94: ldloc.0
-			IL_0a95: stelem.ref
-			IL_0a96: stloc.s 33
-			IL_0a98: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject::.ctor()
-			IL_0a9d: ldc.i4.0
-			IL_0a9e: conv.r8
-			IL_0a9f: ldstr ""
-			IL_0aa4: ldc.i4.0
-			IL_0aa5: ldc.i4.1
-			IL_0aa6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0aab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject>(!!0)
-			IL_0ab0: stloc.s 56
-			IL_0ab2: ldloc.s 37
-			IL_0ab4: ldstr "preventExtensions"
-			IL_0ab9: ldloc.s 56
-			IL_0abb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0ac0: pop
-			IL_0ac1: ldloc.s 54
-			IL_0ac3: ldloc.s 37
-			IL_0ac5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-			IL_0aca: stloc.s 49
-			IL_0acc: ldloc.s 49
-			IL_0ace: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-			IL_0ad3: pop
-			IL_0ad4: leave IL_0b38
+			IL_0ae3: nop
+			IL_0ae4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0ae9: stloc.s 54
+			IL_0aeb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0af0: stloc.s 37
+			IL_0af2: ldc.i4.1
+			IL_0af3: newarr [System.Runtime]System.Object
+			IL_0af8: dup
+			IL_0af9: ldc.i4.0
+			IL_0afa: ldloc.0
+			IL_0afb: stelem.ref
+			IL_0afc: stloc.s 33
+			IL_0afe: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject::.ctor()
+			IL_0b03: ldc.i4.0
+			IL_0b04: conv.r8
+			IL_0b05: ldstr ""
+			IL_0b0a: ldc.i4.0
+			IL_0b0b: ldc.i4.1
+			IL_0b0c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0b11: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject>(!!0)
+			IL_0b16: stloc.s 56
+			IL_0b18: ldloc.s 37
+			IL_0b1a: ldstr "preventExtensions"
+			IL_0b1f: ldloc.s 56
+			IL_0b21: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0b26: pop
+			IL_0b27: ldloc.s 54
+			IL_0b29: ldloc.s 37
+			IL_0b2b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+			IL_0b30: stloc.s 49
+			IL_0b32: ldloc.s 49
+			IL_0b34: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+			IL_0b39: pop
+			IL_0b3a: leave IL_0b9e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0ad9: stloc.s 29
-			IL_0adb: ldloc.s 29
-			IL_0add: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0ae2: dup
-			IL_0ae3: brtrue IL_0af9
+			IL_0b3f: stloc.s 29
+			IL_0b41: ldloc.s 29
+			IL_0b43: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0b48: dup
+			IL_0b49: brtrue IL_0b5f
 
-			IL_0ae8: pop
-			IL_0ae9: ldloc.s 29
-			IL_0aeb: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0af0: dup
-			IL_0af1: brtrue IL_0b05
+			IL_0b4e: pop
+			IL_0b4f: ldloc.s 29
+			IL_0b51: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0b56: dup
+			IL_0b57: brtrue IL_0b6b
 
-			IL_0af6: pop
-			IL_0af7: rethrow
+			IL_0b5c: pop
+			IL_0b5d: rethrow
 
-			IL_0af9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0afe: stloc.s 30
-			IL_0b00: br IL_0b07
+			IL_0b5f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0b64: stloc.s 30
+			IL_0b66: br IL_0b6d
 
-			IL_0b05: stloc.s 30
+			IL_0b6b: stloc.s 30
 
-			IL_0b07: ldloc.s 30
-			IL_0b09: stloc.s 31
-			IL_0b0b: ldloc.s 31
-			IL_0b0d: stloc.s 36
-			IL_0b0f: ldstr "TypeError"
-			IL_0b14: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b19: stloc.s 46
-			IL_0b1b: ldloc.s 36
-			IL_0b1d: ldloc.s 46
-			IL_0b1f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0b24: stloc.s 43
-			IL_0b26: ldloc.s 43
-			IL_0b28: box [System.Runtime]System.Boolean
-			IL_0b2d: stloc.s 53
-			IL_0b2f: ldloc.s 53
-			IL_0b31: stloc.s 28
-			IL_0b33: leave IL_0b38
+			IL_0b6d: ldloc.s 30
+			IL_0b6f: stloc.s 31
+			IL_0b71: ldloc.s 31
+			IL_0b73: stloc.s 36
+			IL_0b75: ldstr "TypeError"
+			IL_0b7a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0b7f: stloc.s 46
+			IL_0b81: ldloc.s 36
+			IL_0b83: ldloc.s 46
+			IL_0b85: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0b8a: stloc.s 43
+			IL_0b8c: ldloc.s 43
+			IL_0b8e: box [System.Runtime]System.Boolean
+			IL_0b93: stloc.s 53
+			IL_0b95: ldloc.s 53
+			IL_0b97: stloc.s 28
+			IL_0b99: leave IL_0b9e
 		} // end handler
 
-		IL_0b38: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0b3d: stloc.s 40
-		IL_0b3f: ldloc.s 40
-		IL_0b41: ldstr "proxyIntegrityInvariants"
-		IL_0b46: ldloc.s 24
-		IL_0b48: ldloc.s 28
-		IL_0b4a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0b4f: pop
-		IL_0b50: ldnull
-		IL_0b51: stloc.s 32
-		IL_0b53: ret
+		IL_0b9e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0ba3: stloc.s 40
+		IL_0ba5: ldloc.s 40
+		IL_0ba7: ldstr "proxyIntegrityInvariants"
+		IL_0bac: ldloc.s 24
+		IL_0bae: ldloc.s 28
+		IL_0bb0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0bb5: pop
+		IL_0bb6: ldnull
+		IL_0bb7: stloc.s 32
+		IL_0bb9: ret
 	} // end of method Function_CallableReflection_ProxyIntegration::__js_module_init__
 
 } // end of class Modules.Function_CallableReflection_ProxyIntegration

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_NonLiteral_RuntimeError.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_NonLiteral_RuntimeError.verified.txt
@@ -116,7 +116,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 325 (0x145)
+		// Code size: 395 (0x18b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_NonLiteral_RuntimeError/Scope,
@@ -153,7 +153,7 @@
 			IL_002d: ldstr "call-no-error"
 			IL_0032: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_0037: pop
-			IL_0038: leave IL_00a4
+			IL_0038: leave IL_00c7
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -188,84 +188,108 @@
 			IL_0079: ldloc.s 10
 			IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 			IL_0080: stloc.s 10
-			IL_0082: ldloc.s 10
-			IL_0084: ldstr "includes"
-			IL_0089: ldstr "string literal arguments"
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0093: stloc.s 11
-			IL_0095: ldloc.s 9
-			IL_0097: ldloc.s 11
-			IL_0099: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_009e: pop
-			IL_009f: leave IL_00a4
+			IL_0082: ldc.i4.0
+			IL_0083: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0088: brfalse IL_00a5
+
+			IL_008d: ldloc.s 10
+			IL_008f: ldstr "string literal arguments"
+			IL_0094: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_0099: box [System.Runtime]System.Boolean
+			IL_009e: stloc.s 11
+			IL_00a0: br IL_00b8
+
+			IL_00a5: ldloc.s 10
+			IL_00a7: ldstr "includes"
+			IL_00ac: ldstr "string literal arguments"
+			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00b6: stloc.s 11
+
+			IL_00b8: ldloc.s 9
+			IL_00ba: ldloc.s 11
+			IL_00bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00c1: pop
+			IL_00c2: leave IL_00c7
 		} // end handler
 		.try
 		{
-			IL_00a4: nop
-			IL_00a5: ldstr "Function"
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00af: stloc.s 11
-			IL_00b1: ldloc.s 11
-			IL_00b3: dup
-			IL_00b4: ldloc.1
-			IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-			IL_00ba: pop
-			IL_00bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00c0: stloc.s 9
-			IL_00c2: ldloc.s 9
-			IL_00c4: ldstr "new-no-error"
-			IL_00c9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00ce: pop
-			IL_00cf: leave IL_0141
+			IL_00c7: nop
+			IL_00c8: ldstr "Function"
+			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00d2: stloc.s 11
+			IL_00d4: ldloc.s 11
+			IL_00d6: dup
+			IL_00d7: ldloc.1
+			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+			IL_00dd: pop
+			IL_00de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00e3: stloc.s 9
+			IL_00e5: ldloc.s 9
+			IL_00e7: ldstr "new-no-error"
+			IL_00ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00f1: pop
+			IL_00f2: leave IL_0187
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_00d4: stloc.s 5
-			IL_00d6: ldloc.s 5
-			IL_00d8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_00dd: dup
-			IL_00de: brtrue IL_00f4
+			IL_00f7: stloc.s 5
+			IL_00f9: ldloc.s 5
+			IL_00fb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0100: dup
+			IL_0101: brtrue IL_0117
 
-			IL_00e3: pop
-			IL_00e4: ldloc.s 5
-			IL_00e6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_00eb: dup
-			IL_00ec: brtrue IL_0100
+			IL_0106: pop
+			IL_0107: ldloc.s 5
+			IL_0109: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_010e: dup
+			IL_010f: brtrue IL_0123
 
-			IL_00f1: pop
-			IL_00f2: rethrow
+			IL_0114: pop
+			IL_0115: rethrow
 
-			IL_00f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_00f9: stloc.s 6
-			IL_00fb: br IL_0102
+			IL_0117: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_011c: stloc.s 6
+			IL_011e: br IL_0125
 
-			IL_0100: stloc.s 6
+			IL_0123: stloc.s 6
 
-			IL_0102: ldloc.s 6
-			IL_0104: stloc.s 7
-			IL_0106: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_010b: stloc.s 9
-			IL_010d: ldloc.s 7
-			IL_010f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0114: stloc.s 10
-			IL_0116: ldloc.s 10
-			IL_0118: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_011d: stloc.s 10
-			IL_011f: ldloc.s 10
-			IL_0121: ldstr "includes"
-			IL_0126: ldstr "string literal arguments"
-			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0130: stloc.s 11
-			IL_0132: ldloc.s 9
-			IL_0134: ldloc.s 11
-			IL_0136: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_013b: pop
-			IL_013c: leave IL_0141
+			IL_0125: ldloc.s 6
+			IL_0127: stloc.s 7
+			IL_0129: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_012e: stloc.s 9
+			IL_0130: ldloc.s 7
+			IL_0132: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0137: stloc.s 10
+			IL_0139: ldloc.s 10
+			IL_013b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0140: stloc.s 10
+			IL_0142: ldc.i4.0
+			IL_0143: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0148: brfalse IL_0165
+
+			IL_014d: ldloc.s 10
+			IL_014f: ldstr "string literal arguments"
+			IL_0154: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_0159: box [System.Runtime]System.Boolean
+			IL_015e: stloc.s 11
+			IL_0160: br IL_0178
+
+			IL_0165: ldloc.s 10
+			IL_0167: ldstr "includes"
+			IL_016c: ldstr "string literal arguments"
+			IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0176: stloc.s 11
+
+			IL_0178: ldloc.s 9
+			IL_017a: ldloc.s 11
+			IL_017c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0181: pop
+			IL_0182: leave IL_0187
 		} // end handler
 
-		IL_0141: ldnull
-		IL_0142: stloc.s 8
-		IL_0144: ret
+		IL_0187: ldnull
+		IL_0188: stloc.s 8
+		IL_018a: ret
 	} // end of method Function_Constructor_NonLiteral_RuntimeError::__js_module_init__
 
 } // end of class Modules.Function_Constructor_NonLiteral_RuntimeError

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_SyntaxError.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_SyntaxError.verified.txt
@@ -78,7 +78,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 220 (0xdc)
+		// Code size: 255 (0xff)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_SyntaxError/Scope,
@@ -122,7 +122,7 @@
 			IL_0034: ldstr "no-error"
 			IL_0039: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_003e: pop
-			IL_003f: leave IL_00d8
+			IL_003f: leave IL_00fb
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -157,36 +157,48 @@
 			IL_007e: ldloc.s 4
 			IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 			IL_0085: stloc.s 8
-			IL_0087: ldloc.s 8
-			IL_0089: ldstr "includes"
-			IL_008e: ldstr "SyntaxError"
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0098: stloc.s 9
-			IL_009a: ldloc.s 7
-			IL_009c: ldloc.s 9
-			IL_009e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00a3: pop
-			IL_00a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00a9: stloc.s 7
-			IL_00ab: ldloc.s 4
-			IL_00ad: callvirt instance int32 [System.Runtime]System.String::get_Length()
-			IL_00b2: conv.r8
-			IL_00b3: ldc.r8 0.0
-			IL_00bc: cgt
-			IL_00be: stloc.s 10
-			IL_00c0: ldloc.s 10
-			IL_00c2: box [System.Runtime]System.Boolean
-			IL_00c7: stloc.s 11
-			IL_00c9: ldloc.s 7
-			IL_00cb: ldloc.s 11
-			IL_00cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00d2: pop
-			IL_00d3: leave IL_00d8
+			IL_0087: ldc.i4.0
+			IL_0088: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_008d: brfalse IL_00aa
+
+			IL_0092: ldloc.s 8
+			IL_0094: ldstr "SyntaxError"
+			IL_0099: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_009e: box [System.Runtime]System.Boolean
+			IL_00a3: stloc.s 9
+			IL_00a5: br IL_00bd
+
+			IL_00aa: ldloc.s 8
+			IL_00ac: ldstr "includes"
+			IL_00b1: ldstr "SyntaxError"
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00bb: stloc.s 9
+
+			IL_00bd: ldloc.s 7
+			IL_00bf: ldloc.s 9
+			IL_00c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00c6: pop
+			IL_00c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00cc: stloc.s 7
+			IL_00ce: ldloc.s 4
+			IL_00d0: callvirt instance int32 [System.Runtime]System.String::get_Length()
+			IL_00d5: conv.r8
+			IL_00d6: ldc.r8 0.0
+			IL_00df: cgt
+			IL_00e1: stloc.s 10
+			IL_00e3: ldloc.s 10
+			IL_00e5: box [System.Runtime]System.Boolean
+			IL_00ea: stloc.s 11
+			IL_00ec: ldloc.s 7
+			IL_00ee: ldloc.s 11
+			IL_00f0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00f5: pop
+			IL_00f6: leave IL_00fb
 		} // end handler
 
-		IL_00d8: ldnull
-		IL_00d9: stloc.s 5
-		IL_00db: ret
+		IL_00fb: ldnull
+		IL_00fc: stloc.s 5
+		IL_00fe: ret
 	} // end of method Function_Constructor_SyntaxError::__js_module_init__
 
 } // end of class Modules.Function_Constructor_SyntaxError

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ExplicitReceiverAbi.verified.txt
@@ -771,7 +771,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2265 (0x8d9)
+		// Code size: 2316 (0x90c)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Function_ExplicitReceiverAbi/Scope,
@@ -1075,478 +1075,498 @@
 		IL_03c8: stloc.s 26
 		IL_03ca: ldloc.s 26
 		IL_03cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03d1: ldstr "indexOf"
-		IL_03d6: ldstr "function"
-		IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03e0: stloc.s 26
-		IL_03e2: ldloc.s 26
-		IL_03e4: ldc.r8 0.0
-		IL_03ed: box [System.Runtime]System.Double
-		IL_03f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_03f7: stloc.s 27
-		IL_03f9: ldloc.s 27
-		IL_03fb: box [System.Runtime]System.Boolean
-		IL_0400: stloc.s 28
-		IL_0402: ldloc.s 23
-		IL_0404: ldloc.s 28
-		IL_0406: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_040b: pop
+		IL_03d1: stloc.s 26
+		IL_03d3: ldc.i4.0
+		IL_03d4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_03d9: brfalse IL_0402
+
+		IL_03de: ldloc.s 26
+		IL_03e0: isinst [System.Runtime]System.String
+		IL_03e5: dup
+		IL_03e6: brfalse IL_0401
+
+		IL_03eb: ldstr "function"
+		IL_03f0: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_03f5: box [System.Runtime]System.Double
+		IL_03fa: stloc.s 26
+		IL_03fc: br IL_0415
+
+		IL_0401: pop
+
+		IL_0402: ldloc.s 26
+		IL_0404: ldstr "indexOf"
+		IL_0409: ldstr "function"
+		IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0413: stloc.s 26
+
+		IL_0415: ldloc.s 26
+		IL_0417: ldc.r8 0.0
+		IL_0420: box [System.Runtime]System.Double
+		IL_0425: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_042a: stloc.s 27
+		IL_042c: ldloc.s 27
+		IL_042e: box [System.Runtime]System.Boolean
+		IL_0433: stloc.s 28
+		IL_0435: ldloc.s 23
+		IL_0437: ldloc.s 28
+		IL_0439: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_043e: pop
 		.try
 		{
-			IL_040c: nop
-			IL_040d: ldstr "Function"
-			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0417: ldstr "prototype"
-			IL_041c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0421: stloc.s 26
-			IL_0423: ldloc.s 26
-			IL_0425: ldstr "apply"
-			IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_042f: stloc.s 26
-			IL_0431: ldloc.s 26
-			IL_0433: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0438: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_043d: stloc.s 24
-			IL_043f: ldstr "call"
-			IL_0444: ldloc.s 24
-			IL_0446: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_044b: pop
-			IL_044c: leave IL_04ba
+			IL_043f: nop
+			IL_0440: ldstr "Function"
+			IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_044a: ldstr "prototype"
+			IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0454: stloc.s 26
+			IL_0456: ldloc.s 26
+			IL_0458: ldstr "apply"
+			IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0462: stloc.s 26
+			IL_0464: ldloc.s 26
+			IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_046b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0470: stloc.s 24
+			IL_0472: ldstr "call"
+			IL_0477: ldloc.s 24
+			IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_047e: pop
+			IL_047f: leave IL_04ed
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0451: stloc.3
-			IL_0452: ldloc.3
-			IL_0453: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0458: dup
-			IL_0459: brtrue IL_046e
+			IL_0484: stloc.3
+			IL_0485: ldloc.3
+			IL_0486: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_048b: dup
+			IL_048c: brtrue IL_04a1
 
-			IL_045e: pop
-			IL_045f: ldloc.3
-			IL_0460: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0465: dup
-			IL_0466: brtrue IL_047a
+			IL_0491: pop
+			IL_0492: ldloc.3
+			IL_0493: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0498: dup
+			IL_0499: brtrue IL_04ad
 
-			IL_046b: pop
-			IL_046c: rethrow
+			IL_049e: pop
+			IL_049f: rethrow
 
-			IL_046e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0473: stloc.s 4
-			IL_0475: br IL_047c
+			IL_04a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_04a6: stloc.s 4
+			IL_04a8: br IL_04af
 
-			IL_047a: stloc.s 4
+			IL_04ad: stloc.s 4
 
-			IL_047c: ldloc.s 4
-			IL_047e: stloc.s 5
-			IL_0480: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0485: stloc.s 23
-			IL_0487: ldloc.s 5
-			IL_0489: stloc.s 26
-			IL_048b: ldstr "TypeError"
-			IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0495: stloc.s 29
-			IL_0497: ldloc.s 26
-			IL_0499: ldloc.s 29
-			IL_049b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_04a0: stloc.s 27
-			IL_04a2: ldloc.s 27
-			IL_04a4: box [System.Runtime]System.Boolean
-			IL_04a9: stloc.s 28
-			IL_04ab: ldloc.s 23
-			IL_04ad: ldloc.s 28
-			IL_04af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04b4: pop
-			IL_04b5: leave IL_04ba
+			IL_04af: ldloc.s 4
+			IL_04b1: stloc.s 5
+			IL_04b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04b8: stloc.s 23
+			IL_04ba: ldloc.s 5
+			IL_04bc: stloc.s 26
+			IL_04be: ldstr "TypeError"
+			IL_04c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04c8: stloc.s 29
+			IL_04ca: ldloc.s 26
+			IL_04cc: ldloc.s 29
+			IL_04ce: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_04d3: stloc.s 27
+			IL_04d5: ldloc.s 27
+			IL_04d7: box [System.Runtime]System.Boolean
+			IL_04dc: stloc.s 28
+			IL_04de: ldloc.s 23
+			IL_04e0: ldloc.s 28
+			IL_04e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04e7: pop
+			IL_04e8: leave IL_04ed
 		} // end handler
 		.try
 		{
-			IL_04ba: nop
-			IL_04bb: ldstr "Function"
-			IL_04c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04c5: ldstr "prototype"
-			IL_04ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04cf: stloc.s 29
-			IL_04d1: ldloc.s 29
-			IL_04d3: ldstr "call"
-			IL_04d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04dd: stloc.s 29
-			IL_04df: ldloc.s 29
-			IL_04e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04e6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_04eb: stloc.s 24
-			IL_04ed: ldstr "call"
-			IL_04f2: ldloc.s 24
-			IL_04f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_04f9: pop
-			IL_04fa: leave IL_056b
+			IL_04ed: nop
+			IL_04ee: ldstr "Function"
+			IL_04f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04f8: ldstr "prototype"
+			IL_04fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0502: stloc.s 29
+			IL_0504: ldloc.s 29
+			IL_0506: ldstr "call"
+			IL_050b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0510: stloc.s 29
+			IL_0512: ldloc.s 29
+			IL_0514: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0519: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_051e: stloc.s 24
+			IL_0520: ldstr "call"
+			IL_0525: ldloc.s 24
+			IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_052c: pop
+			IL_052d: leave IL_059e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_04ff: stloc.s 6
-			IL_0501: ldloc.s 6
-			IL_0503: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0508: dup
-			IL_0509: brtrue IL_051f
+			IL_0532: stloc.s 6
+			IL_0534: ldloc.s 6
+			IL_0536: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_053b: dup
+			IL_053c: brtrue IL_0552
 
-			IL_050e: pop
-			IL_050f: ldloc.s 6
-			IL_0511: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0516: dup
-			IL_0517: brtrue IL_052b
+			IL_0541: pop
+			IL_0542: ldloc.s 6
+			IL_0544: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0549: dup
+			IL_054a: brtrue IL_055e
 
-			IL_051c: pop
-			IL_051d: rethrow
+			IL_054f: pop
+			IL_0550: rethrow
 
-			IL_051f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0524: stloc.s 7
-			IL_0526: br IL_052d
+			IL_0552: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0557: stloc.s 7
+			IL_0559: br IL_0560
 
-			IL_052b: stloc.s 7
+			IL_055e: stloc.s 7
 
-			IL_052d: ldloc.s 7
-			IL_052f: stloc.s 8
-			IL_0531: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0536: stloc.s 23
-			IL_0538: ldloc.s 8
-			IL_053a: stloc.s 29
-			IL_053c: ldstr "TypeError"
-			IL_0541: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0546: stloc.s 26
-			IL_0548: ldloc.s 29
-			IL_054a: ldloc.s 26
-			IL_054c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0551: stloc.s 27
-			IL_0553: ldloc.s 27
-			IL_0555: box [System.Runtime]System.Boolean
-			IL_055a: stloc.s 28
-			IL_055c: ldloc.s 23
-			IL_055e: ldloc.s 28
-			IL_0560: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0565: pop
-			IL_0566: leave IL_056b
+			IL_0560: ldloc.s 7
+			IL_0562: stloc.s 8
+			IL_0564: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0569: stloc.s 23
+			IL_056b: ldloc.s 8
+			IL_056d: stloc.s 29
+			IL_056f: ldstr "TypeError"
+			IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0579: stloc.s 26
+			IL_057b: ldloc.s 29
+			IL_057d: ldloc.s 26
+			IL_057f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0584: stloc.s 27
+			IL_0586: ldloc.s 27
+			IL_0588: box [System.Runtime]System.Boolean
+			IL_058d: stloc.s 28
+			IL_058f: ldloc.s 23
+			IL_0591: ldloc.s 28
+			IL_0593: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0598: pop
+			IL_0599: leave IL_059e
 		} // end handler
 		.try
 		{
-			IL_056b: nop
-			IL_056c: ldstr "Function"
-			IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0576: ldstr "prototype"
-			IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0580: stloc.s 26
-			IL_0582: ldloc.s 26
-			IL_0584: ldstr "bind"
-			IL_0589: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_058e: stloc.s 26
-			IL_0590: ldloc.s 26
-			IL_0592: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0597: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_059c: stloc.s 24
-			IL_059e: ldstr "call"
-			IL_05a3: ldloc.s 24
-			IL_05a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_05aa: pop
-			IL_05ab: leave IL_061c
+			IL_059e: nop
+			IL_059f: ldstr "Function"
+			IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05a9: ldstr "prototype"
+			IL_05ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05b3: stloc.s 26
+			IL_05b5: ldloc.s 26
+			IL_05b7: ldstr "bind"
+			IL_05bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05c1: stloc.s 26
+			IL_05c3: ldloc.s 26
+			IL_05c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05ca: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05cf: stloc.s 24
+			IL_05d1: ldstr "call"
+			IL_05d6: ldloc.s 24
+			IL_05d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_05dd: pop
+			IL_05de: leave IL_064f
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_05b0: stloc.s 9
-			IL_05b2: ldloc.s 9
-			IL_05b4: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_05b9: dup
-			IL_05ba: brtrue IL_05d0
+			IL_05e3: stloc.s 9
+			IL_05e5: ldloc.s 9
+			IL_05e7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_05ec: dup
+			IL_05ed: brtrue IL_0603
 
-			IL_05bf: pop
-			IL_05c0: ldloc.s 9
-			IL_05c2: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_05c7: dup
-			IL_05c8: brtrue IL_05dc
+			IL_05f2: pop
+			IL_05f3: ldloc.s 9
+			IL_05f5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_05fa: dup
+			IL_05fb: brtrue IL_060f
 
-			IL_05cd: pop
-			IL_05ce: rethrow
+			IL_0600: pop
+			IL_0601: rethrow
 
-			IL_05d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_05d5: stloc.s 10
-			IL_05d7: br IL_05de
+			IL_0603: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0608: stloc.s 10
+			IL_060a: br IL_0611
 
-			IL_05dc: stloc.s 10
+			IL_060f: stloc.s 10
 
-			IL_05de: ldloc.s 10
-			IL_05e0: stloc.s 11
-			IL_05e2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_05e7: stloc.s 23
-			IL_05e9: ldloc.s 11
-			IL_05eb: stloc.s 26
-			IL_05ed: ldstr "TypeError"
-			IL_05f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05f7: stloc.s 29
-			IL_05f9: ldloc.s 26
-			IL_05fb: ldloc.s 29
-			IL_05fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0602: stloc.s 27
-			IL_0604: ldloc.s 27
-			IL_0606: box [System.Runtime]System.Boolean
-			IL_060b: stloc.s 28
-			IL_060d: ldloc.s 23
-			IL_060f: ldloc.s 28
-			IL_0611: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0616: pop
-			IL_0617: leave IL_061c
+			IL_0611: ldloc.s 10
+			IL_0613: stloc.s 11
+			IL_0615: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_061a: stloc.s 23
+			IL_061c: ldloc.s 11
+			IL_061e: stloc.s 26
+			IL_0620: ldstr "TypeError"
+			IL_0625: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_062a: stloc.s 29
+			IL_062c: ldloc.s 26
+			IL_062e: ldloc.s 29
+			IL_0630: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0635: stloc.s 27
+			IL_0637: ldloc.s 27
+			IL_0639: box [System.Runtime]System.Boolean
+			IL_063e: stloc.s 28
+			IL_0640: ldloc.s 23
+			IL_0642: ldloc.s 28
+			IL_0644: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0649: pop
+			IL_064a: leave IL_064f
 		} // end handler
 		.try
 		{
-			IL_061c: nop
-			IL_061d: ldstr "Function"
-			IL_0622: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0627: ldstr "prototype"
-			IL_062c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0631: stloc.s 29
-			IL_0633: ldloc.s 29
-			IL_0635: ldstr "toString"
-			IL_063a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_063f: stloc.s 29
-			IL_0641: ldloc.s 29
-			IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0648: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_064d: stloc.s 24
-			IL_064f: ldstr "call"
-			IL_0654: ldloc.s 24
-			IL_0656: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_065b: pop
-			IL_065c: leave IL_06cd
+			IL_064f: nop
+			IL_0650: ldstr "Function"
+			IL_0655: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_065a: ldstr "prototype"
+			IL_065f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0664: stloc.s 29
+			IL_0666: ldloc.s 29
+			IL_0668: ldstr "toString"
+			IL_066d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0672: stloc.s 29
+			IL_0674: ldloc.s 29
+			IL_0676: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_067b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0680: stloc.s 24
+			IL_0682: ldstr "call"
+			IL_0687: ldloc.s 24
+			IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_068e: pop
+			IL_068f: leave IL_0700
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0661: stloc.s 12
-			IL_0663: ldloc.s 12
-			IL_0665: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_066a: dup
-			IL_066b: brtrue IL_0681
+			IL_0694: stloc.s 12
+			IL_0696: ldloc.s 12
+			IL_0698: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_069d: dup
+			IL_069e: brtrue IL_06b4
 
-			IL_0670: pop
-			IL_0671: ldloc.s 12
-			IL_0673: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0678: dup
-			IL_0679: brtrue IL_068d
+			IL_06a3: pop
+			IL_06a4: ldloc.s 12
+			IL_06a6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_06ab: dup
+			IL_06ac: brtrue IL_06c0
 
-			IL_067e: pop
-			IL_067f: rethrow
+			IL_06b1: pop
+			IL_06b2: rethrow
 
-			IL_0681: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0686: stloc.s 13
-			IL_0688: br IL_068f
+			IL_06b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_06b9: stloc.s 13
+			IL_06bb: br IL_06c2
 
-			IL_068d: stloc.s 13
+			IL_06c0: stloc.s 13
 
-			IL_068f: ldloc.s 13
-			IL_0691: stloc.s 14
-			IL_0693: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0698: stloc.s 23
-			IL_069a: ldloc.s 14
-			IL_069c: stloc.s 29
-			IL_069e: ldstr "TypeError"
-			IL_06a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06a8: stloc.s 26
-			IL_06aa: ldloc.s 29
-			IL_06ac: ldloc.s 26
-			IL_06ae: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_06b3: stloc.s 27
-			IL_06b5: ldloc.s 27
-			IL_06b7: box [System.Runtime]System.Boolean
-			IL_06bc: stloc.s 28
-			IL_06be: ldloc.s 23
-			IL_06c0: ldloc.s 28
-			IL_06c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06c7: pop
-			IL_06c8: leave IL_06cd
+			IL_06c2: ldloc.s 13
+			IL_06c4: stloc.s 14
+			IL_06c6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06cb: stloc.s 23
+			IL_06cd: ldloc.s 14
+			IL_06cf: stloc.s 29
+			IL_06d1: ldstr "TypeError"
+			IL_06d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06db: stloc.s 26
+			IL_06dd: ldloc.s 29
+			IL_06df: ldloc.s 26
+			IL_06e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_06e6: stloc.s 27
+			IL_06e8: ldloc.s 27
+			IL_06ea: box [System.Runtime]System.Boolean
+			IL_06ef: stloc.s 28
+			IL_06f1: ldloc.s 23
+			IL_06f3: ldloc.s 28
+			IL_06f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_06fa: pop
+			IL_06fb: leave IL_0700
 		} // end handler
 		.try
 		{
-			IL_06cd: nop
-			IL_06ce: ldloc.1
-			IL_06cf: ldstr "caller"
-			IL_06d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_06d9: pop
-			IL_06da: leave IL_074b
+			IL_0700: nop
+			IL_0701: ldloc.1
+			IL_0702: ldstr "caller"
+			IL_0707: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_070c: pop
+			IL_070d: leave IL_077e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_06df: stloc.s 15
-			IL_06e1: ldloc.s 15
-			IL_06e3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_06e8: dup
-			IL_06e9: brtrue IL_06ff
+			IL_0712: stloc.s 15
+			IL_0714: ldloc.s 15
+			IL_0716: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_071b: dup
+			IL_071c: brtrue IL_0732
 
-			IL_06ee: pop
-			IL_06ef: ldloc.s 15
-			IL_06f1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_06f6: dup
-			IL_06f7: brtrue IL_070b
+			IL_0721: pop
+			IL_0722: ldloc.s 15
+			IL_0724: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0729: dup
+			IL_072a: brtrue IL_073e
 
-			IL_06fc: pop
-			IL_06fd: rethrow
+			IL_072f: pop
+			IL_0730: rethrow
 
-			IL_06ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0704: stloc.s 16
-			IL_0706: br IL_070d
+			IL_0732: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0737: stloc.s 16
+			IL_0739: br IL_0740
 
-			IL_070b: stloc.s 16
+			IL_073e: stloc.s 16
 
-			IL_070d: ldloc.s 16
-			IL_070f: stloc.s 17
-			IL_0711: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0716: stloc.s 23
-			IL_0718: ldloc.s 17
-			IL_071a: stloc.s 26
-			IL_071c: ldstr "TypeError"
-			IL_0721: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0726: stloc.s 29
-			IL_0728: ldloc.s 26
-			IL_072a: ldloc.s 29
-			IL_072c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0731: stloc.s 27
-			IL_0733: ldloc.s 27
-			IL_0735: box [System.Runtime]System.Boolean
-			IL_073a: stloc.s 28
-			IL_073c: ldloc.s 23
-			IL_073e: ldloc.s 28
-			IL_0740: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0745: pop
-			IL_0746: leave IL_074b
+			IL_0740: ldloc.s 16
+			IL_0742: stloc.s 17
+			IL_0744: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0749: stloc.s 23
+			IL_074b: ldloc.s 17
+			IL_074d: stloc.s 26
+			IL_074f: ldstr "TypeError"
+			IL_0754: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0759: stloc.s 29
+			IL_075b: ldloc.s 26
+			IL_075d: ldloc.s 29
+			IL_075f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0764: stloc.s 27
+			IL_0766: ldloc.s 27
+			IL_0768: box [System.Runtime]System.Boolean
+			IL_076d: stloc.s 28
+			IL_076f: ldloc.s 23
+			IL_0771: ldloc.s 28
+			IL_0773: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0778: pop
+			IL_0779: leave IL_077e
 		} // end handler
 		.try
 		{
-			IL_074b: nop
-			IL_074c: ldloc.1
-			IL_074d: ldstr "arguments"
-			IL_0752: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0757: pop
-			IL_0758: leave IL_07c9
+			IL_077e: nop
+			IL_077f: ldloc.1
+			IL_0780: ldstr "arguments"
+			IL_0785: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_078a: pop
+			IL_078b: leave IL_07fc
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_075d: stloc.s 18
-			IL_075f: ldloc.s 18
-			IL_0761: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0766: dup
-			IL_0767: brtrue IL_077d
+			IL_0790: stloc.s 18
+			IL_0792: ldloc.s 18
+			IL_0794: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0799: dup
+			IL_079a: brtrue IL_07b0
 
-			IL_076c: pop
-			IL_076d: ldloc.s 18
-			IL_076f: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0774: dup
-			IL_0775: brtrue IL_0789
+			IL_079f: pop
+			IL_07a0: ldloc.s 18
+			IL_07a2: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_07a7: dup
+			IL_07a8: brtrue IL_07bc
 
-			IL_077a: pop
-			IL_077b: rethrow
+			IL_07ad: pop
+			IL_07ae: rethrow
 
-			IL_077d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0782: stloc.s 19
-			IL_0784: br IL_078b
+			IL_07b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_07b5: stloc.s 19
+			IL_07b7: br IL_07be
 
-			IL_0789: stloc.s 19
+			IL_07bc: stloc.s 19
 
-			IL_078b: ldloc.s 19
-			IL_078d: stloc.s 20
-			IL_078f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0794: stloc.s 23
-			IL_0796: ldloc.s 20
-			IL_0798: stloc.s 29
-			IL_079a: ldstr "TypeError"
-			IL_079f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07a4: stloc.s 26
-			IL_07a6: ldloc.s 29
-			IL_07a8: ldloc.s 26
-			IL_07aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_07af: stloc.s 27
-			IL_07b1: ldloc.s 27
-			IL_07b3: box [System.Runtime]System.Boolean
-			IL_07b8: stloc.s 28
-			IL_07ba: ldloc.s 23
-			IL_07bc: ldloc.s 28
-			IL_07be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_07c3: pop
-			IL_07c4: leave IL_07c9
+			IL_07be: ldloc.s 19
+			IL_07c0: stloc.s 20
+			IL_07c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07c7: stloc.s 23
+			IL_07c9: ldloc.s 20
+			IL_07cb: stloc.s 29
+			IL_07cd: ldstr "TypeError"
+			IL_07d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07d7: stloc.s 26
+			IL_07d9: ldloc.s 29
+			IL_07db: ldloc.s 26
+			IL_07dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_07e2: stloc.s 27
+			IL_07e4: ldloc.s 27
+			IL_07e6: box [System.Runtime]System.Boolean
+			IL_07eb: stloc.s 28
+			IL_07ed: ldloc.s 23
+			IL_07ef: ldloc.s 28
+			IL_07f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_07f6: pop
+			IL_07f7: leave IL_07fc
 		} // end handler
 
-		IL_07c9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_07ce: stloc.s 23
-		IL_07d0: ldstr "Function"
-		IL_07d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_07da: ldstr "prototype"
-		IL_07df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07e4: stloc.s 26
-		IL_07e6: ldloc.s 26
-		IL_07e8: ldstr "apply"
-		IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_07f2: stloc.s 26
-		IL_07f4: ldloc.s 26
-		IL_07f6: ldstr "length"
-		IL_07fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0800: stloc.s 26
-		IL_0802: ldloc.s 23
-		IL_0804: ldloc.s 26
-		IL_0806: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_080b: pop
-		IL_080c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0811: stloc.s 23
-		IL_0813: ldstr "Function"
-		IL_0818: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_081d: ldstr "prototype"
-		IL_0822: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0827: stloc.s 26
-		IL_0829: ldloc.s 26
-		IL_082b: ldstr "call"
-		IL_0830: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0835: stloc.s 26
+		IL_07fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0801: stloc.s 23
+		IL_0803: ldstr "Function"
+		IL_0808: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_080d: ldstr "prototype"
+		IL_0812: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0817: stloc.s 26
+		IL_0819: ldloc.s 26
+		IL_081b: ldstr "apply"
+		IL_0820: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0825: stloc.s 26
+		IL_0827: ldloc.s 26
+		IL_0829: ldstr "length"
+		IL_082e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0833: stloc.s 26
+		IL_0835: ldloc.s 23
 		IL_0837: ldloc.s 26
-		IL_0839: ldstr "length"
-		IL_083e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0843: stloc.s 26
-		IL_0845: ldloc.s 23
-		IL_0847: ldloc.s 26
-		IL_0849: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_084e: pop
-		IL_084f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0854: stloc.s 23
-		IL_0856: ldstr "Function"
-		IL_085b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0860: ldstr "prototype"
-		IL_0865: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_086a: stloc.s 26
-		IL_086c: ldloc.s 26
-		IL_086e: ldstr "bind"
-		IL_0873: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0878: stloc.s 26
+		IL_0839: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_083e: pop
+		IL_083f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0844: stloc.s 23
+		IL_0846: ldstr "Function"
+		IL_084b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0850: ldstr "prototype"
+		IL_0855: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_085a: stloc.s 26
+		IL_085c: ldloc.s 26
+		IL_085e: ldstr "call"
+		IL_0863: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0868: stloc.s 26
+		IL_086a: ldloc.s 26
+		IL_086c: ldstr "length"
+		IL_0871: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0876: stloc.s 26
+		IL_0878: ldloc.s 23
 		IL_087a: ldloc.s 26
-		IL_087c: ldstr "length"
-		IL_0881: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0886: stloc.s 26
-		IL_0888: ldloc.s 23
-		IL_088a: ldloc.s 26
-		IL_088c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0891: pop
-		IL_0892: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0897: stloc.s 23
-		IL_0899: ldstr "Function"
-		IL_089e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_08a3: ldstr "prototype"
-		IL_08a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08ad: stloc.s 26
-		IL_08af: ldloc.s 26
-		IL_08b1: ldstr "toString"
-		IL_08b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08bb: stloc.s 26
+		IL_087c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0881: pop
+		IL_0882: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0887: stloc.s 23
+		IL_0889: ldstr "Function"
+		IL_088e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0893: ldstr "prototype"
+		IL_0898: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_089d: stloc.s 26
+		IL_089f: ldloc.s 26
+		IL_08a1: ldstr "bind"
+		IL_08a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08ab: stloc.s 26
+		IL_08ad: ldloc.s 26
+		IL_08af: ldstr "length"
+		IL_08b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08b9: stloc.s 26
+		IL_08bb: ldloc.s 23
 		IL_08bd: ldloc.s 26
-		IL_08bf: ldstr "length"
-		IL_08c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08c9: stloc.s 26
-		IL_08cb: ldloc.s 23
-		IL_08cd: ldloc.s 26
-		IL_08cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_08d4: pop
-		IL_08d5: ldnull
-		IL_08d6: stloc.s 21
-		IL_08d8: ret
+		IL_08bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08c4: pop
+		IL_08c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08ca: stloc.s 23
+		IL_08cc: ldstr "Function"
+		IL_08d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08d6: ldstr "prototype"
+		IL_08db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08e0: stloc.s 26
+		IL_08e2: ldloc.s 26
+		IL_08e4: ldstr "toString"
+		IL_08e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08ee: stloc.s 26
+		IL_08f0: ldloc.s 26
+		IL_08f2: ldstr "length"
+		IL_08f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08fc: stloc.s 26
+		IL_08fe: ldloc.s 23
+		IL_0900: ldloc.s 26
+		IL_0902: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0907: pop
+		IL_0908: ldnull
+		IL_0909: stloc.s 21
+		IL_090b: ret
 	} // end of method Function_ExplicitReceiverAbi::__js_module_init__
 
 } // end of class Modules.Function_ExplicitReceiverAbi

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous.verified.txt
@@ -181,7 +181,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 152 (0x98)
+		// Code size: 203 (0xcb)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/Scope,
@@ -230,25 +230,45 @@
 		IL_0054: stloc.s 4
 		IL_0056: ldloc.s 4
 		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005d: ldstr "indexOf"
-		IL_0062: ldstr "DynamicFunction_L12C34"
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006c: stloc.s 4
-		IL_006e: ldloc.s 4
-		IL_0070: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0075: ldc.r8 0.0
-		IL_007e: clt
-		IL_0080: ldc.i4.0
-		IL_0081: ceq
-		IL_0083: stloc.s 5
-		IL_0085: ldloc.s 5
-		IL_0087: box [System.Runtime]System.Boolean
-		IL_008c: stloc.s 6
-		IL_008e: ldloc.3
-		IL_008f: ldloc.s 6
-		IL_0091: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0096: pop
-		IL_0097: ret
+		IL_005d: stloc.s 4
+		IL_005f: ldc.i4.0
+		IL_0060: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0065: brfalse IL_008e
+
+		IL_006a: ldloc.s 4
+		IL_006c: isinst [System.Runtime]System.String
+		IL_0071: dup
+		IL_0072: brfalse IL_008d
+
+		IL_0077: ldstr "DynamicFunction_L12C34"
+		IL_007c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_0081: box [System.Runtime]System.Double
+		IL_0086: stloc.s 4
+		IL_0088: br IL_00a1
+
+		IL_008d: pop
+
+		IL_008e: ldloc.s 4
+		IL_0090: ldstr "indexOf"
+		IL_0095: ldstr "DynamicFunction_L12C34"
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009f: stloc.s 4
+
+		IL_00a1: ldloc.s 4
+		IL_00a3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00a8: ldc.r8 0.0
+		IL_00b1: clt
+		IL_00b3: ldc.i4.0
+		IL_00b4: ceq
+		IL_00b6: stloc.s 5
+		IL_00b8: ldloc.s 5
+		IL_00ba: box [System.Runtime]System.Boolean
+		IL_00bf: stloc.s 6
+		IL_00c1: ldloc.3
+		IL_00c2: ldloc.s 6
+		IL_00c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c9: pop
+		IL_00ca: ret
 	} // end of method Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous::__js_module_init__
 
 } // end of class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ToString_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ToString_Basic.verified.txt
@@ -198,7 +198,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 264 (0x108)
+		// Code size: 366 (0x16e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Prototype_ToString_Basic/Scope,
@@ -259,45 +259,85 @@
 		IL_007c: stloc.s 5
 		IL_007e: ldloc.2
 		IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0084: ldstr "indexOf"
-		IL_0089: ldstr "function"
-		IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0093: stloc.s 4
-		IL_0095: ldloc.s 4
-		IL_0097: ldc.r8 0.0
-		IL_00a0: box [System.Runtime]System.Double
-		IL_00a5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00aa: stloc.s 7
-		IL_00ac: ldloc.s 7
-		IL_00ae: box [System.Runtime]System.Boolean
-		IL_00b3: stloc.s 8
-		IL_00b5: ldloc.s 5
-		IL_00b7: ldloc.s 8
-		IL_00b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00be: pop
-		IL_00bf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c4: stloc.s 5
-		IL_00c6: ldloc.2
-		IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cc: ldstr "indexOf"
-		IL_00d1: ldstr "[native code]"
-		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00db: stloc.s 4
-		IL_00dd: ldloc.s 4
-		IL_00df: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_00e4: ldc.r8 0.0
-		IL_00ed: clt
-		IL_00ef: ldc.i4.0
-		IL_00f0: ceq
-		IL_00f2: stloc.s 7
-		IL_00f4: ldloc.s 7
-		IL_00f6: box [System.Runtime]System.Boolean
-		IL_00fb: stloc.s 8
-		IL_00fd: ldloc.s 5
-		IL_00ff: ldloc.s 8
-		IL_0101: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0106: pop
-		IL_0107: ret
+		IL_0084: stloc.s 4
+		IL_0086: ldc.i4.0
+		IL_0087: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_008c: brfalse IL_00b5
+
+		IL_0091: ldloc.s 4
+		IL_0093: isinst [System.Runtime]System.String
+		IL_0098: dup
+		IL_0099: brfalse IL_00b4
+
+		IL_009e: ldstr "function"
+		IL_00a3: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_00a8: box [System.Runtime]System.Double
+		IL_00ad: stloc.s 4
+		IL_00af: br IL_00c8
+
+		IL_00b4: pop
+
+		IL_00b5: ldloc.s 4
+		IL_00b7: ldstr "indexOf"
+		IL_00bc: ldstr "function"
+		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00c6: stloc.s 4
+
+		IL_00c8: ldloc.s 4
+		IL_00ca: ldc.r8 0.0
+		IL_00d3: box [System.Runtime]System.Double
+		IL_00d8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00dd: stloc.s 7
+		IL_00df: ldloc.s 7
+		IL_00e1: box [System.Runtime]System.Boolean
+		IL_00e6: stloc.s 8
+		IL_00e8: ldloc.s 5
+		IL_00ea: ldloc.s 8
+		IL_00ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f1: pop
+		IL_00f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f7: stloc.s 5
+		IL_00f9: ldloc.2
+		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00ff: stloc.s 4
+		IL_0101: ldc.i4.0
+		IL_0102: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0107: brfalse IL_0130
+
+		IL_010c: ldloc.s 4
+		IL_010e: isinst [System.Runtime]System.String
+		IL_0113: dup
+		IL_0114: brfalse IL_012f
+
+		IL_0119: ldstr "[native code]"
+		IL_011e: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_0123: box [System.Runtime]System.Double
+		IL_0128: stloc.s 4
+		IL_012a: br IL_0143
+
+		IL_012f: pop
+
+		IL_0130: ldloc.s 4
+		IL_0132: ldstr "indexOf"
+		IL_0137: ldstr "[native code]"
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0141: stloc.s 4
+
+		IL_0143: ldloc.s 4
+		IL_0145: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_014a: ldc.r8 0.0
+		IL_0153: clt
+		IL_0155: ldc.i4.0
+		IL_0156: ceq
+		IL_0158: stloc.s 7
+		IL_015a: ldloc.s 7
+		IL_015c: box [System.Runtime]System.Boolean
+		IL_0161: stloc.s 8
+		IL_0163: ldloc.s 5
+		IL_0165: ldloc.s 8
+		IL_0167: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_016c: pop
+		IL_016d: ret
 	} // end of method Function_Prototype_ToString_Basic::__js_module_init__
 
 } // end of class Modules.Function_Prototype_ToString_Basic

--- a/tests/Jroc.Tests/Hosting/JavaScript/stringGuardRealmIsolation.js
+++ b/tests/Jroc.Tests/Hosting/JavaScript/stringGuardRealmIsolation.js
@@ -1,0 +1,11 @@
+"use strict";
+
+exports.callTrim = function (value) {
+    return value.trim();
+};
+
+exports.overrideTrim = function (result) {
+    String.prototype.trim = function () {
+        return result;
+    };
+};

--- a/tests/Jroc.Tests/Hosting/ModuleLoadTests.cs
+++ b/tests/Jroc.Tests/Hosting/ModuleLoadTests.cs
@@ -244,6 +244,32 @@ public class ModuleLoadTests
     }
 
     [Fact]
+    public void JsEngine_GuardedStringIntrinsicsRespectRealmPrototypeIsolation()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource(
+            "stringGuardRealmIsolation",
+            "stringGuardRealmIsolation.js");
+        using var first = JsEngine.LoadDynamicModule(
+            module.Assembly,
+            "stringGuardRealmIsolation");
+        using var second = JsEngine.LoadDynamicModule(
+            module.Assembly,
+            "stringGuardRealmIsolation");
+        dynamic firstExports = first;
+        dynamic secondExports = second;
+
+        Assert.Equal("first", (string)firstExports.callTrim("  first  "));
+        Assert.Equal("second", (string)secondExports.callTrim("  second  "));
+
+        firstExports.overrideTrim("first-override");
+
+        Assert.Equal(
+            "first-override",
+            (string)firstExports.callTrim("  first  "));
+        Assert.Equal("second", (string)secondExports.callTrim("  second  "));
+    }
+
+    [Fact]
     public void JsEngine_LoadModule_Dynamic_AllowsMutatingExportsObject()
     {
         using var module = CompileAndLoadModuleAssemblyFromResource("hostingMutable", "Hosting_TypedExports.js");

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
@@ -44,7 +44,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 846 (0x34e)
+		// Code size: 1050 (0x41a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ImportMeta_Url/Scope,
@@ -199,123 +199,203 @@
 		IL_01bf: stloc.s 6
 		IL_01c1: ldloc.s 6
 		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01c8: ldstr "startsWith"
-		IL_01cd: ldstr "file://"
-		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d7: stloc.s 6
-		IL_01d9: ldloc.s 8
-		IL_01db: ldstr "main has file url:"
-		IL_01e0: ldloc.s 6
-		IL_01e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01e7: pop
-		IL_01e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01ed: stloc.s 8
-		IL_01ef: ldarg.3
-		IL_01f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01f5: ldstr "split"
-		IL_01fa: ldstr "\\"
-		IL_01ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0204: stloc.s 6
-		IL_0206: ldloc.s 6
-		IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_020d: ldstr "join"
-		IL_0212: ldstr "/"
-		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_021c: stloc.s 6
-		IL_021e: ldloc.2
-		IL_021f: ldloc.s 6
-		IL_0221: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0226: stloc.s 9
-		IL_0228: ldloc.s 9
-		IL_022a: box [System.Runtime]System.Boolean
-		IL_022f: stloc.s 10
-		IL_0231: ldloc.s 8
-		IL_0233: ldstr "main path matches filename:"
-		IL_0238: ldloc.s 10
-		IL_023a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_023f: pop
-		IL_0240: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0245: stloc.s 8
-		IL_0247: ldloc.3
-		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_024d: ldstr "endsWith"
-		IL_0252: ldstr "/fixtures/main.txt"
-		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_025c: stloc.s 6
-		IL_025e: ldloc.s 8
-		IL_0260: ldstr "main asset path:"
-		IL_0265: ldloc.s 6
-		IL_0267: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_026c: pop
-		IL_026d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0272: stloc.s 8
-		IL_0274: ldloc.0
-		IL_0275: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
-		IL_027a: stloc.s 6
-		IL_027c: ldloc.s 6
-		IL_027e: ldstr "importedUrlHasFileScheme"
-		IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
-		IL_0288: stloc.s 6
-		IL_028a: ldloc.s 8
-		IL_028c: ldstr "lib has file url:"
-		IL_0291: ldloc.s 6
-		IL_0293: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0298: pop
-		IL_0299: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_029e: stloc.s 8
-		IL_02a0: ldloc.s 4
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02a7: ldstr "endsWith"
-		IL_02ac: ldstr "/Import_ImportMeta_Url_Lib"
-		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b6: stloc.s 6
-		IL_02b8: ldloc.s 8
-		IL_02ba: ldstr "lib path:"
-		IL_02bf: ldloc.s 6
-		IL_02c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02c6: pop
-		IL_02c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02cc: stloc.s 8
-		IL_02ce: ldloc.s 5
-		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_02d5: ldstr "endsWith"
-		IL_02da: ldstr "/fixtures/lib.txt"
-		IL_02df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02e4: stloc.s 6
-		IL_02e6: ldloc.s 8
-		IL_02e8: ldstr "lib asset path:"
-		IL_02ed: ldloc.s 6
-		IL_02ef: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02f4: pop
-		IL_02f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02fa: stloc.s 8
-		IL_02fc: ldloc.0
-		IL_02fd: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
-		IL_0302: stloc.s 6
-		IL_0304: ldloc.s 6
-		IL_0306: ldstr "importedModuleFilenameMatches"
-		IL_030b: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
-		IL_0310: stloc.s 6
-		IL_0312: ldloc.s 8
-		IL_0314: ldstr "lib module.filename:"
-		IL_0319: ldloc.s 6
-		IL_031b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0320: pop
-		IL_0321: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0326: stloc.s 8
-		IL_0328: ldloc.0
-		IL_0329: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
-		IL_032e: stloc.s 6
-		IL_0330: ldloc.s 6
-		IL_0332: ldstr "importedModulePathMatches"
-		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
-		IL_033c: stloc.s 6
-		IL_033e: ldloc.s 8
-		IL_0340: ldstr "lib module.path:"
-		IL_0345: ldloc.s 6
-		IL_0347: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_034c: pop
-		IL_034d: ret
+		IL_01c8: stloc.s 6
+		IL_01ca: ldc.i4.0
+		IL_01cb: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_01d0: brfalse IL_01f9
+
+		IL_01d5: ldloc.s 6
+		IL_01d7: isinst [System.Runtime]System.String
+		IL_01dc: dup
+		IL_01dd: brfalse IL_01f8
+
+		IL_01e2: ldstr "file://"
+		IL_01e7: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+		IL_01ec: box [System.Runtime]System.Boolean
+		IL_01f1: stloc.s 6
+		IL_01f3: br IL_020c
+
+		IL_01f8: pop
+
+		IL_01f9: ldloc.s 6
+		IL_01fb: ldstr "startsWith"
+		IL_0200: ldstr "file://"
+		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_020a: stloc.s 6
+
+		IL_020c: ldloc.s 8
+		IL_020e: ldstr "main has file url:"
+		IL_0213: ldloc.s 6
+		IL_0215: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_021a: pop
+		IL_021b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0220: stloc.s 8
+		IL_0222: ldarg.3
+		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0228: ldstr "split"
+		IL_022d: ldstr "\\"
+		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0237: stloc.s 6
+		IL_0239: ldloc.s 6
+		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0240: ldstr "join"
+		IL_0245: ldstr "/"
+		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024f: stloc.s 6
+		IL_0251: ldloc.2
+		IL_0252: ldloc.s 6
+		IL_0254: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0259: stloc.s 9
+		IL_025b: ldloc.s 9
+		IL_025d: box [System.Runtime]System.Boolean
+		IL_0262: stloc.s 10
+		IL_0264: ldloc.s 8
+		IL_0266: ldstr "main path matches filename:"
+		IL_026b: ldloc.s 10
+		IL_026d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0272: pop
+		IL_0273: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0278: stloc.s 8
+		IL_027a: ldloc.3
+		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0280: stloc.s 6
+		IL_0282: ldc.i4.0
+		IL_0283: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0288: brfalse IL_02b1
+
+		IL_028d: ldloc.s 6
+		IL_028f: isinst [System.Runtime]System.String
+		IL_0294: dup
+		IL_0295: brfalse IL_02b0
+
+		IL_029a: ldstr "/fixtures/main.txt"
+		IL_029f: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
+		IL_02a4: box [System.Runtime]System.Boolean
+		IL_02a9: stloc.s 6
+		IL_02ab: br IL_02c4
+
+		IL_02b0: pop
+
+		IL_02b1: ldloc.s 6
+		IL_02b3: ldstr "endsWith"
+		IL_02b8: ldstr "/fixtures/main.txt"
+		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02c2: stloc.s 6
+
+		IL_02c4: ldloc.s 8
+		IL_02c6: ldstr "main asset path:"
+		IL_02cb: ldloc.s 6
+		IL_02cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02d2: pop
+		IL_02d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02d8: stloc.s 8
+		IL_02da: ldloc.0
+		IL_02db: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
+		IL_02e0: stloc.s 6
+		IL_02e2: ldloc.s 6
+		IL_02e4: ldstr "importedUrlHasFileScheme"
+		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
+		IL_02ee: stloc.s 6
+		IL_02f0: ldloc.s 8
+		IL_02f2: ldstr "lib has file url:"
+		IL_02f7: ldloc.s 6
+		IL_02f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02fe: pop
+		IL_02ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0304: stloc.s 8
+		IL_0306: ldloc.s 4
+		IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_030d: stloc.s 6
+		IL_030f: ldc.i4.0
+		IL_0310: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0315: brfalse IL_033e
+
+		IL_031a: ldloc.s 6
+		IL_031c: isinst [System.Runtime]System.String
+		IL_0321: dup
+		IL_0322: brfalse IL_033d
+
+		IL_0327: ldstr "/Import_ImportMeta_Url_Lib"
+		IL_032c: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
+		IL_0331: box [System.Runtime]System.Boolean
+		IL_0336: stloc.s 6
+		IL_0338: br IL_0351
+
+		IL_033d: pop
+
+		IL_033e: ldloc.s 6
+		IL_0340: ldstr "endsWith"
+		IL_0345: ldstr "/Import_ImportMeta_Url_Lib"
+		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_034f: stloc.s 6
+
+		IL_0351: ldloc.s 8
+		IL_0353: ldstr "lib path:"
+		IL_0358: ldloc.s 6
+		IL_035a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_035f: pop
+		IL_0360: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0365: stloc.s 8
+		IL_0367: ldloc.s 5
+		IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_036e: stloc.s 6
+		IL_0370: ldc.i4.0
+		IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0376: brfalse IL_039f
+
+		IL_037b: ldloc.s 6
+		IL_037d: isinst [System.Runtime]System.String
+		IL_0382: dup
+		IL_0383: brfalse IL_039e
+
+		IL_0388: ldstr "/fixtures/lib.txt"
+		IL_038d: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
+		IL_0392: box [System.Runtime]System.Boolean
+		IL_0397: stloc.s 6
+		IL_0399: br IL_03b2
+
+		IL_039e: pop
+
+		IL_039f: ldloc.s 6
+		IL_03a1: ldstr "endsWith"
+		IL_03a6: ldstr "/fixtures/lib.txt"
+		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03b0: stloc.s 6
+
+		IL_03b2: ldloc.s 8
+		IL_03b4: ldstr "lib asset path:"
+		IL_03b9: ldloc.s 6
+		IL_03bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_03c0: pop
+		IL_03c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03c6: stloc.s 8
+		IL_03c8: ldloc.0
+		IL_03c9: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
+		IL_03ce: stloc.s 6
+		IL_03d0: ldloc.s 6
+		IL_03d2: ldstr "importedModuleFilenameMatches"
+		IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
+		IL_03dc: stloc.s 6
+		IL_03de: ldloc.s 8
+		IL_03e0: ldstr "lib module.filename:"
+		IL_03e5: ldloc.s 6
+		IL_03e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_03ec: pop
+		IL_03ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03f2: stloc.s 8
+		IL_03f4: ldloc.0
+		IL_03f5: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
+		IL_03fa: stloc.s 6
+		IL_03fc: ldloc.s 6
+		IL_03fe: ldstr "importedModulePathMatches"
+		IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
+		IL_0408: stloc.s 6
+		IL_040a: ldloc.s 8
+		IL_040c: ldstr "lib module.path:"
+		IL_0411: ldloc.s 6
+		IL_0413: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0418: pop
+		IL_0419: ret
 	} // end of method Import_ImportMeta_Url::__js_module_init__
 
 } // end of class Modules.Import_ImportMeta_Url
@@ -355,7 +435,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 350 (0x15e)
+		// Code size: 400 (0x190)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ImportMeta_Url_Lib/Scope,
@@ -403,72 +483,92 @@
 		IL_0072: pop
 		IL_0073: ldloc.1
 		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0079: ldstr "startsWith"
-		IL_007e: ldstr "file://"
-		IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0088: stloc.2
-		IL_0089: ldstr "Import_ImportMeta_Url_Lib"
-		IL_008e: ldstr "importedUrlHasFileScheme"
-		IL_0093: ldloc.2
-		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::SetLocalExport(string, string, object)
-		IL_0099: pop
-		IL_009a: ldarg.2
-		IL_009b: ldstr "filename"
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00a5: stloc.s 5
-		IL_00a7: ldloc.s 5
-		IL_00a9: ldarg.3
-		IL_00aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00af: stloc.3
-		IL_00b0: ldloc.3
-		IL_00b1: box [System.Runtime]System.Boolean
-		IL_00b6: stloc.s 6
-		IL_00b8: ldstr "Import_ImportMeta_Url_Lib"
-		IL_00bd: ldstr "importedModuleFilenameMatches"
-		IL_00c2: ldloc.s 6
-		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::SetLocalExport(string, string, object)
-		IL_00c9: pop
-		IL_00ca: ldarg.2
-		IL_00cb: ldstr "path"
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d5: stloc.s 5
-		IL_00d7: ldloc.s 5
-		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00de: ldstr "split"
-		IL_00e3: ldstr "\\"
-		IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ed: stloc.s 5
-		IL_00ef: ldloc.s 5
-		IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f6: ldstr "join"
-		IL_00fb: ldstr "/"
-		IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0105: stloc.s 5
-		IL_0107: ldarg.s __dirname
-		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_010e: ldstr "split"
-		IL_0113: ldstr "\\"
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011d: stloc.s 7
-		IL_011f: ldloc.s 7
-		IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0126: ldstr "join"
-		IL_012b: ldstr "/"
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0135: stloc.s 7
-		IL_0137: ldloc.s 5
-		IL_0139: ldloc.s 7
-		IL_013b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0140: stloc.s 4
-		IL_0142: ldloc.s 4
-		IL_0144: box [System.Runtime]System.Boolean
-		IL_0149: stloc.s 6
-		IL_014b: ldstr "Import_ImportMeta_Url_Lib"
-		IL_0150: ldstr "importedModulePathMatches"
-		IL_0155: ldloc.s 6
-		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::SetLocalExport(string, string, object)
-		IL_015c: pop
-		IL_015d: ret
+		IL_0079: stloc.s 5
+		IL_007b: ldc.i4.0
+		IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0081: brfalse IL_00a9
+
+		IL_0086: ldloc.s 5
+		IL_0088: isinst [System.Runtime]System.String
+		IL_008d: dup
+		IL_008e: brfalse IL_00a8
+
+		IL_0093: ldstr "file://"
+		IL_0098: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+		IL_009d: box [System.Runtime]System.Boolean
+		IL_00a2: stloc.2
+		IL_00a3: br IL_00bb
+
+		IL_00a8: pop
+
+		IL_00a9: ldloc.s 5
+		IL_00ab: ldstr "startsWith"
+		IL_00b0: ldstr "file://"
+		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ba: stloc.2
+
+		IL_00bb: ldstr "Import_ImportMeta_Url_Lib"
+		IL_00c0: ldstr "importedUrlHasFileScheme"
+		IL_00c5: ldloc.2
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::SetLocalExport(string, string, object)
+		IL_00cb: pop
+		IL_00cc: ldarg.2
+		IL_00cd: ldstr "filename"
+		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d7: stloc.s 5
+		IL_00d9: ldloc.s 5
+		IL_00db: ldarg.3
+		IL_00dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00e1: stloc.3
+		IL_00e2: ldloc.3
+		IL_00e3: box [System.Runtime]System.Boolean
+		IL_00e8: stloc.s 6
+		IL_00ea: ldstr "Import_ImportMeta_Url_Lib"
+		IL_00ef: ldstr "importedModuleFilenameMatches"
+		IL_00f4: ldloc.s 6
+		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::SetLocalExport(string, string, object)
+		IL_00fb: pop
+		IL_00fc: ldarg.2
+		IL_00fd: ldstr "path"
+		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0107: stloc.s 5
+		IL_0109: ldloc.s 5
+		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0110: ldstr "split"
+		IL_0115: ldstr "\\"
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011f: stloc.s 5
+		IL_0121: ldloc.s 5
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0128: ldstr "join"
+		IL_012d: ldstr "/"
+		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0137: stloc.s 5
+		IL_0139: ldarg.s __dirname
+		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0140: ldstr "split"
+		IL_0145: ldstr "\\"
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014f: stloc.s 7
+		IL_0151: ldloc.s 7
+		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0158: ldstr "join"
+		IL_015d: ldstr "/"
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0167: stloc.s 7
+		IL_0169: ldloc.s 5
+		IL_016b: ldloc.s 7
+		IL_016d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0172: stloc.s 4
+		IL_0174: ldloc.s 4
+		IL_0176: box [System.Runtime]System.Boolean
+		IL_017b: stloc.s 6
+		IL_017d: ldstr "Import_ImportMeta_Url_Lib"
+		IL_0182: ldstr "importedModulePathMatches"
+		IL_0187: ldloc.s 6
+		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::SetLocalExport(string, string, object)
+		IL_018e: pop
+		IL_018f: ret
 	} // end of method Import_ImportMeta_Url_Lib::__js_module_init__
 
 } // end of class Modules.Import_ImportMeta_Url_Lib

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
@@ -1002,7 +1002,7 @@
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
 			// Header size: 12
-			// Code size: 511 (0x1ff)
+			// Code size: 557 (0x22d)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1015,9 +1015,8 @@
 				[7] object,
 				[8] object,
 				[9] float64,
-				[10] string,
-				[11] object,
-				[12] object
+				[10] object,
+				[11] object
 			)
 
 			IL_0000: ldnull
@@ -1056,7 +1055,7 @@
 				IL_005f: ldloc.s 5
 				IL_0061: ldarg.2
 				IL_0062: clt
-				IL_0064: brfalse IL_01f3
+				IL_0064: brfalse IL_0221
 
 				IL_0069: ldarg.0
 				IL_006a: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
@@ -1159,7 +1158,7 @@
 					IL_015f: ldloc.s 5
 					IL_0161: ldloc.s 9
 					IL_0163: clt
-					IL_0165: brfalse IL_01cf
+					IL_0165: brfalse IL_01fd
 
 					IL_016a: ldloc.0
 					IL_016b: ldloc.3
@@ -1169,11 +1168,11 @@
 					IL_0174: ldloc.s 7
 					IL_0176: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
 					IL_017b: ldloc.0
-					IL_017c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0181: stloc.s 10
+					IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+					IL_0181: stloc.s 7
 					IL_0183: ldloc.3
 					IL_0184: box [System.Runtime]System.Double
-					IL_0189: stloc.s 11
+					IL_0189: stloc.s 10
 					IL_018b: ldloc.3
 					IL_018c: stloc.s 9
 					IL_018e: ldloc.s 9
@@ -1182,44 +1181,63 @@
 					IL_019a: stloc.s 9
 					IL_019c: ldloc.s 9
 					IL_019e: box [System.Runtime]System.Double
-					IL_01a3: stloc.s 12
-					IL_01a5: ldloc.s 10
-					IL_01a7: ldloc.s 11
-					IL_01a9: ldloc.s 12
-					IL_01ab: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-					IL_01b0: stloc.s 10
-					IL_01b2: ldarg.0
-					IL_01b3: ldloc.s 10
-					IL_01b5: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-					IL_01ba: ldloc.3
-					IL_01bb: ldc.r8 100
-					IL_01c4: add
-					IL_01c5: stloc.s 9
-					IL_01c7: ldloc.s 9
-					IL_01c9: stloc.3
-					IL_01ca: br IL_014e
+					IL_01a3: stloc.s 11
+					IL_01a5: ldc.i4.0
+					IL_01a6: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+					IL_01ab: brfalse IL_01ce
+
+					IL_01b0: ldloc.s 7
+					IL_01b2: isinst [System.Runtime]System.String
+					IL_01b7: dup
+					IL_01b8: brfalse IL_01cd
+
+					IL_01bd: ldloc.s 10
+					IL_01bf: ldloc.s 11
+					IL_01c1: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+					IL_01c6: stloc.s 7
+					IL_01c8: br IL_01e0
+
+					IL_01cd: pop
+
+					IL_01ce: ldloc.s 7
+					IL_01d0: ldstr "substring"
+					IL_01d5: ldloc.s 10
+					IL_01d7: ldloc.s 11
+					IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_01de: stloc.s 7
+
+					IL_01e0: ldarg.0
+					IL_01e1: ldloc.s 7
+					IL_01e3: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+					IL_01e8: ldloc.3
+					IL_01e9: ldc.r8 100
+					IL_01f2: add
+					IL_01f3: stloc.s 9
+					IL_01f5: ldloc.s 9
+					IL_01f7: stloc.3
+					IL_01f8: br IL_014e
 				// end loop
 
-				IL_01cf: ldarg.0
-				IL_01d0: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-				IL_01d5: stloc.s 7
-				IL_01d7: ldloc.s 7
-				IL_01d9: ldloc.1
-				IL_01da: ldloc.0
-				IL_01db: ldc.i4.1
-				IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-				IL_01e1: pop
-				IL_01e2: ldloc.1
-				IL_01e3: ldc.r8 1
-				IL_01ec: add
-				IL_01ed: stloc.1
-				IL_01ee: br IL_005c
+				IL_01fd: ldarg.0
+				IL_01fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+				IL_0203: stloc.s 7
+				IL_0205: ldloc.s 7
+				IL_0207: ldloc.1
+				IL_0208: ldloc.0
+				IL_0209: ldc.i4.1
+				IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+				IL_020f: pop
+				IL_0210: ldloc.1
+				IL_0211: ldc.r8 1
+				IL_021a: add
+				IL_021b: stloc.1
+				IL_021c: br IL_005c
 			// end loop
 
-			IL_01f3: ldarg.0
-			IL_01f4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-			IL_01f9: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01fe: ret
+			IL_0221: ldarg.0
+			IL_0222: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+			IL_0227: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_022c: ret
 		} // end of method generateTestStrings::__js_call__
 
 	} // end of class generateTestStrings
@@ -11098,7 +11116,7 @@
 					01 00 00 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 19 (0x13)
+				// Code size: 56 (0x38)
 				.maxstack 8
 				.locals init (
 					[0] object
@@ -11106,11 +11124,29 @@
 
 				IL_0000: ldarg.2
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0006: ldstr "toUpperCase"
-				IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_0010: stloc.0
-				IL_0011: ldloc.0
-				IL_0012: ret
+				IL_0006: stloc.0
+				IL_0007: ldc.i4.0
+				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_000d: brfalse IL_002a
+
+				IL_0012: ldloc.0
+				IL_0013: isinst [System.Runtime]System.String
+				IL_0018: dup
+				IL_0019: brfalse IL_0029
+
+				IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+				IL_0023: stloc.0
+				IL_0024: br IL_0036
+
+				IL_0029: pop
+
+				IL_002a: ldloc.0
+				IL_002b: ldstr "toUpperCase"
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0035: stloc.0
+
+				IL_0036: ldloc.0
+				IL_0037: ret
 			} // end of method FunctionExpression_L302C33::__js_call__
 
 		} // end of class FunctionExpression_L302C33

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -3144,7 +3144,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 673 (0x2a1)
+		// Code size: 724 (0x2d4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_PrimeJavaScript/Scope,
@@ -3246,141 +3246,161 @@
 		IL_011b: stloc.s 5
 		IL_011d: ldloc.s 5
 		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0124: ldstr "includes"
-		IL_0129: ldstr "verbose"
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0133: stloc.s 5
-		IL_0135: ldloc.1
-		IL_0136: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
-		IL_013b: ldloc.s 5
-		IL_013d: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_verbose(object)
-		IL_0142: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_0147: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_014c: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_0151: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0156: stloc.s 8
-		IL_0158: ldloc.s 8
-		IL_015a: ldstr "prototype"
-		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0164: stloc.s 5
-		IL_0166: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_016b: stloc.s 9
-		IL_016d: ldloc.s 5
-		IL_016f: ldstr "setBitTrue"
-		IL_0174: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject::.ctor()
-		IL_0179: ldc.i4.1
-		IL_017a: conv.r8
-		IL_017b: ldstr "setBitTrue"
-		IL_0180: ldc.i4.1
-		IL_0181: ldc.i4.1
-		IL_0182: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0187: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject>(!!0)
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0191: pop
-		IL_0192: ldc.i4.1
-		IL_0193: newarr [System.Runtime]System.Object
-		IL_0198: dup
-		IL_0199: ldc.i4.0
-		IL_019a: ldloc.0
-		IL_019b: stelem.ref
-		IL_019c: stloc.s 9
-		IL_019e: ldloc.s 5
-		IL_01a0: ldstr "setBitsTrue"
-		IL_01a5: ldloc.s 9
-		IL_01a7: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject::.ctor(object[])
-		IL_01ac: ldc.i4.3
+		IL_0124: stloc.s 5
+		IL_0126: ldc.i4.0
+		IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_012c: brfalse IL_0155
+
+		IL_0131: ldloc.s 5
+		IL_0133: isinst [System.Runtime]System.String
+		IL_0138: dup
+		IL_0139: brfalse IL_0154
+
+		IL_013e: ldstr "verbose"
+		IL_0143: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_0148: box [System.Runtime]System.Boolean
+		IL_014d: stloc.s 5
+		IL_014f: br IL_0168
+
+		IL_0154: pop
+
+		IL_0155: ldloc.s 5
+		IL_0157: ldstr "includes"
+		IL_015c: ldstr "verbose"
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0166: stloc.s 5
+
+		IL_0168: ldloc.1
+		IL_0169: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
+		IL_016e: ldloc.s 5
+		IL_0170: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_verbose(object)
+		IL_0175: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+		IL_017a: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_017f: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+		IL_0184: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0189: stloc.s 8
+		IL_018b: ldloc.s 8
+		IL_018d: ldstr "prototype"
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0197: stloc.s 5
+		IL_0199: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_019e: stloc.s 9
+		IL_01a0: ldloc.s 5
+		IL_01a2: ldstr "setBitTrue"
+		IL_01a7: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject::.ctor()
+		IL_01ac: ldc.i4.1
 		IL_01ad: conv.r8
-		IL_01ae: ldstr "setBitsTrue"
+		IL_01ae: ldstr "setBitTrue"
 		IL_01b3: ldc.i4.1
 		IL_01b4: ldc.i4.1
-		IL_01b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject>(!!0)
+		IL_01b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject>(!!0)
 		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_01c4: pop
-		IL_01c5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01ca: stloc.s 9
-		IL_01cc: ldloc.s 5
-		IL_01ce: ldstr "testBitTrue"
-		IL_01d3: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject::.ctor()
-		IL_01d8: ldc.i4.1
-		IL_01d9: conv.r8
-		IL_01da: ldstr "testBitTrue"
-		IL_01df: ldc.i4.1
-		IL_01e0: ldc.i4.1
-		IL_01e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject>(!!0)
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01f0: pop
-		IL_01f1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01f6: stloc.s 9
-		IL_01f8: ldloc.s 5
-		IL_01fa: ldstr "searchBitFalse"
-		IL_01ff: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject::.ctor()
-		IL_0204: ldc.i4.1
-		IL_0205: conv.r8
-		IL_0206: ldstr "searchBitFalse"
+		IL_01c5: ldc.i4.1
+		IL_01c6: newarr [System.Runtime]System.Object
+		IL_01cb: dup
+		IL_01cc: ldc.i4.0
+		IL_01cd: ldloc.0
+		IL_01ce: stelem.ref
+		IL_01cf: stloc.s 9
+		IL_01d1: ldloc.s 5
+		IL_01d3: ldstr "setBitsTrue"
+		IL_01d8: ldloc.s 9
+		IL_01da: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject::.ctor(object[])
+		IL_01df: ldc.i4.3
+		IL_01e0: conv.r8
+		IL_01e1: ldstr "setBitsTrue"
+		IL_01e6: ldc.i4.1
+		IL_01e7: ldc.i4.1
+		IL_01e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject>(!!0)
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01f7: pop
+		IL_01f8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01fd: stloc.s 9
+		IL_01ff: ldloc.s 5
+		IL_0201: ldstr "testBitTrue"
+		IL_0206: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject::.ctor()
 		IL_020b: ldc.i4.1
-		IL_020c: ldc.i4.1
-		IL_020d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject>(!!0)
-		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_021c: pop
-		IL_021d: ldc.i4.1
-		IL_021e: newarr [System.Runtime]System.Object
-		IL_0223: dup
-		IL_0224: ldc.i4.0
-		IL_0225: ldloc.0
-		IL_0226: stelem.ref
-		IL_0227: stloc.s 9
-		IL_0229: ldloc.s 9
-		IL_022b: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
-		IL_0230: ldloc.s 8
-		IL_0232: ldloc.s 9
-		IL_0234: ldc.i4.1
-		IL_0235: conv.r8
-		IL_0236: ldc.i4.0
-		IL_0237: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_023c: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_ctor/FunctionObject
-		IL_0241: stloc.s 10
-		IL_0243: ldloc.0
-		IL_0244: ldloc.s 10
-		IL_0246: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
-		IL_024b: nop
-		IL_024c: ldc.i4.1
-		IL_024d: newarr [System.Runtime]System.Object
-		IL_0252: dup
-		IL_0253: ldc.i4.0
-		IL_0254: ldloc.0
-		IL_0255: stelem.ref
-		IL_0256: stloc.s 9
-		IL_0258: ldloc.s 9
-		IL_025a: ldc.i4.0
-		IL_025b: ldelem.ref
-		IL_025c: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_0261: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
-		IL_0266: ldc.i4.1
-		IL_0267: conv.r8
-		IL_0268: ldstr ""
-		IL_026d: ldc.i4.0
-		IL_026e: ldc.i4.0
-		IL_026f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0274: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0)
-		IL_0279: stloc.s 11
-		IL_027b: ldloc.s 11
-		IL_027d: ldstr "runSieveBatch"
-		IL_0282: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_0287: stloc.s 5
-		IL_0289: ldloc.0
-		IL_028a: ldloc.s 5
-		IL_028c: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
-		IL_0291: nop
-		IL_0292: ldloc.0
-		IL_0293: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_0298: ldnull
-		IL_0299: ldloc.1
-		IL_029a: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
-		IL_029f: pop
-		IL_02a0: ret
+		IL_020c: conv.r8
+		IL_020d: ldstr "testBitTrue"
+		IL_0212: ldc.i4.1
+		IL_0213: ldc.i4.1
+		IL_0214: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0219: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject>(!!0)
+		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0223: pop
+		IL_0224: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0229: stloc.s 9
+		IL_022b: ldloc.s 5
+		IL_022d: ldstr "searchBitFalse"
+		IL_0232: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject::.ctor()
+		IL_0237: ldc.i4.1
+		IL_0238: conv.r8
+		IL_0239: ldstr "searchBitFalse"
+		IL_023e: ldc.i4.1
+		IL_023f: ldc.i4.1
+		IL_0240: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0245: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject>(!!0)
+		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_024f: pop
+		IL_0250: ldc.i4.1
+		IL_0251: newarr [System.Runtime]System.Object
+		IL_0256: dup
+		IL_0257: ldc.i4.0
+		IL_0258: ldloc.0
+		IL_0259: stelem.ref
+		IL_025a: stloc.s 9
+		IL_025c: ldloc.s 9
+		IL_025e: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
+		IL_0263: ldloc.s 8
+		IL_0265: ldloc.s 9
+		IL_0267: ldc.i4.1
+		IL_0268: conv.r8
+		IL_0269: ldc.i4.0
+		IL_026a: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_026f: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_ctor/FunctionObject
+		IL_0274: stloc.s 10
+		IL_0276: ldloc.0
+		IL_0277: ldloc.s 10
+		IL_0279: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
+		IL_027e: nop
+		IL_027f: ldc.i4.1
+		IL_0280: newarr [System.Runtime]System.Object
+		IL_0285: dup
+		IL_0286: ldc.i4.0
+		IL_0287: ldloc.0
+		IL_0288: stelem.ref
+		IL_0289: stloc.s 9
+		IL_028b: ldloc.s 9
+		IL_028d: ldc.i4.0
+		IL_028e: ldelem.ref
+		IL_028f: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_0294: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
+		IL_0299: ldc.i4.1
+		IL_029a: conv.r8
+		IL_029b: ldstr ""
+		IL_02a0: ldc.i4.0
+		IL_02a1: ldc.i4.0
+		IL_02a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0)
+		IL_02ac: stloc.s 11
+		IL_02ae: ldloc.s 11
+		IL_02b0: ldstr "runSieveBatch"
+		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_02ba: stloc.s 5
+		IL_02bc: ldloc.0
+		IL_02bd: ldloc.s 5
+		IL_02bf: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
+		IL_02c4: nop
+		IL_02c5: ldloc.0
+		IL_02c6: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_02cb: ldnull
+		IL_02cc: ldloc.1
+		IL_02cd: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
+		IL_02d2: pop
+		IL_02d3: ret
 	} // end of method Compile_Performance_PrimeJavaScript::__js_module_init__
 
 } // end of class Modules.Compile_Performance_PrimeJavaScript

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -475,7 +475,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 121 (0x79)
+			// Code size: 158 (0x9e)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -526,11 +526,29 @@
 			IL_0065: stloc.2
 			IL_0066: ldloc.2
 			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_006c: ldstr "trim"
-			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0076: stloc.2
-			IL_0077: ldloc.2
-			IL_0078: ret
+			IL_006c: stloc.2
+			IL_006d: ldc.i4.0
+			IL_006e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0073: brfalse IL_0090
+
+			IL_0078: ldloc.2
+			IL_0079: isinst [System.Runtime]System.String
+			IL_007e: dup
+			IL_007f: brfalse IL_008f
+
+			IL_0084: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0089: stloc.2
+			IL_008a: br IL_009c
+
+			IL_008f: pop
+
+			IL_0090: ldloc.2
+			IL_0091: ldstr "trim"
+			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_009b: stloc.2
+
+			IL_009c: ldloc.2
+			IL_009d: ret
 		} // end of method parseCurrentVersion::__js_call__
 
 	} // end of class parseCurrentVersion
@@ -1692,7 +1710,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 171 (0xab)
+			// Code size: 218 (0xda)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1703,65 +1721,85 @@
 
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0006: ldstr "includes"
-			IL_000b: ldstr "<Version>"
-			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0015: stloc.0
-			IL_0016: ldloc.0
-			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_001c: stloc.1
-			IL_001d: ldloc.1
-			IL_001e: brfalse IL_0067
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.0
+			IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_000d: brfalse IL_0034
 
-			IL_0023: ldarg.1
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0029: stloc.0
-			IL_002a: ldstr "<Version>[^<]+<\\/Version>"
-			IL_002f: ldstr ""
-			IL_0034: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0039: stloc.2
-			IL_003a: ldarg.2
-			IL_003b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0040: stloc.3
-			IL_0041: ldstr "<Version>"
-			IL_0046: ldloc.3
-			IL_0047: call string [System.Runtime]System.String::Concat(string, string)
-			IL_004c: ldstr "</Version>"
-			IL_0051: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0056: stloc.3
-			IL_0057: ldloc.0
-			IL_0058: ldstr "replace"
-			IL_005d: ldloc.2
-			IL_005e: ldloc.3
-			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0064: stloc.0
-			IL_0065: ldloc.0
-			IL_0066: ret
+			IL_0012: ldloc.0
+			IL_0013: isinst [System.Runtime]System.String
+			IL_0018: dup
+			IL_0019: brfalse IL_0033
 
-			IL_0067: ldarg.1
-			IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_006d: stloc.0
-			IL_006e: ldstr "(<PropertyGroup>\\s*\\n)"
-			IL_0073: ldstr ""
-			IL_0078: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_007d: stloc.2
-			IL_007e: ldarg.2
-			IL_007f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0084: stloc.3
-			IL_0085: ldstr "$1    <Version>"
-			IL_008a: ldloc.3
-			IL_008b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0090: ldstr "</Version>\n"
-			IL_0095: call string [System.Runtime]System.String::Concat(string, string)
-			IL_009a: stloc.3
-			IL_009b: ldloc.0
-			IL_009c: ldstr "replace"
-			IL_00a1: ldloc.2
-			IL_00a2: ldloc.3
-			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00a8: stloc.0
-			IL_00a9: ldloc.0
-			IL_00aa: ret
+			IL_001e: ldstr "<Version>"
+			IL_0023: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_0028: box [System.Runtime]System.Boolean
+			IL_002d: stloc.0
+			IL_002e: br IL_0045
+
+			IL_0033: pop
+
+			IL_0034: ldloc.0
+			IL_0035: ldstr "includes"
+			IL_003a: ldstr "<Version>"
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0044: stloc.0
+
+			IL_0045: ldloc.0
+			IL_0046: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_004b: stloc.1
+			IL_004c: ldloc.1
+			IL_004d: brfalse IL_0096
+
+			IL_0052: ldarg.1
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0058: stloc.0
+			IL_0059: ldstr "<Version>[^<]+<\\/Version>"
+			IL_005e: ldstr ""
+			IL_0063: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0068: stloc.2
+			IL_0069: ldarg.2
+			IL_006a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_006f: stloc.3
+			IL_0070: ldstr "<Version>"
+			IL_0075: ldloc.3
+			IL_0076: call string [System.Runtime]System.String::Concat(string, string)
+			IL_007b: ldstr "</Version>"
+			IL_0080: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0085: stloc.3
+			IL_0086: ldloc.0
+			IL_0087: ldstr "replace"
+			IL_008c: ldloc.2
+			IL_008d: ldloc.3
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0093: stloc.0
+			IL_0094: ldloc.0
+			IL_0095: ret
+
+			IL_0096: ldarg.1
+			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009c: stloc.0
+			IL_009d: ldstr "(<PropertyGroup>\\s*\\n)"
+			IL_00a2: ldstr ""
+			IL_00a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_00ac: stloc.2
+			IL_00ad: ldarg.2
+			IL_00ae: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00b3: stloc.3
+			IL_00b4: ldstr "$1    <Version>"
+			IL_00b9: ldloc.3
+			IL_00ba: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00bf: ldstr "</Version>\n"
+			IL_00c4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00c9: stloc.3
+			IL_00ca: ldloc.0
+			IL_00cb: ldstr "replace"
+			IL_00d0: ldloc.2
+			IL_00d1: ldloc.3
+			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00d7: stloc.0
+			IL_00d8: ldloc.0
+			IL_00d9: ret
 		} // end of method updateCsprojVersion::__js_call__
 
 	} // end of class updateCsprojVersion
@@ -2155,7 +2193,7 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 529 (0x211)
+			// Code size: 751 (0x2ef)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2166,10 +2204,10 @@
 				[5] object,
 				[6] object,
 				[7] object,
-				[8] float64,
-				[9] object,
-				[10] bool,
-				[11] object,
+				[8] object,
+				[9] float64,
+				[10] object,
+				[11] bool,
 				[12] object,
 				[13] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 				[14] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
@@ -2177,176 +2215,270 @@
 
 			IL_0000: ldarg.2
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0006: ldstr "indexOf"
-			IL_000b: ldstr "## Unreleased"
-			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0015: stloc.0
-			IL_0016: ldc.r8 1
-			IL_001f: neg
-			IL_0020: stloc.s 8
-			IL_0022: ldloc.s 8
-			IL_0024: box [System.Runtime]System.Double
-			IL_0029: stloc.s 9
-			IL_002b: ldloc.0
-			IL_002c: ldloc.s 9
-			IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0033: stloc.s 10
-			IL_0035: ldloc.s 10
-			IL_0037: brfalse IL_005c
+			IL_0006: stloc.s 8
+			IL_0008: ldc.i4.0
+			IL_0009: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_000e: brfalse IL_0036
 
-			IL_003c: ldstr "CHANGELOG.md missing \"## Unreleased\" section"
-			IL_0041: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0046: stloc.1
-			IL_0047: ldloc.1
-			IL_0048: isinst [System.Runtime]System.Exception
-			IL_004d: dup
-			IL_004e: brtrue IL_005b
+			IL_0013: ldloc.s 8
+			IL_0015: isinst [System.Runtime]System.String
+			IL_001a: dup
+			IL_001b: brfalse IL_0035
 
-			IL_0053: pop
-			IL_0054: ldloc.1
-			IL_0055: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_005a: throw
+			IL_0020: ldstr "## Unreleased"
+			IL_0025: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_002a: box [System.Runtime]System.Double
+			IL_002f: stloc.0
+			IL_0030: br IL_0048
 
-			IL_005b: throw
+			IL_0035: pop
 
-			IL_005c: ldarg.2
-			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0062: ldstr "indexOf"
-			IL_0067: ldstr "\n"
-			IL_006c: ldloc.0
-			IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0072: stloc.2
-			IL_0073: ldarg.2
-			IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0079: stloc.s 11
-			IL_007b: ldloc.2
-			IL_007c: ldc.r8 1
-			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_008a: stloc.s 12
-			IL_008c: ldloc.s 11
-			IL_008e: ldstr "slice"
-			IL_0093: ldloc.s 12
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_009a: stloc.s 11
-			IL_009c: ldloc.s 11
-			IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a3: stloc.s 11
-			IL_00a5: ldstr "\\n## v?\\d+\\.\\d+\\.\\d+ "
-			IL_00aa: ldstr ""
-			IL_00af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_00b4: stloc.s 13
-			IL_00b6: ldloc.s 11
-			IL_00b8: ldstr "match"
-			IL_00bd: ldloc.s 13
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00c4: stloc.3
-			IL_00c5: ldc.r8 1
-			IL_00ce: neg
-			IL_00cf: stloc.s 8
-			IL_00d1: ldloc.s 8
-			IL_00d3: box [System.Runtime]System.Double
-			IL_00d8: stloc.s 4
-			IL_00da: ldloc.3
-			IL_00db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00e0: stloc.s 10
-			IL_00e2: ldloc.s 10
-			IL_00e4: brfalse IL_0128
+			IL_0036: ldloc.s 8
+			IL_0038: ldstr "indexOf"
+			IL_003d: ldstr "## Unreleased"
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0047: stloc.0
 
-			IL_00e9: ldloc.2
-			IL_00ea: ldc.r8 1
-			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_00f8: stloc.s 12
-			IL_00fa: ldloc.3
-			IL_00fb: ldstr "index"
-			IL_0100: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0105: stloc.s 11
-			IL_0107: ldloc.s 12
-			IL_0109: ldloc.s 11
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0110: stloc.s 12
-			IL_0112: ldloc.s 12
-			IL_0114: ldc.r8 1
-			IL_011d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0122: stloc.s 12
-			IL_0124: ldloc.s 12
-			IL_0126: stloc.s 4
+			IL_0048: ldc.r8 1
+			IL_0051: neg
+			IL_0052: stloc.s 9
+			IL_0054: ldloc.s 9
+			IL_0056: box [System.Runtime]System.Double
+			IL_005b: stloc.s 10
+			IL_005d: ldloc.0
+			IL_005e: ldloc.s 10
+			IL_0060: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0065: stloc.s 11
+			IL_0067: ldloc.s 11
+			IL_0069: brfalse IL_008e
 
-			IL_0128: ldloc.s 4
-			IL_012a: stloc.s 12
-			IL_012c: ldc.r8 1
-			IL_0135: neg
-			IL_0136: stloc.s 8
-			IL_0138: ldloc.s 8
-			IL_013a: box [System.Runtime]System.Double
-			IL_013f: stloc.s 9
-			IL_0141: ldloc.s 12
-			IL_0143: ldloc.s 9
-			IL_0145: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_014a: stloc.s 10
-			IL_014c: ldloc.s 10
-			IL_014e: brfalse IL_0169
+			IL_006e: ldstr "CHANGELOG.md missing \"## Unreleased\" section"
+			IL_0073: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0078: stloc.1
+			IL_0079: ldloc.1
+			IL_007a: isinst [System.Runtime]System.Exception
+			IL_007f: dup
+			IL_0080: brtrue IL_008d
 
-			IL_0153: ldarg.2
-			IL_0154: ldstr "length"
-			IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_015e: stloc.s 11
-			IL_0160: ldloc.s 11
-			IL_0162: stloc.s 5
-			IL_0164: br IL_018d
+			IL_0085: pop
+			IL_0086: ldloc.1
+			IL_0087: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_008c: throw
 
-			IL_0169: ldloc.s 4
-			IL_016b: stloc.s 12
-			IL_016d: ldloc.s 12
-			IL_016f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0174: ldc.r8 1
-			IL_017d: sub
-			IL_017e: stloc.s 8
-			IL_0180: ldloc.s 8
-			IL_0182: box [System.Runtime]System.Double
-			IL_0187: stloc.s 9
-			IL_0189: ldloc.s 9
-			IL_018b: stloc.s 5
+			IL_008d: throw
 
-			IL_018d: ldloc.s 5
-			IL_018f: stloc.s 6
-			IL_0191: ldarg.2
-			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0197: stloc.s 11
-			IL_0199: ldloc.2
-			IL_019a: ldc.r8 1
-			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_01a8: stloc.s 12
-			IL_01aa: ldloc.s 11
-			IL_01ac: ldstr "slice"
-			IL_01b1: ldloc.s 12
-			IL_01b3: ldloc.s 6
-			IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01ba: stloc.s 11
-			IL_01bc: ldloc.s 11
-			IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c3: ldstr "trim"
-			IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_01cd: stloc.s 7
-			IL_01cf: ldloc.2
-			IL_01d0: ldc.r8 1
-			IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_01de: stloc.s 12
-			IL_01e0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_01e5: dup
-			IL_01e6: ldstr "body"
-			IL_01eb: ldloc.s 7
-			IL_01ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01f2: dup
-			IL_01f3: ldstr "start"
-			IL_01f8: ldloc.s 12
-			IL_01fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01ff: dup
-			IL_0200: ldstr "end"
-			IL_0205: ldloc.s 6
-			IL_0207: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_020c: stloc.s 14
-			IL_020e: ldloc.s 14
-			IL_0210: ret
+			IL_008e: ldarg.2
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0094: stloc.s 8
+			IL_0096: ldc.i4.0
+			IL_0097: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_009c: brfalse IL_00c5
+
+			IL_00a1: ldloc.s 8
+			IL_00a3: isinst [System.Runtime]System.String
+			IL_00a8: dup
+			IL_00a9: brfalse IL_00c4
+
+			IL_00ae: ldstr "\n"
+			IL_00b3: ldloc.0
+			IL_00b4: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string, object)
+			IL_00b9: box [System.Runtime]System.Double
+			IL_00be: stloc.2
+			IL_00bf: br IL_00d8
+
+			IL_00c4: pop
+
+			IL_00c5: ldloc.s 8
+			IL_00c7: ldstr "indexOf"
+			IL_00cc: ldstr "\n"
+			IL_00d1: ldloc.0
+			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00d7: stloc.2
+
+			IL_00d8: ldarg.2
+			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00de: stloc.s 8
+			IL_00e0: ldloc.2
+			IL_00e1: ldc.r8 1
+			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_00ef: stloc.s 12
+			IL_00f1: ldc.i4.0
+			IL_00f2: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00f7: brfalse IL_0118
+
+			IL_00fc: ldloc.s 8
+			IL_00fe: isinst [System.Runtime]System.String
+			IL_0103: dup
+			IL_0104: brfalse IL_0117
+
+			IL_0109: ldloc.s 12
+			IL_010b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
+			IL_0110: stloc.s 8
+			IL_0112: br IL_0128
+
+			IL_0117: pop
+
+			IL_0118: ldloc.s 8
+			IL_011a: ldstr "slice"
+			IL_011f: ldloc.s 12
+			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0126: stloc.s 8
+
+			IL_0128: ldloc.s 8
+			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_012f: stloc.s 8
+			IL_0131: ldstr "\\n## v?\\d+\\.\\d+\\.\\d+ "
+			IL_0136: ldstr ""
+			IL_013b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0140: stloc.s 13
+			IL_0142: ldloc.s 8
+			IL_0144: ldstr "match"
+			IL_0149: ldloc.s 13
+			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0150: stloc.3
+			IL_0151: ldc.r8 1
+			IL_015a: neg
+			IL_015b: stloc.s 9
+			IL_015d: ldloc.s 9
+			IL_015f: box [System.Runtime]System.Double
+			IL_0164: stloc.s 4
+			IL_0166: ldloc.3
+			IL_0167: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_016c: stloc.s 11
+			IL_016e: ldloc.s 11
+			IL_0170: brfalse IL_01b4
+
+			IL_0175: ldloc.2
+			IL_0176: ldc.r8 1
+			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0184: stloc.s 12
+			IL_0186: ldloc.3
+			IL_0187: ldstr "index"
+			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0191: stloc.s 8
+			IL_0193: ldloc.s 12
+			IL_0195: ldloc.s 8
+			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_019c: stloc.s 12
+			IL_019e: ldloc.s 12
+			IL_01a0: ldc.r8 1
+			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01ae: stloc.s 12
+			IL_01b0: ldloc.s 12
+			IL_01b2: stloc.s 4
+
+			IL_01b4: ldloc.s 4
+			IL_01b6: stloc.s 12
+			IL_01b8: ldc.r8 1
+			IL_01c1: neg
+			IL_01c2: stloc.s 9
+			IL_01c4: ldloc.s 9
+			IL_01c6: box [System.Runtime]System.Double
+			IL_01cb: stloc.s 10
+			IL_01cd: ldloc.s 12
+			IL_01cf: ldloc.s 10
+			IL_01d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01d6: stloc.s 11
+			IL_01d8: ldloc.s 11
+			IL_01da: brfalse IL_01f5
+
+			IL_01df: ldarg.2
+			IL_01e0: ldstr "length"
+			IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ea: stloc.s 8
+			IL_01ec: ldloc.s 8
+			IL_01ee: stloc.s 5
+			IL_01f0: br IL_0219
+
+			IL_01f5: ldloc.s 4
+			IL_01f7: stloc.s 12
+			IL_01f9: ldloc.s 12
+			IL_01fb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0200: ldc.r8 1
+			IL_0209: sub
+			IL_020a: stloc.s 9
+			IL_020c: ldloc.s 9
+			IL_020e: box [System.Runtime]System.Double
+			IL_0213: stloc.s 10
+			IL_0215: ldloc.s 10
+			IL_0217: stloc.s 5
+
+			IL_0219: ldloc.s 5
+			IL_021b: stloc.s 6
+			IL_021d: ldarg.2
+			IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0223: stloc.s 8
+			IL_0225: ldloc.2
+			IL_0226: ldc.r8 1
+			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0234: stloc.s 12
+			IL_0236: ldc.i4.0
+			IL_0237: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_023c: brfalse IL_025f
+
+			IL_0241: ldloc.s 8
+			IL_0243: isinst [System.Runtime]System.String
+			IL_0248: dup
+			IL_0249: brfalse IL_025e
+
+			IL_024e: ldloc.s 12
+			IL_0250: ldloc.s 6
+			IL_0252: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+			IL_0257: stloc.s 8
+			IL_0259: br IL_0271
+
+			IL_025e: pop
+
+			IL_025f: ldloc.s 8
+			IL_0261: ldstr "slice"
+			IL_0266: ldloc.s 12
+			IL_0268: ldloc.s 6
+			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_026f: stloc.s 8
+
+			IL_0271: ldloc.s 8
+			IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0278: stloc.s 8
+			IL_027a: ldc.i4.0
+			IL_027b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0280: brfalse IL_029f
+
+			IL_0285: ldloc.s 8
+			IL_0287: isinst [System.Runtime]System.String
+			IL_028c: dup
+			IL_028d: brfalse IL_029e
+
+			IL_0292: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0297: stloc.s 7
+			IL_0299: br IL_02ad
+
+			IL_029e: pop
+
+			IL_029f: ldloc.s 8
+			IL_02a1: ldstr "trim"
+			IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_02ab: stloc.s 7
+
+			IL_02ad: ldloc.2
+			IL_02ae: ldc.r8 1
+			IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_02bc: stloc.s 12
+			IL_02be: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02c3: dup
+			IL_02c4: ldstr "body"
+			IL_02c9: ldloc.s 7
+			IL_02cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_02d0: dup
+			IL_02d1: ldstr "start"
+			IL_02d6: ldloc.s 12
+			IL_02d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_02dd: dup
+			IL_02de: ldstr "end"
+			IL_02e3: ldloc.s 6
+			IL_02e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_02ea: stloc.s 14
+			IL_02ec: ldloc.s 14
+			IL_02ee: ret
 		} // end of method extractUnreleased::__js_call__
 
 	} // end of class extractUnreleased
@@ -2481,7 +2613,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 43 (0x2b)
+			// Code size: 80 (0x50)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -2494,15 +2626,33 @@
 			IL_000f: stloc.0
 			IL_0010: ldarg.1
 			IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0016: ldstr "trim"
-			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0020: stloc.1
-			IL_0021: ldloc.0
+			IL_0016: stloc.1
+			IL_0017: ldc.i4.0
+			IL_0018: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_001d: brfalse IL_003a
+
 			IL_0022: ldloc.1
-			IL_0023: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_0028: stloc.1
-			IL_0029: ldloc.1
-			IL_002a: ret
+			IL_0023: isinst [System.Runtime]System.String
+			IL_0028: dup
+			IL_0029: brfalse IL_0039
+
+			IL_002e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0033: stloc.1
+			IL_0034: br IL_0046
+
+			IL_0039: pop
+
+			IL_003a: ldloc.1
+			IL_003b: ldstr "trim"
+			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0045: stloc.1
+
+			IL_0046: ldloc.0
+			IL_0047: ldloc.1
+			IL_0048: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_004d: stloc.1
+			IL_004e: ldloc.1
+			IL_004f: ret
 		} // end of method isPlaceholder::__js_call__
 
 	} // end of class isPlaceholder
@@ -2626,7 +2776,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 126 (0x7e)
+				// Code size: 163 (0xa3)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -2637,62 +2787,80 @@
 
 				IL_0000: ldarg.2
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0006: ldstr "trim"
-				IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_0010: stloc.0
-				IL_0011: ldloc.0
-				IL_0012: ldstr "length"
-				IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_001c: stloc.0
-				IL_001d: ldloc.0
-				IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0023: ldc.r8 0.0
-				IL_002c: cgt
-				IL_002e: stloc.1
-				IL_002f: ldloc.1
-				IL_0030: box [System.Runtime]System.Boolean
-				IL_0035: stloc.2
-				IL_0036: ldloc.2
-				IL_0037: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_003c: stloc.1
-				IL_003d: ldloc.1
-				IL_003e: brfalse IL_007c
+				IL_0006: stloc.0
+				IL_0007: ldc.i4.0
+				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_000d: brfalse IL_002a
 
-				IL_0043: ldarg.0
-				IL_0044: ldc.i4.0
-				IL_0045: ldelem.ref
-				IL_0046: castclass Modules.Compile_Scripts_BumpVersion/Scope
-				IL_004b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
-				IL_0050: ldc.i4.2
-				IL_0051: newarr [System.Runtime]System.Object
-				IL_0056: dup
-				IL_0057: ldc.i4.0
-				IL_0058: ldarg.0
-				IL_0059: ldc.i4.0
-				IL_005a: ldelem.ref
-				IL_005b: stelem.ref
-				IL_005c: dup
-				IL_005d: ldc.i4.1
-				IL_005e: ldarg.0
-				IL_005f: ldc.i4.1
-				IL_0060: ldelem.ref
-				IL_0061: stelem.ref
-				IL_0062: stloc.3
-				IL_0063: ldloc.3
-				IL_0064: ldarg.2
-				IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_006a: stloc.0
-				IL_006b: ldloc.0
-				IL_006c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0071: ldc.i4.0
-				IL_0072: ceq
-				IL_0074: stloc.1
-				IL_0075: ldloc.1
-				IL_0076: box [System.Runtime]System.Boolean
-				IL_007b: ret
+				IL_0012: ldloc.0
+				IL_0013: isinst [System.Runtime]System.String
+				IL_0018: dup
+				IL_0019: brfalse IL_0029
 
-				IL_007c: ldloc.2
-				IL_007d: ret
+				IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_0023: stloc.0
+				IL_0024: br IL_0036
+
+				IL_0029: pop
+
+				IL_002a: ldloc.0
+				IL_002b: ldstr "trim"
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0035: stloc.0
+
+				IL_0036: ldloc.0
+				IL_0037: ldstr "length"
+				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0041: stloc.0
+				IL_0042: ldloc.0
+				IL_0043: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0048: ldc.r8 0.0
+				IL_0051: cgt
+				IL_0053: stloc.1
+				IL_0054: ldloc.1
+				IL_0055: box [System.Runtime]System.Boolean
+				IL_005a: stloc.2
+				IL_005b: ldloc.2
+				IL_005c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0061: stloc.1
+				IL_0062: ldloc.1
+				IL_0063: brfalse IL_00a1
+
+				IL_0068: ldarg.0
+				IL_0069: ldc.i4.0
+				IL_006a: ldelem.ref
+				IL_006b: castclass Modules.Compile_Scripts_BumpVersion/Scope
+				IL_0070: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
+				IL_0075: ldc.i4.2
+				IL_0076: newarr [System.Runtime]System.Object
+				IL_007b: dup
+				IL_007c: ldc.i4.0
+				IL_007d: ldarg.0
+				IL_007e: ldc.i4.0
+				IL_007f: ldelem.ref
+				IL_0080: stelem.ref
+				IL_0081: dup
+				IL_0082: ldc.i4.1
+				IL_0083: ldarg.0
+				IL_0084: ldc.i4.1
+				IL_0085: ldelem.ref
+				IL_0086: stelem.ref
+				IL_0087: stloc.3
+				IL_0088: ldloc.3
+				IL_0089: ldarg.2
+				IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_008f: stloc.0
+				IL_0090: ldloc.0
+				IL_0091: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0096: ldc.i4.0
+				IL_0097: ceq
+				IL_0099: stloc.1
+				IL_009a: ldloc.1
+				IL_009b: box [System.Runtime]System.Boolean
+				IL_00a0: ret
+
+				IL_00a1: ldloc.2
+				IL_00a2: ret
 			} // end of method ArrowFunction_L113C44::__js_call__
 
 		} // end of class ArrowFunction_L113C44
@@ -2845,7 +3013,7 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 329 (0x149)
+			// Code size: 397 (0x18d)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/Scope,
@@ -2873,100 +3041,122 @@
 			IL_001e: stloc.s 4
 			IL_0020: ldloc.s 4
 			IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0027: ldstr "slice"
-			IL_002c: ldc.r8 0.0
-			IL_0035: box [System.Runtime]System.Double
-			IL_003a: ldc.r8 10
-			IL_0043: box [System.Runtime]System.Double
-			IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_004d: stloc.1
-			IL_004e: ldarg.3
-			IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0054: stloc.s 4
-			IL_0056: ldstr "\\r?\\n"
-			IL_005b: ldstr ""
-			IL_0060: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0065: stloc.s 5
-			IL_0067: ldloc.s 4
-			IL_0069: ldstr "split"
-			IL_006e: ldloc.s 5
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0075: stloc.s 4
-			IL_0077: ldloc.s 4
-			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007e: stloc.s 4
-			IL_0080: ldc.i4.2
-			IL_0081: newarr [System.Runtime]System.Object
-			IL_0086: dup
-			IL_0087: ldc.i4.0
-			IL_0088: ldarg.0
-			IL_0089: stelem.ref
-			IL_008a: dup
-			IL_008b: ldc.i4.1
-			IL_008c: ldloc.0
-			IL_008d: stelem.ref
-			IL_008e: stloc.s 6
-			IL_0090: ldloc.s 6
-			IL_0092: ldc.i4.0
-			IL_0093: ldelem.ref
-			IL_0094: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0099: ldloc.s 6
-			IL_009b: newobj instance void Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope, object[])
-			IL_00a0: ldc.i4.1
-			IL_00a1: conv.r8
-			IL_00a2: ldstr ""
-			IL_00a7: ldc.i4.0
-			IL_00a8: ldc.i4.0
-			IL_00a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_00ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject>(!!0)
-			IL_00b3: stloc.s 7
-			IL_00b5: ldloc.s 4
-			IL_00b7: ldstr "filter"
-			IL_00bc: ldloc.s 7
-			IL_00be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00c3: stloc.s 4
-			IL_00c5: ldloc.s 4
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00cc: ldstr "join"
-			IL_00d1: ldstr "\n"
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00db: stloc.2
-			IL_00dc: ldloc.2
-			IL_00dd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_00e2: ldc.i4.0
-			IL_00e3: ceq
-			IL_00e5: stloc.s 8
-			IL_00e7: ldloc.s 8
-			IL_00e9: brfalse IL_00f8
+			IL_0027: stloc.s 4
+			IL_0029: ldc.i4.0
+			IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_002f: brfalse IL_0069
 
-			IL_00ee: ldstr "\n"
-			IL_00f3: stloc.s 9
-			IL_00f5: ldloc.s 9
-			IL_00f7: stloc.2
+			IL_0034: ldloc.s 4
+			IL_0036: isinst [System.Runtime]System.String
+			IL_003b: dup
+			IL_003c: brfalse IL_0068
 
-			IL_00f8: ldarg.2
-			IL_00f9: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00fe: stloc.s 9
-			IL_0100: ldstr "## v"
-			IL_0105: ldloc.s 9
-			IL_0107: call string [System.Runtime]System.String::Concat(string, string)
-			IL_010c: ldstr " - "
-			IL_0111: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0116: ldloc.1
-			IL_0117: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_011c: stloc.s 9
-			IL_011e: ldloc.s 9
-			IL_0120: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0125: ldstr "\n\n"
-			IL_012a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_012f: ldloc.2
-			IL_0130: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0135: stloc.s 9
-			IL_0137: ldloc.s 9
-			IL_0139: call string [System.Runtime]System.String::Concat(string, string)
-			IL_013e: ldstr "\n"
-			IL_0143: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0148: ret
+			IL_0041: ldc.r8 0.0
+			IL_004a: box [System.Runtime]System.Double
+			IL_004f: ldc.r8 10
+			IL_0058: box [System.Runtime]System.Double
+			IL_005d: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+			IL_0062: stloc.1
+			IL_0063: br IL_0092
+
+			IL_0068: pop
+
+			IL_0069: ldloc.s 4
+			IL_006b: ldstr "slice"
+			IL_0070: ldc.r8 0.0
+			IL_0079: box [System.Runtime]System.Double
+			IL_007e: ldc.r8 10
+			IL_0087: box [System.Runtime]System.Double
+			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0091: stloc.1
+
+			IL_0092: ldarg.3
+			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0098: stloc.s 4
+			IL_009a: ldstr "\\r?\\n"
+			IL_009f: ldstr ""
+			IL_00a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_00a9: stloc.s 5
+			IL_00ab: ldloc.s 4
+			IL_00ad: ldstr "split"
+			IL_00b2: ldloc.s 5
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00b9: stloc.s 4
+			IL_00bb: ldloc.s 4
+			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c2: stloc.s 4
+			IL_00c4: ldc.i4.2
+			IL_00c5: newarr [System.Runtime]System.Object
+			IL_00ca: dup
+			IL_00cb: ldc.i4.0
+			IL_00cc: ldarg.0
+			IL_00cd: stelem.ref
+			IL_00ce: dup
+			IL_00cf: ldc.i4.1
+			IL_00d0: ldloc.0
+			IL_00d1: stelem.ref
+			IL_00d2: stloc.s 6
+			IL_00d4: ldloc.s 6
+			IL_00d6: ldc.i4.0
+			IL_00d7: ldelem.ref
+			IL_00d8: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_00dd: ldloc.s 6
+			IL_00df: newobj instance void Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope, object[])
+			IL_00e4: ldc.i4.1
+			IL_00e5: conv.r8
+			IL_00e6: ldstr ""
+			IL_00eb: ldc.i4.0
+			IL_00ec: ldc.i4.0
+			IL_00ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject>(!!0)
+			IL_00f7: stloc.s 7
+			IL_00f9: ldloc.s 4
+			IL_00fb: ldstr "filter"
+			IL_0100: ldloc.s 7
+			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0107: stloc.s 4
+			IL_0109: ldloc.s 4
+			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0110: ldstr "join"
+			IL_0115: ldstr "\n"
+			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_011f: stloc.2
+			IL_0120: ldloc.2
+			IL_0121: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0126: ldc.i4.0
+			IL_0127: ceq
+			IL_0129: stloc.s 8
+			IL_012b: ldloc.s 8
+			IL_012d: brfalse IL_013c
+
+			IL_0132: ldstr "\n"
+			IL_0137: stloc.s 9
+			IL_0139: ldloc.s 9
+			IL_013b: stloc.2
+
+			IL_013c: ldarg.2
+			IL_013d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0142: stloc.s 9
+			IL_0144: ldstr "## v"
+			IL_0149: ldloc.s 9
+			IL_014b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0150: ldstr " - "
+			IL_0155: call string [System.Runtime]System.String::Concat(string, string)
+			IL_015a: ldloc.1
+			IL_015b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0160: stloc.s 9
+			IL_0162: ldloc.s 9
+			IL_0164: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0169: ldstr "\n\n"
+			IL_016e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0173: ldloc.2
+			IL_0174: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0179: stloc.s 9
+			IL_017b: ldloc.s 9
+			IL_017d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0182: ldstr "\n"
+			IL_0187: call string [System.Runtime]System.String::Concat(string, string)
+			IL_018c: ret
 		} // end of method generateReleaseSection::__js_call__
 
 	} // end of class generateReleaseSection
@@ -3090,7 +3280,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 101 (0x65)
+				// Code size: 138 (0x8a)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -3101,54 +3291,72 @@
 
 				IL_0000: ldarg.2
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0006: ldstr "trim"
-				IL_000b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_0010: stloc.0
-				IL_0011: ldloc.0
-				IL_0012: ldstr "length"
-				IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_001c: stloc.0
-				IL_001d: ldloc.0
-				IL_001e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0023: stloc.1
-				IL_0024: ldloc.1
-				IL_0025: brfalse IL_0063
+				IL_0006: stloc.0
+				IL_0007: ldc.i4.0
+				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_000d: brfalse IL_002a
 
-				IL_002a: ldarg.0
-				IL_002b: ldc.i4.0
-				IL_002c: ldelem.ref
-				IL_002d: castclass Modules.Compile_Scripts_BumpVersion/Scope
-				IL_0032: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
-				IL_0037: ldc.i4.2
-				IL_0038: newarr [System.Runtime]System.Object
-				IL_003d: dup
-				IL_003e: ldc.i4.0
-				IL_003f: ldarg.0
-				IL_0040: ldc.i4.0
-				IL_0041: ldelem.ref
-				IL_0042: stelem.ref
-				IL_0043: dup
-				IL_0044: ldc.i4.1
-				IL_0045: ldarg.0
-				IL_0046: ldc.i4.1
-				IL_0047: ldelem.ref
-				IL_0048: stelem.ref
-				IL_0049: stloc.2
-				IL_004a: ldloc.2
-				IL_004b: ldarg.2
-				IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0051: stloc.3
-				IL_0052: ldloc.3
-				IL_0053: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0058: ldc.i4.0
-				IL_0059: ceq
-				IL_005b: stloc.1
-				IL_005c: ldloc.1
-				IL_005d: box [System.Runtime]System.Boolean
-				IL_0062: ret
+				IL_0012: ldloc.0
+				IL_0013: isinst [System.Runtime]System.String
+				IL_0018: dup
+				IL_0019: brfalse IL_0029
 
-				IL_0063: ldloc.0
-				IL_0064: ret
+				IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_0023: stloc.0
+				IL_0024: br IL_0036
+
+				IL_0029: pop
+
+				IL_002a: ldloc.0
+				IL_002b: ldstr "trim"
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0035: stloc.0
+
+				IL_0036: ldloc.0
+				IL_0037: ldstr "length"
+				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0041: stloc.0
+				IL_0042: ldloc.0
+				IL_0043: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0048: stloc.1
+				IL_0049: ldloc.1
+				IL_004a: brfalse IL_0088
+
+				IL_004f: ldarg.0
+				IL_0050: ldc.i4.0
+				IL_0051: ldelem.ref
+				IL_0052: castclass Modules.Compile_Scripts_BumpVersion/Scope
+				IL_0057: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
+				IL_005c: ldc.i4.2
+				IL_005d: newarr [System.Runtime]System.Object
+				IL_0062: dup
+				IL_0063: ldc.i4.0
+				IL_0064: ldarg.0
+				IL_0065: ldc.i4.0
+				IL_0066: ldelem.ref
+				IL_0067: stelem.ref
+				IL_0068: dup
+				IL_0069: ldc.i4.1
+				IL_006a: ldarg.0
+				IL_006b: ldc.i4.1
+				IL_006c: ldelem.ref
+				IL_006d: stelem.ref
+				IL_006e: stloc.2
+				IL_006f: ldloc.2
+				IL_0070: ldarg.2
+				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0076: stloc.3
+				IL_0077: ldloc.3
+				IL_0078: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_007d: ldc.i4.0
+				IL_007e: ceq
+				IL_0080: stloc.1
+				IL_0081: ldloc.1
+				IL_0082: box [System.Runtime]System.Boolean
+				IL_0087: ret
+
+				IL_0088: ldloc.0
+				IL_0089: ret
 			} // end of method ArrowFunction_L136C51::__js_call__
 
 		} // end of class ArrowFunction_L136C51
@@ -3327,7 +3535,7 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1921 (0x781)
+			// Code size: 2071 (0x817)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_BumpVersion/perform/Scope,
@@ -3391,731 +3599,791 @@
 			IL_0041: stloc.s 30
 			IL_0043: ldloc.s 30
 			IL_0045: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004a: ldstr "includes"
-			IL_004f: ldstr "--skip-empty"
-			IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0059: stloc.2
-			IL_005a: ldarg.0
-			IL_005b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_0060: ldc.i4.1
-			IL_0061: newarr [System.Runtime]System.Object
-			IL_0066: dup
-			IL_0067: ldc.i4.0
-			IL_0068: ldarg.0
-			IL_0069: stelem.ref
-			IL_006a: stloc.s 31
-			IL_006c: ldarg.0
-			IL_006d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_0072: stloc.s 30
-			IL_0074: ldloc.s 31
-			IL_0076: ldloc.s 30
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_007d: stloc.3
-			IL_007e: ldarg.0
-			IL_007f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_0084: ldc.i4.1
-			IL_0085: newarr [System.Runtime]System.Object
-			IL_008a: dup
-			IL_008b: ldc.i4.0
+			IL_004a: stloc.s 30
+			IL_004c: ldc.i4.0
+			IL_004d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0052: brfalse IL_007a
+
+			IL_0057: ldloc.s 30
+			IL_0059: isinst [System.Runtime]System.String
+			IL_005e: dup
+			IL_005f: brfalse IL_0079
+
+			IL_0064: ldstr "--skip-empty"
+			IL_0069: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_006e: box [System.Runtime]System.Boolean
+			IL_0073: stloc.2
+			IL_0074: br IL_008c
+
+			IL_0079: pop
+
+			IL_007a: ldloc.s 30
+			IL_007c: ldstr "includes"
+			IL_0081: ldstr "--skip-empty"
+			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_008b: stloc.2
+
 			IL_008c: ldarg.0
-			IL_008d: stelem.ref
-			IL_008e: stloc.s 31
-			IL_0090: ldarg.0
-			IL_0091: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_0096: stloc.s 30
-			IL_0098: ldloc.s 31
-			IL_009a: ldloc.s 30
-			IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00a1: stloc.s 4
-			IL_00a3: ldarg.0
-			IL_00a4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_00a9: ldc.i4.1
-			IL_00aa: newarr [System.Runtime]System.Object
-			IL_00af: dup
-			IL_00b0: ldc.i4.0
-			IL_00b1: ldarg.0
-			IL_00b2: stelem.ref
-			IL_00b3: stloc.s 31
-			IL_00b5: ldarg.0
-			IL_00b6: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_00bb: stloc.s 30
-			IL_00bd: ldloc.s 31
-			IL_00bf: ldloc.s 30
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00c6: stloc.s 5
-			IL_00c8: ldarg.0
-			IL_00c9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_00ce: ldc.i4.1
-			IL_00cf: newarr [System.Runtime]System.Object
-			IL_00d4: dup
-			IL_00d5: ldc.i4.0
-			IL_00d6: ldarg.0
-			IL_00d7: stelem.ref
-			IL_00d8: stloc.s 31
-			IL_00da: ldarg.0
-			IL_00db: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_00e0: stloc.s 30
-			IL_00e2: ldloc.s 31
-			IL_00e4: ldloc.s 30
-			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00eb: stloc.s 6
-			IL_00ed: ldarg.0
-			IL_00ee: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_00f3: ldc.i4.1
-			IL_00f4: newarr [System.Runtime]System.Object
-			IL_00f9: dup
-			IL_00fa: ldc.i4.0
-			IL_00fb: ldarg.0
-			IL_00fc: stelem.ref
-			IL_00fd: stloc.s 31
-			IL_00ff: ldarg.0
-			IL_0100: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_0105: stloc.s 30
-			IL_0107: ldloc.s 31
-			IL_0109: ldloc.s 30
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0110: stloc.s 7
-			IL_0112: ldarg.0
-			IL_0113: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_0118: ldc.i4.1
-			IL_0119: newarr [System.Runtime]System.Object
-			IL_011e: dup
-			IL_011f: ldc.i4.0
-			IL_0120: ldarg.0
-			IL_0121: stelem.ref
-			IL_0122: stloc.s 31
-			IL_0124: ldarg.0
-			IL_0125: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_012a: stloc.s 30
-			IL_012c: ldloc.s 31
-			IL_012e: ldloc.s 30
-			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0135: stloc.s 8
-			IL_0137: ldarg.0
-			IL_0138: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::parseCurrentVersion
-			IL_013d: ldc.i4.1
-			IL_013e: newarr [System.Runtime]System.Object
-			IL_0143: dup
-			IL_0144: ldc.i4.0
-			IL_0145: ldarg.0
-			IL_0146: stelem.ref
-			IL_0147: ldloc.3
-			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_014d: stloc.s 9
-			IL_014f: ldarg.0
-			IL_0150: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::resolveTargetVersion
-			IL_0155: ldc.i4.1
-			IL_0156: newarr [System.Runtime]System.Object
-			IL_015b: dup
-			IL_015c: ldc.i4.0
-			IL_015d: ldarg.0
-			IL_015e: stelem.ref
-			IL_015f: ldloc.1
-			IL_0160: ldloc.s 9
-			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0167: stloc.s 10
-			IL_0169: ldloc.s 9
-			IL_016b: ldloc.s 10
-			IL_016d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0172: stloc.s 32
-			IL_0174: ldloc.s 32
-			IL_0176: brfalse IL_01e4
+			IL_008d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_0092: ldc.i4.1
+			IL_0093: newarr [System.Runtime]System.Object
+			IL_0098: dup
+			IL_0099: ldc.i4.0
+			IL_009a: ldarg.0
+			IL_009b: stelem.ref
+			IL_009c: stloc.s 31
+			IL_009e: ldarg.0
+			IL_009f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_00a4: stloc.s 30
+			IL_00a6: ldloc.s 31
+			IL_00a8: ldloc.s 30
+			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00af: stloc.3
+			IL_00b0: ldarg.0
+			IL_00b1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_00b6: ldc.i4.1
+			IL_00b7: newarr [System.Runtime]System.Object
+			IL_00bc: dup
+			IL_00bd: ldc.i4.0
+			IL_00be: ldarg.0
+			IL_00bf: stelem.ref
+			IL_00c0: stloc.s 31
+			IL_00c2: ldarg.0
+			IL_00c3: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_00c8: stloc.s 30
+			IL_00ca: ldloc.s 31
+			IL_00cc: ldloc.s 30
+			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00d3: stloc.s 4
+			IL_00d5: ldarg.0
+			IL_00d6: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_00db: ldc.i4.1
+			IL_00dc: newarr [System.Runtime]System.Object
+			IL_00e1: dup
+			IL_00e2: ldc.i4.0
+			IL_00e3: ldarg.0
+			IL_00e4: stelem.ref
+			IL_00e5: stloc.s 31
+			IL_00e7: ldarg.0
+			IL_00e8: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_00ed: stloc.s 30
+			IL_00ef: ldloc.s 31
+			IL_00f1: ldloc.s 30
+			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00f8: stloc.s 5
+			IL_00fa: ldarg.0
+			IL_00fb: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_0100: ldc.i4.1
+			IL_0101: newarr [System.Runtime]System.Object
+			IL_0106: dup
+			IL_0107: ldc.i4.0
+			IL_0108: ldarg.0
+			IL_0109: stelem.ref
+			IL_010a: stloc.s 31
+			IL_010c: ldarg.0
+			IL_010d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_0112: stloc.s 30
+			IL_0114: ldloc.s 31
+			IL_0116: ldloc.s 30
+			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_011d: stloc.s 6
+			IL_011f: ldarg.0
+			IL_0120: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_0125: ldc.i4.1
+			IL_0126: newarr [System.Runtime]System.Object
+			IL_012b: dup
+			IL_012c: ldc.i4.0
+			IL_012d: ldarg.0
+			IL_012e: stelem.ref
+			IL_012f: stloc.s 31
+			IL_0131: ldarg.0
+			IL_0132: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_0137: stloc.s 30
+			IL_0139: ldloc.s 31
+			IL_013b: ldloc.s 30
+			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0142: stloc.s 7
+			IL_0144: ldarg.0
+			IL_0145: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_014a: ldc.i4.1
+			IL_014b: newarr [System.Runtime]System.Object
+			IL_0150: dup
+			IL_0151: ldc.i4.0
+			IL_0152: ldarg.0
+			IL_0153: stelem.ref
+			IL_0154: stloc.s 31
+			IL_0156: ldarg.0
+			IL_0157: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
+			IL_015c: stloc.s 30
+			IL_015e: ldloc.s 31
+			IL_0160: ldloc.s 30
+			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0167: stloc.s 8
+			IL_0169: ldarg.0
+			IL_016a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::parseCurrentVersion
+			IL_016f: ldc.i4.1
+			IL_0170: newarr [System.Runtime]System.Object
+			IL_0175: dup
+			IL_0176: ldc.i4.0
+			IL_0177: ldarg.0
+			IL_0178: stelem.ref
+			IL_0179: ldloc.3
+			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_017f: stloc.s 9
+			IL_0181: ldarg.0
+			IL_0182: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::resolveTargetVersion
+			IL_0187: ldc.i4.1
+			IL_0188: newarr [System.Runtime]System.Object
+			IL_018d: dup
+			IL_018e: ldc.i4.0
+			IL_018f: ldarg.0
+			IL_0190: stelem.ref
+			IL_0191: ldloc.1
+			IL_0192: ldloc.s 9
+			IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0199: stloc.s 10
+			IL_019b: ldloc.s 9
+			IL_019d: ldloc.s 10
+			IL_019f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01a4: stloc.s 32
+			IL_01a6: ldloc.s 32
+			IL_01a8: brfalse IL_0216
 
-			IL_017b: ldstr "console"
-			IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018a: stloc.s 30
-			IL_018c: ldloc.s 9
-			IL_018e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0193: stloc.s 33
-			IL_0195: ldstr "Version unchanged ("
-			IL_019a: ldloc.s 33
-			IL_019c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01a1: ldstr "); aborting."
-			IL_01a6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01ab: stloc.s 33
-			IL_01ad: ldloc.s 30
-			IL_01af: ldstr "error"
-			IL_01b4: ldloc.s 33
-			IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01bb: pop
-			IL_01bc: ldstr "process"
-			IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01cb: ldstr "exit"
-			IL_01d0: ldc.r8 1
-			IL_01d9: box [System.Runtime]System.Double
-			IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01e3: pop
+			IL_01ad: ldstr "console"
+			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01bc: stloc.s 30
+			IL_01be: ldloc.s 9
+			IL_01c0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01c5: stloc.s 33
+			IL_01c7: ldstr "Version unchanged ("
+			IL_01cc: ldloc.s 33
+			IL_01ce: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01d3: ldstr "); aborting."
+			IL_01d8: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01dd: stloc.s 33
+			IL_01df: ldloc.s 30
+			IL_01e1: ldstr "error"
+			IL_01e6: ldloc.s 33
+			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01ed: pop
+			IL_01ee: ldstr "process"
+			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01fd: ldstr "exit"
+			IL_0202: ldc.r8 1
+			IL_020b: box [System.Runtime]System.Double
+			IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0215: pop
 
-			IL_01e4: ldarg.0
-			IL_01e5: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::extractUnreleased
-			IL_01ea: ldc.i4.1
-			IL_01eb: newarr [System.Runtime]System.Object
-			IL_01f0: dup
-			IL_01f1: ldc.i4.0
-			IL_01f2: ldarg.0
-			IL_01f3: stelem.ref
-			IL_01f4: ldloc.s 8
-			IL_01f6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01fb: stloc.s 30
-			IL_01fd: ldloc.s 30
-			IL_01ff: brfalse IL_0210
-
-			IL_0204: ldloc.s 30
-			IL_0206: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_020b: brfalse IL_0221
-
-			IL_0210: ldloc.s 30
-			IL_0212: ldstr ""
-			IL_0217: ldstr "body"
-			IL_021c: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
-
-			IL_0221: ldloc.s 30
-			IL_0223: ldstr "body"
-			IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_022d: stloc.s 11
+			IL_0216: ldarg.0
+			IL_0217: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::extractUnreleased
+			IL_021c: ldc.i4.1
+			IL_021d: newarr [System.Runtime]System.Object
+			IL_0222: dup
+			IL_0223: ldc.i4.0
+			IL_0224: ldarg.0
+			IL_0225: stelem.ref
+			IL_0226: ldloc.s 8
+			IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_022d: stloc.s 30
 			IL_022f: ldloc.s 30
-			IL_0231: ldstr "start"
-			IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_023b: stloc.s 12
-			IL_023d: ldloc.s 30
-			IL_023f: ldstr "end"
-			IL_0244: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0249: stloc.s 13
-			IL_024b: ldloc.s 11
-			IL_024d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0252: stloc.s 30
-			IL_0254: ldstr "\\r?\\n"
-			IL_0259: ldstr ""
-			IL_025e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0263: stloc.s 34
-			IL_0265: ldloc.s 30
-			IL_0267: ldstr "split"
-			IL_026c: ldloc.s 34
-			IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0273: stloc.s 30
-			IL_0275: ldloc.s 30
-			IL_0277: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_027c: stloc.s 30
-			IL_027e: ldc.i4.2
-			IL_027f: newarr [System.Runtime]System.Object
-			IL_0284: dup
-			IL_0285: ldc.i4.0
-			IL_0286: ldarg.0
-			IL_0287: stelem.ref
-			IL_0288: dup
-			IL_0289: ldc.i4.1
-			IL_028a: ldloc.0
-			IL_028b: stelem.ref
-			IL_028c: stloc.s 31
-			IL_028e: ldloc.s 31
-			IL_0290: ldc.i4.0
-			IL_0291: ldelem.ref
-			IL_0292: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_0297: ldloc.s 31
-			IL_0299: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope, object[])
-			IL_029e: ldc.i4.1
-			IL_029f: conv.r8
-			IL_02a0: ldstr ""
-			IL_02a5: ldc.i4.0
-			IL_02a6: ldc.i4.0
-			IL_02a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_02ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject>(!!0)
-			IL_02b1: stloc.s 35
-			IL_02b3: ldloc.s 30
-			IL_02b5: ldstr "some"
-			IL_02ba: ldloc.s 35
-			IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02c1: stloc.s 14
-			IL_02c3: ldloc.s 14
-			IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_02ca: ldc.i4.0
-			IL_02cb: ceq
-			IL_02cd: stloc.s 32
-			IL_02cf: ldloc.s 32
-			IL_02d1: box [System.Runtime]System.Boolean
-			IL_02d6: stloc.s 36
-			IL_02d8: ldloc.s 36
-			IL_02da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02df: stloc.s 32
-			IL_02e1: ldloc.s 32
-			IL_02e3: brfalse IL_02f0
+			IL_0231: brfalse IL_0242
 
-			IL_02e8: ldloc.2
-			IL_02e9: stloc.s 38
-			IL_02eb: br IL_02f4
+			IL_0236: ldloc.s 30
+			IL_0238: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_023d: brfalse IL_0253
 
-			IL_02f0: ldloc.s 36
-			IL_02f2: stloc.s 38
+			IL_0242: ldloc.s 30
+			IL_0244: ldstr ""
+			IL_0249: ldstr "body"
+			IL_024e: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
-			IL_02f4: ldloc.s 38
-			IL_02f6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02fb: stloc.s 32
-			IL_02fd: ldloc.s 32
-			IL_02ff: brfalse IL_0472
+			IL_0253: ldloc.s 30
+			IL_0255: ldstr "body"
+			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_025f: stloc.s 11
+			IL_0261: ldloc.s 30
+			IL_0263: ldstr "start"
+			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_026d: stloc.s 12
+			IL_026f: ldloc.s 30
+			IL_0271: ldstr "end"
+			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_027b: stloc.s 13
+			IL_027d: ldloc.s 11
+			IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0284: stloc.s 30
+			IL_0286: ldstr "\\r?\\n"
+			IL_028b: ldstr ""
+			IL_0290: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0295: stloc.s 34
+			IL_0297: ldloc.s 30
+			IL_0299: ldstr "split"
+			IL_029e: ldloc.s 34
+			IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02a5: stloc.s 30
+			IL_02a7: ldloc.s 30
+			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02ae: stloc.s 30
+			IL_02b0: ldc.i4.2
+			IL_02b1: newarr [System.Runtime]System.Object
+			IL_02b6: dup
+			IL_02b7: ldc.i4.0
+			IL_02b8: ldarg.0
+			IL_02b9: stelem.ref
+			IL_02ba: dup
+			IL_02bb: ldc.i4.1
+			IL_02bc: ldloc.0
+			IL_02bd: stelem.ref
+			IL_02be: stloc.s 31
+			IL_02c0: ldloc.s 31
+			IL_02c2: ldc.i4.0
+			IL_02c3: ldelem.ref
+			IL_02c4: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_02c9: ldloc.s 31
+			IL_02cb: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope, object[])
+			IL_02d0: ldc.i4.1
+			IL_02d1: conv.r8
+			IL_02d2: ldstr ""
+			IL_02d7: ldc.i4.0
+			IL_02d8: ldc.i4.0
+			IL_02d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_02de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject>(!!0)
+			IL_02e3: stloc.s 35
+			IL_02e5: ldloc.s 30
+			IL_02e7: ldstr "some"
+			IL_02ec: ldloc.s 35
+			IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02f3: stloc.s 14
+			IL_02f5: ldloc.s 14
+			IL_02f7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_02fc: ldc.i4.0
+			IL_02fd: ceq
+			IL_02ff: stloc.s 32
+			IL_0301: ldloc.s 32
+			IL_0303: box [System.Runtime]System.Boolean
+			IL_0308: stloc.s 36
+			IL_030a: ldloc.s 36
+			IL_030c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0311: stloc.s 32
+			IL_0313: ldloc.s 32
+			IL_0315: brfalse IL_0322
 
-			IL_0304: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0309: stloc.s 39
-			IL_030b: ldloc.s 39
-			IL_030d: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
-			IL_0312: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0317: pop
-			IL_0318: ldarg.0
-			IL_0319: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_031e: ldc.i4.1
-			IL_031f: newarr [System.Runtime]System.Object
-			IL_0324: dup
-			IL_0325: ldc.i4.0
-			IL_0326: ldarg.0
-			IL_0327: stelem.ref
-			IL_0328: ldloc.3
-			IL_0329: ldloc.s 10
-			IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0330: stloc.s 15
-			IL_0332: ldarg.0
-			IL_0333: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0338: ldc.i4.1
-			IL_0339: newarr [System.Runtime]System.Object
-			IL_033e: dup
-			IL_033f: ldc.i4.0
-			IL_0340: ldarg.0
-			IL_0341: stelem.ref
-			IL_0342: ldloc.s 4
-			IL_0344: ldloc.s 10
-			IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_034b: stloc.s 16
-			IL_034d: ldarg.0
-			IL_034e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0353: ldc.i4.1
-			IL_0354: newarr [System.Runtime]System.Object
-			IL_0359: dup
-			IL_035a: ldc.i4.0
-			IL_035b: ldarg.0
-			IL_035c: stelem.ref
-			IL_035d: ldloc.s 5
-			IL_035f: ldloc.s 10
-			IL_0361: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0366: stloc.s 17
-			IL_0368: ldarg.0
-			IL_0369: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_036e: ldc.i4.1
-			IL_036f: newarr [System.Runtime]System.Object
-			IL_0374: dup
-			IL_0375: ldc.i4.0
-			IL_0376: ldarg.0
-			IL_0377: stelem.ref
-			IL_0378: ldloc.s 6
-			IL_037a: ldloc.s 10
-			IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0381: stloc.s 18
-			IL_0383: ldarg.0
-			IL_0384: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
-			IL_0389: ldc.i4.1
-			IL_038a: newarr [System.Runtime]System.Object
-			IL_038f: dup
-			IL_0390: ldc.i4.0
-			IL_0391: ldarg.0
-			IL_0392: stelem.ref
-			IL_0393: ldloc.s 7
-			IL_0395: ldloc.s 10
-			IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_039c: stloc.s 19
-			IL_039e: ldarg.0
-			IL_039f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_03a4: stloc.s 30
-			IL_03a6: ldc.i4.1
-			IL_03a7: newarr [System.Runtime]System.Object
-			IL_03ac: dup
-			IL_03ad: ldc.i4.0
-			IL_03ae: ldarg.0
-			IL_03af: stelem.ref
-			IL_03b0: stloc.s 31
-			IL_03b2: ldarg.0
-			IL_03b3: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_03b8: stloc.s 40
-			IL_03ba: ldloc.s 30
-			IL_03bc: ldloc.s 31
-			IL_03be: ldloc.s 40
-			IL_03c0: ldloc.s 15
-			IL_03c2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03c7: pop
-			IL_03c8: ldarg.0
-			IL_03c9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_03ce: stloc.s 40
-			IL_03d0: ldc.i4.1
-			IL_03d1: newarr [System.Runtime]System.Object
-			IL_03d6: dup
-			IL_03d7: ldc.i4.0
-			IL_03d8: ldarg.0
-			IL_03d9: stelem.ref
-			IL_03da: stloc.s 31
-			IL_03dc: ldarg.0
-			IL_03dd: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_03e2: stloc.s 30
-			IL_03e4: ldloc.s 40
-			IL_03e6: ldloc.s 31
-			IL_03e8: ldloc.s 30
-			IL_03ea: ldloc.s 16
-			IL_03ec: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03f1: pop
-			IL_03f2: ldarg.0
-			IL_03f3: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_03f8: stloc.s 30
-			IL_03fa: ldc.i4.1
-			IL_03fb: newarr [System.Runtime]System.Object
-			IL_0400: dup
-			IL_0401: ldc.i4.0
-			IL_0402: ldarg.0
-			IL_0403: stelem.ref
-			IL_0404: stloc.s 31
-			IL_0406: ldarg.0
-			IL_0407: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_040c: stloc.s 40
-			IL_040e: ldloc.s 30
-			IL_0410: ldloc.s 31
-			IL_0412: ldloc.s 40
-			IL_0414: ldloc.s 17
-			IL_0416: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_041b: pop
-			IL_041c: ldarg.0
-			IL_041d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0422: stloc.s 40
-			IL_0424: ldc.i4.1
-			IL_0425: newarr [System.Runtime]System.Object
-			IL_042a: dup
-			IL_042b: ldc.i4.0
-			IL_042c: ldarg.0
-			IL_042d: stelem.ref
-			IL_042e: stloc.s 31
-			IL_0430: ldarg.0
-			IL_0431: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_0436: stloc.s 30
-			IL_0438: ldloc.s 40
-			IL_043a: ldloc.s 31
-			IL_043c: ldloc.s 30
-			IL_043e: ldloc.s 18
-			IL_0440: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0445: pop
-			IL_0446: ldarg.0
-			IL_0447: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_044c: stloc.s 30
-			IL_044e: ldc.i4.1
-			IL_044f: newarr [System.Runtime]System.Object
-			IL_0454: dup
-			IL_0455: ldc.i4.0
-			IL_0456: ldarg.0
-			IL_0457: stelem.ref
-			IL_0458: stloc.s 31
-			IL_045a: ldarg.0
-			IL_045b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_0460: stloc.s 40
-			IL_0462: ldloc.s 30
-			IL_0464: ldloc.s 31
-			IL_0466: ldloc.s 40
-			IL_0468: ldloc.s 19
-			IL_046a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_046f: pop
-			IL_0470: ldnull
-			IL_0471: ret
+			IL_031a: ldloc.2
+			IL_031b: stloc.s 38
+			IL_031d: br IL_0326
 
-			IL_0472: ldarg.0
-			IL_0473: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::generateReleaseSection
-			IL_0478: ldc.i4.1
-			IL_0479: newarr [System.Runtime]System.Object
-			IL_047e: dup
-			IL_047f: ldc.i4.0
-			IL_0480: ldarg.0
-			IL_0481: stelem.ref
-			IL_0482: ldloc.s 10
-			IL_0484: ldloc.s 11
-			IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_048b: stloc.s 20
-			IL_048d: ldloc.s 8
-			IL_048f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0494: ldstr "slice"
-			IL_0499: ldc.r8 0.0
-			IL_04a2: box [System.Runtime]System.Double
-			IL_04a7: ldloc.s 12
-			IL_04a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_04ae: stloc.s 21
-			IL_04b0: ldloc.s 8
-			IL_04b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04b7: ldstr "slice"
-			IL_04bc: ldloc.s 13
-			IL_04be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_04c3: stloc.s 22
-			IL_04c5: ldstr "\n_Nothing yet._\n\n"
-			IL_04ca: stloc.s 23
-			IL_04cc: ldloc.s 21
-			IL_04ce: ldloc.s 23
-			IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_04d5: stloc.s 38
-			IL_04d7: ldloc.s 38
-			IL_04d9: ldloc.s 20
-			IL_04db: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_04e0: stloc.s 38
-			IL_04e2: ldloc.s 38
-			IL_04e4: ldloc.s 22
-			IL_04e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_04eb: stloc.s 24
-			IL_04ed: ldarg.0
-			IL_04ee: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_04f3: ldc.i4.1
-			IL_04f4: newarr [System.Runtime]System.Object
-			IL_04f9: dup
-			IL_04fa: ldc.i4.0
-			IL_04fb: ldarg.0
-			IL_04fc: stelem.ref
-			IL_04fd: ldloc.3
-			IL_04fe: ldloc.s 10
-			IL_0500: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0505: stloc.s 25
-			IL_0507: ldarg.0
-			IL_0508: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_050d: ldc.i4.1
-			IL_050e: newarr [System.Runtime]System.Object
-			IL_0513: dup
-			IL_0514: ldc.i4.0
-			IL_0515: ldarg.0
-			IL_0516: stelem.ref
-			IL_0517: ldloc.s 4
-			IL_0519: ldloc.s 10
-			IL_051b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0520: stloc.s 26
-			IL_0522: ldarg.0
-			IL_0523: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0528: ldc.i4.1
-			IL_0529: newarr [System.Runtime]System.Object
-			IL_052e: dup
-			IL_052f: ldc.i4.0
-			IL_0530: ldarg.0
-			IL_0531: stelem.ref
-			IL_0532: ldloc.s 5
-			IL_0534: ldloc.s 10
-			IL_0536: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_053b: stloc.s 27
-			IL_053d: ldarg.0
-			IL_053e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0543: ldc.i4.1
-			IL_0544: newarr [System.Runtime]System.Object
-			IL_0549: dup
-			IL_054a: ldc.i4.0
-			IL_054b: ldarg.0
-			IL_054c: stelem.ref
-			IL_054d: ldloc.s 6
-			IL_054f: ldloc.s 10
-			IL_0551: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0556: stloc.s 28
-			IL_0558: ldarg.0
-			IL_0559: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
-			IL_055e: ldc.i4.1
-			IL_055f: newarr [System.Runtime]System.Object
-			IL_0564: dup
-			IL_0565: ldc.i4.0
-			IL_0566: ldarg.0
-			IL_0567: stelem.ref
-			IL_0568: ldloc.s 7
-			IL_056a: ldloc.s 10
-			IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0571: stloc.s 29
-			IL_0573: ldarg.0
-			IL_0574: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0579: stloc.s 40
-			IL_057b: ldc.i4.1
-			IL_057c: newarr [System.Runtime]System.Object
-			IL_0581: dup
-			IL_0582: ldc.i4.0
+			IL_0322: ldloc.s 36
+			IL_0324: stloc.s 38
+
+			IL_0326: ldloc.s 38
+			IL_0328: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_032d: stloc.s 32
+			IL_032f: ldloc.s 32
+			IL_0331: brfalse IL_04a4
+
+			IL_0336: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_033b: stloc.s 39
+			IL_033d: ldloc.s 39
+			IL_033f: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
+			IL_0344: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0349: pop
+			IL_034a: ldarg.0
+			IL_034b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0350: ldc.i4.1
+			IL_0351: newarr [System.Runtime]System.Object
+			IL_0356: dup
+			IL_0357: ldc.i4.0
+			IL_0358: ldarg.0
+			IL_0359: stelem.ref
+			IL_035a: ldloc.3
+			IL_035b: ldloc.s 10
+			IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0362: stloc.s 15
+			IL_0364: ldarg.0
+			IL_0365: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_036a: ldc.i4.1
+			IL_036b: newarr [System.Runtime]System.Object
+			IL_0370: dup
+			IL_0371: ldc.i4.0
+			IL_0372: ldarg.0
+			IL_0373: stelem.ref
+			IL_0374: ldloc.s 4
+			IL_0376: ldloc.s 10
+			IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_037d: stloc.s 16
+			IL_037f: ldarg.0
+			IL_0380: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0385: ldc.i4.1
+			IL_0386: newarr [System.Runtime]System.Object
+			IL_038b: dup
+			IL_038c: ldc.i4.0
+			IL_038d: ldarg.0
+			IL_038e: stelem.ref
+			IL_038f: ldloc.s 5
+			IL_0391: ldloc.s 10
+			IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0398: stloc.s 17
+			IL_039a: ldarg.0
+			IL_039b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_03a0: ldc.i4.1
+			IL_03a1: newarr [System.Runtime]System.Object
+			IL_03a6: dup
+			IL_03a7: ldc.i4.0
+			IL_03a8: ldarg.0
+			IL_03a9: stelem.ref
+			IL_03aa: ldloc.s 6
+			IL_03ac: ldloc.s 10
+			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03b3: stloc.s 18
+			IL_03b5: ldarg.0
+			IL_03b6: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
+			IL_03bb: ldc.i4.1
+			IL_03bc: newarr [System.Runtime]System.Object
+			IL_03c1: dup
+			IL_03c2: ldc.i4.0
+			IL_03c3: ldarg.0
+			IL_03c4: stelem.ref
+			IL_03c5: ldloc.s 7
+			IL_03c7: ldloc.s 10
+			IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03ce: stloc.s 19
+			IL_03d0: ldarg.0
+			IL_03d1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_03d6: stloc.s 30
+			IL_03d8: ldc.i4.1
+			IL_03d9: newarr [System.Runtime]System.Object
+			IL_03de: dup
+			IL_03df: ldc.i4.0
+			IL_03e0: ldarg.0
+			IL_03e1: stelem.ref
+			IL_03e2: stloc.s 31
+			IL_03e4: ldarg.0
+			IL_03e5: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_03ea: stloc.s 40
+			IL_03ec: ldloc.s 30
+			IL_03ee: ldloc.s 31
+			IL_03f0: ldloc.s 40
+			IL_03f2: ldloc.s 15
+			IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03f9: pop
+			IL_03fa: ldarg.0
+			IL_03fb: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0400: stloc.s 40
+			IL_0402: ldc.i4.1
+			IL_0403: newarr [System.Runtime]System.Object
+			IL_0408: dup
+			IL_0409: ldc.i4.0
+			IL_040a: ldarg.0
+			IL_040b: stelem.ref
+			IL_040c: stloc.s 31
+			IL_040e: ldarg.0
+			IL_040f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_0414: stloc.s 30
+			IL_0416: ldloc.s 40
+			IL_0418: ldloc.s 31
+			IL_041a: ldloc.s 30
+			IL_041c: ldloc.s 16
+			IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0423: pop
+			IL_0424: ldarg.0
+			IL_0425: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_042a: stloc.s 30
+			IL_042c: ldc.i4.1
+			IL_042d: newarr [System.Runtime]System.Object
+			IL_0432: dup
+			IL_0433: ldc.i4.0
+			IL_0434: ldarg.0
+			IL_0435: stelem.ref
+			IL_0436: stloc.s 31
+			IL_0438: ldarg.0
+			IL_0439: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_043e: stloc.s 40
+			IL_0440: ldloc.s 30
+			IL_0442: ldloc.s 31
+			IL_0444: ldloc.s 40
+			IL_0446: ldloc.s 17
+			IL_0448: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_044d: pop
+			IL_044e: ldarg.0
+			IL_044f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0454: stloc.s 40
+			IL_0456: ldc.i4.1
+			IL_0457: newarr [System.Runtime]System.Object
+			IL_045c: dup
+			IL_045d: ldc.i4.0
+			IL_045e: ldarg.0
+			IL_045f: stelem.ref
+			IL_0460: stloc.s 31
+			IL_0462: ldarg.0
+			IL_0463: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_0468: stloc.s 30
+			IL_046a: ldloc.s 40
+			IL_046c: ldloc.s 31
+			IL_046e: ldloc.s 30
+			IL_0470: ldloc.s 18
+			IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0477: pop
+			IL_0478: ldarg.0
+			IL_0479: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_047e: stloc.s 30
+			IL_0480: ldc.i4.1
+			IL_0481: newarr [System.Runtime]System.Object
+			IL_0486: dup
+			IL_0487: ldc.i4.0
+			IL_0488: ldarg.0
+			IL_0489: stelem.ref
+			IL_048a: stloc.s 31
+			IL_048c: ldarg.0
+			IL_048d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_0492: stloc.s 40
+			IL_0494: ldloc.s 30
+			IL_0496: ldloc.s 31
+			IL_0498: ldloc.s 40
+			IL_049a: ldloc.s 19
+			IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04a1: pop
+			IL_04a2: ldnull
+			IL_04a3: ret
+
+			IL_04a4: ldarg.0
+			IL_04a5: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::generateReleaseSection
+			IL_04aa: ldc.i4.1
+			IL_04ab: newarr [System.Runtime]System.Object
+			IL_04b0: dup
+			IL_04b1: ldc.i4.0
+			IL_04b2: ldarg.0
+			IL_04b3: stelem.ref
+			IL_04b4: ldloc.s 10
+			IL_04b6: ldloc.s 11
+			IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04bd: stloc.s 20
+			IL_04bf: ldloc.s 8
+			IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04c6: stloc.s 40
+			IL_04c8: ldc.i4.0
+			IL_04c9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_04ce: brfalse IL_04fd
+
+			IL_04d3: ldloc.s 40
+			IL_04d5: isinst [System.Runtime]System.String
+			IL_04da: dup
+			IL_04db: brfalse IL_04fc
+
+			IL_04e0: ldc.r8 0.0
+			IL_04e9: box [System.Runtime]System.Double
+			IL_04ee: ldloc.s 12
+			IL_04f0: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+			IL_04f5: stloc.s 21
+			IL_04f7: br IL_051b
+
+			IL_04fc: pop
+
+			IL_04fd: ldloc.s 40
+			IL_04ff: ldstr "slice"
+			IL_0504: ldc.r8 0.0
+			IL_050d: box [System.Runtime]System.Double
+			IL_0512: ldloc.s 12
+			IL_0514: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0519: stloc.s 21
+
+			IL_051b: ldloc.s 8
+			IL_051d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0522: stloc.s 40
+			IL_0524: ldc.i4.0
+			IL_0525: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_052a: brfalse IL_054b
+
+			IL_052f: ldloc.s 40
+			IL_0531: isinst [System.Runtime]System.String
+			IL_0536: dup
+			IL_0537: brfalse IL_054a
+
+			IL_053c: ldloc.s 13
+			IL_053e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
+			IL_0543: stloc.s 22
+			IL_0545: br IL_055b
+
+			IL_054a: pop
+
+			IL_054b: ldloc.s 40
+			IL_054d: ldstr "slice"
+			IL_0552: ldloc.s 13
+			IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0559: stloc.s 22
+
+			IL_055b: ldstr "\n_Nothing yet._\n\n"
+			IL_0560: stloc.s 23
+			IL_0562: ldloc.s 21
+			IL_0564: ldloc.s 23
+			IL_0566: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_056b: stloc.s 38
+			IL_056d: ldloc.s 38
+			IL_056f: ldloc.s 20
+			IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0576: stloc.s 38
+			IL_0578: ldloc.s 38
+			IL_057a: ldloc.s 22
+			IL_057c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0581: stloc.s 24
 			IL_0583: ldarg.0
-			IL_0584: stelem.ref
-			IL_0585: stloc.s 31
-			IL_0587: ldarg.0
-			IL_0588: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_058d: stloc.s 30
-			IL_058f: ldloc.s 40
-			IL_0591: ldloc.s 31
-			IL_0593: ldloc.s 30
-			IL_0595: ldloc.s 24
-			IL_0597: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_059c: pop
+			IL_0584: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0589: ldc.i4.1
+			IL_058a: newarr [System.Runtime]System.Object
+			IL_058f: dup
+			IL_0590: ldc.i4.0
+			IL_0591: ldarg.0
+			IL_0592: stelem.ref
+			IL_0593: ldloc.3
+			IL_0594: ldloc.s 10
+			IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_059b: stloc.s 25
 			IL_059d: ldarg.0
-			IL_059e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_05a3: stloc.s 30
-			IL_05a5: ldc.i4.1
-			IL_05a6: newarr [System.Runtime]System.Object
-			IL_05ab: dup
-			IL_05ac: ldc.i4.0
-			IL_05ad: ldarg.0
-			IL_05ae: stelem.ref
-			IL_05af: stloc.s 31
-			IL_05b1: ldarg.0
-			IL_05b2: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_05b7: stloc.s 40
-			IL_05b9: ldloc.s 30
-			IL_05bb: ldloc.s 31
-			IL_05bd: ldloc.s 40
-			IL_05bf: ldloc.s 25
-			IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05c6: pop
-			IL_05c7: ldarg.0
-			IL_05c8: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_05cd: stloc.s 40
-			IL_05cf: ldc.i4.1
-			IL_05d0: newarr [System.Runtime]System.Object
-			IL_05d5: dup
-			IL_05d6: ldc.i4.0
-			IL_05d7: ldarg.0
-			IL_05d8: stelem.ref
-			IL_05d9: stloc.s 31
-			IL_05db: ldarg.0
-			IL_05dc: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_05e1: stloc.s 30
-			IL_05e3: ldloc.s 40
-			IL_05e5: ldloc.s 31
-			IL_05e7: ldloc.s 30
-			IL_05e9: ldloc.s 26
-			IL_05eb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05f0: pop
-			IL_05f1: ldarg.0
-			IL_05f2: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_05f7: stloc.s 30
-			IL_05f9: ldc.i4.1
-			IL_05fa: newarr [System.Runtime]System.Object
-			IL_05ff: dup
-			IL_0600: ldc.i4.0
-			IL_0601: ldarg.0
-			IL_0602: stelem.ref
-			IL_0603: stloc.s 31
-			IL_0605: ldarg.0
-			IL_0606: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_060b: stloc.s 40
-			IL_060d: ldloc.s 30
-			IL_060f: ldloc.s 31
-			IL_0611: ldloc.s 40
-			IL_0613: ldloc.s 27
-			IL_0615: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_061a: pop
-			IL_061b: ldarg.0
-			IL_061c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0621: stloc.s 40
-			IL_0623: ldc.i4.1
-			IL_0624: newarr [System.Runtime]System.Object
-			IL_0629: dup
-			IL_062a: ldc.i4.0
-			IL_062b: ldarg.0
-			IL_062c: stelem.ref
-			IL_062d: stloc.s 31
-			IL_062f: ldarg.0
-			IL_0630: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_0635: stloc.s 30
-			IL_0637: ldloc.s 40
-			IL_0639: ldloc.s 31
-			IL_063b: ldloc.s 30
-			IL_063d: ldloc.s 28
-			IL_063f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0644: pop
-			IL_0645: ldarg.0
-			IL_0646: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_064b: stloc.s 30
-			IL_064d: ldc.i4.1
-			IL_064e: newarr [System.Runtime]System.Object
-			IL_0653: dup
-			IL_0654: ldc.i4.0
-			IL_0655: ldarg.0
-			IL_0656: stelem.ref
-			IL_0657: stloc.s 31
-			IL_0659: ldarg.0
-			IL_065a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_065f: stloc.s 40
-			IL_0661: ldloc.s 30
-			IL_0663: ldloc.s 31
-			IL_0665: ldloc.s 40
-			IL_0667: ldloc.s 29
-			IL_0669: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_066e: pop
-			IL_066f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0674: stloc.s 39
-			IL_0676: ldloc.s 9
-			IL_0678: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_067d: stloc.s 33
-			IL_067f: ldstr "Bumped version: "
-			IL_0684: ldloc.s 33
-			IL_0686: call string [System.Runtime]System.String::Concat(string, string)
-			IL_068b: ldstr " -> "
-			IL_0690: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0695: ldloc.s 10
-			IL_0697: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_069c: stloc.s 33
-			IL_069e: ldloc.s 33
-			IL_06a0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_06a5: stloc.s 33
-			IL_06a7: ldloc.s 39
-			IL_06a9: ldloc.s 33
-			IL_06ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_059e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_05a3: ldc.i4.1
+			IL_05a4: newarr [System.Runtime]System.Object
+			IL_05a9: dup
+			IL_05aa: ldc.i4.0
+			IL_05ab: ldarg.0
+			IL_05ac: stelem.ref
+			IL_05ad: ldloc.s 4
+			IL_05af: ldloc.s 10
+			IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05b6: stloc.s 26
+			IL_05b8: ldarg.0
+			IL_05b9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_05be: ldc.i4.1
+			IL_05bf: newarr [System.Runtime]System.Object
+			IL_05c4: dup
+			IL_05c5: ldc.i4.0
+			IL_05c6: ldarg.0
+			IL_05c7: stelem.ref
+			IL_05c8: ldloc.s 5
+			IL_05ca: ldloc.s 10
+			IL_05cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05d1: stloc.s 27
+			IL_05d3: ldarg.0
+			IL_05d4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_05d9: ldc.i4.1
+			IL_05da: newarr [System.Runtime]System.Object
+			IL_05df: dup
+			IL_05e0: ldc.i4.0
+			IL_05e1: ldarg.0
+			IL_05e2: stelem.ref
+			IL_05e3: ldloc.s 6
+			IL_05e5: ldloc.s 10
+			IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05ec: stloc.s 28
+			IL_05ee: ldarg.0
+			IL_05ef: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
+			IL_05f4: ldc.i4.1
+			IL_05f5: newarr [System.Runtime]System.Object
+			IL_05fa: dup
+			IL_05fb: ldc.i4.0
+			IL_05fc: ldarg.0
+			IL_05fd: stelem.ref
+			IL_05fe: ldloc.s 7
+			IL_0600: ldloc.s 10
+			IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0607: stloc.s 29
+			IL_0609: ldarg.0
+			IL_060a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_060f: stloc.s 40
+			IL_0611: ldc.i4.1
+			IL_0612: newarr [System.Runtime]System.Object
+			IL_0617: dup
+			IL_0618: ldc.i4.0
+			IL_0619: ldarg.0
+			IL_061a: stelem.ref
+			IL_061b: stloc.s 31
+			IL_061d: ldarg.0
+			IL_061e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
+			IL_0623: stloc.s 30
+			IL_0625: ldloc.s 40
+			IL_0627: ldloc.s 31
+			IL_0629: ldloc.s 30
+			IL_062b: ldloc.s 24
+			IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0632: pop
+			IL_0633: ldarg.0
+			IL_0634: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0639: stloc.s 30
+			IL_063b: ldc.i4.1
+			IL_063c: newarr [System.Runtime]System.Object
+			IL_0641: dup
+			IL_0642: ldc.i4.0
+			IL_0643: ldarg.0
+			IL_0644: stelem.ref
+			IL_0645: stloc.s 31
+			IL_0647: ldarg.0
+			IL_0648: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_064d: stloc.s 40
+			IL_064f: ldloc.s 30
+			IL_0651: ldloc.s 31
+			IL_0653: ldloc.s 40
+			IL_0655: ldloc.s 25
+			IL_0657: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_065c: pop
+			IL_065d: ldarg.0
+			IL_065e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0663: stloc.s 40
+			IL_0665: ldc.i4.1
+			IL_0666: newarr [System.Runtime]System.Object
+			IL_066b: dup
+			IL_066c: ldc.i4.0
+			IL_066d: ldarg.0
+			IL_066e: stelem.ref
+			IL_066f: stloc.s 31
+			IL_0671: ldarg.0
+			IL_0672: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_0677: stloc.s 30
+			IL_0679: ldloc.s 40
+			IL_067b: ldloc.s 31
+			IL_067d: ldloc.s 30
+			IL_067f: ldloc.s 26
+			IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0686: pop
+			IL_0687: ldarg.0
+			IL_0688: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_068d: stloc.s 30
+			IL_068f: ldc.i4.1
+			IL_0690: newarr [System.Runtime]System.Object
+			IL_0695: dup
+			IL_0696: ldc.i4.0
+			IL_0697: ldarg.0
+			IL_0698: stelem.ref
+			IL_0699: stloc.s 31
+			IL_069b: ldarg.0
+			IL_069c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_06a1: stloc.s 40
+			IL_06a3: ldloc.s 30
+			IL_06a5: ldloc.s 31
+			IL_06a7: ldloc.s 40
+			IL_06a9: ldloc.s 27
+			IL_06ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
 			IL_06b0: pop
-			IL_06b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06b6: stloc.s 39
-			IL_06b8: ldloc.s 39
-			IL_06ba: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_06bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06c4: pop
-			IL_06c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06ca: stloc.s 39
-			IL_06cc: ldloc.s 39
-			IL_06ce: ldstr "\nNext steps:"
-			IL_06d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06d8: pop
-			IL_06d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06de: stloc.s 39
-			IL_06e0: ldloc.s 39
-			IL_06e2: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_06e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06ec: pop
-			IL_06ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06f2: stloc.s 39
-			IL_06f4: ldloc.s 10
-			IL_06f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_06fb: stloc.s 33
-			IL_06fd: ldstr "  git commit -m \"chore(release): cut "
-			IL_0702: ldloc.s 33
-			IL_0704: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0709: ldstr "\""
-			IL_070e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_06b1: ldarg.0
+			IL_06b2: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_06b7: stloc.s 40
+			IL_06b9: ldc.i4.1
+			IL_06ba: newarr [System.Runtime]System.Object
+			IL_06bf: dup
+			IL_06c0: ldc.i4.0
+			IL_06c1: ldarg.0
+			IL_06c2: stelem.ref
+			IL_06c3: stloc.s 31
+			IL_06c5: ldarg.0
+			IL_06c6: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_06cb: stloc.s 30
+			IL_06cd: ldloc.s 40
+			IL_06cf: ldloc.s 31
+			IL_06d1: ldloc.s 30
+			IL_06d3: ldloc.s 28
+			IL_06d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_06da: pop
+			IL_06db: ldarg.0
+			IL_06dc: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_06e1: stloc.s 30
+			IL_06e3: ldc.i4.1
+			IL_06e4: newarr [System.Runtime]System.Object
+			IL_06e9: dup
+			IL_06ea: ldc.i4.0
+			IL_06eb: ldarg.0
+			IL_06ec: stelem.ref
+			IL_06ed: stloc.s 31
+			IL_06ef: ldarg.0
+			IL_06f0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_06f5: stloc.s 40
+			IL_06f7: ldloc.s 30
+			IL_06f9: ldloc.s 31
+			IL_06fb: ldloc.s 40
+			IL_06fd: ldloc.s 29
+			IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0704: pop
+			IL_0705: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_070a: stloc.s 39
+			IL_070c: ldloc.s 9
+			IL_070e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0713: stloc.s 33
-			IL_0715: ldloc.s 39
-			IL_0717: ldloc.s 33
-			IL_0719: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_071e: pop
-			IL_071f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0724: stloc.s 39
-			IL_0726: ldloc.s 10
-			IL_0728: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_072d: stloc.s 33
-			IL_072f: ldstr "  git tag -a v"
+			IL_0715: ldstr "Bumped version: "
+			IL_071a: ldloc.s 33
+			IL_071c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0721: ldstr " -> "
+			IL_0726: call string [System.Runtime]System.String::Concat(string, string)
+			IL_072b: ldloc.s 10
+			IL_072d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0732: stloc.s 33
 			IL_0734: ldloc.s 33
 			IL_0736: call string [System.Runtime]System.String::Concat(string, string)
-			IL_073b: ldstr " -m \"Release "
-			IL_0740: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0745: ldloc.s 10
-			IL_0747: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_074c: stloc.s 33
-			IL_074e: ldloc.s 33
-			IL_0750: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0755: ldstr "\""
-			IL_075a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_075f: stloc.s 33
-			IL_0761: ldloc.s 39
-			IL_0763: ldloc.s 33
-			IL_0765: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_076a: pop
-			IL_076b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0770: stloc.s 39
-			IL_0772: ldloc.s 39
-			IL_0774: ldstr "  git push && git push --tags"
-			IL_0779: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_077e: pop
-			IL_077f: ldnull
-			IL_0780: ret
+			IL_073b: stloc.s 33
+			IL_073d: ldloc.s 39
+			IL_073f: ldloc.s 33
+			IL_0741: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0746: pop
+			IL_0747: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_074c: stloc.s 39
+			IL_074e: ldloc.s 39
+			IL_0750: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_0755: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_075a: pop
+			IL_075b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0760: stloc.s 39
+			IL_0762: ldloc.s 39
+			IL_0764: ldstr "\nNext steps:"
+			IL_0769: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_076e: pop
+			IL_076f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0774: stloc.s 39
+			IL_0776: ldloc.s 39
+			IL_0778: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_077d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0782: pop
+			IL_0783: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0788: stloc.s 39
+			IL_078a: ldloc.s 10
+			IL_078c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0791: stloc.s 33
+			IL_0793: ldstr "  git commit -m \"chore(release): cut "
+			IL_0798: ldloc.s 33
+			IL_079a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_079f: ldstr "\""
+			IL_07a4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07a9: stloc.s 33
+			IL_07ab: ldloc.s 39
+			IL_07ad: ldloc.s 33
+			IL_07af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_07b4: pop
+			IL_07b5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07ba: stloc.s 39
+			IL_07bc: ldloc.s 10
+			IL_07be: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_07c3: stloc.s 33
+			IL_07c5: ldstr "  git tag -a v"
+			IL_07ca: ldloc.s 33
+			IL_07cc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07d1: ldstr " -m \"Release "
+			IL_07d6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07db: ldloc.s 10
+			IL_07dd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_07e2: stloc.s 33
+			IL_07e4: ldloc.s 33
+			IL_07e6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07eb: ldstr "\""
+			IL_07f0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07f5: stloc.s 33
+			IL_07f7: ldloc.s 39
+			IL_07f9: ldloc.s 33
+			IL_07fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0800: pop
+			IL_0801: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0806: stloc.s 39
+			IL_0808: ldloc.s 39
+			IL_080a: ldstr "  git push && git push --tags"
+			IL_080f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0814: pop
+			IL_0815: ldnull
+			IL_0816: ret
 		} // end of method perform::__js_call__
 
 	} // end of class perform

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -270,7 +270,7 @@
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 654 (0x28e)
+			// Code size: 842 (0x34a)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -312,7 +312,7 @@
 				IL_003f: ldloc.3
 				IL_0040: ldloc.s 4
 				IL_0042: clt
-				IL_0044: brfalse IL_028c
+				IL_0044: brfalse IL_0348
 
 				IL_0049: ldarg.2
 				IL_004a: ldloc.1
@@ -384,147 +384,225 @@
 				IL_00f5: ldc.r8 1
 				IL_00fe: add
 				IL_00ff: stloc.1
-				IL_0100: br IL_027b
+				IL_0100: br IL_0337
 
 				IL_0105: ldloc.2
 				IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_010b: ldstr "startsWith"
-				IL_0110: ldstr "--in="
-				IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_011a: stloc.s 10
-				IL_011c: ldloc.s 10
-				IL_011e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0123: stloc.s 5
-				IL_0125: ldloc.s 5
-				IL_0127: brfalse IL_0166
+				IL_010b: stloc.s 10
+				IL_010d: ldc.i4.0
+				IL_010e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0113: brfalse IL_013c
 
-				IL_012c: ldloc.2
-				IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0132: ldstr "--in="
-				IL_0137: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_013c: conv.r8
-				IL_013d: box [System.Runtime]System.Double
-				IL_0142: stloc.s 12
-				IL_0144: ldstr "substring"
-				IL_0149: ldloc.s 12
-				IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0150: stloc.s 10
-				IL_0152: ldloc.0
-				IL_0153: ldstr "inFile"
-				IL_0158: ldloc.s 10
-				IL_015a: ldc.i4.1
-				IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0160: pop
-				IL_0161: br IL_027b
+				IL_0118: ldloc.s 10
+				IL_011a: isinst [System.Runtime]System.String
+				IL_011f: dup
+				IL_0120: brfalse IL_013b
 
-				IL_0166: ldloc.2
-				IL_0167: ldstr "--out"
-				IL_016c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0171: stloc.s 5
-				IL_0173: ldloc.s 5
-				IL_0175: box [System.Runtime]System.Boolean
-				IL_017a: stloc.s 6
-				IL_017c: ldloc.s 6
-				IL_017e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0183: stloc.s 5
-				IL_0185: ldloc.s 5
-				IL_0187: brtrue IL_01ab
+				IL_0125: ldstr "--in="
+				IL_012a: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+				IL_012f: box [System.Runtime]System.Boolean
+				IL_0134: stloc.s 10
+				IL_0136: br IL_014f
 
-				IL_018c: ldloc.2
-				IL_018d: ldstr "-o"
-				IL_0192: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0197: stloc.s 5
-				IL_0199: ldloc.s 5
-				IL_019b: box [System.Runtime]System.Boolean
-				IL_01a0: stloc.s 7
-				IL_01a2: ldloc.s 7
-				IL_01a4: stloc.s 13
-				IL_01a6: br IL_01af
+				IL_013b: pop
 
-				IL_01ab: ldloc.s 6
-				IL_01ad: stloc.s 13
+				IL_013c: ldloc.s 10
+				IL_013e: ldstr "startsWith"
+				IL_0143: ldstr "--in="
+				IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_014d: stloc.s 10
 
-				IL_01af: ldloc.s 13
-				IL_01b1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01b6: stloc.s 5
-				IL_01b8: ldloc.s 5
-				IL_01ba: brfalse IL_021a
+				IL_014f: ldloc.s 10
+				IL_0151: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0156: stloc.s 5
+				IL_0158: ldloc.s 5
+				IL_015a: brfalse IL_01c4
 
-				IL_01bf: ldloc.1
-				IL_01c0: stloc.s 4
-				IL_01c2: ldloc.s 4
-				IL_01c4: ldc.r8 1
-				IL_01cd: add
-				IL_01ce: stloc.s 4
-				IL_01d0: ldarg.2
-				IL_01d1: ldloc.s 4
-				IL_01d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_01d8: stloc.s 10
-				IL_01da: ldloc.s 10
+				IL_015f: ldloc.2
+				IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0165: stloc.s 10
+				IL_0167: ldstr "--in="
+				IL_016c: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_0171: conv.r8
+				IL_0172: box [System.Runtime]System.Double
+				IL_0177: stloc.s 12
+				IL_0179: ldc.i4.0
+				IL_017a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_017f: brfalse IL_01a0
+
+				IL_0184: ldloc.s 10
+				IL_0186: isinst [System.Runtime]System.String
+				IL_018b: dup
+				IL_018c: brfalse IL_019f
+
+				IL_0191: ldloc.s 12
+				IL_0193: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+				IL_0198: stloc.s 10
+				IL_019a: br IL_01b0
+
+				IL_019f: pop
+
+				IL_01a0: ldloc.s 10
+				IL_01a2: ldstr "substring"
+				IL_01a7: ldloc.s 12
+				IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01ae: stloc.s 10
+
+				IL_01b0: ldloc.0
+				IL_01b1: ldstr "inFile"
+				IL_01b6: ldloc.s 10
+				IL_01b8: ldc.i4.1
+				IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_01be: pop
+				IL_01bf: br IL_0337
+
+				IL_01c4: ldloc.2
+				IL_01c5: ldstr "--out"
+				IL_01ca: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01cf: stloc.s 5
+				IL_01d1: ldloc.s 5
+				IL_01d3: box [System.Runtime]System.Boolean
+				IL_01d8: stloc.s 6
+				IL_01da: ldloc.s 6
 				IL_01dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_01e1: stloc.s 5
 				IL_01e3: ldloc.s 5
-				IL_01e5: brtrue IL_01f6
+				IL_01e5: brtrue IL_0209
 
-				IL_01ea: ldstr ""
-				IL_01ef: stloc.s 14
-				IL_01f1: br IL_01fa
+				IL_01ea: ldloc.2
+				IL_01eb: ldstr "-o"
+				IL_01f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_01f5: stloc.s 5
+				IL_01f7: ldloc.s 5
+				IL_01f9: box [System.Runtime]System.Boolean
+				IL_01fe: stloc.s 7
+				IL_0200: ldloc.s 7
+				IL_0202: stloc.s 13
+				IL_0204: br IL_020d
 
-				IL_01f6: ldloc.s 10
-				IL_01f8: stloc.s 14
+				IL_0209: ldloc.s 6
+				IL_020b: stloc.s 13
 
-				IL_01fa: ldloc.0
-				IL_01fb: ldstr "outFile"
-				IL_0200: ldloc.s 14
-				IL_0202: ldc.i4.1
-				IL_0203: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0208: pop
-				IL_0209: ldloc.1
-				IL_020a: ldc.r8 1
-				IL_0213: add
-				IL_0214: stloc.1
-				IL_0215: br IL_027b
+				IL_020d: ldloc.s 13
+				IL_020f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0214: stloc.s 5
+				IL_0216: ldloc.s 5
+				IL_0218: brfalse IL_0278
 
-				IL_021a: ldloc.2
-				IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0220: ldstr "startsWith"
-				IL_0225: ldstr "--out="
-				IL_022a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_022f: stloc.s 10
-				IL_0231: ldloc.s 10
-				IL_0233: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0238: stloc.s 5
-				IL_023a: ldloc.s 5
-				IL_023c: brfalse IL_027b
+				IL_021d: ldloc.1
+				IL_021e: stloc.s 4
+				IL_0220: ldloc.s 4
+				IL_0222: ldc.r8 1
+				IL_022b: add
+				IL_022c: stloc.s 4
+				IL_022e: ldarg.2
+				IL_022f: ldloc.s 4
+				IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0236: stloc.s 10
+				IL_0238: ldloc.s 10
+				IL_023a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_023f: stloc.s 5
+				IL_0241: ldloc.s 5
+				IL_0243: brtrue IL_0254
 
-				IL_0241: ldloc.2
-				IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0247: ldstr "--out="
-				IL_024c: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_0251: conv.r8
-				IL_0252: box [System.Runtime]System.Double
-				IL_0257: stloc.s 12
-				IL_0259: ldstr "substring"
-				IL_025e: ldloc.s 12
-				IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0265: stloc.s 10
-				IL_0267: ldloc.0
-				IL_0268: ldstr "outFile"
-				IL_026d: ldloc.s 10
-				IL_026f: ldc.i4.1
-				IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0275: pop
-				IL_0276: br IL_027b
+				IL_0248: ldstr ""
+				IL_024d: stloc.s 14
+				IL_024f: br IL_0258
 
-				IL_027b: ldloc.1
-				IL_027c: ldc.r8 1
-				IL_0285: add
-				IL_0286: stloc.1
-				IL_0287: br IL_0030
+				IL_0254: ldloc.s 10
+				IL_0256: stloc.s 14
+
+				IL_0258: ldloc.0
+				IL_0259: ldstr "outFile"
+				IL_025e: ldloc.s 14
+				IL_0260: ldc.i4.1
+				IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0266: pop
+				IL_0267: ldloc.1
+				IL_0268: ldc.r8 1
+				IL_0271: add
+				IL_0272: stloc.1
+				IL_0273: br IL_0337
+
+				IL_0278: ldloc.2
+				IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_027e: stloc.s 10
+				IL_0280: ldc.i4.0
+				IL_0281: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0286: brfalse IL_02af
+
+				IL_028b: ldloc.s 10
+				IL_028d: isinst [System.Runtime]System.String
+				IL_0292: dup
+				IL_0293: brfalse IL_02ae
+
+				IL_0298: ldstr "--out="
+				IL_029d: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+				IL_02a2: box [System.Runtime]System.Boolean
+				IL_02a7: stloc.s 10
+				IL_02a9: br IL_02c2
+
+				IL_02ae: pop
+
+				IL_02af: ldloc.s 10
+				IL_02b1: ldstr "startsWith"
+				IL_02b6: ldstr "--out="
+				IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_02c0: stloc.s 10
+
+				IL_02c2: ldloc.s 10
+				IL_02c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_02c9: stloc.s 5
+				IL_02cb: ldloc.s 5
+				IL_02cd: brfalse IL_0337
+
+				IL_02d2: ldloc.2
+				IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02d8: stloc.s 10
+				IL_02da: ldstr "--out="
+				IL_02df: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_02e4: conv.r8
+				IL_02e5: box [System.Runtime]System.Double
+				IL_02ea: stloc.s 12
+				IL_02ec: ldc.i4.0
+				IL_02ed: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_02f2: brfalse IL_0313
+
+				IL_02f7: ldloc.s 10
+				IL_02f9: isinst [System.Runtime]System.String
+				IL_02fe: dup
+				IL_02ff: brfalse IL_0312
+
+				IL_0304: ldloc.s 12
+				IL_0306: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+				IL_030b: stloc.s 10
+				IL_030d: br IL_0323
+
+				IL_0312: pop
+
+				IL_0313: ldloc.s 10
+				IL_0315: ldstr "substring"
+				IL_031a: ldloc.s 12
+				IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0321: stloc.s 10
+
+				IL_0323: ldloc.0
+				IL_0324: ldstr "outFile"
+				IL_0329: ldloc.s 10
+				IL_032b: ldc.i4.1
+				IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_0331: pop
+				IL_0332: br IL_0337
+
+				IL_0337: ldloc.1
+				IL_0338: ldc.r8 1
+				IL_0341: add
+				IL_0342: stloc.1
+				IL_0343: br IL_0030
 			// end loop
 
-			IL_028c: ldloc.0
-			IL_028d: ret
+			IL_0348: ldloc.0
+			IL_0349: ret
 		} // end of method parseArgs::__js_call__
 
 	} // end of class parseArgs
@@ -630,7 +708,7 @@
 					01 00 00 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 396 (0x18c)
+				// Code size: 470 (0x1d6)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -669,114 +747,145 @@
 
 				IL_002d: ldloc.s 10
 				IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0034: ldstr "toLowerCase"
-				IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_003e: stloc.0
-				IL_003f: ldloc.0
-				IL_0040: ldstr "h1"
-				IL_0045: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_004a: stloc.s 8
-				IL_004c: ldloc.s 8
-				IL_004e: brfalse IL_0067
+				IL_0034: stloc.s 7
+				IL_0036: ldc.i4.0
+				IL_0037: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_003c: brfalse IL_0053
 
-				IL_0053: ldc.r8 1
-				IL_005c: box [System.Runtime]System.Double
-				IL_0061: stloc.1
-				IL_0062: br IL_00a0
+				IL_0041: ldloc.s 7
+				IL_0043: castclass [System.Runtime]System.String
+				IL_0048: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
+				IL_004d: stloc.0
+				IL_004e: br IL_0060
 
-				IL_0067: ldloc.0
-				IL_0068: ldstr "h2"
-				IL_006d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0072: stloc.s 8
-				IL_0074: ldloc.s 8
-				IL_0076: brfalse IL_008f
+				IL_0053: ldloc.s 7
+				IL_0055: ldstr "toLowerCase"
+				IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_005f: stloc.0
 
-				IL_007b: ldc.r8 2
-				IL_0084: box [System.Runtime]System.Double
-				IL_0089: stloc.2
-				IL_008a: br IL_009e
+				IL_0060: ldloc.0
+				IL_0061: ldstr "h1"
+				IL_0066: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_006b: stloc.s 8
+				IL_006d: ldloc.s 8
+				IL_006f: brfalse IL_0088
 
-				IL_008f: ldc.r8 3
-				IL_0098: box [System.Runtime]System.Double
-				IL_009d: stloc.2
+				IL_0074: ldc.r8 1
+				IL_007d: box [System.Runtime]System.Double
+				IL_0082: stloc.1
+				IL_0083: br IL_00c1
 
-				IL_009e: ldloc.2
-				IL_009f: stloc.1
+				IL_0088: ldloc.0
+				IL_0089: ldstr "h2"
+				IL_008e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0093: stloc.s 8
+				IL_0095: ldloc.s 8
+				IL_0097: brfalse IL_00b0
 
-				IL_00a0: ldloc.1
-				IL_00a1: stloc.3
-				IL_00a2: ldc.r8 2
-				IL_00ab: ldloc.3
-				IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(float64, object)
-				IL_00b1: stloc.s 10
-				IL_00b3: ldc.i4.2
-				IL_00b4: newarr [System.Runtime]System.Object
-				IL_00b9: dup
-				IL_00ba: ldc.i4.0
-				IL_00bb: ldc.r8 6
-				IL_00c4: box [System.Runtime]System.Double
-				IL_00c9: stelem.ref
-				IL_00ca: dup
-				IL_00cb: ldc.i4.1
-				IL_00cc: ldloc.s 10
-				IL_00ce: stelem.ref
-				IL_00cf: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::min(object[])
-				IL_00d4: stloc.s 4
-				IL_00d6: ldloc.s 4
-				IL_00d8: box [System.Runtime]System.Double
-				IL_00dd: stloc.s 11
-				IL_00df: ldstr "#"
-				IL_00e4: ldstr "repeat"
-				IL_00e9: ldloc.s 11
-				IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00f0: stloc.s 5
-				IL_00f2: ldarg.1
-				IL_00f3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00f8: stloc.s 8
-				IL_00fa: ldloc.s 8
-				IL_00fc: brtrue IL_010d
+				IL_009c: ldc.r8 2
+				IL_00a5: box [System.Runtime]System.Double
+				IL_00aa: stloc.2
+				IL_00ab: br IL_00bf
 
-				IL_0101: ldstr ""
-				IL_0106: stloc.s 12
-				IL_0108: br IL_0110
+				IL_00b0: ldc.r8 3
+				IL_00b9: box [System.Runtime]System.Double
+				IL_00be: stloc.2
 
-				IL_010d: ldarg.1
-				IL_010e: stloc.s 12
+				IL_00bf: ldloc.2
+				IL_00c0: stloc.1
 
-				IL_0110: ldloc.s 12
-				IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0117: stloc.s 7
-				IL_0119: ldstr "\\s+"
-				IL_011e: ldstr "g"
-				IL_0123: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_0128: stloc.s 13
-				IL_012a: ldloc.s 7
-				IL_012c: ldstr "replace"
-				IL_0131: ldloc.s 13
-				IL_0133: ldstr " "
-				IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_013d: stloc.s 7
-				IL_013f: ldloc.s 7
-				IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0146: ldstr "trim"
-				IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_0150: stloc.s 6
-				IL_0152: ldloc.s 5
-				IL_0154: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0159: stloc.s 14
-				IL_015b: ldstr "\n\n"
-				IL_0160: ldloc.s 14
-				IL_0162: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0167: ldstr " "
-				IL_016c: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0171: ldloc.s 6
-				IL_0173: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0178: stloc.s 14
-				IL_017a: ldloc.s 14
-				IL_017c: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0181: ldstr "\n\n"
-				IL_0186: call string [System.Runtime]System.String::Concat(string, string)
-				IL_018b: ret
+				IL_00c1: ldloc.1
+				IL_00c2: stloc.3
+				IL_00c3: ldc.r8 2
+				IL_00cc: ldloc.3
+				IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(float64, object)
+				IL_00d2: stloc.s 10
+				IL_00d4: ldc.i4.2
+				IL_00d5: newarr [System.Runtime]System.Object
+				IL_00da: dup
+				IL_00db: ldc.i4.0
+				IL_00dc: ldc.r8 6
+				IL_00e5: box [System.Runtime]System.Double
+				IL_00ea: stelem.ref
+				IL_00eb: dup
+				IL_00ec: ldc.i4.1
+				IL_00ed: ldloc.s 10
+				IL_00ef: stelem.ref
+				IL_00f0: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::min(object[])
+				IL_00f5: stloc.s 4
+				IL_00f7: ldloc.s 4
+				IL_00f9: box [System.Runtime]System.Double
+				IL_00fe: stloc.s 11
+				IL_0100: ldstr "#"
+				IL_0105: ldstr "repeat"
+				IL_010a: ldloc.s 11
+				IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0111: stloc.s 5
+				IL_0113: ldarg.1
+				IL_0114: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0119: stloc.s 8
+				IL_011b: ldloc.s 8
+				IL_011d: brtrue IL_012e
+
+				IL_0122: ldstr ""
+				IL_0127: stloc.s 12
+				IL_0129: br IL_0131
+
+				IL_012e: ldarg.1
+				IL_012f: stloc.s 12
+
+				IL_0131: ldloc.s 12
+				IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0138: stloc.s 7
+				IL_013a: ldstr "\\s+"
+				IL_013f: ldstr "g"
+				IL_0144: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_0149: stloc.s 13
+				IL_014b: ldloc.s 7
+				IL_014d: ldstr "replace"
+				IL_0152: ldloc.s 13
+				IL_0154: ldstr " "
+				IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_015e: stloc.s 7
+				IL_0160: ldloc.s 7
+				IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0167: stloc.s 7
+				IL_0169: ldc.i4.0
+				IL_016a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_016f: brfalse IL_018e
+
+				IL_0174: ldloc.s 7
+				IL_0176: isinst [System.Runtime]System.String
+				IL_017b: dup
+				IL_017c: brfalse IL_018d
+
+				IL_0181: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_0186: stloc.s 6
+				IL_0188: br IL_019c
+
+				IL_018d: pop
+
+				IL_018e: ldloc.s 7
+				IL_0190: ldstr "trim"
+				IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_019a: stloc.s 6
+
+				IL_019c: ldloc.s 5
+				IL_019e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01a3: stloc.s 14
+				IL_01a5: ldstr "\n\n"
+				IL_01aa: ldloc.s 14
+				IL_01ac: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01b1: ldstr " "
+				IL_01b6: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01bb: ldloc.s 6
+				IL_01bd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01c2: stloc.s 14
+				IL_01c4: ldloc.s 14
+				IL_01c6: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01cb: ldstr "\n\n"
+				IL_01d0: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01d5: ret
 			} // end of method FunctionExpression_L61C15::__js_call__
 
 		} // end of class FunctionExpression_L61C15
@@ -874,7 +983,7 @@
 					01 00 00 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 140 (0x8c)
+				// Code size: 180 (0xb4)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -914,27 +1023,45 @@
 				IL_0046: stloc.s 4
 				IL_0048: ldloc.s 4
 				IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004f: ldstr "trim"
-				IL_0054: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_0059: stloc.0
-				IL_005a: ldloc.0
-				IL_005b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0060: stloc.1
-				IL_0061: ldloc.1
-				IL_0062: brfalse IL_0086
+				IL_004f: stloc.s 4
+				IL_0051: ldc.i4.0
+				IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0057: brfalse IL_0075
 
-				IL_0067: ldloc.0
-				IL_0068: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_006d: stloc.s 6
-				IL_006f: ldstr "`"
-				IL_0074: ldloc.s 6
-				IL_0076: call string [System.Runtime]System.String::Concat(string, string)
-				IL_007b: ldstr "`"
-				IL_0080: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0085: ret
+				IL_005c: ldloc.s 4
+				IL_005e: isinst [System.Runtime]System.String
+				IL_0063: dup
+				IL_0064: brfalse IL_0074
 
-				IL_0086: ldstr ""
-				IL_008b: ret
+				IL_0069: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_006e: stloc.0
+				IL_006f: br IL_0082
+
+				IL_0074: pop
+
+				IL_0075: ldloc.s 4
+				IL_0077: ldstr "trim"
+				IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0081: stloc.0
+
+				IL_0082: ldloc.0
+				IL_0083: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0088: stloc.1
+				IL_0089: ldloc.1
+				IL_008a: brfalse IL_00ae
+
+				IL_008f: ldloc.0
+				IL_0090: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0095: stloc.s 6
+				IL_0097: ldstr "`"
+				IL_009c: ldloc.s 6
+				IL_009e: call string [System.Runtime]System.String::Concat(string, string)
+				IL_00a3: ldstr "`"
+				IL_00a8: call string [System.Runtime]System.String::Concat(string, string)
+				IL_00ad: ret
+
+				IL_00ae: ldstr ""
+				IL_00b3: ret
 			} // end of method FunctionExpression_L74C15::__js_call__
 
 		} // end of class FunctionExpression_L74C15
@@ -1705,7 +1832,7 @@
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 626 (0x272)
+			// Code size: 663 (0x297)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/Scope,
@@ -1932,15 +2059,33 @@
 			IL_0250: stloc.3
 			IL_0251: ldloc.3
 			IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0257: ldstr "trim"
-			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0261: stloc.3
-			IL_0262: ldloc.3
-			IL_0263: ldstr "\n"
-			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_026d: stloc.s 12
-			IL_026f: ldloc.s 12
-			IL_0271: ret
+			IL_0257: stloc.3
+			IL_0258: ldc.i4.0
+			IL_0259: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_025e: brfalse IL_027b
+
+			IL_0263: ldloc.3
+			IL_0264: isinst [System.Runtime]System.String
+			IL_0269: dup
+			IL_026a: brfalse IL_027a
+
+			IL_026f: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0274: stloc.3
+			IL_0275: br IL_0287
+
+			IL_027a: pop
+
+			IL_027b: ldloc.3
+			IL_027c: ldstr "trim"
+			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0286: stloc.3
+
+			IL_0287: ldloc.3
+			IL_0288: ldstr "\n"
+			IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0292: stloc.s 12
+			IL_0294: ldloc.s 12
+			IL_0296: ret
 		} // end of method convertHtmlToMarkdown::__js_call__
 
 	} // end of class convertHtmlToMarkdown

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -380,7 +380,7 @@
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 273 (0x111)
+			// Code size: 296 (0x128)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -399,89 +399,99 @@
 			IL_0007: ldloc.2
 			IL_0008: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 			IL_000d: stloc.2
-			IL_000e: ldloc.2
-			IL_000f: ldstr "trim"
-			IL_0014: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0019: stloc.3
-			IL_001a: ldloc.3
-			IL_001b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0020: stloc.3
-			IL_0021: ldstr "[\\\\/]+"
-			IL_0026: ldstr "g"
-			IL_002b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0030: stloc.s 4
-			IL_0032: ldloc.3
-			IL_0033: ldstr "replace"
-			IL_0038: ldloc.s 4
-			IL_003a: ldstr "."
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0044: stloc.3
-			IL_0045: ldloc.3
-			IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_004b: ldstr "split"
-			IL_0050: ldstr "."
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_005a: stloc.3
-			IL_005b: ldloc.3
-			IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0061: ldstr "Boolean"
-			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_006b: stloc.3
-			IL_006c: ldstr "filter"
-			IL_0071: ldloc.3
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0077: stloc.0
-			IL_0078: ldloc.0
-			IL_0079: ldstr "length"
-			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0083: stloc.3
-			IL_0084: ldloc.3
-			IL_0085: ldc.r8 0.0
-			IL_008e: box [System.Runtime]System.Double
-			IL_0093: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0098: stloc.s 5
-			IL_009a: ldloc.s 5
-			IL_009c: brfalse IL_00c1
+			IL_000e: ldc.i4.0
+			IL_000f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0014: brfalse IL_0025
 
-			IL_00a1: ldstr "Category must contain at least one name segment."
-			IL_00a6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00ab: stloc.1
-			IL_00ac: ldloc.1
-			IL_00ad: isinst [System.Runtime]System.Exception
-			IL_00b2: dup
-			IL_00b3: brtrue IL_00c0
+			IL_0019: ldloc.2
+			IL_001a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_001f: stloc.3
+			IL_0020: br IL_0031
 
-			IL_00b8: pop
-			IL_00b9: ldloc.1
-			IL_00ba: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00bf: throw
+			IL_0025: ldloc.2
+			IL_0026: ldstr "trim"
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0030: stloc.3
 
-			IL_00c0: throw
+			IL_0031: ldloc.3
+			IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0037: stloc.3
+			IL_0038: ldstr "[\\\\/]+"
+			IL_003d: ldstr "g"
+			IL_0042: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0047: stloc.s 4
+			IL_0049: ldloc.3
+			IL_004a: ldstr "replace"
+			IL_004f: ldloc.s 4
+			IL_0051: ldstr "."
+			IL_0056: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_005b: stloc.3
+			IL_005c: ldloc.3
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0062: ldstr "split"
+			IL_0067: ldstr "."
+			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0071: stloc.3
+			IL_0072: ldloc.3
+			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0078: ldstr "Boolean"
+			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0082: stloc.3
+			IL_0083: ldstr "filter"
+			IL_0088: ldloc.3
+			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_008e: stloc.0
+			IL_008f: ldloc.0
+			IL_0090: ldstr "length"
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_009a: stloc.3
+			IL_009b: ldloc.3
+			IL_009c: ldc.r8 0.0
+			IL_00a5: box [System.Runtime]System.Double
+			IL_00aa: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00af: stloc.s 5
+			IL_00b1: ldloc.s 5
+			IL_00b3: brfalse IL_00d8
 
-			IL_00c1: ldloc.0
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c7: ldstr "join"
-			IL_00cc: ldstr "."
-			IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00d6: stloc.3
-			IL_00d7: ldloc.0
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00dd: ldstr "join"
-			IL_00e2: ldstr "/"
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00ec: stloc.s 6
-			IL_00ee: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00f3: dup
-			IL_00f4: ldstr "namespace"
-			IL_00f9: ldloc.3
-			IL_00fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00ff: dup
-			IL_0100: ldstr "path"
-			IL_0105: ldloc.s 6
-			IL_0107: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_010c: stloc.s 7
-			IL_010e: ldloc.s 7
-			IL_0110: ret
+			IL_00b8: ldstr "Category must contain at least one name segment."
+			IL_00bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00c2: stloc.1
+			IL_00c3: ldloc.1
+			IL_00c4: isinst [System.Runtime]System.Exception
+			IL_00c9: dup
+			IL_00ca: brtrue IL_00d7
+
+			IL_00cf: pop
+			IL_00d0: ldloc.1
+			IL_00d1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00d6: throw
+
+			IL_00d7: throw
+
+			IL_00d8: ldloc.0
+			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00de: ldstr "join"
+			IL_00e3: ldstr "."
+			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00ed: stloc.3
+			IL_00ee: ldloc.0
+			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f4: ldstr "join"
+			IL_00f9: ldstr "/"
+			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0103: stloc.s 6
+			IL_0105: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_010a: dup
+			IL_010b: ldstr "namespace"
+			IL_0110: ldloc.3
+			IL_0111: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0116: dup
+			IL_0117: ldstr "path"
+			IL_011c: ldloc.s 6
+			IL_011e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0123: stloc.s 7
+			IL_0125: ldloc.s 7
+			IL_0127: ret
 		} // end of method normalizeCategory::__js_call__
 
 	} // end of class normalizeCategory
@@ -3172,7 +3182,7 @@
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 2095 (0x82f)
+			// Code size: 2149 (0x865)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3215,658 +3225,678 @@
 			IL_0014: stloc.s 18
 			IL_0016: ldloc.s 18
 			IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_001d: ldstr "slice"
-			IL_0022: ldc.r8 2
-			IL_002b: box [System.Runtime]System.Double
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0035: stloc.0
-			IL_0036: ldloc.0
-			IL_0037: ldstr "length"
-			IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0041: stloc.s 18
-			IL_0043: ldloc.s 18
-			IL_0045: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_004a: ldc.r8 2
-			IL_0053: clt
-			IL_0055: brfalse IL_011d
+			IL_001d: stloc.s 18
+			IL_001f: ldc.i4.0
+			IL_0020: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0025: brfalse IL_0051
 
-			IL_005a: ldstr "console"
-			IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0069: ldstr "error"
-			IL_006e: ldstr "Usage: node scripts/decompileGeneratorTest.js <Category> <TestName>"
-			IL_0073: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0078: pop
-			IL_0079: ldstr "console"
-			IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0088: ldstr "error"
-			IL_008d: ldstr ""
-			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0097: pop
-			IL_0098: ldstr "console"
-			IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00a7: ldstr "error"
-			IL_00ac: ldstr "Examples:"
-			IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00b6: pop
-			IL_00b7: ldstr "console"
-			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c6: ldstr "error"
-			IL_00cb: ldstr "  node scripts/decompileGeneratorTest.js Async Async_HelloWorld"
-			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00d5: pop
-			IL_00d6: ldstr "console"
-			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e5: ldstr "error"
-			IL_00ea: ldstr "  node scripts/decompileGeneratorTest.js Function Function_ReturnsStaticValueAndLogs"
-			IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00f4: pop
-			IL_00f5: ldstr "process"
-			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0104: ldstr "exit"
-			IL_0109: ldc.r8 1
-			IL_0112: box [System.Runtime]System.Double
-			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_011c: pop
+			IL_002a: ldloc.s 18
+			IL_002c: isinst [System.Runtime]System.String
+			IL_0031: dup
+			IL_0032: brfalse IL_0050
 
-			IL_011d: ldarg.0
-			IL_011e: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::normalizeCategory
-			IL_0123: ldc.i4.1
-			IL_0124: newarr [System.Runtime]System.Object
-			IL_0129: dup
-			IL_012a: ldc.i4.0
-			IL_012b: ldarg.0
-			IL_012c: stelem.ref
-			IL_012d: stloc.s 19
-			IL_012f: ldloc.0
-			IL_0130: ldc.r8 0.0
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_013e: stloc.s 18
-			IL_0140: ldloc.s 19
-			IL_0142: ldloc.s 18
-			IL_0144: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0149: stloc.1
-			IL_014a: ldloc.0
-			IL_014b: ldc.r8 1
-			IL_0154: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0159: stloc.2
-			IL_015a: ldarg.0
-			IL_015b: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getGeneratorTestSnapshotPath
-			IL_0160: ldc.i4.1
-			IL_0161: newarr [System.Runtime]System.Object
-			IL_0166: dup
-			IL_0167: ldc.i4.0
-			IL_0168: ldarg.0
-			IL_0169: stelem.ref
-			IL_016a: stloc.s 19
-			IL_016c: ldloc.1
-			IL_016d: ldstr "path"
-			IL_0172: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0177: stloc.s 18
-			IL_0179: ldloc.s 19
-			IL_017b: ldloc.s 18
-			IL_017d: ldloc.2
-			IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0183: stloc.3
-			IL_0184: ldarg.0
-			IL_0185: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-			IL_018a: stloc.s 20
-			IL_018c: ldloc.s 20
-			IL_018e: ldloc.3
-			IL_018f: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_0194: box [System.Runtime]System.Boolean
-			IL_0199: stloc.s 18
-			IL_019b: ldloc.s 18
-			IL_019d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01a2: ldc.i4.0
-			IL_01a3: ceq
-			IL_01a5: stloc.s 21
-			IL_01a7: ldloc.s 21
-			IL_01a9: brfalse IL_022b
+			IL_0037: ldc.r8 2
+			IL_0040: box [System.Runtime]System.Double
+			IL_0045: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
+			IL_004a: stloc.0
+			IL_004b: br IL_006c
 
-			IL_01ae: ldstr "console"
-			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01bd: stloc.s 18
-			IL_01bf: ldloc.3
-			IL_01c0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01c5: stloc.s 22
-			IL_01c7: ldstr "Generator test snapshot not found: "
-			IL_01cc: ldloc.s 22
-			IL_01ce: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01d3: stloc.s 22
-			IL_01d5: ldloc.s 18
-			IL_01d7: ldstr "error"
-			IL_01dc: ldloc.s 22
-			IL_01de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01e3: pop
+			IL_0050: pop
+
+			IL_0051: ldloc.s 18
+			IL_0053: ldstr "slice"
+			IL_0058: ldc.r8 2
+			IL_0061: box [System.Runtime]System.Double
+			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_006b: stloc.0
+
+			IL_006c: ldloc.0
+			IL_006d: ldstr "length"
+			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0077: stloc.s 18
+			IL_0079: ldloc.s 18
+			IL_007b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0080: ldc.r8 2
+			IL_0089: clt
+			IL_008b: brfalse IL_0153
+
+			IL_0090: ldstr "console"
+			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009f: ldstr "error"
+			IL_00a4: ldstr "Usage: node scripts/decompileGeneratorTest.js <Category> <TestName>"
+			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00ae: pop
+			IL_00af: ldstr "console"
+			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00be: ldstr "error"
+			IL_00c3: ldstr ""
+			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00cd: pop
+			IL_00ce: ldstr "console"
+			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00dd: ldstr "error"
+			IL_00e2: ldstr "Examples:"
+			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00ec: pop
+			IL_00ed: ldstr "console"
+			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00fc: ldstr "error"
+			IL_0101: ldstr "  node scripts/decompileGeneratorTest.js Async Async_HelloWorld"
+			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_010b: pop
+			IL_010c: ldstr "console"
+			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_011b: ldstr "error"
+			IL_0120: ldstr "  node scripts/decompileGeneratorTest.js Function Function_ReturnsStaticValueAndLogs"
+			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_012a: pop
+			IL_012b: ldstr "process"
+			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_013a: ldstr "exit"
+			IL_013f: ldc.r8 1
+			IL_0148: box [System.Runtime]System.Double
+			IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0152: pop
+
+			IL_0153: ldarg.0
+			IL_0154: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::normalizeCategory
+			IL_0159: ldc.i4.1
+			IL_015a: newarr [System.Runtime]System.Object
+			IL_015f: dup
+			IL_0160: ldc.i4.0
+			IL_0161: ldarg.0
+			IL_0162: stelem.ref
+			IL_0163: stloc.s 19
+			IL_0165: ldloc.0
+			IL_0166: ldc.r8 0.0
+			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0174: stloc.s 18
+			IL_0176: ldloc.s 19
+			IL_0178: ldloc.s 18
+			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_017f: stloc.1
+			IL_0180: ldloc.0
+			IL_0181: ldc.r8 1
+			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_018f: stloc.2
+			IL_0190: ldarg.0
+			IL_0191: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getGeneratorTestSnapshotPath
+			IL_0196: ldc.i4.1
+			IL_0197: newarr [System.Runtime]System.Object
+			IL_019c: dup
+			IL_019d: ldc.i4.0
+			IL_019e: ldarg.0
+			IL_019f: stelem.ref
+			IL_01a0: stloc.s 19
+			IL_01a2: ldloc.1
+			IL_01a3: ldstr "path"
+			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ad: stloc.s 18
+			IL_01af: ldloc.s 19
+			IL_01b1: ldloc.s 18
+			IL_01b3: ldloc.2
+			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01b9: stloc.3
+			IL_01ba: ldarg.0
+			IL_01bb: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+			IL_01c0: stloc.s 20
+			IL_01c2: ldloc.s 20
+			IL_01c4: ldloc.3
+			IL_01c5: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_01ca: box [System.Runtime]System.Boolean
+			IL_01cf: stloc.s 18
+			IL_01d1: ldloc.s 18
+			IL_01d3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01d8: ldc.i4.0
+			IL_01d9: ceq
+			IL_01db: stloc.s 21
+			IL_01dd: ldloc.s 21
+			IL_01df: brfalse IL_0261
+
 			IL_01e4: ldstr "console"
 			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
 			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f3: ldstr "error"
-			IL_01f8: ldstr "Check the category and test name before running the helper."
-			IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0202: pop
-			IL_0203: ldstr "process"
-			IL_0208: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_020d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0212: ldstr "exit"
-			IL_0217: ldc.r8 1
-			IL_0220: box [System.Runtime]System.Double
-			IL_0225: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_022a: pop
+			IL_01f3: stloc.s 18
+			IL_01f5: ldloc.3
+			IL_01f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01fb: stloc.s 22
+			IL_01fd: ldstr "Generator test snapshot not found: "
+			IL_0202: ldloc.s 22
+			IL_0204: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0209: stloc.s 22
+			IL_020b: ldloc.s 18
+			IL_020d: ldstr "error"
+			IL_0212: ldloc.s 22
+			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0219: pop
+			IL_021a: ldstr "console"
+			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0229: ldstr "error"
+			IL_022e: ldstr "Check the category and test name before running the helper."
+			IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0238: pop
+			IL_0239: ldstr "process"
+			IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0248: ldstr "exit"
+			IL_024d: ldc.r8 1
+			IL_0256: box [System.Runtime]System.Double
+			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0260: pop
 
-			IL_022b: ldloc.1
-			IL_022c: ldstr "namespace"
-			IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0236: stloc.s 18
-			IL_0238: ldloc.s 18
-			IL_023a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_023f: stloc.s 22
-			IL_0241: ldstr "Jroc.Tests."
-			IL_0246: ldloc.s 22
-			IL_0248: call string [System.Runtime]System.String::Concat(string, string)
-			IL_024d: ldstr ".GeneratorTests."
-			IL_0252: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0257: ldloc.2
-			IL_0258: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_025d: stloc.s 22
-			IL_025f: ldloc.s 22
-			IL_0261: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0266: stloc.s 4
-			IL_0268: ldarg.0
-			IL_0269: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-			IL_026e: stloc.s 23
-			IL_0270: ldarg.0
-			IL_0271: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_0276: stloc.s 18
-			IL_0278: ldloc.s 23
-			IL_027a: ldc.i4.4
-			IL_027b: newarr [System.Runtime]System.Object
-			IL_0280: dup
-			IL_0281: ldc.i4.0
-			IL_0282: ldloc.s 18
-			IL_0284: stelem.ref
-			IL_0285: dup
-			IL_0286: ldc.i4.1
-			IL_0287: ldstr "tests"
-			IL_028c: stelem.ref
-			IL_028d: dup
-			IL_028e: ldc.i4.2
-			IL_028f: ldstr "Jroc.Tests"
-			IL_0294: stelem.ref
-			IL_0295: dup
-			IL_0296: ldc.i4.3
-			IL_0297: ldstr "Jroc.Tests.csproj"
-			IL_029c: stelem.ref
-			IL_029d: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_02a2: stloc.s 5
-			IL_02a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02a9: stloc.s 24
-			IL_02ab: ldloc.s 4
-			IL_02ad: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02b2: stloc.s 22
-			IL_02b4: ldstr "Running test: "
-			IL_02b9: ldloc.s 22
-			IL_02bb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02c0: stloc.s 22
-			IL_02c2: ldloc.s 24
-			IL_02c4: ldloc.s 22
-			IL_02c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02cb: pop
-			IL_02cc: ldstr "process"
-			IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02d6: ldstr "env"
-			IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02e0: stloc.s 18
-			IL_02e2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02e7: stloc.s 25
-			IL_02e9: ldloc.s 25
-			IL_02eb: ldloc.s 18
-			IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
-			IL_02f2: pop
-			IL_02f3: ldloc.s 25
-			IL_02f5: ldstr "JROC_WRITE_TEST_ARTIFACTS"
-			IL_02fa: ldstr "1"
-			IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0304: pop
-			IL_0305: ldloc.s 25
-			IL_0307: stloc.s 6
-			IL_0309: ldarg.0
-			IL_030a: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_030f: stloc.s 26
-			IL_0311: ldloc.s 4
-			IL_0313: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0318: stloc.s 22
-			IL_031a: ldstr "FullyQualifiedName="
-			IL_031f: ldloc.s 22
-			IL_0321: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0326: stloc.s 22
-			IL_0328: ldc.i4.5
-			IL_0329: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_032e: dup
-			IL_032f: ldstr "test"
-			IL_0334: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0339: dup
-			IL_033a: ldloc.s 5
-			IL_033c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0341: dup
-			IL_0342: ldstr "--filter"
-			IL_0347: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_034c: dup
-			IL_034d: ldloc.s 22
-			IL_034f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0354: dup
-			IL_0355: ldstr "--no-build"
-			IL_035a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_035f: stloc.s 27
-			IL_0361: ldarg.0
-			IL_0362: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_0367: stloc.s 18
-			IL_0369: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_036e: dup
-			IL_036f: ldstr "stdio"
-			IL_0374: ldstr "inherit"
-			IL_0379: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_037e: dup
-			IL_037f: ldstr "shell"
-			IL_0384: ldc.i4.1
-			IL_0385: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0261: ldloc.1
+			IL_0262: ldstr "namespace"
+			IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_026c: stloc.s 18
+			IL_026e: ldloc.s 18
+			IL_0270: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0275: stloc.s 22
+			IL_0277: ldstr "Jroc.Tests."
+			IL_027c: ldloc.s 22
+			IL_027e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0283: ldstr ".GeneratorTests."
+			IL_0288: call string [System.Runtime]System.String::Concat(string, string)
+			IL_028d: ldloc.2
+			IL_028e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0293: stloc.s 22
+			IL_0295: ldloc.s 22
+			IL_0297: call string [System.Runtime]System.String::Concat(string, string)
+			IL_029c: stloc.s 4
+			IL_029e: ldarg.0
+			IL_029f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+			IL_02a4: stloc.s 23
+			IL_02a6: ldarg.0
+			IL_02a7: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_02ac: stloc.s 18
+			IL_02ae: ldloc.s 23
+			IL_02b0: ldc.i4.4
+			IL_02b1: newarr [System.Runtime]System.Object
+			IL_02b6: dup
+			IL_02b7: ldc.i4.0
+			IL_02b8: ldloc.s 18
+			IL_02ba: stelem.ref
+			IL_02bb: dup
+			IL_02bc: ldc.i4.1
+			IL_02bd: ldstr "tests"
+			IL_02c2: stelem.ref
+			IL_02c3: dup
+			IL_02c4: ldc.i4.2
+			IL_02c5: ldstr "Jroc.Tests"
+			IL_02ca: stelem.ref
+			IL_02cb: dup
+			IL_02cc: ldc.i4.3
+			IL_02cd: ldstr "Jroc.Tests.csproj"
+			IL_02d2: stelem.ref
+			IL_02d3: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_02d8: stloc.s 5
+			IL_02da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02df: stloc.s 24
+			IL_02e1: ldloc.s 4
+			IL_02e3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02e8: stloc.s 22
+			IL_02ea: ldstr "Running test: "
+			IL_02ef: ldloc.s 22
+			IL_02f1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02f6: stloc.s 22
+			IL_02f8: ldloc.s 24
+			IL_02fa: ldloc.s 22
+			IL_02fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0301: pop
+			IL_0302: ldstr "process"
+			IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_030c: ldstr "env"
+			IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0316: stloc.s 18
+			IL_0318: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_031d: stloc.s 25
+			IL_031f: ldloc.s 25
+			IL_0321: ldloc.s 18
+			IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
+			IL_0328: pop
+			IL_0329: ldloc.s 25
+			IL_032b: ldstr "JROC_WRITE_TEST_ARTIFACTS"
+			IL_0330: ldstr "1"
+			IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_033a: pop
+			IL_033b: ldloc.s 25
+			IL_033d: stloc.s 6
+			IL_033f: ldarg.0
+			IL_0340: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_0345: stloc.s 26
+			IL_0347: ldloc.s 4
+			IL_0349: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_034e: stloc.s 22
+			IL_0350: ldstr "FullyQualifiedName="
+			IL_0355: ldloc.s 22
+			IL_0357: call string [System.Runtime]System.String::Concat(string, string)
+			IL_035c: stloc.s 22
+			IL_035e: ldc.i4.5
+			IL_035f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0364: dup
+			IL_0365: ldstr "test"
+			IL_036a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_036f: dup
+			IL_0370: ldloc.s 5
+			IL_0372: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0377: dup
+			IL_0378: ldstr "--filter"
+			IL_037d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0382: dup
+			IL_0383: ldloc.s 22
+			IL_0385: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_038a: dup
-			IL_038b: ldstr "cwd"
-			IL_0390: ldloc.s 18
-			IL_0392: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0397: dup
-			IL_0398: ldstr "env"
-			IL_039d: ldloc.s 6
-			IL_039f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_03a4: stloc.s 25
-			IL_03a6: ldloc.s 26
-			IL_03a8: ldstr "dotnet"
-			IL_03ad: ldloc.s 27
-			IL_03af: ldloc.s 25
-			IL_03b1: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
-			IL_03b6: stloc.s 7
-			IL_03b8: ldarg.0
-			IL_03b9: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
-			IL_03be: ldc.i4.1
-			IL_03bf: newarr [System.Runtime]System.Object
-			IL_03c4: dup
-			IL_03c5: ldc.i4.0
-			IL_03c6: ldarg.0
-			IL_03c7: stelem.ref
-			IL_03c8: ldloc.2
-			IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_03ce: stloc.s 8
-			IL_03d0: ldloc.s 7
-			IL_03d2: ldstr "status"
-			IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03dc: stloc.s 18
-			IL_03de: ldloc.s 18
-			IL_03e0: ldc.r8 0.0
-			IL_03e9: box [System.Runtime]System.Double
-			IL_03ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_03f3: stloc.s 21
-			IL_03f5: ldloc.s 21
-			IL_03f7: brfalse IL_041f
-
+			IL_038b: ldstr "--no-build"
+			IL_0390: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0395: stloc.s 27
+			IL_0397: ldarg.0
+			IL_0398: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_039d: stloc.s 18
+			IL_039f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_03a4: dup
+			IL_03a5: ldstr "stdio"
+			IL_03aa: ldstr "inherit"
+			IL_03af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03b4: dup
+			IL_03b5: ldstr "shell"
+			IL_03ba: ldc.i4.1
+			IL_03bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_03c0: dup
+			IL_03c1: ldstr "cwd"
+			IL_03c6: ldloc.s 18
+			IL_03c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03cd: dup
+			IL_03ce: ldstr "env"
+			IL_03d3: ldloc.s 6
+			IL_03d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03da: stloc.s 25
+			IL_03dc: ldloc.s 26
+			IL_03de: ldstr "dotnet"
+			IL_03e3: ldloc.s 27
+			IL_03e5: ldloc.s 25
+			IL_03e7: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
+			IL_03ec: stloc.s 7
+			IL_03ee: ldarg.0
+			IL_03ef: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
+			IL_03f4: ldc.i4.1
+			IL_03f5: newarr [System.Runtime]System.Object
+			IL_03fa: dup
+			IL_03fb: ldc.i4.0
 			IL_03fc: ldarg.0
-			IL_03fd: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
-			IL_0402: ldc.i4.1
-			IL_0403: newarr [System.Runtime]System.Object
-			IL_0408: dup
-			IL_0409: ldc.i4.0
-			IL_040a: ldarg.0
-			IL_040b: stelem.ref
-			IL_040c: ldloc.1
-			IL_040d: ldloc.s 8
-			IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0414: stloc.s 18
-			IL_0416: ldloc.s 18
-			IL_0418: stloc.s 9
-			IL_041a: br IL_0427
+			IL_03fd: stelem.ref
+			IL_03fe: ldloc.2
+			IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0404: stloc.s 8
+			IL_0406: ldloc.s 7
+			IL_0408: ldstr "status"
+			IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0412: stloc.s 18
+			IL_0414: ldloc.s 18
+			IL_0416: ldc.r8 0.0
+			IL_041f: box [System.Runtime]System.Double
+			IL_0424: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0429: stloc.s 21
+			IL_042b: ldloc.s 21
+			IL_042d: brfalse IL_0455
 
-			IL_041f: ldc.i4.0
-			IL_0420: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0425: stloc.s 9
+			IL_0432: ldarg.0
+			IL_0433: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
+			IL_0438: ldc.i4.1
+			IL_0439: newarr [System.Runtime]System.Object
+			IL_043e: dup
+			IL_043f: ldc.i4.0
+			IL_0440: ldarg.0
+			IL_0441: stelem.ref
+			IL_0442: ldloc.1
+			IL_0443: ldloc.s 8
+			IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_044a: stloc.s 18
+			IL_044c: ldloc.s 18
+			IL_044e: stloc.s 9
+			IL_0450: br IL_045d
 
-			IL_0427: ldloc.s 9
-			IL_0429: stloc.s 10
-			IL_042b: ldloc.s 10
-			IL_042d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0432: ldc.i4.0
-			IL_0433: ceq
-			IL_0435: stloc.s 21
-			IL_0437: ldloc.s 21
-			IL_0439: brfalse IL_05a9
+			IL_0455: ldc.i4.0
+			IL_0456: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_045b: stloc.s 9
 
-			IL_043e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0443: stloc.s 24
-			IL_0445: ldloc.s 24
-			IL_0447: ldstr "Test did not produce an assembly, retrying with build..."
-			IL_044c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0451: pop
-			IL_0452: ldarg.0
-			IL_0453: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_0458: stloc.s 26
-			IL_045a: ldloc.s 4
-			IL_045c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0461: stloc.s 22
-			IL_0463: ldstr "FullyQualifiedName="
-			IL_0468: ldloc.s 22
-			IL_046a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_046f: stloc.s 22
-			IL_0471: ldc.i4.4
-			IL_0472: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0477: dup
-			IL_0478: ldstr "test"
-			IL_047d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0482: dup
-			IL_0483: ldloc.s 5
-			IL_0485: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_048a: dup
-			IL_048b: ldstr "--filter"
-			IL_0490: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0495: dup
-			IL_0496: ldloc.s 22
-			IL_0498: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_049d: stloc.s 27
-			IL_049f: ldarg.0
-			IL_04a0: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_04a5: stloc.s 18
-			IL_04a7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_04ac: dup
-			IL_04ad: ldstr "stdio"
-			IL_04b2: ldstr "inherit"
-			IL_04b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04bc: dup
-			IL_04bd: ldstr "shell"
-			IL_04c2: ldc.i4.1
-			IL_04c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_04c8: dup
-			IL_04c9: ldstr "cwd"
-			IL_04ce: ldloc.s 18
-			IL_04d0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04d5: dup
-			IL_04d6: ldstr "env"
-			IL_04db: ldloc.s 6
-			IL_04dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04e2: stloc.s 25
-			IL_04e4: ldloc.s 26
-			IL_04e6: ldstr "dotnet"
-			IL_04eb: ldloc.s 27
-			IL_04ed: ldloc.s 25
-			IL_04ef: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
-			IL_04f4: stloc.s 11
-			IL_04f6: ldloc.s 11
-			IL_04f8: ldstr "status"
-			IL_04fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0502: stloc.s 18
+			IL_045d: ldloc.s 9
+			IL_045f: stloc.s 10
+			IL_0461: ldloc.s 10
+			IL_0463: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0468: ldc.i4.0
+			IL_0469: ceq
+			IL_046b: stloc.s 21
+			IL_046d: ldloc.s 21
+			IL_046f: brfalse IL_05df
+
+			IL_0474: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0479: stloc.s 24
+			IL_047b: ldloc.s 24
+			IL_047d: ldstr "Test did not produce an assembly, retrying with build..."
+			IL_0482: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0487: pop
+			IL_0488: ldarg.0
+			IL_0489: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_048e: stloc.s 26
+			IL_0490: ldloc.s 4
+			IL_0492: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0497: stloc.s 22
+			IL_0499: ldstr "FullyQualifiedName="
+			IL_049e: ldloc.s 22
+			IL_04a0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04a5: stloc.s 22
+			IL_04a7: ldc.i4.4
+			IL_04a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_04ad: dup
+			IL_04ae: ldstr "test"
+			IL_04b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_04b8: dup
+			IL_04b9: ldloc.s 5
+			IL_04bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_04c0: dup
+			IL_04c1: ldstr "--filter"
+			IL_04c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_04cb: dup
+			IL_04cc: ldloc.s 22
+			IL_04ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_04d3: stloc.s 27
+			IL_04d5: ldarg.0
+			IL_04d6: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_04db: stloc.s 18
+			IL_04dd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_04e2: dup
+			IL_04e3: ldstr "stdio"
+			IL_04e8: ldstr "inherit"
+			IL_04ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_04f2: dup
+			IL_04f3: ldstr "shell"
+			IL_04f8: ldc.i4.1
+			IL_04f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_04fe: dup
+			IL_04ff: ldstr "cwd"
 			IL_0504: ldloc.s 18
-			IL_0506: ldc.r8 0.0
-			IL_050f: box [System.Runtime]System.Double
-			IL_0514: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_0519: stloc.s 21
-			IL_051b: ldloc.s 21
-			IL_051d: brfalse IL_058b
+			IL_0506: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_050b: dup
+			IL_050c: ldstr "env"
+			IL_0511: ldloc.s 6
+			IL_0513: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0518: stloc.s 25
+			IL_051a: ldloc.s 26
+			IL_051c: ldstr "dotnet"
+			IL_0521: ldloc.s 27
+			IL_0523: ldloc.s 25
+			IL_0525: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
+			IL_052a: stloc.s 11
+			IL_052c: ldloc.s 11
+			IL_052e: ldstr "status"
+			IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0538: stloc.s 18
+			IL_053a: ldloc.s 18
+			IL_053c: ldc.r8 0.0
+			IL_0545: box [System.Runtime]System.Double
+			IL_054a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_054f: stloc.s 21
+			IL_0551: ldloc.s 21
+			IL_0553: brfalse IL_05c1
 
-			IL_0522: ldstr "console"
-			IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0531: stloc.s 18
-			IL_0533: ldloc.s 4
-			IL_0535: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_053a: stloc.s 22
-			IL_053c: ldstr "Test "
-			IL_0541: ldloc.s 22
-			IL_0543: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0548: ldstr " failed or not found."
-			IL_054d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0552: stloc.s 22
-			IL_0554: ldloc.s 18
-			IL_0556: ldstr "error"
-			IL_055b: ldloc.s 22
-			IL_055d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0562: pop
-			IL_0563: ldstr "process"
-			IL_0568: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_056d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0572: ldstr "exit"
-			IL_0577: ldc.r8 1
-			IL_0580: box [System.Runtime]System.Double
-			IL_0585: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_058a: pop
+			IL_0558: ldstr "console"
+			IL_055d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0562: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0567: stloc.s 18
+			IL_0569: ldloc.s 4
+			IL_056b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0570: stloc.s 22
+			IL_0572: ldstr "Test "
+			IL_0577: ldloc.s 22
+			IL_0579: call string [System.Runtime]System.String::Concat(string, string)
+			IL_057e: ldstr " failed or not found."
+			IL_0583: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0588: stloc.s 22
+			IL_058a: ldloc.s 18
+			IL_058c: ldstr "error"
+			IL_0591: ldloc.s 22
+			IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0598: pop
+			IL_0599: ldstr "process"
+			IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05a8: ldstr "exit"
+			IL_05ad: ldc.r8 1
+			IL_05b6: box [System.Runtime]System.Double
+			IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_05c0: pop
 
-			IL_058b: ldarg.0
-			IL_058c: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
-			IL_0591: ldc.i4.1
-			IL_0592: newarr [System.Runtime]System.Object
-			IL_0597: dup
-			IL_0598: ldc.i4.0
-			IL_0599: ldarg.0
-			IL_059a: stelem.ref
-			IL_059b: ldloc.1
-			IL_059c: ldloc.s 8
-			IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05a3: stloc.s 18
-			IL_05a5: ldloc.s 18
-			IL_05a7: stloc.s 10
+			IL_05c1: ldarg.0
+			IL_05c2: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
+			IL_05c7: ldc.i4.1
+			IL_05c8: newarr [System.Runtime]System.Object
+			IL_05cd: dup
+			IL_05ce: ldc.i4.0
+			IL_05cf: ldarg.0
+			IL_05d0: stelem.ref
+			IL_05d1: ldloc.1
+			IL_05d2: ldloc.s 8
+			IL_05d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05d9: stloc.s 18
+			IL_05db: ldloc.s 18
+			IL_05dd: stloc.s 10
 
-			IL_05a9: ldloc.s 10
-			IL_05ab: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_05b0: ldc.i4.0
-			IL_05b1: ceq
-			IL_05b3: stloc.s 21
-			IL_05b5: ldloc.s 21
-			IL_05b7: brfalse IL_071d
+			IL_05df: ldloc.s 10
+			IL_05e1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_05e6: ldc.i4.0
+			IL_05e7: ceq
+			IL_05e9: stloc.s 21
+			IL_05eb: ldloc.s 21
+			IL_05ed: brfalse IL_0753
 
-			IL_05bc: ldstr "console"
-			IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05cb: stloc.s 18
-			IL_05cd: ldloc.1
-			IL_05ce: ldstr "path"
-			IL_05d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05d8: stloc.s 28
-			IL_05da: ldloc.s 28
-			IL_05dc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05e1: stloc.s 22
-			IL_05e3: ldstr "Assembly not found for category '"
-			IL_05e8: ldloc.s 22
-			IL_05ea: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05ef: ldstr "' and test '"
-			IL_05f4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05f9: ldloc.2
-			IL_05fa: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05ff: stloc.s 22
-			IL_0601: ldloc.s 22
-			IL_0603: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0608: ldstr "'."
-			IL_060d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0612: stloc.s 22
-			IL_0614: ldloc.s 18
-			IL_0616: ldstr "error"
-			IL_061b: ldloc.s 22
-			IL_061d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0622: pop
-			IL_0623: ldstr "console"
-			IL_0628: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0632: ldstr "error"
-			IL_0637: ldstr "Looked under:"
-			IL_063c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0641: pop
-			IL_0642: ldarg.0
-			IL_0643: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
-			IL_0648: ldc.i4.1
-			IL_0649: newarr [System.Runtime]System.Object
-			IL_064e: dup
-			IL_064f: ldc.i4.0
-			IL_0650: ldarg.0
-			IL_0651: stelem.ref
-			IL_0652: ldloc.1
-			IL_0653: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0658: stloc.s 12
-			IL_065a: ldc.r8 0.0
-			IL_0663: stloc.s 13
-			// loop start (head: IL_0665)
-				IL_0665: ldloc.s 13
-				IL_0667: stloc.s 29
-				IL_0669: ldloc.s 12
-				IL_066b: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
-				IL_0670: stloc.s 30
-				IL_0672: ldloc.s 29
-				IL_0674: ldloc.s 30
-				IL_0676: clt
-				IL_0678: brfalse IL_06d6
+			IL_05f2: ldstr "console"
+			IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0601: stloc.s 18
+			IL_0603: ldloc.1
+			IL_0604: ldstr "path"
+			IL_0609: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_060e: stloc.s 28
+			IL_0610: ldloc.s 28
+			IL_0612: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0617: stloc.s 22
+			IL_0619: ldstr "Assembly not found for category '"
+			IL_061e: ldloc.s 22
+			IL_0620: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0625: ldstr "' and test '"
+			IL_062a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_062f: ldloc.2
+			IL_0630: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0635: stloc.s 22
+			IL_0637: ldloc.s 22
+			IL_0639: call string [System.Runtime]System.String::Concat(string, string)
+			IL_063e: ldstr "'."
+			IL_0643: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0648: stloc.s 22
+			IL_064a: ldloc.s 18
+			IL_064c: ldstr "error"
+			IL_0651: ldloc.s 22
+			IL_0653: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0658: pop
+			IL_0659: ldstr "console"
+			IL_065e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0663: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0668: ldstr "error"
+			IL_066d: ldstr "Looked under:"
+			IL_0672: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0677: pop
+			IL_0678: ldarg.0
+			IL_0679: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
+			IL_067e: ldc.i4.1
+			IL_067f: newarr [System.Runtime]System.Object
+			IL_0684: dup
+			IL_0685: ldc.i4.0
+			IL_0686: ldarg.0
+			IL_0687: stelem.ref
+			IL_0688: ldloc.1
+			IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_068e: stloc.s 12
+			IL_0690: ldc.r8 0.0
+			IL_0699: stloc.s 13
+			// loop start (head: IL_069b)
+				IL_069b: ldloc.s 13
+				IL_069d: stloc.s 29
+				IL_069f: ldloc.s 12
+				IL_06a1: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
+				IL_06a6: stloc.s 30
+				IL_06a8: ldloc.s 29
+				IL_06aa: ldloc.s 30
+				IL_06ac: clt
+				IL_06ae: brfalse IL_070c
 
-				IL_067d: ldstr "console"
-				IL_0682: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0687: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_068c: stloc.s 18
-				IL_068e: ldloc.s 12
-				IL_0690: ldloc.s 13
-				IL_0692: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0697: stloc.s 28
-				IL_0699: ldloc.s 28
-				IL_069b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_06a0: stloc.s 22
-				IL_06a2: ldstr "  - "
-				IL_06a7: ldloc.s 22
-				IL_06a9: call string [System.Runtime]System.String::Concat(string, string)
-				IL_06ae: stloc.s 22
-				IL_06b0: ldloc.s 18
-				IL_06b2: ldstr "error"
-				IL_06b7: ldloc.s 22
-				IL_06b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_06be: pop
-				IL_06bf: ldloc.s 13
-				IL_06c1: ldc.r8 1
-				IL_06ca: add
-				IL_06cb: stloc.s 30
-				IL_06cd: ldloc.s 30
-				IL_06cf: stloc.s 13
-				IL_06d1: br IL_0665
+				IL_06b3: ldstr "console"
+				IL_06b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_06c2: stloc.s 18
+				IL_06c4: ldloc.s 12
+				IL_06c6: ldloc.s 13
+				IL_06c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_06cd: stloc.s 28
+				IL_06cf: ldloc.s 28
+				IL_06d1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_06d6: stloc.s 22
+				IL_06d8: ldstr "  - "
+				IL_06dd: ldloc.s 22
+				IL_06df: call string [System.Runtime]System.String::Concat(string, string)
+				IL_06e4: stloc.s 22
+				IL_06e6: ldloc.s 18
+				IL_06e8: ldstr "error"
+				IL_06ed: ldloc.s 22
+				IL_06ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_06f4: pop
+				IL_06f5: ldloc.s 13
+				IL_06f7: ldc.r8 1
+				IL_0700: add
+				IL_0701: stloc.s 30
+				IL_0703: ldloc.s 30
+				IL_0705: stloc.s 13
+				IL_0707: br IL_069b
 			// end loop
 
-			IL_06d6: ldstr "console"
-			IL_06db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06e5: ldstr "error"
-			IL_06ea: ldstr "Make sure the test ran successfully and generated the assembly."
-			IL_06ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_06f4: pop
-			IL_06f5: ldstr "process"
-			IL_06fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0704: ldstr "exit"
-			IL_0709: ldc.r8 1
-			IL_0712: box [System.Runtime]System.Double
-			IL_0717: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_071c: pop
+			IL_070c: ldstr "console"
+			IL_0711: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0716: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_071b: ldstr "error"
+			IL_0720: ldstr "Make sure the test ran successfully and generated the assembly."
+			IL_0725: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_072a: pop
+			IL_072b: ldstr "process"
+			IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0735: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_073a: ldstr "exit"
+			IL_073f: ldc.r8 1
+			IL_0748: box [System.Runtime]System.Double
+			IL_074d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0752: pop
 
-			IL_071d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0722: stloc.s 24
-			IL_0724: ldloc.s 10
-			IL_0726: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_072b: stloc.s 22
-			IL_072d: ldstr "Found assembly: "
-			IL_0732: ldloc.s 22
-			IL_0734: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0739: stloc.s 22
-			IL_073b: ldloc.s 24
-			IL_073d: ldloc.s 22
-			IL_073f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0744: pop
+			IL_0753: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0758: stloc.s 24
+			IL_075a: ldloc.s 10
+			IL_075c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0761: stloc.s 22
+			IL_0763: ldstr "Found assembly: "
+			IL_0768: ldloc.s 22
+			IL_076a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_076f: stloc.s 22
+			IL_0771: ldloc.s 24
+			IL_0773: ldloc.s 22
+			IL_0775: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_077a: pop
 			.try
 			{
-				IL_0745: nop
-				IL_0746: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_074b: stloc.s 24
-				IL_074d: ldloc.s 24
-				IL_074f: ldstr "Opening in ILSpy..."
-				IL_0754: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_0759: pop
-				IL_075a: ldarg.0
-				IL_075b: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
-				IL_0760: stloc.s 18
-				IL_0762: ldloc.s 18
-				IL_0764: ldc.i4.1
-				IL_0765: newarr [System.Runtime]System.Object
-				IL_076a: dup
-				IL_076b: ldc.i4.0
-				IL_076c: ldarg.0
-				IL_076d: stelem.ref
-				IL_076e: ldloc.s 10
-				IL_0770: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0775: pop
-				IL_0776: leave IL_0815
+				IL_077b: nop
+				IL_077c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0781: stloc.s 24
+				IL_0783: ldloc.s 24
+				IL_0785: ldstr "Opening in ILSpy..."
+				IL_078a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_078f: pop
+				IL_0790: ldarg.0
+				IL_0791: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
+				IL_0796: stloc.s 18
+				IL_0798: ldloc.s 18
+				IL_079a: ldc.i4.1
+				IL_079b: newarr [System.Runtime]System.Object
+				IL_07a0: dup
+				IL_07a1: ldc.i4.0
+				IL_07a2: ldarg.0
+				IL_07a3: stelem.ref
+				IL_07a4: ldloc.s 10
+				IL_07a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_07ab: pop
+				IL_07ac: leave IL_084b
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_077b: stloc.s 14
-				IL_077d: ldloc.s 14
-				IL_077f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_0784: dup
-				IL_0785: brtrue IL_079b
+				IL_07b1: stloc.s 14
+				IL_07b3: ldloc.s 14
+				IL_07b5: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_07ba: dup
+				IL_07bb: brtrue IL_07d1
 
-				IL_078a: pop
-				IL_078b: ldloc.s 14
-				IL_078d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_0792: dup
-				IL_0793: brtrue IL_07a7
+				IL_07c0: pop
+				IL_07c1: ldloc.s 14
+				IL_07c3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_07c8: dup
+				IL_07c9: brtrue IL_07dd
 
-				IL_0798: pop
-				IL_0799: rethrow
+				IL_07ce: pop
+				IL_07cf: rethrow
 
-				IL_079b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_07a0: stloc.s 15
-				IL_07a2: br IL_07a9
+				IL_07d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_07d6: stloc.s 15
+				IL_07d8: br IL_07df
 
-				IL_07a7: stloc.s 15
+				IL_07dd: stloc.s 15
 
-				IL_07a9: ldloc.s 15
-				IL_07ab: stloc.s 16
-				IL_07ad: ldstr "console"
-				IL_07b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_07b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_07bc: ldstr "error"
-				IL_07c1: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
-				IL_07c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_07cb: pop
-				IL_07cc: ldstr "console"
-				IL_07d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_07d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_07db: ldstr "error"
-				IL_07e0: ldloc.s 16
-				IL_07e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_07e7: pop
-				IL_07e8: ldstr "process"
-				IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_07f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_07f7: ldstr "exit"
-				IL_07fc: ldc.r8 1
-				IL_0805: box [System.Runtime]System.Double
-				IL_080a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_080f: pop
-				IL_0810: leave IL_0815
+				IL_07df: ldloc.s 15
+				IL_07e1: stloc.s 16
+				IL_07e3: ldstr "console"
+				IL_07e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_07f2: ldstr "error"
+				IL_07f7: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
+				IL_07fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0801: pop
+				IL_0802: ldstr "console"
+				IL_0807: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_080c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0811: ldstr "error"
+				IL_0816: ldloc.s 16
+				IL_0818: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_081d: pop
+				IL_081e: ldstr "process"
+				IL_0823: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0828: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_082d: ldstr "exit"
+				IL_0832: ldc.r8 1
+				IL_083b: box [System.Runtime]System.Double
+				IL_0840: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0845: pop
+				IL_0846: leave IL_084b
 			} // end handler
 
-			IL_0815: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_081a: stloc.s 24
-			IL_081c: ldloc.s 24
-			IL_081e: ldstr "Done!"
-			IL_0823: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0828: pop
-			IL_0829: ldnull
-			IL_082a: stloc.s 17
-			IL_082c: ldloc.s 17
-			IL_082e: ret
+			IL_084b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0850: stloc.s 24
+			IL_0852: ldloc.s 24
+			IL_0854: ldstr "Done!"
+			IL_0859: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_085e: pop
+			IL_085f: ldnull
+			IL_0860: stloc.s 17
+			IL_0862: ldloc.s 17
+			IL_0864: ret
 		} // end of method main::__js_call__
 
 	} // end of class main

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -740,7 +740,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 292 (0x124)
+			// Code size: 436 (0x1b4)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -752,97 +752,156 @@
 
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0006: ldstr "includes"
-			IL_000b: ldstr " -> "
-			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0015: stloc.0
-			IL_0016: ldloc.0
-			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_001c: stloc.1
-			IL_001d: ldloc.1
-			IL_001e: brfalse IL_007a
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.0
+			IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_000d: brfalse IL_0034
 
-			IL_0023: ldarg.1
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0029: stloc.0
-			IL_002a: ldarg.1
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0030: ldstr "indexOf"
-			IL_0035: ldstr " -> "
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_003f: stloc.2
-			IL_0040: ldloc.2
-			IL_0041: ldc.r8 4
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_004f: stloc.3
-			IL_0050: ldloc.0
-			IL_0051: ldstr "substring"
-			IL_0056: ldc.r8 0.0
-			IL_005f: box [System.Runtime]System.Double
-			IL_0064: ldloc.3
-			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_006a: stloc.0
-			IL_006b: ldloc.0
-			IL_006c: ldstr "<outFile>"
-			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0076: stloc.3
-			IL_0077: ldloc.3
-			IL_0078: starg.s text
+			IL_0012: ldloc.0
+			IL_0013: isinst [System.Runtime]System.String
+			IL_0018: dup
+			IL_0019: brfalse IL_0033
 
-			IL_007a: ldarg.1
-			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0080: stloc.0
-			IL_0081: ldarg.2
-			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0087: stloc.2
-			IL_0088: ldstr "[.*+?^${}()|[\\]\\\\]"
-			IL_008d: ldstr "g"
-			IL_0092: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0097: stloc.s 4
-			IL_0099: ldloc.2
-			IL_009a: ldstr "replace"
-			IL_009f: ldloc.s 4
-			IL_00a1: ldstr "\\$&"
-			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00ab: stloc.2
-			IL_00ac: ldloc.2
-			IL_00ad: ldstr "g"
-			IL_00b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_00b7: stloc.s 4
+			IL_001e: ldstr " -> "
+			IL_0023: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_0028: box [System.Runtime]System.Boolean
+			IL_002d: stloc.0
+			IL_002e: br IL_0045
+
+			IL_0033: pop
+
+			IL_0034: ldloc.0
+			IL_0035: ldstr "includes"
+			IL_003a: ldstr " -> "
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0044: stloc.0
+
+			IL_0045: ldloc.0
+			IL_0046: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_004b: stloc.1
+			IL_004c: ldloc.1
+			IL_004d: brfalse IL_010a
+
+			IL_0052: ldarg.1
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0058: stloc.0
+			IL_0059: ldarg.1
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005f: stloc.2
+			IL_0060: ldc.i4.0
+			IL_0061: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0066: brfalse IL_008d
+
+			IL_006b: ldloc.2
+			IL_006c: isinst [System.Runtime]System.String
+			IL_0071: dup
+			IL_0072: brfalse IL_008c
+
+			IL_0077: ldstr " -> "
+			IL_007c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0081: box [System.Runtime]System.Double
+			IL_0086: stloc.2
+			IL_0087: br IL_009e
+
+			IL_008c: pop
+
+			IL_008d: ldloc.2
+			IL_008e: ldstr "indexOf"
+			IL_0093: ldstr " -> "
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_009d: stloc.2
+
+			IL_009e: ldloc.2
+			IL_009f: ldc.r8 4
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_00ad: stloc.3
+			IL_00ae: ldc.i4.0
+			IL_00af: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00b4: brfalse IL_00e0
+
 			IL_00b9: ldloc.0
-			IL_00ba: ldstr "replace"
-			IL_00bf: ldloc.s 4
-			IL_00c1: ldstr "<outFile>"
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00cb: stloc.0
-			IL_00cc: ldloc.0
-			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d2: stloc.0
-			IL_00d3: ldstr "127\\.0\\.0\\.1:\\d+"
-			IL_00d8: ldstr "g"
-			IL_00dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_00e2: stloc.s 4
-			IL_00e4: ldloc.0
-			IL_00e5: ldstr "replace"
-			IL_00ea: ldloc.s 4
-			IL_00ec: ldstr "127.0.0.1:<port>"
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00f6: stloc.0
-			IL_00f7: ldloc.0
-			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00fd: stloc.0
-			IL_00fe: ldstr "\\r\\n"
-			IL_0103: ldstr "g"
-			IL_0108: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_010d: stloc.s 4
-			IL_010f: ldloc.0
-			IL_0110: ldstr "replace"
-			IL_0115: ldloc.s 4
-			IL_0117: ldstr "\n"
-			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0121: stloc.0
-			IL_0122: ldloc.0
-			IL_0123: ret
+			IL_00ba: isinst [System.Runtime]System.String
+			IL_00bf: dup
+			IL_00c0: brfalse IL_00df
+
+			IL_00c5: ldc.r8 0.0
+			IL_00ce: box [System.Runtime]System.Double
+			IL_00d3: ldloc.3
+			IL_00d4: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_00d9: stloc.0
+			IL_00da: br IL_00fb
+
+			IL_00df: pop
+
+			IL_00e0: ldloc.0
+			IL_00e1: ldstr "substring"
+			IL_00e6: ldc.r8 0.0
+			IL_00ef: box [System.Runtime]System.Double
+			IL_00f4: ldloc.3
+			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00fa: stloc.0
+
+			IL_00fb: ldloc.0
+			IL_00fc: ldstr "<outFile>"
+			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0106: stloc.3
+			IL_0107: ldloc.3
+			IL_0108: starg.s text
+
+			IL_010a: ldarg.1
+			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0110: stloc.0
+			IL_0111: ldarg.2
+			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0117: stloc.2
+			IL_0118: ldstr "[.*+?^${}()|[\\]\\\\]"
+			IL_011d: ldstr "g"
+			IL_0122: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0127: stloc.s 4
+			IL_0129: ldloc.2
+			IL_012a: ldstr "replace"
+			IL_012f: ldloc.s 4
+			IL_0131: ldstr "\\$&"
+			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_013b: stloc.2
+			IL_013c: ldloc.2
+			IL_013d: ldstr "g"
+			IL_0142: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0147: stloc.s 4
+			IL_0149: ldloc.0
+			IL_014a: ldstr "replace"
+			IL_014f: ldloc.s 4
+			IL_0151: ldstr "<outFile>"
+			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_015b: stloc.0
+			IL_015c: ldloc.0
+			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0162: stloc.0
+			IL_0163: ldstr "127\\.0\\.0\\.1:\\d+"
+			IL_0168: ldstr "g"
+			IL_016d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0172: stloc.s 4
+			IL_0174: ldloc.0
+			IL_0175: ldstr "replace"
+			IL_017a: ldloc.s 4
+			IL_017c: ldstr "127.0.0.1:<port>"
+			IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0186: stloc.0
+			IL_0187: ldloc.0
+			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_018d: stloc.0
+			IL_018e: ldstr "\\r\\n"
+			IL_0193: ldstr "g"
+			IL_0198: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_019d: stloc.s 4
+			IL_019f: ldloc.0
+			IL_01a0: ldstr "replace"
+			IL_01a5: ldloc.s 4
+			IL_01a7: ldstr "\n"
+			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01b1: stloc.0
+			IL_01b2: ldloc.0
+			IL_01b3: ret
 		} // end of method normalize::__js_call__
 
 	} // end of class normalize
@@ -3496,7 +3555,7 @@
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
-			// Code size: 502 (0x1f6)
+			// Code size: 542 (0x21e)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3704,14 +3763,32 @@
 			IL_01d2: ldc.r8 1
 			IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
 			IL_01e0: stloc.s 9
-			IL_01e2: ldloc.s 5
-			IL_01e4: ldstr "substring"
-			IL_01e9: ldloc.s 9
-			IL_01eb: ldloc.0
-			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01f1: stloc.s 5
-			IL_01f3: ldloc.s 5
-			IL_01f5: ret
+			IL_01e2: ldc.i4.0
+			IL_01e3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01e8: brfalse IL_020a
+
+			IL_01ed: ldloc.s 5
+			IL_01ef: isinst [System.Runtime]System.String
+			IL_01f4: dup
+			IL_01f5: brfalse IL_0209
+
+			IL_01fa: ldloc.s 9
+			IL_01fc: ldloc.0
+			IL_01fd: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_0202: stloc.s 5
+			IL_0204: br IL_021b
+
+			IL_0209: pop
+
+			IL_020a: ldloc.s 5
+			IL_020c: ldstr "substring"
+			IL_0211: ldloc.s 9
+			IL_0213: ldloc.0
+			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0219: stloc.s 5
+
+			IL_021b: ldloc.s 5
+			IL_021d: ret
 		} // end of method findTagNameAt::__js_call__
 
 	} // end of class findTagNameAt
@@ -4064,7 +4141,7 @@
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
-			// Code size: 935 (0x3a7)
+			// Code size: 1172 (0x494)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -4111,310 +4188,409 @@
 			IL_003d: stloc.1
 			IL_003e: ldarg.2
 			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0044: ldstr "indexOf"
-			IL_0049: ldloc.0
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_004f: stloc.2
-			IL_0050: ldloc.2
-			IL_0051: stloc.s 15
-			IL_0053: ldloc.s 15
-			IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_005a: ldc.r8 0.0
-			IL_0063: clt
-			IL_0065: brfalse IL_0080
+			IL_0044: stloc.s 15
+			IL_0046: ldc.i4.0
+			IL_0047: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_004c: brfalse IL_0070
 
-			IL_006a: ldarg.2
-			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0070: ldstr "indexOf"
-			IL_0075: ldloc.1
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_007b: stloc.s 15
-			IL_007d: ldloc.s 15
-			IL_007f: stloc.2
+			IL_0051: ldloc.s 15
+			IL_0053: isinst [System.Runtime]System.String
+			IL_0058: dup
+			IL_0059: brfalse IL_006f
 
-			IL_0080: ldloc.2
-			IL_0081: stloc.s 15
-			IL_0083: ldloc.s 15
-			IL_0085: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_008a: ldc.r8 0.0
-			IL_0093: clt
-			IL_0095: brfalse IL_00d7
+			IL_005e: ldloc.0
+			IL_005f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0064: box [System.Runtime]System.Double
+			IL_0069: stloc.2
+			IL_006a: br IL_007e
 
-			IL_009a: ldarg.3
-			IL_009b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00a0: stloc.s 14
-			IL_00a2: ldstr "Could not find id '"
-			IL_00a7: ldloc.s 14
-			IL_00a9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00ae: ldstr "' in input HTML."
-			IL_00b3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00b8: stloc.s 14
-			IL_00ba: ldloc.s 14
-			IL_00bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00c1: stloc.3
-			IL_00c2: ldloc.3
-			IL_00c3: isinst [System.Runtime]System.Exception
-			IL_00c8: dup
-			IL_00c9: brtrue IL_00d6
+			IL_006f: pop
 
-			IL_00ce: pop
-			IL_00cf: ldloc.3
-			IL_00d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00d5: throw
+			IL_0070: ldloc.s 15
+			IL_0072: ldstr "indexOf"
+			IL_0077: ldloc.0
+			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_007d: stloc.2
 
-			IL_00d6: throw
+			IL_007e: ldloc.2
+			IL_007f: stloc.s 15
+			IL_0081: ldloc.s 15
+			IL_0083: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0088: ldc.r8 0.0
+			IL_0091: clt
+			IL_0093: brfalse IL_00dd
 
-			IL_00d7: ldarg.2
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00dd: ldstr "lastIndexOf"
-			IL_00e2: ldstr "<"
-			IL_00e7: ldloc.2
-			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00ed: stloc.s 4
-			IL_00ef: ldloc.s 4
-			IL_00f1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00f6: ldc.r8 0.0
-			IL_00ff: clt
-			IL_0101: brfalse IL_0146
+			IL_0098: ldarg.2
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009e: stloc.s 15
+			IL_00a0: ldc.i4.0
+			IL_00a1: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00a6: brfalse IL_00cb
 
-			IL_0106: ldarg.3
-			IL_0107: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_010c: stloc.s 14
-			IL_010e: ldstr "Could not locate tag start for id '"
-			IL_0113: ldloc.s 14
-			IL_0115: call string [System.Runtime]System.String::Concat(string, string)
-			IL_011a: ldstr "'."
-			IL_011f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0124: stloc.s 14
-			IL_0126: ldloc.s 14
-			IL_0128: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_012d: stloc.s 5
-			IL_012f: ldloc.s 5
-			IL_0131: isinst [System.Runtime]System.Exception
-			IL_0136: dup
-			IL_0137: brtrue IL_0145
+			IL_00ab: ldloc.s 15
+			IL_00ad: isinst [System.Runtime]System.String
+			IL_00b2: dup
+			IL_00b3: brfalse IL_00ca
 
-			IL_013c: pop
-			IL_013d: ldloc.s 5
-			IL_013f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0144: throw
+			IL_00b8: ldloc.1
+			IL_00b9: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_00be: box [System.Runtime]System.Double
+			IL_00c3: stloc.s 15
+			IL_00c5: br IL_00da
 
-			IL_0145: throw
+			IL_00ca: pop
 
-			IL_0146: ldarg.0
-			IL_0147: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
-			IL_014c: ldc.i4.1
-			IL_014d: newarr [System.Runtime]System.Object
-			IL_0152: dup
-			IL_0153: ldc.i4.0
-			IL_0154: ldarg.0
-			IL_0155: stelem.ref
-			IL_0156: stloc.s 16
-			IL_0158: ldloc.s 16
-			IL_015a: ldarg.2
-			IL_015b: ldloc.s 4
-			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0162: stloc.s 6
-			IL_0164: ldloc.s 6
-			IL_0166: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_016b: ldc.i4.0
-			IL_016c: ceq
-			IL_016e: stloc.s 17
-			IL_0170: ldloc.s 17
-			IL_0172: brfalse IL_01b7
+			IL_00cb: ldloc.s 15
+			IL_00cd: ldstr "indexOf"
+			IL_00d2: ldloc.1
+			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00d8: stloc.s 15
 
-			IL_0177: ldarg.3
-			IL_0178: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_017d: stloc.s 14
-			IL_017f: ldstr "Could not determine tag name for id '"
-			IL_0184: ldloc.s 14
-			IL_0186: call string [System.Runtime]System.String::Concat(string, string)
-			IL_018b: ldstr "'."
-			IL_0190: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0195: stloc.s 14
-			IL_0197: ldloc.s 14
-			IL_0199: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_019e: stloc.s 7
-			IL_01a0: ldloc.s 7
-			IL_01a2: isinst [System.Runtime]System.Exception
-			IL_01a7: dup
-			IL_01a8: brtrue IL_01b6
+			IL_00da: ldloc.s 15
+			IL_00dc: stloc.2
 
-			IL_01ad: pop
-			IL_01ae: ldloc.s 7
-			IL_01b0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_01b5: throw
+			IL_00dd: ldloc.2
+			IL_00de: stloc.s 15
+			IL_00e0: ldloc.s 15
+			IL_00e2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00e7: ldc.r8 0.0
+			IL_00f0: clt
+			IL_00f2: brfalse IL_0134
 
-			IL_01b6: throw
+			IL_00f7: ldarg.3
+			IL_00f8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00fd: stloc.s 14
+			IL_00ff: ldstr "Could not find id '"
+			IL_0104: ldloc.s 14
+			IL_0106: call string [System.Runtime]System.String::Concat(string, string)
+			IL_010b: ldstr "' in input HTML."
+			IL_0110: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0115: stloc.s 14
+			IL_0117: ldloc.s 14
+			IL_0119: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_011e: stloc.3
+			IL_011f: ldloc.3
+			IL_0120: isinst [System.Runtime]System.Exception
+			IL_0125: dup
+			IL_0126: brtrue IL_0133
 
-			IL_01b7: ldarg.0
-			IL_01b8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
-			IL_01bd: ldc.i4.1
-			IL_01be: newarr [System.Runtime]System.Object
-			IL_01c3: dup
-			IL_01c4: ldc.i4.0
-			IL_01c5: ldarg.0
-			IL_01c6: stelem.ref
-			IL_01c7: ldloc.s 6
-			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01ce: stloc.s 15
-			IL_01d0: ldloc.s 15
-			IL_01d2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01d7: stloc.s 14
-			IL_01d9: ldstr "<\\/?"
-			IL_01de: ldloc.s 14
-			IL_01e0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01e5: ldstr "\\b[^>]*>"
-			IL_01ea: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01ef: stloc.s 14
-			IL_01f1: ldloc.s 14
-			IL_01f3: ldstr "gi"
-			IL_01f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_01fd: stloc.s 8
-			IL_01ff: ldloc.s 8
-			IL_0201: ldstr "lastIndex"
-			IL_0206: ldloc.s 4
-			IL_0208: ldc.i4.1
-			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_020e: pop
-			IL_020f: ldc.r8 0.0
-			IL_0218: stloc.s 9
-			IL_021a: ldc.r8 1
-			IL_0223: neg
-			IL_0224: stloc.s 18
-			IL_0226: ldloc.s 18
-			IL_0228: box [System.Runtime]System.Double
-			IL_022d: stloc.s 10
-			// loop start (head: IL_022f)
-				IL_022f: ldc.i4.1
-				IL_0230: brfalse IL_034b
+			IL_012b: pop
+			IL_012c: ldloc.3
+			IL_012d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0132: throw
 
-				IL_0235: ldloc.s 8
-				IL_0237: ldstr "exec"
-				IL_023c: ldarg.2
-				IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0242: stloc.s 11
-				IL_0244: ldloc.s 11
-				IL_0246: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_024b: ldc.i4.0
-				IL_024c: ceq
-				IL_024e: stloc.s 17
-				IL_0250: ldloc.s 17
-				IL_0252: brfalse IL_025c
+			IL_0133: throw
 
-				IL_0257: br IL_034b
+			IL_0134: ldarg.2
+			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_013a: stloc.s 15
+			IL_013c: ldc.i4.0
+			IL_013d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0142: brfalse IL_016c
 
-				IL_025c: ldloc.s 11
-				IL_025e: ldc.r8 0.0
-				IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_026c: stloc.s 12
-				IL_026e: ldloc.s 10
-				IL_0270: stloc.s 19
-				IL_0272: ldloc.s 19
-				IL_0274: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0279: ldc.r8 0.0
-				IL_0282: clt
-				IL_0284: brfalse IL_029b
+			IL_0147: ldloc.s 15
+			IL_0149: isinst [System.Runtime]System.String
+			IL_014e: dup
+			IL_014f: brfalse IL_016b
 
-				IL_0289: ldloc.s 11
-				IL_028b: ldstr "index"
-				IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0295: stloc.s 15
-				IL_0297: ldloc.s 15
-				IL_0299: stloc.s 10
+			IL_0154: ldstr "<"
+			IL_0159: ldloc.2
+			IL_015a: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+			IL_015f: box [System.Runtime]System.Double
+			IL_0164: stloc.s 4
+			IL_0166: br IL_0180
 
-				IL_029b: ldloc.s 12
-				IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02a2: ldstr "startsWith"
-				IL_02a7: ldstr "</"
-				IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_02b1: stloc.s 15
-				IL_02b3: ldloc.s 15
-				IL_02b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02ba: stloc.s 17
-				IL_02bc: ldloc.s 17
-				IL_02be: brfalse IL_0338
+			IL_016b: pop
 
-				IL_02c3: ldloc.s 9
-				IL_02c5: ldc.r8 1
-				IL_02ce: sub
-				IL_02cf: stloc.s 9
-				IL_02d1: ldloc.s 9
-				IL_02d3: stloc.s 18
-				IL_02d5: ldloc.s 18
-				IL_02d7: ldc.r8 0.0
-				IL_02e0: ceq
-				IL_02e2: brfalse IL_0333
+			IL_016c: ldloc.s 15
+			IL_016e: ldstr "lastIndexOf"
+			IL_0173: ldstr "<"
+			IL_0178: ldloc.2
+			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_017e: stloc.s 4
 
-				IL_02e7: ldarg.2
-				IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02ed: stloc.s 15
-				IL_02ef: ldloc.s 8
-				IL_02f1: ldstr "lastIndex"
-				IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02fb: stloc.s 20
-				IL_02fd: ldloc.s 15
-				IL_02ff: ldstr "substring"
-				IL_0304: ldloc.s 10
-				IL_0306: ldloc.s 20
-				IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_030d: stloc.s 20
-				IL_030f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0314: dup
-				IL_0315: ldstr "tagName"
-				IL_031a: ldloc.s 6
-				IL_031c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0321: dup
-				IL_0322: ldstr "html"
-				IL_0327: ldloc.s 20
-				IL_0329: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_032e: stloc.s 21
-				IL_0330: ldloc.s 21
-				IL_0332: ret
+			IL_0180: ldloc.s 4
+			IL_0182: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0187: ldc.r8 0.0
+			IL_0190: clt
+			IL_0192: brfalse IL_01d7
 
-				IL_0333: br IL_0346
+			IL_0197: ldarg.3
+			IL_0198: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_019d: stloc.s 14
+			IL_019f: ldstr "Could not locate tag start for id '"
+			IL_01a4: ldloc.s 14
+			IL_01a6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ab: ldstr "'."
+			IL_01b0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01b5: stloc.s 14
+			IL_01b7: ldloc.s 14
+			IL_01b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01be: stloc.s 5
+			IL_01c0: ldloc.s 5
+			IL_01c2: isinst [System.Runtime]System.Exception
+			IL_01c7: dup
+			IL_01c8: brtrue IL_01d6
 
-				IL_0338: ldloc.s 9
-				IL_033a: ldc.r8 1
-				IL_0343: add
-				IL_0344: stloc.s 9
+			IL_01cd: pop
+			IL_01ce: ldloc.s 5
+			IL_01d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_01d5: throw
 
-				IL_0346: br IL_022f
+			IL_01d6: throw
+
+			IL_01d7: ldarg.0
+			IL_01d8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
+			IL_01dd: ldc.i4.1
+			IL_01de: newarr [System.Runtime]System.Object
+			IL_01e3: dup
+			IL_01e4: ldc.i4.0
+			IL_01e5: ldarg.0
+			IL_01e6: stelem.ref
+			IL_01e7: stloc.s 16
+			IL_01e9: ldloc.s 16
+			IL_01eb: ldarg.2
+			IL_01ec: ldloc.s 4
+			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01f3: stloc.s 6
+			IL_01f5: ldloc.s 6
+			IL_01f7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01fc: ldc.i4.0
+			IL_01fd: ceq
+			IL_01ff: stloc.s 17
+			IL_0201: ldloc.s 17
+			IL_0203: brfalse IL_0248
+
+			IL_0208: ldarg.3
+			IL_0209: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_020e: stloc.s 14
+			IL_0210: ldstr "Could not determine tag name for id '"
+			IL_0215: ldloc.s 14
+			IL_0217: call string [System.Runtime]System.String::Concat(string, string)
+			IL_021c: ldstr "'."
+			IL_0221: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0226: stloc.s 14
+			IL_0228: ldloc.s 14
+			IL_022a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_022f: stloc.s 7
+			IL_0231: ldloc.s 7
+			IL_0233: isinst [System.Runtime]System.Exception
+			IL_0238: dup
+			IL_0239: brtrue IL_0247
+
+			IL_023e: pop
+			IL_023f: ldloc.s 7
+			IL_0241: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0246: throw
+
+			IL_0247: throw
+
+			IL_0248: ldarg.0
+			IL_0249: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
+			IL_024e: ldc.i4.1
+			IL_024f: newarr [System.Runtime]System.Object
+			IL_0254: dup
+			IL_0255: ldc.i4.0
+			IL_0256: ldarg.0
+			IL_0257: stelem.ref
+			IL_0258: ldloc.s 6
+			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_025f: stloc.s 15
+			IL_0261: ldloc.s 15
+			IL_0263: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0268: stloc.s 14
+			IL_026a: ldstr "<\\/?"
+			IL_026f: ldloc.s 14
+			IL_0271: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0276: ldstr "\\b[^>]*>"
+			IL_027b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0280: stloc.s 14
+			IL_0282: ldloc.s 14
+			IL_0284: ldstr "gi"
+			IL_0289: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_028e: stloc.s 8
+			IL_0290: ldloc.s 8
+			IL_0292: ldstr "lastIndex"
+			IL_0297: ldloc.s 4
+			IL_0299: ldc.i4.1
+			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_029f: pop
+			IL_02a0: ldc.r8 0.0
+			IL_02a9: stloc.s 9
+			IL_02ab: ldc.r8 1
+			IL_02b4: neg
+			IL_02b5: stloc.s 18
+			IL_02b7: ldloc.s 18
+			IL_02b9: box [System.Runtime]System.Double
+			IL_02be: stloc.s 10
+			// loop start (head: IL_02c0)
+				IL_02c0: ldc.i4.1
+				IL_02c1: brfalse IL_0438
+
+				IL_02c6: ldloc.s 8
+				IL_02c8: ldstr "exec"
+				IL_02cd: ldarg.2
+				IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_02d3: stloc.s 11
+				IL_02d5: ldloc.s 11
+				IL_02d7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_02dc: ldc.i4.0
+				IL_02dd: ceq
+				IL_02df: stloc.s 17
+				IL_02e1: ldloc.s 17
+				IL_02e3: brfalse IL_02ed
+
+				IL_02e8: br IL_0438
+
+				IL_02ed: ldloc.s 11
+				IL_02ef: ldc.r8 0.0
+				IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02fd: stloc.s 12
+				IL_02ff: ldloc.s 10
+				IL_0301: stloc.s 19
+				IL_0303: ldloc.s 19
+				IL_0305: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_030a: ldc.r8 0.0
+				IL_0313: clt
+				IL_0315: brfalse IL_032c
+
+				IL_031a: ldloc.s 11
+				IL_031c: ldstr "index"
+				IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0326: stloc.s 15
+				IL_0328: ldloc.s 15
+				IL_032a: stloc.s 10
+
+				IL_032c: ldloc.s 12
+				IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0333: stloc.s 15
+				IL_0335: ldc.i4.0
+				IL_0336: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_033b: brfalse IL_0364
+
+				IL_0340: ldloc.s 15
+				IL_0342: isinst [System.Runtime]System.String
+				IL_0347: dup
+				IL_0348: brfalse IL_0363
+
+				IL_034d: ldstr "</"
+				IL_0352: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+				IL_0357: box [System.Runtime]System.Boolean
+				IL_035c: stloc.s 15
+				IL_035e: br IL_0377
+
+				IL_0363: pop
+
+				IL_0364: ldloc.s 15
+				IL_0366: ldstr "startsWith"
+				IL_036b: ldstr "</"
+				IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0375: stloc.s 15
+
+				IL_0377: ldloc.s 15
+				IL_0379: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_037e: stloc.s 17
+				IL_0380: ldloc.s 17
+				IL_0382: brfalse IL_0425
+
+				IL_0387: ldloc.s 9
+				IL_0389: ldc.r8 1
+				IL_0392: sub
+				IL_0393: stloc.s 9
+				IL_0395: ldloc.s 9
+				IL_0397: stloc.s 18
+				IL_0399: ldloc.s 18
+				IL_039b: ldc.r8 0.0
+				IL_03a4: ceq
+				IL_03a6: brfalse IL_0420
+
+				IL_03ab: ldarg.2
+				IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_03b1: stloc.s 15
+				IL_03b3: ldloc.s 8
+				IL_03b5: ldstr "lastIndex"
+				IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_03bf: stloc.s 20
+				IL_03c1: ldc.i4.0
+				IL_03c2: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_03c7: brfalse IL_03ea
+
+				IL_03cc: ldloc.s 15
+				IL_03ce: isinst [System.Runtime]System.String
+				IL_03d3: dup
+				IL_03d4: brfalse IL_03e9
+
+				IL_03d9: ldloc.s 10
+				IL_03db: ldloc.s 20
+				IL_03dd: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+				IL_03e2: stloc.s 20
+				IL_03e4: br IL_03fc
+
+				IL_03e9: pop
+
+				IL_03ea: ldloc.s 15
+				IL_03ec: ldstr "substring"
+				IL_03f1: ldloc.s 10
+				IL_03f3: ldloc.s 20
+				IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_03fa: stloc.s 20
+
+				IL_03fc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0401: dup
+				IL_0402: ldstr "tagName"
+				IL_0407: ldloc.s 6
+				IL_0409: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_040e: dup
+				IL_040f: ldstr "html"
+				IL_0414: ldloc.s 20
+				IL_0416: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_041b: stloc.s 21
+				IL_041d: ldloc.s 21
+				IL_041f: ret
+
+				IL_0420: br IL_0433
+
+				IL_0425: ldloc.s 9
+				IL_0427: ldc.r8 1
+				IL_0430: add
+				IL_0431: stloc.s 9
+
+				IL_0433: br IL_02c0
 			// end loop
 
-			IL_034b: ldloc.s 6
-			IL_034d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0352: stloc.s 14
-			IL_0354: ldstr "Could not find a matching closing </"
-			IL_0359: ldloc.s 14
-			IL_035b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0360: ldstr "> for id '"
-			IL_0365: call string [System.Runtime]System.String::Concat(string, string)
-			IL_036a: ldarg.3
-			IL_036b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0370: stloc.s 14
-			IL_0372: ldloc.s 14
-			IL_0374: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0379: ldstr "'."
-			IL_037e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0383: stloc.s 14
-			IL_0385: ldloc.s 14
-			IL_0387: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_038c: stloc.s 13
-			IL_038e: ldloc.s 13
-			IL_0390: isinst [System.Runtime]System.Exception
-			IL_0395: dup
-			IL_0396: brtrue IL_03a4
+			IL_0438: ldloc.s 6
+			IL_043a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_043f: stloc.s 14
+			IL_0441: ldstr "Could not find a matching closing </"
+			IL_0446: ldloc.s 14
+			IL_0448: call string [System.Runtime]System.String::Concat(string, string)
+			IL_044d: ldstr "> for id '"
+			IL_0452: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0457: ldarg.3
+			IL_0458: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_045d: stloc.s 14
+			IL_045f: ldloc.s 14
+			IL_0461: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0466: ldstr "'."
+			IL_046b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0470: stloc.s 14
+			IL_0472: ldloc.s 14
+			IL_0474: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0479: stloc.s 13
+			IL_047b: ldloc.s 13
+			IL_047d: isinst [System.Runtime]System.Exception
+			IL_0482: dup
+			IL_0483: brtrue IL_0491
 
-			IL_039b: pop
-			IL_039c: ldloc.s 13
-			IL_039e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_03a3: throw
+			IL_0488: pop
+			IL_0489: ldloc.s 13
+			IL_048b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0490: throw
 
-			IL_03a4: throw
+			IL_0491: throw
 
-			IL_03a5: ldnull
-			IL_03a6: ret
+			IL_0492: ldnull
+			IL_0493: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -4592,7 +4768,7 @@
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
-			// Code size: 458 (0x1ca)
+			// Code size: 584 (0x248)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -4705,76 +4881,119 @@
 
 			IL_00e7: ldloc.3
 			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ed: ldstr "indexOf"
-			IL_00f2: ldstr "#"
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00fc: stloc.s 4
-			IL_00fe: ldloc.s 4
-			IL_0100: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0105: ldc.r8 0.0
-			IL_010e: clt
-			IL_0110: ldc.i4.0
-			IL_0111: ceq
-			IL_0113: brfalse IL_0143
+			IL_00ed: stloc.s 10
+			IL_00ef: ldc.i4.0
+			IL_00f0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00f5: brfalse IL_0117
 
-			IL_0118: ldloc.3
-			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011e: ldstr "substring"
-			IL_0123: ldc.r8 0.0
-			IL_012c: box [System.Runtime]System.Double
-			IL_0131: ldloc.s 4
-			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0138: stloc.s 10
-			IL_013a: ldloc.s 10
-			IL_013c: stloc.s 5
-			IL_013e: br IL_0146
+			IL_00fa: ldloc.s 10
+			IL_00fc: castclass [System.Runtime]System.String
+			IL_0101: ldstr "#"
+			IL_0106: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_010b: box [System.Runtime]System.Double
+			IL_0110: stloc.s 4
+			IL_0112: br IL_012a
 
-			IL_0143: ldloc.3
-			IL_0144: stloc.s 5
+			IL_0117: ldloc.s 10
+			IL_0119: ldstr "indexOf"
+			IL_011e: ldstr "#"
+			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0128: stloc.s 4
 
-			IL_0146: ldloc.s 4
-			IL_0148: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_014d: ldc.r8 0.0
-			IL_0156: clt
-			IL_0158: ldc.i4.0
-			IL_0159: ceq
-			IL_015b: brfalse IL_0193
+			IL_012a: ldloc.s 4
+			IL_012c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0131: ldc.r8 0.0
+			IL_013a: clt
+			IL_013c: ldc.i4.0
+			IL_013d: ceq
+			IL_013f: brfalse IL_01a1
 
-			IL_0160: ldloc.3
-			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0166: stloc.s 10
-			IL_0168: ldloc.s 4
-			IL_016a: ldc.r8 1
-			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0178: stloc.s 14
+			IL_0144: ldloc.3
+			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014a: stloc.s 10
+			IL_014c: ldc.i4.0
+			IL_014d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0152: brfalse IL_017a
+
+			IL_0157: ldloc.s 10
+			IL_0159: castclass [System.Runtime]System.String
+			IL_015e: ldc.r8 0.0
+			IL_0167: box [System.Runtime]System.Double
+			IL_016c: ldloc.s 4
+			IL_016e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_0173: stloc.s 10
+			IL_0175: br IL_0198
+
 			IL_017a: ldloc.s 10
 			IL_017c: ldstr "substring"
-			IL_0181: ldloc.s 14
-			IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0188: stloc.s 10
-			IL_018a: ldloc.s 10
-			IL_018c: stloc.s 6
-			IL_018e: br IL_019a
+			IL_0181: ldc.r8 0.0
+			IL_018a: box [System.Runtime]System.Double
+			IL_018f: ldloc.s 4
+			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0196: stloc.s 10
 
-			IL_0193: ldstr ""
-			IL_0198: stloc.s 6
+			IL_0198: ldloc.s 10
+			IL_019a: stloc.s 5
+			IL_019c: br IL_01a4
 
-			IL_019a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_019f: dup
-			IL_01a0: ldstr "href"
-			IL_01a5: ldloc.3
-			IL_01a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01ab: dup
-			IL_01ac: ldstr "filePart"
-			IL_01b1: ldloc.s 5
-			IL_01b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01b8: dup
-			IL_01b9: ldstr "fragment"
-			IL_01be: ldloc.s 6
-			IL_01c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01c5: stloc.s 16
-			IL_01c7: ldloc.s 16
-			IL_01c9: ret
+			IL_01a1: ldloc.3
+			IL_01a2: stloc.s 5
+
+			IL_01a4: ldloc.s 4
+			IL_01a6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_01ab: ldc.r8 0.0
+			IL_01b4: clt
+			IL_01b6: ldc.i4.0
+			IL_01b7: ceq
+			IL_01b9: brfalse IL_0211
+
+			IL_01be: ldloc.3
+			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c4: stloc.s 10
+			IL_01c6: ldloc.s 4
+			IL_01c8: ldc.r8 1
+			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01d6: stloc.s 14
+			IL_01d8: ldc.i4.0
+			IL_01d9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01de: brfalse IL_01f8
+
+			IL_01e3: ldloc.s 10
+			IL_01e5: castclass [System.Runtime]System.String
+			IL_01ea: ldloc.s 14
+			IL_01ec: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_01f1: stloc.s 10
+			IL_01f3: br IL_0208
+
+			IL_01f8: ldloc.s 10
+			IL_01fa: ldstr "substring"
+			IL_01ff: ldloc.s 14
+			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0206: stloc.s 10
+
+			IL_0208: ldloc.s 10
+			IL_020a: stloc.s 6
+			IL_020c: br IL_0218
+
+			IL_0211: ldstr ""
+			IL_0216: stloc.s 6
+
+			IL_0218: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_021d: dup
+			IL_021e: ldstr "href"
+			IL_0223: ldloc.3
+			IL_0224: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0229: dup
+			IL_022a: ldstr "filePart"
+			IL_022f: ldloc.s 5
+			IL_0231: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0236: dup
+			IL_0237: ldstr "fragment"
+			IL_023c: ldloc.s 6
+			IL_023e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0243: stloc.s 16
+			IL_0245: ldloc.s 16
+			IL_0247: ret
 		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
 
 	} // end of class resolveSectionLinkFromMultipageIndexHtml
@@ -5257,7 +5476,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 3007 (0xbbf)
+			// Code size: 3152 (0xc50)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -5286,8 +5505,8 @@
 				[23] bool,
 				[24] object,
 				[25] object,
-				[26] string,
-				[27] object,
+				[26] object,
+				[27] string,
 				[28] object,
 				[29] object,
 				[30] object,
@@ -5453,11 +5672,11 @@
 			IL_012d: dup
 			IL_012e: ldc.i4.s 25
 			IL_0130: ldelem.ref
-			IL_0131: castclass [System.Runtime]System.String
-			IL_0136: stloc.s 26
-			IL_0138: dup
-			IL_0139: ldc.i4.s 26
-			IL_013b: ldelem.ref
+			IL_0131: stloc.s 26
+			IL_0133: dup
+			IL_0134: ldc.i4.s 26
+			IL_0136: ldelem.ref
+			IL_0137: castclass [System.Runtime]System.String
 			IL_013c: stloc.s 27
 			IL_013e: dup
 			IL_013f: ldc.i4.s 27
@@ -5490,7 +5709,7 @@
 
 			IL_0172: ldloc.0
 			IL_0173: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0178: switch (IL_018d, IL_050b, IL_0765, IL_08f6)
+			IL_0178: switch (IL_018d, IL_054e, IL_07d1, IL_0987)
 
 			IL_018d: ldarg.0
 			IL_018e: ldc.i4.1
@@ -5684,978 +5903,1039 @@
 			IL_039d: ldloc.s 25
 			IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_03a4: stloc.s 22
-			IL_03a6: ldloc.s 22
-			IL_03a8: ldstr "trim"
-			IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_03b2: stloc.s 9
-			IL_03b4: ldstr ""
-			IL_03b9: stloc.s 10
-			IL_03bb: ldloc.1
-			IL_03bc: ldstr "auto"
-			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03c6: stloc.s 22
-			IL_03c8: ldloc.s 22
-			IL_03ca: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03cf: stloc.s 23
-			IL_03d1: ldloc.s 23
-			IL_03d3: brfalse IL_07c3
+			IL_03a6: ldc.i4.0
+			IL_03a7: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_03ac: brfalse IL_03c4
 
-			IL_03d8: ldloc.1
-			IL_03d9: ldstr "indexUrl"
-			IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03e3: stloc.s 22
-			IL_03e5: ldloc.s 22
-			IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03ec: stloc.s 22
-			IL_03ee: ldloc.s 22
-			IL_03f0: ldstr "trim"
-			IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_03fa: stloc.s 11
-			IL_03fc: ldarg.0
-			IL_03fd: ldc.i4.1
-			IL_03fe: ldelem.ref
-			IL_03ff: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0404: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0409: ldc.i4.1
-			IL_040a: newarr [System.Runtime]System.Object
-			IL_040f: dup
-			IL_0410: ldc.i4.0
-			IL_0411: ldarg.0
-			IL_0412: ldc.i4.1
-			IL_0413: ldelem.ref
-			IL_0414: stelem.ref
-			IL_0415: stloc.s 21
-			IL_0417: ldloc.s 21
-			IL_0419: ldloc.s 11
-			IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0420: stloc.s 22
-			IL_0422: ldloc.0
-			IL_0423: ldc.i4.1
-			IL_0424: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0429: ldloc.0
-			IL_042a: ldloc.s 22
-			IL_042c: ldarg.0
-			IL_042d: ldc.i4.1
-			IL_042e: ldloc.0
-			IL_042f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0434: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0439: ldloc.0
-			IL_043a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_043f: dup
-			IL_0440: ldc.i4.0
-			IL_0441: ldloc.1
-			IL_0442: stelem.ref
-			IL_0443: dup
-			IL_0444: ldc.i4.1
-			IL_0445: ldloc.2
-			IL_0446: stelem.ref
-			IL_0447: dup
-			IL_0448: ldc.i4.2
-			IL_0449: ldloc.3
-			IL_044a: stelem.ref
-			IL_044b: dup
-			IL_044c: ldc.i4.3
-			IL_044d: ldloc.s 4
-			IL_044f: stelem.ref
-			IL_0450: dup
-			IL_0451: ldc.i4.4
-			IL_0452: ldloc.s 5
-			IL_0454: stelem.ref
-			IL_0455: dup
-			IL_0456: ldc.i4.5
-			IL_0457: ldloc.s 6
-			IL_0459: stelem.ref
-			IL_045a: dup
-			IL_045b: ldc.i4.6
-			IL_045c: ldloc.s 7
-			IL_045e: stelem.ref
-			IL_045f: dup
-			IL_0460: ldc.i4.7
-			IL_0461: ldloc.s 8
-			IL_0463: stelem.ref
-			IL_0464: dup
-			IL_0465: ldc.i4.8
-			IL_0466: ldloc.s 9
-			IL_0468: stelem.ref
-			IL_0469: dup
-			IL_046a: ldc.i4.s 9
-			IL_046c: ldloc.s 10
-			IL_046e: stelem.ref
-			IL_046f: dup
-			IL_0470: ldc.i4.s 10
-			IL_0472: ldloc.s 11
-			IL_0474: stelem.ref
-			IL_0475: dup
-			IL_0476: ldc.i4.s 11
-			IL_0478: ldloc.s 12
-			IL_047a: stelem.ref
-			IL_047b: dup
-			IL_047c: ldc.i4.s 12
-			IL_047e: ldloc.s 13
-			IL_0480: stelem.ref
-			IL_0481: dup
-			IL_0482: ldc.i4.s 13
-			IL_0484: ldloc.s 14
-			IL_0486: stelem.ref
-			IL_0487: dup
-			IL_0488: ldc.i4.s 14
-			IL_048a: ldloc.s 15
-			IL_048c: stelem.ref
-			IL_048d: dup
-			IL_048e: ldc.i4.s 15
-			IL_0490: ldloc.s 16
+			IL_03b1: ldloc.s 22
+			IL_03b3: castclass [System.Runtime]System.String
+			IL_03b8: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_03bd: stloc.s 9
+			IL_03bf: br IL_03d2
+
+			IL_03c4: ldloc.s 22
+			IL_03c6: ldstr "trim"
+			IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_03d0: stloc.s 9
+
+			IL_03d2: ldstr ""
+			IL_03d7: stloc.s 10
+			IL_03d9: ldloc.1
+			IL_03da: ldstr "auto"
+			IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e4: stloc.s 22
+			IL_03e6: ldloc.s 22
+			IL_03e8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03ed: stloc.s 23
+			IL_03ef: ldloc.s 23
+			IL_03f1: brfalse IL_082f
+
+			IL_03f6: ldloc.1
+			IL_03f7: ldstr "indexUrl"
+			IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0401: stloc.s 22
+			IL_0403: ldloc.s 22
+			IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_040a: stloc.s 22
+			IL_040c: ldc.i4.0
+			IL_040d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0412: brfalse IL_0431
+
+			IL_0417: ldloc.s 22
+			IL_0419: isinst [System.Runtime]System.String
+			IL_041e: dup
+			IL_041f: brfalse IL_0430
+
+			IL_0424: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0429: stloc.s 11
+			IL_042b: br IL_043f
+
+			IL_0430: pop
+
+			IL_0431: ldloc.s 22
+			IL_0433: ldstr "trim"
+			IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_043d: stloc.s 11
+
+			IL_043f: ldarg.0
+			IL_0440: ldc.i4.1
+			IL_0441: ldelem.ref
+			IL_0442: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0447: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_044c: ldc.i4.1
+			IL_044d: newarr [System.Runtime]System.Object
+			IL_0452: dup
+			IL_0453: ldc.i4.0
+			IL_0454: ldarg.0
+			IL_0455: ldc.i4.1
+			IL_0456: ldelem.ref
+			IL_0457: stelem.ref
+			IL_0458: stloc.s 21
+			IL_045a: ldloc.s 21
+			IL_045c: ldloc.s 11
+			IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0463: stloc.s 22
+			IL_0465: ldloc.0
+			IL_0466: ldc.i4.1
+			IL_0467: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_046c: ldloc.0
+			IL_046d: ldloc.s 22
+			IL_046f: ldarg.0
+			IL_0470: ldc.i4.1
+			IL_0471: ldloc.0
+			IL_0472: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0477: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_047c: ldloc.0
+			IL_047d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0482: dup
+			IL_0483: ldc.i4.0
+			IL_0484: ldloc.1
+			IL_0485: stelem.ref
+			IL_0486: dup
+			IL_0487: ldc.i4.1
+			IL_0488: ldloc.2
+			IL_0489: stelem.ref
+			IL_048a: dup
+			IL_048b: ldc.i4.2
+			IL_048c: ldloc.3
+			IL_048d: stelem.ref
+			IL_048e: dup
+			IL_048f: ldc.i4.3
+			IL_0490: ldloc.s 4
 			IL_0492: stelem.ref
 			IL_0493: dup
-			IL_0494: ldc.i4.s 16
-			IL_0496: ldloc.s 17
-			IL_0498: stelem.ref
-			IL_0499: dup
-			IL_049a: ldc.i4.s 17
-			IL_049c: ldloc.s 18
-			IL_049e: stelem.ref
-			IL_049f: dup
-			IL_04a0: ldc.i4.s 18
-			IL_04a2: ldloc.s 19
-			IL_04a4: stelem.ref
-			IL_04a5: dup
-			IL_04a6: ldc.i4.s 19
-			IL_04a8: ldloc.s 20
-			IL_04aa: stelem.ref
-			IL_04ab: dup
-			IL_04ac: ldc.i4.s 20
-			IL_04ae: ldloc.s 21
-			IL_04b0: stelem.ref
-			IL_04b1: dup
-			IL_04b2: ldc.i4.s 21
-			IL_04b4: ldloc.s 22
-			IL_04b6: stelem.ref
-			IL_04b7: dup
-			IL_04b8: ldc.i4.s 22
-			IL_04ba: ldloc.s 23
-			IL_04bc: box [System.Runtime]System.Boolean
-			IL_04c1: stelem.ref
-			IL_04c2: dup
-			IL_04c3: ldc.i4.s 23
-			IL_04c5: ldloc.s 24
-			IL_04c7: stelem.ref
-			IL_04c8: dup
-			IL_04c9: ldc.i4.s 24
-			IL_04cb: ldloc.s 25
-			IL_04cd: stelem.ref
-			IL_04ce: dup
-			IL_04cf: ldc.i4.s 25
-			IL_04d1: ldloc.s 26
-			IL_04d3: stelem.ref
-			IL_04d4: dup
-			IL_04d5: ldc.i4.s 26
-			IL_04d7: ldloc.s 27
-			IL_04d9: stelem.ref
-			IL_04da: dup
-			IL_04db: ldc.i4.s 27
-			IL_04dd: ldloc.s 28
-			IL_04df: stelem.ref
-			IL_04e0: dup
-			IL_04e1: ldc.i4.s 28
-			IL_04e3: ldloc.s 29
-			IL_04e5: stelem.ref
-			IL_04e6: dup
-			IL_04e7: ldc.i4.s 29
-			IL_04e9: ldloc.s 30
-			IL_04eb: stelem.ref
-			IL_04ec: dup
-			IL_04ed: ldc.i4.s 30
-			IL_04ef: ldloc.s 31
-			IL_04f1: stelem.ref
-			IL_04f2: dup
-			IL_04f3: ldc.i4.s 31
-			IL_04f5: ldloc.s 32
-			IL_04f7: stelem.ref
-			IL_04f8: dup
-			IL_04f9: ldc.i4.s 32
-			IL_04fb: ldloc.s 33
-			IL_04fd: stelem.ref
-			IL_04fe: pop
-			IL_04ff: ldloc.0
-			IL_0500: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0505: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_050a: ret
+			IL_0494: ldc.i4.4
+			IL_0495: ldloc.s 5
+			IL_0497: stelem.ref
+			IL_0498: dup
+			IL_0499: ldc.i4.5
+			IL_049a: ldloc.s 6
+			IL_049c: stelem.ref
+			IL_049d: dup
+			IL_049e: ldc.i4.6
+			IL_049f: ldloc.s 7
+			IL_04a1: stelem.ref
+			IL_04a2: dup
+			IL_04a3: ldc.i4.7
+			IL_04a4: ldloc.s 8
+			IL_04a6: stelem.ref
+			IL_04a7: dup
+			IL_04a8: ldc.i4.8
+			IL_04a9: ldloc.s 9
+			IL_04ab: stelem.ref
+			IL_04ac: dup
+			IL_04ad: ldc.i4.s 9
+			IL_04af: ldloc.s 10
+			IL_04b1: stelem.ref
+			IL_04b2: dup
+			IL_04b3: ldc.i4.s 10
+			IL_04b5: ldloc.s 11
+			IL_04b7: stelem.ref
+			IL_04b8: dup
+			IL_04b9: ldc.i4.s 11
+			IL_04bb: ldloc.s 12
+			IL_04bd: stelem.ref
+			IL_04be: dup
+			IL_04bf: ldc.i4.s 12
+			IL_04c1: ldloc.s 13
+			IL_04c3: stelem.ref
+			IL_04c4: dup
+			IL_04c5: ldc.i4.s 13
+			IL_04c7: ldloc.s 14
+			IL_04c9: stelem.ref
+			IL_04ca: dup
+			IL_04cb: ldc.i4.s 14
+			IL_04cd: ldloc.s 15
+			IL_04cf: stelem.ref
+			IL_04d0: dup
+			IL_04d1: ldc.i4.s 15
+			IL_04d3: ldloc.s 16
+			IL_04d5: stelem.ref
+			IL_04d6: dup
+			IL_04d7: ldc.i4.s 16
+			IL_04d9: ldloc.s 17
+			IL_04db: stelem.ref
+			IL_04dc: dup
+			IL_04dd: ldc.i4.s 17
+			IL_04df: ldloc.s 18
+			IL_04e1: stelem.ref
+			IL_04e2: dup
+			IL_04e3: ldc.i4.s 18
+			IL_04e5: ldloc.s 19
+			IL_04e7: stelem.ref
+			IL_04e8: dup
+			IL_04e9: ldc.i4.s 19
+			IL_04eb: ldloc.s 20
+			IL_04ed: stelem.ref
+			IL_04ee: dup
+			IL_04ef: ldc.i4.s 20
+			IL_04f1: ldloc.s 21
+			IL_04f3: stelem.ref
+			IL_04f4: dup
+			IL_04f5: ldc.i4.s 21
+			IL_04f7: ldloc.s 22
+			IL_04f9: stelem.ref
+			IL_04fa: dup
+			IL_04fb: ldc.i4.s 22
+			IL_04fd: ldloc.s 23
+			IL_04ff: box [System.Runtime]System.Boolean
+			IL_0504: stelem.ref
+			IL_0505: dup
+			IL_0506: ldc.i4.s 23
+			IL_0508: ldloc.s 24
+			IL_050a: stelem.ref
+			IL_050b: dup
+			IL_050c: ldc.i4.s 24
+			IL_050e: ldloc.s 25
+			IL_0510: stelem.ref
+			IL_0511: dup
+			IL_0512: ldc.i4.s 25
+			IL_0514: ldloc.s 26
+			IL_0516: stelem.ref
+			IL_0517: dup
+			IL_0518: ldc.i4.s 26
+			IL_051a: ldloc.s 27
+			IL_051c: stelem.ref
+			IL_051d: dup
+			IL_051e: ldc.i4.s 27
+			IL_0520: ldloc.s 28
+			IL_0522: stelem.ref
+			IL_0523: dup
+			IL_0524: ldc.i4.s 28
+			IL_0526: ldloc.s 29
+			IL_0528: stelem.ref
+			IL_0529: dup
+			IL_052a: ldc.i4.s 29
+			IL_052c: ldloc.s 30
+			IL_052e: stelem.ref
+			IL_052f: dup
+			IL_0530: ldc.i4.s 30
+			IL_0532: ldloc.s 31
+			IL_0534: stelem.ref
+			IL_0535: dup
+			IL_0536: ldc.i4.s 31
+			IL_0538: ldloc.s 32
+			IL_053a: stelem.ref
+			IL_053b: dup
+			IL_053c: ldc.i4.s 32
+			IL_053e: ldloc.s 33
+			IL_0540: stelem.ref
+			IL_0541: pop
+			IL_0542: ldloc.0
+			IL_0543: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0548: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_054d: ret
 
-			IL_050b: ldloc.0
-			IL_050c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
-			IL_0511: stloc.s 12
-			IL_0513: ldarg.0
-			IL_0514: ldc.i4.1
-			IL_0515: ldelem.ref
-			IL_0516: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_051b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
-			IL_0520: ldc.i4.1
-			IL_0521: newarr [System.Runtime]System.Object
-			IL_0526: dup
-			IL_0527: ldc.i4.0
-			IL_0528: ldarg.0
-			IL_0529: ldc.i4.1
-			IL_052a: ldelem.ref
-			IL_052b: stelem.ref
-			IL_052c: stloc.s 21
-			IL_052e: ldloc.1
-			IL_052f: ldstr "section"
-			IL_0534: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0539: stloc.s 22
-			IL_053b: ldloc.s 22
-			IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0542: stloc.s 22
-			IL_0544: ldloc.s 22
-			IL_0546: ldstr "trim"
-			IL_054b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0550: stloc.s 22
-			IL_0552: ldloc.s 21
-			IL_0554: ldloc.s 12
-			IL_0556: ldloc.s 22
-			IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_055d: stloc.s 13
-			IL_055f: ldloc.s 13
-			IL_0561: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0566: ldc.i4.0
-			IL_0567: ceq
-			IL_0569: stloc.s 23
-			IL_056b: ldloc.s 23
-			IL_056d: brfalse IL_05e9
+			IL_054e: ldloc.0
+			IL_054f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_0554: stloc.s 12
+			IL_0556: ldarg.0
+			IL_0557: ldc.i4.1
+			IL_0558: ldelem.ref
+			IL_0559: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_055e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
+			IL_0563: stloc.s 22
+			IL_0565: ldc.i4.1
+			IL_0566: newarr [System.Runtime]System.Object
+			IL_056b: dup
+			IL_056c: ldc.i4.0
+			IL_056d: ldarg.0
+			IL_056e: ldc.i4.1
+			IL_056f: ldelem.ref
+			IL_0570: stelem.ref
+			IL_0571: stloc.s 21
+			IL_0573: ldloc.1
+			IL_0574: ldstr "section"
+			IL_0579: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_057e: stloc.s 26
+			IL_0580: ldloc.s 26
+			IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0587: stloc.s 26
+			IL_0589: ldc.i4.0
+			IL_058a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_058f: brfalse IL_05ae
 
-			IL_0572: ldloc.1
-			IL_0573: ldstr "section"
-			IL_0578: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_057d: stloc.s 22
-			IL_057f: ldloc.s 22
-			IL_0581: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0586: stloc.s 26
-			IL_0588: ldstr "Could not find section '"
-			IL_058d: ldloc.s 26
-			IL_058f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0594: ldstr "' in multipage index: "
-			IL_0599: call string [System.Runtime]System.String::Concat(string, string)
-			IL_059e: ldloc.s 11
-			IL_05a0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05a5: stloc.s 26
-			IL_05a7: ldloc.s 26
-			IL_05a9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05ae: stloc.s 26
-			IL_05b0: ldloc.s 26
-			IL_05b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_05b7: stloc.s 14
-			IL_05b9: ldloc.0
-			IL_05ba: ldc.i4.m1
-			IL_05bb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05c0: ldloc.0
-			IL_05c1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_05cb: ldarg.0
-			IL_05cc: ldc.i4.1
-			IL_05cd: newarr [System.Runtime]System.Object
-			IL_05d2: dup
-			IL_05d3: ldc.i4.0
-			IL_05d4: ldloc.s 14
-			IL_05d6: stelem.ref
-			IL_05d7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_05dc: pop
-			IL_05dd: ldloc.0
-			IL_05de: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05e3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05e8: ret
+			IL_0594: ldloc.s 26
+			IL_0596: isinst [System.Runtime]System.String
+			IL_059b: dup
+			IL_059c: brfalse IL_05ad
 
-			IL_05e9: ldarg.0
-			IL_05ea: ldc.i4.1
-			IL_05eb: ldelem.ref
-			IL_05ec: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_05f1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_05f6: stloc.s 22
-			IL_05f8: ldloc.s 13
-			IL_05fa: ldstr "filePart"
-			IL_05ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0604: stloc.s 27
-			IL_0606: ldloc.s 27
-			IL_0608: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_060d: stloc.s 23
-			IL_060f: ldloc.s 23
-			IL_0611: brtrue IL_062d
+			IL_05a1: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_05a6: stloc.s 26
+			IL_05a8: br IL_05bc
 
-			IL_0616: ldloc.s 13
-			IL_0618: ldstr "href"
-			IL_061d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0622: stloc.s 28
-			IL_0624: ldloc.s 28
-			IL_0626: stloc.s 29
-			IL_0628: br IL_0631
+			IL_05ad: pop
 
-			IL_062d: ldloc.s 27
-			IL_062f: stloc.s 29
+			IL_05ae: ldloc.s 26
+			IL_05b0: ldstr "trim"
+			IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_05ba: stloc.s 26
 
-			IL_0631: ldloc.s 22
-			IL_0633: dup
-			IL_0634: ldloc.s 29
-			IL_0636: ldloc.s 11
-			IL_0638: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
-			IL_063d: stloc.s 22
-			IL_063f: ldloc.s 22
-			IL_0641: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0646: stloc.s 22
-			IL_0648: ldloc.s 22
-			IL_064a: ldstr "toString"
-			IL_064f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0654: stloc.s 15
-			IL_0656: ldarg.0
-			IL_0657: ldc.i4.1
-			IL_0658: ldelem.ref
-			IL_0659: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_065e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0663: ldc.i4.1
-			IL_0664: newarr [System.Runtime]System.Object
-			IL_0669: dup
-			IL_066a: ldc.i4.0
-			IL_066b: ldarg.0
-			IL_066c: ldc.i4.1
-			IL_066d: ldelem.ref
-			IL_066e: stelem.ref
-			IL_066f: stloc.s 21
-			IL_0671: ldloc.s 21
-			IL_0673: ldloc.s 15
-			IL_0675: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_067a: stloc.s 22
-			IL_067c: ldloc.0
-			IL_067d: ldc.i4.2
-			IL_067e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0683: ldloc.0
-			IL_0684: ldloc.s 22
-			IL_0686: ldarg.0
-			IL_0687: ldc.i4.2
-			IL_0688: ldloc.0
-			IL_0689: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_068e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0693: ldloc.0
-			IL_0694: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0699: dup
-			IL_069a: ldc.i4.0
-			IL_069b: ldloc.1
-			IL_069c: stelem.ref
-			IL_069d: dup
-			IL_069e: ldc.i4.1
-			IL_069f: ldloc.2
-			IL_06a0: stelem.ref
-			IL_06a1: dup
-			IL_06a2: ldc.i4.2
-			IL_06a3: ldloc.3
-			IL_06a4: stelem.ref
-			IL_06a5: dup
-			IL_06a6: ldc.i4.3
-			IL_06a7: ldloc.s 4
-			IL_06a9: stelem.ref
-			IL_06aa: dup
-			IL_06ab: ldc.i4.4
-			IL_06ac: ldloc.s 5
-			IL_06ae: stelem.ref
-			IL_06af: dup
-			IL_06b0: ldc.i4.5
-			IL_06b1: ldloc.s 6
-			IL_06b3: stelem.ref
-			IL_06b4: dup
-			IL_06b5: ldc.i4.6
-			IL_06b6: ldloc.s 7
-			IL_06b8: stelem.ref
-			IL_06b9: dup
-			IL_06ba: ldc.i4.7
-			IL_06bb: ldloc.s 8
-			IL_06bd: stelem.ref
-			IL_06be: dup
-			IL_06bf: ldc.i4.8
-			IL_06c0: ldloc.s 9
-			IL_06c2: stelem.ref
-			IL_06c3: dup
-			IL_06c4: ldc.i4.s 9
-			IL_06c6: ldloc.s 10
-			IL_06c8: stelem.ref
-			IL_06c9: dup
-			IL_06ca: ldc.i4.s 10
-			IL_06cc: ldloc.s 11
-			IL_06ce: stelem.ref
-			IL_06cf: dup
-			IL_06d0: ldc.i4.s 11
-			IL_06d2: ldloc.s 12
-			IL_06d4: stelem.ref
+			IL_05bc: ldloc.s 22
+			IL_05be: ldloc.s 21
+			IL_05c0: ldloc.s 12
+			IL_05c2: ldloc.s 26
+			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05c9: stloc.s 13
+			IL_05cb: ldloc.s 13
+			IL_05cd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_05d2: ldc.i4.0
+			IL_05d3: ceq
+			IL_05d5: stloc.s 23
+			IL_05d7: ldloc.s 23
+			IL_05d9: brfalse IL_0655
+
+			IL_05de: ldloc.1
+			IL_05df: ldstr "section"
+			IL_05e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05e9: stloc.s 26
+			IL_05eb: ldloc.s 26
+			IL_05ed: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_05f2: stloc.s 27
+			IL_05f4: ldstr "Could not find section '"
+			IL_05f9: ldloc.s 27
+			IL_05fb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0600: ldstr "' in multipage index: "
+			IL_0605: call string [System.Runtime]System.String::Concat(string, string)
+			IL_060a: ldloc.s 11
+			IL_060c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0611: stloc.s 27
+			IL_0613: ldloc.s 27
+			IL_0615: call string [System.Runtime]System.String::Concat(string, string)
+			IL_061a: stloc.s 27
+			IL_061c: ldloc.s 27
+			IL_061e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0623: stloc.s 14
+			IL_0625: ldloc.0
+			IL_0626: ldc.i4.m1
+			IL_0627: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_062c: ldloc.0
+			IL_062d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0632: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0637: ldarg.0
+			IL_0638: ldc.i4.1
+			IL_0639: newarr [System.Runtime]System.Object
+			IL_063e: dup
+			IL_063f: ldc.i4.0
+			IL_0640: ldloc.s 14
+			IL_0642: stelem.ref
+			IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0648: pop
+			IL_0649: ldloc.0
+			IL_064a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_064f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0654: ret
+
+			IL_0655: ldarg.0
+			IL_0656: ldc.i4.1
+			IL_0657: ldelem.ref
+			IL_0658: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_065d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_0662: stloc.s 26
+			IL_0664: ldloc.s 13
+			IL_0666: ldstr "filePart"
+			IL_066b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0670: stloc.s 22
+			IL_0672: ldloc.s 22
+			IL_0674: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0679: stloc.s 23
+			IL_067b: ldloc.s 23
+			IL_067d: brtrue IL_0699
+
+			IL_0682: ldloc.s 13
+			IL_0684: ldstr "href"
+			IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_068e: stloc.s 28
+			IL_0690: ldloc.s 28
+			IL_0692: stloc.s 29
+			IL_0694: br IL_069d
+
+			IL_0699: ldloc.s 22
+			IL_069b: stloc.s 29
+
+			IL_069d: ldloc.s 26
+			IL_069f: dup
+			IL_06a0: ldloc.s 29
+			IL_06a2: ldloc.s 11
+			IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
+			IL_06a9: stloc.s 26
+			IL_06ab: ldloc.s 26
+			IL_06ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06b2: stloc.s 26
+			IL_06b4: ldloc.s 26
+			IL_06b6: ldstr "toString"
+			IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_06c0: stloc.s 15
+			IL_06c2: ldarg.0
+			IL_06c3: ldc.i4.1
+			IL_06c4: ldelem.ref
+			IL_06c5: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_06ca: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_06cf: ldc.i4.1
+			IL_06d0: newarr [System.Runtime]System.Object
 			IL_06d5: dup
-			IL_06d6: ldc.i4.s 12
-			IL_06d8: ldloc.s 13
+			IL_06d6: ldc.i4.0
+			IL_06d7: ldarg.0
+			IL_06d8: ldc.i4.1
+			IL_06d9: ldelem.ref
 			IL_06da: stelem.ref
-			IL_06db: dup
-			IL_06dc: ldc.i4.s 13
-			IL_06de: ldloc.s 14
-			IL_06e0: stelem.ref
-			IL_06e1: dup
-			IL_06e2: ldc.i4.s 14
-			IL_06e4: ldloc.s 15
-			IL_06e6: stelem.ref
-			IL_06e7: dup
-			IL_06e8: ldc.i4.s 15
-			IL_06ea: ldloc.s 16
-			IL_06ec: stelem.ref
-			IL_06ed: dup
-			IL_06ee: ldc.i4.s 16
-			IL_06f0: ldloc.s 17
-			IL_06f2: stelem.ref
-			IL_06f3: dup
-			IL_06f4: ldc.i4.s 17
-			IL_06f6: ldloc.s 18
-			IL_06f8: stelem.ref
-			IL_06f9: dup
-			IL_06fa: ldc.i4.s 18
-			IL_06fc: ldloc.s 19
-			IL_06fe: stelem.ref
-			IL_06ff: dup
-			IL_0700: ldc.i4.s 19
-			IL_0702: ldloc.s 20
-			IL_0704: stelem.ref
+			IL_06db: stloc.s 21
+			IL_06dd: ldloc.s 21
+			IL_06df: ldloc.s 15
+			IL_06e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_06e6: stloc.s 26
+			IL_06e8: ldloc.0
+			IL_06e9: ldc.i4.2
+			IL_06ea: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06ef: ldloc.0
+			IL_06f0: ldloc.s 26
+			IL_06f2: ldarg.0
+			IL_06f3: ldc.i4.2
+			IL_06f4: ldloc.0
+			IL_06f5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_06fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_06ff: ldloc.0
+			IL_0700: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_0705: dup
-			IL_0706: ldc.i4.s 20
-			IL_0708: ldloc.s 21
-			IL_070a: stelem.ref
-			IL_070b: dup
-			IL_070c: ldc.i4.s 21
-			IL_070e: ldloc.s 22
+			IL_0706: ldc.i4.0
+			IL_0707: ldloc.1
+			IL_0708: stelem.ref
+			IL_0709: dup
+			IL_070a: ldc.i4.1
+			IL_070b: ldloc.2
+			IL_070c: stelem.ref
+			IL_070d: dup
+			IL_070e: ldc.i4.2
+			IL_070f: ldloc.3
 			IL_0710: stelem.ref
 			IL_0711: dup
-			IL_0712: ldc.i4.s 22
-			IL_0714: ldloc.s 23
-			IL_0716: box [System.Runtime]System.Boolean
-			IL_071b: stelem.ref
-			IL_071c: dup
-			IL_071d: ldc.i4.s 23
-			IL_071f: ldloc.s 24
-			IL_0721: stelem.ref
-			IL_0722: dup
-			IL_0723: ldc.i4.s 24
-			IL_0725: ldloc.s 25
-			IL_0727: stelem.ref
-			IL_0728: dup
-			IL_0729: ldc.i4.s 25
-			IL_072b: ldloc.s 26
-			IL_072d: stelem.ref
-			IL_072e: dup
-			IL_072f: ldc.i4.s 26
-			IL_0731: ldloc.s 27
-			IL_0733: stelem.ref
-			IL_0734: dup
-			IL_0735: ldc.i4.s 27
-			IL_0737: ldloc.s 28
-			IL_0739: stelem.ref
-			IL_073a: dup
-			IL_073b: ldc.i4.s 28
-			IL_073d: ldloc.s 29
-			IL_073f: stelem.ref
-			IL_0740: dup
-			IL_0741: ldc.i4.s 29
-			IL_0743: ldloc.s 30
-			IL_0745: stelem.ref
-			IL_0746: dup
-			IL_0747: ldc.i4.s 30
-			IL_0749: ldloc.s 31
-			IL_074b: stelem.ref
-			IL_074c: dup
-			IL_074d: ldc.i4.s 31
-			IL_074f: ldloc.s 32
-			IL_0751: stelem.ref
-			IL_0752: dup
-			IL_0753: ldc.i4.s 32
-			IL_0755: ldloc.s 33
-			IL_0757: stelem.ref
-			IL_0758: pop
-			IL_0759: ldloc.0
-			IL_075a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_075f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0764: ret
+			IL_0712: ldc.i4.3
+			IL_0713: ldloc.s 4
+			IL_0715: stelem.ref
+			IL_0716: dup
+			IL_0717: ldc.i4.4
+			IL_0718: ldloc.s 5
+			IL_071a: stelem.ref
+			IL_071b: dup
+			IL_071c: ldc.i4.5
+			IL_071d: ldloc.s 6
+			IL_071f: stelem.ref
+			IL_0720: dup
+			IL_0721: ldc.i4.6
+			IL_0722: ldloc.s 7
+			IL_0724: stelem.ref
+			IL_0725: dup
+			IL_0726: ldc.i4.7
+			IL_0727: ldloc.s 8
+			IL_0729: stelem.ref
+			IL_072a: dup
+			IL_072b: ldc.i4.8
+			IL_072c: ldloc.s 9
+			IL_072e: stelem.ref
+			IL_072f: dup
+			IL_0730: ldc.i4.s 9
+			IL_0732: ldloc.s 10
+			IL_0734: stelem.ref
+			IL_0735: dup
+			IL_0736: ldc.i4.s 10
+			IL_0738: ldloc.s 11
+			IL_073a: stelem.ref
+			IL_073b: dup
+			IL_073c: ldc.i4.s 11
+			IL_073e: ldloc.s 12
+			IL_0740: stelem.ref
+			IL_0741: dup
+			IL_0742: ldc.i4.s 12
+			IL_0744: ldloc.s 13
+			IL_0746: stelem.ref
+			IL_0747: dup
+			IL_0748: ldc.i4.s 13
+			IL_074a: ldloc.s 14
+			IL_074c: stelem.ref
+			IL_074d: dup
+			IL_074e: ldc.i4.s 14
+			IL_0750: ldloc.s 15
+			IL_0752: stelem.ref
+			IL_0753: dup
+			IL_0754: ldc.i4.s 15
+			IL_0756: ldloc.s 16
+			IL_0758: stelem.ref
+			IL_0759: dup
+			IL_075a: ldc.i4.s 16
+			IL_075c: ldloc.s 17
+			IL_075e: stelem.ref
+			IL_075f: dup
+			IL_0760: ldc.i4.s 17
+			IL_0762: ldloc.s 18
+			IL_0764: stelem.ref
+			IL_0765: dup
+			IL_0766: ldc.i4.s 18
+			IL_0768: ldloc.s 19
+			IL_076a: stelem.ref
+			IL_076b: dup
+			IL_076c: ldc.i4.s 19
+			IL_076e: ldloc.s 20
+			IL_0770: stelem.ref
+			IL_0771: dup
+			IL_0772: ldc.i4.s 20
+			IL_0774: ldloc.s 21
+			IL_0776: stelem.ref
+			IL_0777: dup
+			IL_0778: ldc.i4.s 21
+			IL_077a: ldloc.s 22
+			IL_077c: stelem.ref
+			IL_077d: dup
+			IL_077e: ldc.i4.s 22
+			IL_0780: ldloc.s 23
+			IL_0782: box [System.Runtime]System.Boolean
+			IL_0787: stelem.ref
+			IL_0788: dup
+			IL_0789: ldc.i4.s 23
+			IL_078b: ldloc.s 24
+			IL_078d: stelem.ref
+			IL_078e: dup
+			IL_078f: ldc.i4.s 24
+			IL_0791: ldloc.s 25
+			IL_0793: stelem.ref
+			IL_0794: dup
+			IL_0795: ldc.i4.s 25
+			IL_0797: ldloc.s 26
+			IL_0799: stelem.ref
+			IL_079a: dup
+			IL_079b: ldc.i4.s 26
+			IL_079d: ldloc.s 27
+			IL_079f: stelem.ref
+			IL_07a0: dup
+			IL_07a1: ldc.i4.s 27
+			IL_07a3: ldloc.s 28
+			IL_07a5: stelem.ref
+			IL_07a6: dup
+			IL_07a7: ldc.i4.s 28
+			IL_07a9: ldloc.s 29
+			IL_07ab: stelem.ref
+			IL_07ac: dup
+			IL_07ad: ldc.i4.s 29
+			IL_07af: ldloc.s 30
+			IL_07b1: stelem.ref
+			IL_07b2: dup
+			IL_07b3: ldc.i4.s 30
+			IL_07b5: ldloc.s 31
+			IL_07b7: stelem.ref
+			IL_07b8: dup
+			IL_07b9: ldc.i4.s 31
+			IL_07bb: ldloc.s 32
+			IL_07bd: stelem.ref
+			IL_07be: dup
+			IL_07bf: ldc.i4.s 32
+			IL_07c1: ldloc.s 33
+			IL_07c3: stelem.ref
+			IL_07c4: pop
+			IL_07c5: ldloc.0
+			IL_07c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_07cb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_07d0: ret
 
-			IL_0765: ldloc.0
-			IL_0766: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_076b: stloc.s 22
-			IL_076d: ldloc.s 22
-			IL_076f: stloc.s 8
-			IL_0771: ldloc.s 15
-			IL_0773: stloc.s 22
-			IL_0775: ldloc.s 22
-			IL_0777: stloc.s 10
-			IL_0779: ldloc.s 9
-			IL_077b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0780: ldc.i4.0
-			IL_0781: ceq
-			IL_0783: stloc.s 23
-			IL_0785: ldloc.s 23
-			IL_0787: brfalse IL_07be
+			IL_07d1: ldloc.0
+			IL_07d2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_07d7: stloc.s 26
+			IL_07d9: ldloc.s 26
+			IL_07db: stloc.s 8
+			IL_07dd: ldloc.s 15
+			IL_07df: stloc.s 26
+			IL_07e1: ldloc.s 26
+			IL_07e3: stloc.s 10
+			IL_07e5: ldloc.s 9
+			IL_07e7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_07ec: ldc.i4.0
+			IL_07ed: ceq
+			IL_07ef: stloc.s 23
+			IL_07f1: ldloc.s 23
+			IL_07f3: brfalse IL_082a
 
-			IL_078c: ldloc.s 13
-			IL_078e: ldstr "fragment"
-			IL_0793: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0798: stloc.s 22
-			IL_079a: ldloc.s 22
-			IL_079c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_07a1: stloc.s 23
-			IL_07a3: ldloc.s 23
-			IL_07a5: brtrue IL_07b6
+			IL_07f8: ldloc.s 13
+			IL_07fa: ldstr "fragment"
+			IL_07ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0804: stloc.s 26
+			IL_0806: ldloc.s 26
+			IL_0808: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_080d: stloc.s 23
+			IL_080f: ldloc.s 23
+			IL_0811: brtrue IL_0822
 
-			IL_07aa: ldstr ""
-			IL_07af: stloc.s 30
-			IL_07b1: br IL_07ba
+			IL_0816: ldstr ""
+			IL_081b: stloc.s 30
+			IL_081d: br IL_0826
 
-			IL_07b6: ldloc.s 22
-			IL_07b8: stloc.s 30
+			IL_0822: ldloc.s 26
+			IL_0824: stloc.s 30
 
-			IL_07ba: ldloc.s 30
-			IL_07bc: stloc.s 9
+			IL_0826: ldloc.s 30
+			IL_0828: stloc.s 9
 
-			IL_07be: br IL_090a
+			IL_082a: br IL_099b
 
-			IL_07c3: ldloc.1
-			IL_07c4: ldstr "url"
-			IL_07c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07ce: stloc.s 22
-			IL_07d0: ldloc.s 22
-			IL_07d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07d7: stloc.s 22
-			IL_07d9: ldloc.s 22
-			IL_07db: ldstr "trim"
-			IL_07e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_07e5: stloc.s 16
-			IL_07e7: ldarg.0
-			IL_07e8: ldc.i4.1
-			IL_07e9: ldelem.ref
-			IL_07ea: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_07ef: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_07f4: ldc.i4.1
-			IL_07f5: newarr [System.Runtime]System.Object
-			IL_07fa: dup
-			IL_07fb: ldc.i4.0
-			IL_07fc: ldarg.0
-			IL_07fd: ldc.i4.1
-			IL_07fe: ldelem.ref
-			IL_07ff: stelem.ref
-			IL_0800: stloc.s 21
-			IL_0802: ldloc.s 21
-			IL_0804: ldloc.s 16
-			IL_0806: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_080b: stloc.s 22
-			IL_080d: ldloc.0
-			IL_080e: ldc.i4.3
-			IL_080f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0814: ldloc.0
-			IL_0815: ldloc.s 22
-			IL_0817: ldarg.0
-			IL_0818: ldc.i4.3
-			IL_0819: ldloc.0
-			IL_081a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_081f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0824: ldloc.0
-			IL_0825: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_082a: dup
-			IL_082b: ldc.i4.0
-			IL_082c: ldloc.1
-			IL_082d: stelem.ref
-			IL_082e: dup
-			IL_082f: ldc.i4.1
-			IL_0830: ldloc.2
-			IL_0831: stelem.ref
-			IL_0832: dup
-			IL_0833: ldc.i4.2
-			IL_0834: ldloc.3
-			IL_0835: stelem.ref
-			IL_0836: dup
-			IL_0837: ldc.i4.3
-			IL_0838: ldloc.s 4
-			IL_083a: stelem.ref
-			IL_083b: dup
-			IL_083c: ldc.i4.4
-			IL_083d: ldloc.s 5
-			IL_083f: stelem.ref
-			IL_0840: dup
-			IL_0841: ldc.i4.5
-			IL_0842: ldloc.s 6
-			IL_0844: stelem.ref
-			IL_0845: dup
-			IL_0846: ldc.i4.6
-			IL_0847: ldloc.s 7
-			IL_0849: stelem.ref
-			IL_084a: dup
-			IL_084b: ldc.i4.7
-			IL_084c: ldloc.s 8
-			IL_084e: stelem.ref
-			IL_084f: dup
-			IL_0850: ldc.i4.8
-			IL_0851: ldloc.s 9
-			IL_0853: stelem.ref
-			IL_0854: dup
-			IL_0855: ldc.i4.s 9
-			IL_0857: ldloc.s 10
-			IL_0859: stelem.ref
-			IL_085a: dup
-			IL_085b: ldc.i4.s 10
-			IL_085d: ldloc.s 11
-			IL_085f: stelem.ref
-			IL_0860: dup
-			IL_0861: ldc.i4.s 11
-			IL_0863: ldloc.s 12
-			IL_0865: stelem.ref
-			IL_0866: dup
-			IL_0867: ldc.i4.s 12
-			IL_0869: ldloc.s 13
-			IL_086b: stelem.ref
-			IL_086c: dup
-			IL_086d: ldc.i4.s 13
-			IL_086f: ldloc.s 14
-			IL_0871: stelem.ref
-			IL_0872: dup
-			IL_0873: ldc.i4.s 14
-			IL_0875: ldloc.s 15
-			IL_0877: stelem.ref
-			IL_0878: dup
-			IL_0879: ldc.i4.s 15
-			IL_087b: ldloc.s 16
-			IL_087d: stelem.ref
-			IL_087e: dup
-			IL_087f: ldc.i4.s 16
-			IL_0881: ldloc.s 17
-			IL_0883: stelem.ref
-			IL_0884: dup
-			IL_0885: ldc.i4.s 17
-			IL_0887: ldloc.s 18
-			IL_0889: stelem.ref
-			IL_088a: dup
-			IL_088b: ldc.i4.s 18
-			IL_088d: ldloc.s 19
-			IL_088f: stelem.ref
-			IL_0890: dup
-			IL_0891: ldc.i4.s 19
-			IL_0893: ldloc.s 20
-			IL_0895: stelem.ref
-			IL_0896: dup
-			IL_0897: ldc.i4.s 20
-			IL_0899: ldloc.s 21
-			IL_089b: stelem.ref
-			IL_089c: dup
-			IL_089d: ldc.i4.s 21
-			IL_089f: ldloc.s 22
-			IL_08a1: stelem.ref
-			IL_08a2: dup
-			IL_08a3: ldc.i4.s 22
-			IL_08a5: ldloc.s 23
-			IL_08a7: box [System.Runtime]System.Boolean
-			IL_08ac: stelem.ref
-			IL_08ad: dup
-			IL_08ae: ldc.i4.s 23
-			IL_08b0: ldloc.s 24
-			IL_08b2: stelem.ref
-			IL_08b3: dup
-			IL_08b4: ldc.i4.s 24
-			IL_08b6: ldloc.s 25
-			IL_08b8: stelem.ref
-			IL_08b9: dup
-			IL_08ba: ldc.i4.s 25
-			IL_08bc: ldloc.s 26
+			IL_082f: ldloc.1
+			IL_0830: ldstr "url"
+			IL_0835: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_083a: stloc.s 26
+			IL_083c: ldloc.s 26
+			IL_083e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0843: stloc.s 26
+			IL_0845: ldc.i4.0
+			IL_0846: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_084b: brfalse IL_086a
+
+			IL_0850: ldloc.s 26
+			IL_0852: isinst [System.Runtime]System.String
+			IL_0857: dup
+			IL_0858: brfalse IL_0869
+
+			IL_085d: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0862: stloc.s 16
+			IL_0864: br IL_0878
+
+			IL_0869: pop
+
+			IL_086a: ldloc.s 26
+			IL_086c: ldstr "trim"
+			IL_0871: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0876: stloc.s 16
+
+			IL_0878: ldarg.0
+			IL_0879: ldc.i4.1
+			IL_087a: ldelem.ref
+			IL_087b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0880: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_0885: ldc.i4.1
+			IL_0886: newarr [System.Runtime]System.Object
+			IL_088b: dup
+			IL_088c: ldc.i4.0
+			IL_088d: ldarg.0
+			IL_088e: ldc.i4.1
+			IL_088f: ldelem.ref
+			IL_0890: stelem.ref
+			IL_0891: stloc.s 21
+			IL_0893: ldloc.s 21
+			IL_0895: ldloc.s 16
+			IL_0897: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_089c: stloc.s 26
+			IL_089e: ldloc.0
+			IL_089f: ldc.i4.3
+			IL_08a0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08a5: ldloc.0
+			IL_08a6: ldloc.s 26
+			IL_08a8: ldarg.0
+			IL_08a9: ldc.i4.3
+			IL_08aa: ldloc.0
+			IL_08ab: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_08b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_08b5: ldloc.0
+			IL_08b6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_08bb: dup
+			IL_08bc: ldc.i4.0
+			IL_08bd: ldloc.1
 			IL_08be: stelem.ref
 			IL_08bf: dup
-			IL_08c0: ldc.i4.s 26
-			IL_08c2: ldloc.s 27
-			IL_08c4: stelem.ref
-			IL_08c5: dup
-			IL_08c6: ldc.i4.s 27
-			IL_08c8: ldloc.s 28
-			IL_08ca: stelem.ref
-			IL_08cb: dup
-			IL_08cc: ldc.i4.s 28
-			IL_08ce: ldloc.s 29
+			IL_08c0: ldc.i4.1
+			IL_08c1: ldloc.2
+			IL_08c2: stelem.ref
+			IL_08c3: dup
+			IL_08c4: ldc.i4.2
+			IL_08c5: ldloc.3
+			IL_08c6: stelem.ref
+			IL_08c7: dup
+			IL_08c8: ldc.i4.3
+			IL_08c9: ldloc.s 4
+			IL_08cb: stelem.ref
+			IL_08cc: dup
+			IL_08cd: ldc.i4.4
+			IL_08ce: ldloc.s 5
 			IL_08d0: stelem.ref
 			IL_08d1: dup
-			IL_08d2: ldc.i4.s 29
-			IL_08d4: ldloc.s 30
-			IL_08d6: stelem.ref
-			IL_08d7: dup
-			IL_08d8: ldc.i4.s 30
-			IL_08da: ldloc.s 31
-			IL_08dc: stelem.ref
-			IL_08dd: dup
-			IL_08de: ldc.i4.s 31
-			IL_08e0: ldloc.s 32
-			IL_08e2: stelem.ref
-			IL_08e3: dup
-			IL_08e4: ldc.i4.s 32
-			IL_08e6: ldloc.s 33
-			IL_08e8: stelem.ref
-			IL_08e9: pop
-			IL_08ea: ldloc.0
-			IL_08eb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08f0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08f5: ret
+			IL_08d2: ldc.i4.5
+			IL_08d3: ldloc.s 6
+			IL_08d5: stelem.ref
+			IL_08d6: dup
+			IL_08d7: ldc.i4.6
+			IL_08d8: ldloc.s 7
+			IL_08da: stelem.ref
+			IL_08db: dup
+			IL_08dc: ldc.i4.7
+			IL_08dd: ldloc.s 8
+			IL_08df: stelem.ref
+			IL_08e0: dup
+			IL_08e1: ldc.i4.8
+			IL_08e2: ldloc.s 9
+			IL_08e4: stelem.ref
+			IL_08e5: dup
+			IL_08e6: ldc.i4.s 9
+			IL_08e8: ldloc.s 10
+			IL_08ea: stelem.ref
+			IL_08eb: dup
+			IL_08ec: ldc.i4.s 10
+			IL_08ee: ldloc.s 11
+			IL_08f0: stelem.ref
+			IL_08f1: dup
+			IL_08f2: ldc.i4.s 11
+			IL_08f4: ldloc.s 12
+			IL_08f6: stelem.ref
+			IL_08f7: dup
+			IL_08f8: ldc.i4.s 12
+			IL_08fa: ldloc.s 13
+			IL_08fc: stelem.ref
+			IL_08fd: dup
+			IL_08fe: ldc.i4.s 13
+			IL_0900: ldloc.s 14
+			IL_0902: stelem.ref
+			IL_0903: dup
+			IL_0904: ldc.i4.s 14
+			IL_0906: ldloc.s 15
+			IL_0908: stelem.ref
+			IL_0909: dup
+			IL_090a: ldc.i4.s 15
+			IL_090c: ldloc.s 16
+			IL_090e: stelem.ref
+			IL_090f: dup
+			IL_0910: ldc.i4.s 16
+			IL_0912: ldloc.s 17
+			IL_0914: stelem.ref
+			IL_0915: dup
+			IL_0916: ldc.i4.s 17
+			IL_0918: ldloc.s 18
+			IL_091a: stelem.ref
+			IL_091b: dup
+			IL_091c: ldc.i4.s 18
+			IL_091e: ldloc.s 19
+			IL_0920: stelem.ref
+			IL_0921: dup
+			IL_0922: ldc.i4.s 19
+			IL_0924: ldloc.s 20
+			IL_0926: stelem.ref
+			IL_0927: dup
+			IL_0928: ldc.i4.s 20
+			IL_092a: ldloc.s 21
+			IL_092c: stelem.ref
+			IL_092d: dup
+			IL_092e: ldc.i4.s 21
+			IL_0930: ldloc.s 22
+			IL_0932: stelem.ref
+			IL_0933: dup
+			IL_0934: ldc.i4.s 22
+			IL_0936: ldloc.s 23
+			IL_0938: box [System.Runtime]System.Boolean
+			IL_093d: stelem.ref
+			IL_093e: dup
+			IL_093f: ldc.i4.s 23
+			IL_0941: ldloc.s 24
+			IL_0943: stelem.ref
+			IL_0944: dup
+			IL_0945: ldc.i4.s 24
+			IL_0947: ldloc.s 25
+			IL_0949: stelem.ref
+			IL_094a: dup
+			IL_094b: ldc.i4.s 25
+			IL_094d: ldloc.s 26
+			IL_094f: stelem.ref
+			IL_0950: dup
+			IL_0951: ldc.i4.s 26
+			IL_0953: ldloc.s 27
+			IL_0955: stelem.ref
+			IL_0956: dup
+			IL_0957: ldc.i4.s 27
+			IL_0959: ldloc.s 28
+			IL_095b: stelem.ref
+			IL_095c: dup
+			IL_095d: ldc.i4.s 28
+			IL_095f: ldloc.s 29
+			IL_0961: stelem.ref
+			IL_0962: dup
+			IL_0963: ldc.i4.s 29
+			IL_0965: ldloc.s 30
+			IL_0967: stelem.ref
+			IL_0968: dup
+			IL_0969: ldc.i4.s 30
+			IL_096b: ldloc.s 31
+			IL_096d: stelem.ref
+			IL_096e: dup
+			IL_096f: ldc.i4.s 31
+			IL_0971: ldloc.s 32
+			IL_0973: stelem.ref
+			IL_0974: dup
+			IL_0975: ldc.i4.s 32
+			IL_0977: ldloc.s 33
+			IL_0979: stelem.ref
+			IL_097a: pop
+			IL_097b: ldloc.0
+			IL_097c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0981: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0986: ret
 
-			IL_08f6: ldloc.0
-			IL_08f7: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_08fc: stloc.s 22
-			IL_08fe: ldloc.s 22
-			IL_0900: stloc.s 8
-			IL_0902: ldloc.s 16
-			IL_0904: stloc.s 22
-			IL_0906: ldloc.s 22
-			IL_0908: stloc.s 10
+			IL_0987: ldloc.0
+			IL_0988: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_098d: stloc.s 26
+			IL_098f: ldloc.s 26
+			IL_0991: stloc.s 8
+			IL_0993: ldloc.s 16
+			IL_0995: stloc.s 26
+			IL_0997: ldloc.s 26
+			IL_0999: stloc.s 10
 
-			IL_090a: ldloc.s 9
-			IL_090c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0911: ldc.i4.0
-			IL_0912: ceq
-			IL_0914: stloc.s 23
-			IL_0916: ldloc.s 23
-			IL_0918: brfalse IL_0984
+			IL_099b: ldloc.s 9
+			IL_099d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_09a2: ldc.i4.0
+			IL_09a3: ceq
+			IL_09a5: stloc.s 23
+			IL_09a7: ldloc.s 23
+			IL_09a9: brfalse IL_0a15
 
-			IL_091d: ldloc.1
-			IL_091e: ldstr "section"
-			IL_0923: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0928: stloc.s 22
-			IL_092a: ldloc.s 22
-			IL_092c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0931: stloc.s 26
-			IL_0933: ldstr "Could not infer an element id for section '"
-			IL_0938: ldloc.s 26
-			IL_093a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_093f: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0944: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0949: stloc.s 26
-			IL_094b: ldloc.s 26
-			IL_094d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0952: stloc.s 17
-			IL_0954: ldloc.0
-			IL_0955: ldc.i4.m1
-			IL_0956: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_095b: ldloc.0
-			IL_095c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0961: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0966: ldarg.0
-			IL_0967: ldc.i4.1
-			IL_0968: newarr [System.Runtime]System.Object
-			IL_096d: dup
-			IL_096e: ldc.i4.0
-			IL_096f: ldloc.s 17
-			IL_0971: stelem.ref
-			IL_0972: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0977: pop
-			IL_0978: ldloc.0
-			IL_0979: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_097e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0983: ret
+			IL_09ae: ldloc.1
+			IL_09af: ldstr "section"
+			IL_09b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09b9: stloc.s 26
+			IL_09bb: ldloc.s 26
+			IL_09bd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_09c2: stloc.s 27
+			IL_09c4: ldstr "Could not infer an element id for section '"
+			IL_09c9: ldloc.s 27
+			IL_09cb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09d0: ldstr "'. Try passing --id sec-... explicitly."
+			IL_09d5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09da: stloc.s 27
+			IL_09dc: ldloc.s 27
+			IL_09de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_09e3: stloc.s 17
+			IL_09e5: ldloc.0
+			IL_09e6: ldc.i4.m1
+			IL_09e7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_09ec: ldloc.0
+			IL_09ed: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_09f7: ldarg.0
+			IL_09f8: ldc.i4.1
+			IL_09f9: newarr [System.Runtime]System.Object
+			IL_09fe: dup
+			IL_09ff: ldc.i4.0
+			IL_0a00: ldloc.s 17
+			IL_0a02: stelem.ref
+			IL_0a03: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0a08: pop
+			IL_0a09: ldloc.0
+			IL_0a0a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a0f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0a14: ret
 
-			IL_0984: ldarg.0
-			IL_0985: ldc.i4.1
-			IL_0986: ldelem.ref
-			IL_0987: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_098c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
-			IL_0991: ldc.i4.1
-			IL_0992: newarr [System.Runtime]System.Object
-			IL_0997: dup
-			IL_0998: ldc.i4.0
-			IL_0999: ldarg.0
-			IL_099a: ldc.i4.1
-			IL_099b: ldelem.ref
-			IL_099c: stelem.ref
-			IL_099d: stloc.s 21
-			IL_099f: ldloc.s 21
-			IL_09a1: ldloc.s 8
-			IL_09a3: ldloc.s 9
-			IL_09a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_09aa: stloc.s 18
-			IL_09ac: ldarg.0
-			IL_09ad: ldc.i4.1
-			IL_09ae: ldelem.ref
-			IL_09af: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_09b4: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_09b9: stloc.s 31
-			IL_09bb: ldstr "process"
-			IL_09c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09c5: stloc.s 22
-			IL_09c7: ldloc.s 22
-			IL_09c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09ce: stloc.s 22
-			IL_09d0: ldloc.s 22
-			IL_09d2: ldstr "cwd"
-			IL_09d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_09dc: stloc.s 22
-			IL_09de: ldloc.1
-			IL_09df: ldstr "outFile"
-			IL_09e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09e9: stloc.s 27
-			IL_09eb: ldloc.s 31
-			IL_09ed: ldc.i4.2
-			IL_09ee: newarr [System.Runtime]System.Object
-			IL_09f3: dup
-			IL_09f4: ldc.i4.0
-			IL_09f5: ldloc.s 22
-			IL_09f7: stelem.ref
-			IL_09f8: dup
-			IL_09f9: ldc.i4.1
-			IL_09fa: ldloc.s 27
-			IL_09fc: stelem.ref
-			IL_09fd: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0a02: stloc.s 19
-			IL_0a04: ldarg.0
-			IL_0a05: ldc.i4.1
-			IL_0a06: ldelem.ref
-			IL_0a07: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a0c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
-			IL_0a11: ldc.i4.1
-			IL_0a12: newarr [System.Runtime]System.Object
-			IL_0a17: dup
-			IL_0a18: ldc.i4.0
-			IL_0a19: ldarg.0
-			IL_0a1a: ldc.i4.1
-			IL_0a1b: ldelem.ref
-			IL_0a1c: stelem.ref
-			IL_0a1d: stloc.s 21
-			IL_0a1f: ldloc.s 18
-			IL_0a21: ldstr "html"
-			IL_0a26: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a2b: stloc.s 27
-			IL_0a2d: ldloc.1
-			IL_0a2e: ldstr "section"
-			IL_0a33: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a38: stloc.s 22
-			IL_0a3a: ldloc.s 22
-			IL_0a3c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a41: stloc.s 26
-			IL_0a43: ldstr "ECMA-262 "
-			IL_0a48: ldloc.s 26
-			IL_0a4a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a4f: stloc.s 26
-			IL_0a51: ldloc.s 21
-			IL_0a53: ldloc.s 27
-			IL_0a55: ldloc.s 26
-			IL_0a57: ldloc.s 10
-			IL_0a59: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0a5e: stloc.s 20
-			IL_0a60: ldarg.0
-			IL_0a61: ldc.i4.1
-			IL_0a62: ldelem.ref
-			IL_0a63: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a68: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0a6d: stloc.s 32
-			IL_0a6f: ldloc.s 32
-			IL_0a71: ldloc.s 19
-			IL_0a73: ldloc.s 20
-			IL_0a75: ldstr "utf8"
-			IL_0a7a: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_0a7f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a84: stloc.s 33
-			IL_0a86: ldarg.0
-			IL_0a87: ldc.i4.1
-			IL_0a88: ldelem.ref
-			IL_0a89: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a8e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0a93: ldc.i4.1
-			IL_0a94: newarr [System.Runtime]System.Object
-			IL_0a99: dup
-			IL_0a9a: ldc.i4.0
-			IL_0a9b: ldarg.0
-			IL_0a9c: ldc.i4.1
-			IL_0a9d: ldelem.ref
-			IL_0a9e: stelem.ref
-			IL_0a9f: stloc.s 21
-			IL_0aa1: ldloc.1
-			IL_0aa2: ldstr "section"
-			IL_0aa7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0aac: stloc.s 27
-			IL_0aae: ldloc.s 27
-			IL_0ab0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ab5: stloc.s 26
-			IL_0ab7: ldstr "Extracted section "
-			IL_0abc: ldloc.s 26
-			IL_0abe: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ac3: ldstr " (id="
-			IL_0ac8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0acd: ldloc.s 9
-			IL_0acf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ad4: stloc.s 26
-			IL_0ad6: ldloc.s 26
-			IL_0ad8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0add: ldstr ", tag="
-			IL_0ae2: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ae7: ldloc.s 18
-			IL_0ae9: ldstr "tagName"
-			IL_0aee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0af3: stloc.s 27
-			IL_0af5: ldloc.s 27
-			IL_0af7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0afc: stloc.s 26
-			IL_0afe: ldloc.s 26
-			IL_0b00: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b05: ldstr ") -> "
-			IL_0b0a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b0f: ldloc.s 19
-			IL_0b11: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b16: stloc.s 26
-			IL_0b18: ldloc.s 26
-			IL_0b1a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b1f: stloc.s 26
-			IL_0b21: ldloc.s 21
-			IL_0b23: ldloc.s 26
-			IL_0b25: ldloc.s 19
-			IL_0b27: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b2c: stloc.s 27
-			IL_0b2e: ldloc.s 33
-			IL_0b30: ldloc.s 27
-			IL_0b32: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0b37: pop
-			IL_0b38: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0b3d: stloc.s 33
-			IL_0b3f: ldarg.0
-			IL_0b40: ldc.i4.1
-			IL_0b41: ldelem.ref
-			IL_0b42: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b47: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0b4c: stloc.s 27
-			IL_0b4e: ldc.i4.1
-			IL_0b4f: newarr [System.Runtime]System.Object
-			IL_0b54: dup
-			IL_0b55: ldc.i4.0
-			IL_0b56: ldarg.0
-			IL_0b57: ldc.i4.1
-			IL_0b58: ldelem.ref
-			IL_0b59: stelem.ref
-			IL_0b5a: stloc.s 21
-			IL_0b5c: ldarg.0
-			IL_0b5d: ldc.i4.1
-			IL_0b5e: ldelem.ref
-			IL_0b5f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b64: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0b69: stloc.s 32
-			IL_0b6b: ldloc.s 32
-			IL_0b6d: ldloc.s 19
-			IL_0b6f: ldstr "utf8"
-			IL_0b74: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0b79: stloc.s 22
-			IL_0b7b: ldloc.s 27
-			IL_0b7d: ldloc.s 21
-			IL_0b7f: ldloc.s 22
-			IL_0b81: ldloc.s 19
-			IL_0b83: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b88: stloc.s 22
-			IL_0b8a: ldloc.s 33
-			IL_0b8c: ldloc.s 22
-			IL_0b8e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0b93: pop
-			IL_0b94: ldloc.0
-			IL_0b95: ldc.i4.m1
-			IL_0b96: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0b9b: ldloc.0
-			IL_0b9c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0ba1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0ba6: ldarg.0
-			IL_0ba7: ldc.i4.1
-			IL_0ba8: newarr [System.Runtime]System.Object
-			IL_0bad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0bb2: pop
-			IL_0bb3: ldloc.0
-			IL_0bb4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bb9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0bbe: ret
+			IL_0a15: ldarg.0
+			IL_0a16: ldc.i4.1
+			IL_0a17: ldelem.ref
+			IL_0a18: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a1d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
+			IL_0a22: ldc.i4.1
+			IL_0a23: newarr [System.Runtime]System.Object
+			IL_0a28: dup
+			IL_0a29: ldc.i4.0
+			IL_0a2a: ldarg.0
+			IL_0a2b: ldc.i4.1
+			IL_0a2c: ldelem.ref
+			IL_0a2d: stelem.ref
+			IL_0a2e: stloc.s 21
+			IL_0a30: ldloc.s 21
+			IL_0a32: ldloc.s 8
+			IL_0a34: ldloc.s 9
+			IL_0a36: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0a3b: stloc.s 18
+			IL_0a3d: ldarg.0
+			IL_0a3e: ldc.i4.1
+			IL_0a3f: ldelem.ref
+			IL_0a40: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a45: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_0a4a: stloc.s 31
+			IL_0a4c: ldstr "process"
+			IL_0a51: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a56: stloc.s 26
+			IL_0a58: ldloc.s 26
+			IL_0a5a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a5f: stloc.s 26
+			IL_0a61: ldloc.s 26
+			IL_0a63: ldstr "cwd"
+			IL_0a68: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0a6d: stloc.s 26
+			IL_0a6f: ldloc.1
+			IL_0a70: ldstr "outFile"
+			IL_0a75: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a7a: stloc.s 22
+			IL_0a7c: ldloc.s 31
+			IL_0a7e: ldc.i4.2
+			IL_0a7f: newarr [System.Runtime]System.Object
+			IL_0a84: dup
+			IL_0a85: ldc.i4.0
+			IL_0a86: ldloc.s 26
+			IL_0a88: stelem.ref
+			IL_0a89: dup
+			IL_0a8a: ldc.i4.1
+			IL_0a8b: ldloc.s 22
+			IL_0a8d: stelem.ref
+			IL_0a8e: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0a93: stloc.s 19
+			IL_0a95: ldarg.0
+			IL_0a96: ldc.i4.1
+			IL_0a97: ldelem.ref
+			IL_0a98: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a9d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
+			IL_0aa2: ldc.i4.1
+			IL_0aa3: newarr [System.Runtime]System.Object
+			IL_0aa8: dup
+			IL_0aa9: ldc.i4.0
+			IL_0aaa: ldarg.0
+			IL_0aab: ldc.i4.1
+			IL_0aac: ldelem.ref
+			IL_0aad: stelem.ref
+			IL_0aae: stloc.s 21
+			IL_0ab0: ldloc.s 18
+			IL_0ab2: ldstr "html"
+			IL_0ab7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0abc: stloc.s 22
+			IL_0abe: ldloc.1
+			IL_0abf: ldstr "section"
+			IL_0ac4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ac9: stloc.s 26
+			IL_0acb: ldloc.s 26
+			IL_0acd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ad2: stloc.s 27
+			IL_0ad4: ldstr "ECMA-262 "
+			IL_0ad9: ldloc.s 27
+			IL_0adb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ae0: stloc.s 27
+			IL_0ae2: ldloc.s 21
+			IL_0ae4: ldloc.s 22
+			IL_0ae6: ldloc.s 27
+			IL_0ae8: ldloc.s 10
+			IL_0aea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0aef: stloc.s 20
+			IL_0af1: ldarg.0
+			IL_0af2: ldc.i4.1
+			IL_0af3: ldelem.ref
+			IL_0af4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0af9: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0afe: stloc.s 32
+			IL_0b00: ldloc.s 32
+			IL_0b02: ldloc.s 19
+			IL_0b04: ldloc.s 20
+			IL_0b06: ldstr "utf8"
+			IL_0b0b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_0b10: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0b15: stloc.s 33
+			IL_0b17: ldarg.0
+			IL_0b18: ldc.i4.1
+			IL_0b19: ldelem.ref
+			IL_0b1a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b1f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0b24: ldc.i4.1
+			IL_0b25: newarr [System.Runtime]System.Object
+			IL_0b2a: dup
+			IL_0b2b: ldc.i4.0
+			IL_0b2c: ldarg.0
+			IL_0b2d: ldc.i4.1
+			IL_0b2e: ldelem.ref
+			IL_0b2f: stelem.ref
+			IL_0b30: stloc.s 21
+			IL_0b32: ldloc.1
+			IL_0b33: ldstr "section"
+			IL_0b38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b3d: stloc.s 22
+			IL_0b3f: ldloc.s 22
+			IL_0b41: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b46: stloc.s 27
+			IL_0b48: ldstr "Extracted section "
+			IL_0b4d: ldloc.s 27
+			IL_0b4f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b54: ldstr " (id="
+			IL_0b59: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b5e: ldloc.s 9
+			IL_0b60: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b65: stloc.s 27
+			IL_0b67: ldloc.s 27
+			IL_0b69: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b6e: ldstr ", tag="
+			IL_0b73: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b78: ldloc.s 18
+			IL_0b7a: ldstr "tagName"
+			IL_0b7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b84: stloc.s 22
+			IL_0b86: ldloc.s 22
+			IL_0b88: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b8d: stloc.s 27
+			IL_0b8f: ldloc.s 27
+			IL_0b91: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b96: ldstr ") -> "
+			IL_0b9b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ba0: ldloc.s 19
+			IL_0ba2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ba7: stloc.s 27
+			IL_0ba9: ldloc.s 27
+			IL_0bab: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0bb0: stloc.s 27
+			IL_0bb2: ldloc.s 21
+			IL_0bb4: ldloc.s 27
+			IL_0bb6: ldloc.s 19
+			IL_0bb8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0bbd: stloc.s 22
+			IL_0bbf: ldloc.s 33
+			IL_0bc1: ldloc.s 22
+			IL_0bc3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0bc8: pop
+			IL_0bc9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0bce: stloc.s 33
+			IL_0bd0: ldarg.0
+			IL_0bd1: ldc.i4.1
+			IL_0bd2: ldelem.ref
+			IL_0bd3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0bd8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0bdd: stloc.s 22
+			IL_0bdf: ldc.i4.1
+			IL_0be0: newarr [System.Runtime]System.Object
+			IL_0be5: dup
+			IL_0be6: ldc.i4.0
+			IL_0be7: ldarg.0
+			IL_0be8: ldc.i4.1
+			IL_0be9: ldelem.ref
+			IL_0bea: stelem.ref
+			IL_0beb: stloc.s 21
+			IL_0bed: ldarg.0
+			IL_0bee: ldc.i4.1
+			IL_0bef: ldelem.ref
+			IL_0bf0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0bf5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0bfa: stloc.s 32
+			IL_0bfc: ldloc.s 32
+			IL_0bfe: ldloc.s 19
+			IL_0c00: ldstr "utf8"
+			IL_0c05: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0c0a: stloc.s 26
+			IL_0c0c: ldloc.s 22
+			IL_0c0e: ldloc.s 21
+			IL_0c10: ldloc.s 26
+			IL_0c12: ldloc.s 19
+			IL_0c14: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0c19: stloc.s 26
+			IL_0c1b: ldloc.s 33
+			IL_0c1d: ldloc.s 26
+			IL_0c1f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0c24: pop
+			IL_0c25: ldloc.0
+			IL_0c26: ldc.i4.m1
+			IL_0c27: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0c2c: ldloc.0
+			IL_0c2d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c32: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0c37: ldarg.0
+			IL_0c38: ldc.i4.1
+			IL_0c39: newarr [System.Runtime]System.Object
+			IL_0c3e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0c43: pop
+			IL_0c44: ldloc.0
+			IL_0c45: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c4a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0c4f: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -740,7 +740,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 292 (0x124)
+			// Code size: 436 (0x1b4)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -752,97 +752,156 @@
 
 			IL_0000: ldarg.1
 			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0006: ldstr "includes"
-			IL_000b: ldstr " -> "
-			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0015: stloc.0
-			IL_0016: ldloc.0
-			IL_0017: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_001c: stloc.1
-			IL_001d: ldloc.1
-			IL_001e: brfalse IL_007a
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.0
+			IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_000d: brfalse IL_0034
 
-			IL_0023: ldarg.1
-			IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0029: stloc.0
-			IL_002a: ldarg.1
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0030: ldstr "indexOf"
-			IL_0035: ldstr " -> "
-			IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_003f: stloc.2
-			IL_0040: ldloc.2
-			IL_0041: ldc.r8 4
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_004f: stloc.3
-			IL_0050: ldloc.0
-			IL_0051: ldstr "substring"
-			IL_0056: ldc.r8 0.0
-			IL_005f: box [System.Runtime]System.Double
-			IL_0064: ldloc.3
-			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_006a: stloc.0
-			IL_006b: ldloc.0
-			IL_006c: ldstr "<outFile>"
-			IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0076: stloc.3
-			IL_0077: ldloc.3
-			IL_0078: starg.s text
+			IL_0012: ldloc.0
+			IL_0013: isinst [System.Runtime]System.String
+			IL_0018: dup
+			IL_0019: brfalse IL_0033
 
-			IL_007a: ldarg.1
-			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0080: stloc.0
-			IL_0081: ldarg.2
-			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0087: stloc.2
-			IL_0088: ldstr "[.*+?^${}()|[\\]\\\\]"
-			IL_008d: ldstr "g"
-			IL_0092: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0097: stloc.s 4
-			IL_0099: ldloc.2
-			IL_009a: ldstr "replace"
-			IL_009f: ldloc.s 4
-			IL_00a1: ldstr "\\$&"
-			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00ab: stloc.2
-			IL_00ac: ldloc.2
-			IL_00ad: ldstr "g"
-			IL_00b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_00b7: stloc.s 4
+			IL_001e: ldstr " -> "
+			IL_0023: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_0028: box [System.Runtime]System.Boolean
+			IL_002d: stloc.0
+			IL_002e: br IL_0045
+
+			IL_0033: pop
+
+			IL_0034: ldloc.0
+			IL_0035: ldstr "includes"
+			IL_003a: ldstr " -> "
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0044: stloc.0
+
+			IL_0045: ldloc.0
+			IL_0046: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_004b: stloc.1
+			IL_004c: ldloc.1
+			IL_004d: brfalse IL_010a
+
+			IL_0052: ldarg.1
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0058: stloc.0
+			IL_0059: ldarg.1
+			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_005f: stloc.2
+			IL_0060: ldc.i4.0
+			IL_0061: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0066: brfalse IL_008d
+
+			IL_006b: ldloc.2
+			IL_006c: isinst [System.Runtime]System.String
+			IL_0071: dup
+			IL_0072: brfalse IL_008c
+
+			IL_0077: ldstr " -> "
+			IL_007c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0081: box [System.Runtime]System.Double
+			IL_0086: stloc.2
+			IL_0087: br IL_009e
+
+			IL_008c: pop
+
+			IL_008d: ldloc.2
+			IL_008e: ldstr "indexOf"
+			IL_0093: ldstr " -> "
+			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_009d: stloc.2
+
+			IL_009e: ldloc.2
+			IL_009f: ldc.r8 4
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_00ad: stloc.3
+			IL_00ae: ldc.i4.0
+			IL_00af: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00b4: brfalse IL_00e0
+
 			IL_00b9: ldloc.0
-			IL_00ba: ldstr "replace"
-			IL_00bf: ldloc.s 4
-			IL_00c1: ldstr "<outFile>"
-			IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00cb: stloc.0
-			IL_00cc: ldloc.0
-			IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00d2: stloc.0
-			IL_00d3: ldstr "127\\.0\\.0\\.1:\\d+"
-			IL_00d8: ldstr "g"
-			IL_00dd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_00e2: stloc.s 4
-			IL_00e4: ldloc.0
-			IL_00e5: ldstr "replace"
-			IL_00ea: ldloc.s 4
-			IL_00ec: ldstr "127.0.0.1:<port>"
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00f6: stloc.0
-			IL_00f7: ldloc.0
-			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00fd: stloc.0
-			IL_00fe: ldstr "\\r\\n"
-			IL_0103: ldstr "g"
-			IL_0108: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_010d: stloc.s 4
-			IL_010f: ldloc.0
-			IL_0110: ldstr "replace"
-			IL_0115: ldloc.s 4
-			IL_0117: ldstr "\n"
-			IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0121: stloc.0
-			IL_0122: ldloc.0
-			IL_0123: ret
+			IL_00ba: isinst [System.Runtime]System.String
+			IL_00bf: dup
+			IL_00c0: brfalse IL_00df
+
+			IL_00c5: ldc.r8 0.0
+			IL_00ce: box [System.Runtime]System.Double
+			IL_00d3: ldloc.3
+			IL_00d4: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_00d9: stloc.0
+			IL_00da: br IL_00fb
+
+			IL_00df: pop
+
+			IL_00e0: ldloc.0
+			IL_00e1: ldstr "substring"
+			IL_00e6: ldc.r8 0.0
+			IL_00ef: box [System.Runtime]System.Double
+			IL_00f4: ldloc.3
+			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00fa: stloc.0
+
+			IL_00fb: ldloc.0
+			IL_00fc: ldstr "<outFile>"
+			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0106: stloc.3
+			IL_0107: ldloc.3
+			IL_0108: starg.s text
+
+			IL_010a: ldarg.1
+			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0110: stloc.0
+			IL_0111: ldarg.2
+			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0117: stloc.2
+			IL_0118: ldstr "[.*+?^${}()|[\\]\\\\]"
+			IL_011d: ldstr "g"
+			IL_0122: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0127: stloc.s 4
+			IL_0129: ldloc.2
+			IL_012a: ldstr "replace"
+			IL_012f: ldloc.s 4
+			IL_0131: ldstr "\\$&"
+			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_013b: stloc.2
+			IL_013c: ldloc.2
+			IL_013d: ldstr "g"
+			IL_0142: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0147: stloc.s 4
+			IL_0149: ldloc.0
+			IL_014a: ldstr "replace"
+			IL_014f: ldloc.s 4
+			IL_0151: ldstr "<outFile>"
+			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_015b: stloc.0
+			IL_015c: ldloc.0
+			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0162: stloc.0
+			IL_0163: ldstr "127\\.0\\.0\\.1:\\d+"
+			IL_0168: ldstr "g"
+			IL_016d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0172: stloc.s 4
+			IL_0174: ldloc.0
+			IL_0175: ldstr "replace"
+			IL_017a: ldloc.s 4
+			IL_017c: ldstr "127.0.0.1:<port>"
+			IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0186: stloc.0
+			IL_0187: ldloc.0
+			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_018d: stloc.0
+			IL_018e: ldstr "\\r\\n"
+			IL_0193: ldstr "g"
+			IL_0198: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_019d: stloc.s 4
+			IL_019f: ldloc.0
+			IL_01a0: ldstr "replace"
+			IL_01a5: ldloc.s 4
+			IL_01a7: ldstr "\n"
+			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01b1: stloc.0
+			IL_01b2: ldloc.0
+			IL_01b3: ret
 		} // end of method normalize::__js_call__
 
 	} // end of class normalize
@@ -3496,7 +3555,7 @@
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
-			// Code size: 502 (0x1f6)
+			// Code size: 542 (0x21e)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3704,14 +3763,32 @@
 			IL_01d2: ldc.r8 1
 			IL_01db: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
 			IL_01e0: stloc.s 9
-			IL_01e2: ldloc.s 5
-			IL_01e4: ldstr "substring"
-			IL_01e9: ldloc.s 9
-			IL_01eb: ldloc.0
-			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01f1: stloc.s 5
-			IL_01f3: ldloc.s 5
-			IL_01f5: ret
+			IL_01e2: ldc.i4.0
+			IL_01e3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01e8: brfalse IL_020a
+
+			IL_01ed: ldloc.s 5
+			IL_01ef: isinst [System.Runtime]System.String
+			IL_01f4: dup
+			IL_01f5: brfalse IL_0209
+
+			IL_01fa: ldloc.s 9
+			IL_01fc: ldloc.0
+			IL_01fd: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_0202: stloc.s 5
+			IL_0204: br IL_021b
+
+			IL_0209: pop
+
+			IL_020a: ldloc.s 5
+			IL_020c: ldstr "substring"
+			IL_0211: ldloc.s 9
+			IL_0213: ldloc.0
+			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0219: stloc.s 5
+
+			IL_021b: ldloc.s 5
+			IL_021d: ret
 		} // end of method findTagNameAt::__js_call__
 
 	} // end of class findTagNameAt
@@ -4064,7 +4141,7 @@
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
-			// Code size: 935 (0x3a7)
+			// Code size: 1172 (0x494)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -4111,310 +4188,409 @@
 			IL_003d: stloc.1
 			IL_003e: ldarg.2
 			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0044: ldstr "indexOf"
-			IL_0049: ldloc.0
-			IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_004f: stloc.2
-			IL_0050: ldloc.2
-			IL_0051: stloc.s 15
-			IL_0053: ldloc.s 15
-			IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_005a: ldc.r8 0.0
-			IL_0063: clt
-			IL_0065: brfalse IL_0080
+			IL_0044: stloc.s 15
+			IL_0046: ldc.i4.0
+			IL_0047: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_004c: brfalse IL_0070
 
-			IL_006a: ldarg.2
-			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0070: ldstr "indexOf"
-			IL_0075: ldloc.1
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_007b: stloc.s 15
-			IL_007d: ldloc.s 15
-			IL_007f: stloc.2
+			IL_0051: ldloc.s 15
+			IL_0053: isinst [System.Runtime]System.String
+			IL_0058: dup
+			IL_0059: brfalse IL_006f
 
-			IL_0080: ldloc.2
-			IL_0081: stloc.s 15
-			IL_0083: ldloc.s 15
-			IL_0085: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_008a: ldc.r8 0.0
-			IL_0093: clt
-			IL_0095: brfalse IL_00d7
+			IL_005e: ldloc.0
+			IL_005f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0064: box [System.Runtime]System.Double
+			IL_0069: stloc.2
+			IL_006a: br IL_007e
 
-			IL_009a: ldarg.3
-			IL_009b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00a0: stloc.s 14
-			IL_00a2: ldstr "Could not find id '"
-			IL_00a7: ldloc.s 14
-			IL_00a9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00ae: ldstr "' in input HTML."
-			IL_00b3: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00b8: stloc.s 14
-			IL_00ba: ldloc.s 14
-			IL_00bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00c1: stloc.3
-			IL_00c2: ldloc.3
-			IL_00c3: isinst [System.Runtime]System.Exception
-			IL_00c8: dup
-			IL_00c9: brtrue IL_00d6
+			IL_006f: pop
 
-			IL_00ce: pop
-			IL_00cf: ldloc.3
-			IL_00d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00d5: throw
+			IL_0070: ldloc.s 15
+			IL_0072: ldstr "indexOf"
+			IL_0077: ldloc.0
+			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_007d: stloc.2
 
-			IL_00d6: throw
+			IL_007e: ldloc.2
+			IL_007f: stloc.s 15
+			IL_0081: ldloc.s 15
+			IL_0083: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0088: ldc.r8 0.0
+			IL_0091: clt
+			IL_0093: brfalse IL_00dd
 
-			IL_00d7: ldarg.2
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00dd: ldstr "lastIndexOf"
-			IL_00e2: ldstr "<"
-			IL_00e7: ldloc.2
-			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00ed: stloc.s 4
-			IL_00ef: ldloc.s 4
-			IL_00f1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00f6: ldc.r8 0.0
-			IL_00ff: clt
-			IL_0101: brfalse IL_0146
+			IL_0098: ldarg.2
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009e: stloc.s 15
+			IL_00a0: ldc.i4.0
+			IL_00a1: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00a6: brfalse IL_00cb
 
-			IL_0106: ldarg.3
-			IL_0107: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_010c: stloc.s 14
-			IL_010e: ldstr "Could not locate tag start for id '"
-			IL_0113: ldloc.s 14
-			IL_0115: call string [System.Runtime]System.String::Concat(string, string)
-			IL_011a: ldstr "'."
-			IL_011f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0124: stloc.s 14
-			IL_0126: ldloc.s 14
-			IL_0128: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_012d: stloc.s 5
-			IL_012f: ldloc.s 5
-			IL_0131: isinst [System.Runtime]System.Exception
-			IL_0136: dup
-			IL_0137: brtrue IL_0145
+			IL_00ab: ldloc.s 15
+			IL_00ad: isinst [System.Runtime]System.String
+			IL_00b2: dup
+			IL_00b3: brfalse IL_00ca
 
-			IL_013c: pop
-			IL_013d: ldloc.s 5
-			IL_013f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0144: throw
+			IL_00b8: ldloc.1
+			IL_00b9: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_00be: box [System.Runtime]System.Double
+			IL_00c3: stloc.s 15
+			IL_00c5: br IL_00da
 
-			IL_0145: throw
+			IL_00ca: pop
 
-			IL_0146: ldarg.0
-			IL_0147: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
-			IL_014c: ldc.i4.1
-			IL_014d: newarr [System.Runtime]System.Object
-			IL_0152: dup
-			IL_0153: ldc.i4.0
-			IL_0154: ldarg.0
-			IL_0155: stelem.ref
-			IL_0156: stloc.s 16
-			IL_0158: ldloc.s 16
-			IL_015a: ldarg.2
-			IL_015b: ldloc.s 4
-			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0162: stloc.s 6
-			IL_0164: ldloc.s 6
-			IL_0166: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_016b: ldc.i4.0
-			IL_016c: ceq
-			IL_016e: stloc.s 17
-			IL_0170: ldloc.s 17
-			IL_0172: brfalse IL_01b7
+			IL_00cb: ldloc.s 15
+			IL_00cd: ldstr "indexOf"
+			IL_00d2: ldloc.1
+			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00d8: stloc.s 15
 
-			IL_0177: ldarg.3
-			IL_0178: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_017d: stloc.s 14
-			IL_017f: ldstr "Could not determine tag name for id '"
-			IL_0184: ldloc.s 14
-			IL_0186: call string [System.Runtime]System.String::Concat(string, string)
-			IL_018b: ldstr "'."
-			IL_0190: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0195: stloc.s 14
-			IL_0197: ldloc.s 14
-			IL_0199: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_019e: stloc.s 7
-			IL_01a0: ldloc.s 7
-			IL_01a2: isinst [System.Runtime]System.Exception
-			IL_01a7: dup
-			IL_01a8: brtrue IL_01b6
+			IL_00da: ldloc.s 15
+			IL_00dc: stloc.2
 
-			IL_01ad: pop
-			IL_01ae: ldloc.s 7
-			IL_01b0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_01b5: throw
+			IL_00dd: ldloc.2
+			IL_00de: stloc.s 15
+			IL_00e0: ldloc.s 15
+			IL_00e2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00e7: ldc.r8 0.0
+			IL_00f0: clt
+			IL_00f2: brfalse IL_0134
 
-			IL_01b6: throw
+			IL_00f7: ldarg.3
+			IL_00f8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00fd: stloc.s 14
+			IL_00ff: ldstr "Could not find id '"
+			IL_0104: ldloc.s 14
+			IL_0106: call string [System.Runtime]System.String::Concat(string, string)
+			IL_010b: ldstr "' in input HTML."
+			IL_0110: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0115: stloc.s 14
+			IL_0117: ldloc.s 14
+			IL_0119: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_011e: stloc.3
+			IL_011f: ldloc.3
+			IL_0120: isinst [System.Runtime]System.Exception
+			IL_0125: dup
+			IL_0126: brtrue IL_0133
 
-			IL_01b7: ldarg.0
-			IL_01b8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
-			IL_01bd: ldc.i4.1
-			IL_01be: newarr [System.Runtime]System.Object
-			IL_01c3: dup
-			IL_01c4: ldc.i4.0
-			IL_01c5: ldarg.0
-			IL_01c6: stelem.ref
-			IL_01c7: ldloc.s 6
-			IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_01ce: stloc.s 15
-			IL_01d0: ldloc.s 15
-			IL_01d2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01d7: stloc.s 14
-			IL_01d9: ldstr "<\\/?"
-			IL_01de: ldloc.s 14
-			IL_01e0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01e5: ldstr "\\b[^>]*>"
-			IL_01ea: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01ef: stloc.s 14
-			IL_01f1: ldloc.s 14
-			IL_01f3: ldstr "gi"
-			IL_01f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_01fd: stloc.s 8
-			IL_01ff: ldloc.s 8
-			IL_0201: ldstr "lastIndex"
-			IL_0206: ldloc.s 4
-			IL_0208: ldc.i4.1
-			IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_020e: pop
-			IL_020f: ldc.r8 0.0
-			IL_0218: stloc.s 9
-			IL_021a: ldc.r8 1
-			IL_0223: neg
-			IL_0224: stloc.s 18
-			IL_0226: ldloc.s 18
-			IL_0228: box [System.Runtime]System.Double
-			IL_022d: stloc.s 10
-			// loop start (head: IL_022f)
-				IL_022f: ldc.i4.1
-				IL_0230: brfalse IL_034b
+			IL_012b: pop
+			IL_012c: ldloc.3
+			IL_012d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0132: throw
 
-				IL_0235: ldloc.s 8
-				IL_0237: ldstr "exec"
-				IL_023c: ldarg.2
-				IL_023d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0242: stloc.s 11
-				IL_0244: ldloc.s 11
-				IL_0246: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_024b: ldc.i4.0
-				IL_024c: ceq
-				IL_024e: stloc.s 17
-				IL_0250: ldloc.s 17
-				IL_0252: brfalse IL_025c
+			IL_0133: throw
 
-				IL_0257: br IL_034b
+			IL_0134: ldarg.2
+			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_013a: stloc.s 15
+			IL_013c: ldc.i4.0
+			IL_013d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0142: brfalse IL_016c
 
-				IL_025c: ldloc.s 11
-				IL_025e: ldc.r8 0.0
-				IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_026c: stloc.s 12
-				IL_026e: ldloc.s 10
-				IL_0270: stloc.s 19
-				IL_0272: ldloc.s 19
-				IL_0274: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0279: ldc.r8 0.0
-				IL_0282: clt
-				IL_0284: brfalse IL_029b
+			IL_0147: ldloc.s 15
+			IL_0149: isinst [System.Runtime]System.String
+			IL_014e: dup
+			IL_014f: brfalse IL_016b
 
-				IL_0289: ldloc.s 11
-				IL_028b: ldstr "index"
-				IL_0290: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0295: stloc.s 15
-				IL_0297: ldloc.s 15
-				IL_0299: stloc.s 10
+			IL_0154: ldstr "<"
+			IL_0159: ldloc.2
+			IL_015a: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+			IL_015f: box [System.Runtime]System.Double
+			IL_0164: stloc.s 4
+			IL_0166: br IL_0180
 
-				IL_029b: ldloc.s 12
-				IL_029d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02a2: ldstr "startsWith"
-				IL_02a7: ldstr "</"
-				IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_02b1: stloc.s 15
-				IL_02b3: ldloc.s 15
-				IL_02b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02ba: stloc.s 17
-				IL_02bc: ldloc.s 17
-				IL_02be: brfalse IL_0338
+			IL_016b: pop
 
-				IL_02c3: ldloc.s 9
-				IL_02c5: ldc.r8 1
-				IL_02ce: sub
-				IL_02cf: stloc.s 9
-				IL_02d1: ldloc.s 9
-				IL_02d3: stloc.s 18
-				IL_02d5: ldloc.s 18
-				IL_02d7: ldc.r8 0.0
-				IL_02e0: ceq
-				IL_02e2: brfalse IL_0333
+			IL_016c: ldloc.s 15
+			IL_016e: ldstr "lastIndexOf"
+			IL_0173: ldstr "<"
+			IL_0178: ldloc.2
+			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_017e: stloc.s 4
 
-				IL_02e7: ldarg.2
-				IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02ed: stloc.s 15
-				IL_02ef: ldloc.s 8
-				IL_02f1: ldstr "lastIndex"
-				IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_02fb: stloc.s 20
-				IL_02fd: ldloc.s 15
-				IL_02ff: ldstr "substring"
-				IL_0304: ldloc.s 10
-				IL_0306: ldloc.s 20
-				IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_030d: stloc.s 20
-				IL_030f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0314: dup
-				IL_0315: ldstr "tagName"
-				IL_031a: ldloc.s 6
-				IL_031c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_0321: dup
-				IL_0322: ldstr "html"
-				IL_0327: ldloc.s 20
-				IL_0329: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_032e: stloc.s 21
-				IL_0330: ldloc.s 21
-				IL_0332: ret
+			IL_0180: ldloc.s 4
+			IL_0182: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0187: ldc.r8 0.0
+			IL_0190: clt
+			IL_0192: brfalse IL_01d7
 
-				IL_0333: br IL_0346
+			IL_0197: ldarg.3
+			IL_0198: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_019d: stloc.s 14
+			IL_019f: ldstr "Could not locate tag start for id '"
+			IL_01a4: ldloc.s 14
+			IL_01a6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ab: ldstr "'."
+			IL_01b0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01b5: stloc.s 14
+			IL_01b7: ldloc.s 14
+			IL_01b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01be: stloc.s 5
+			IL_01c0: ldloc.s 5
+			IL_01c2: isinst [System.Runtime]System.Exception
+			IL_01c7: dup
+			IL_01c8: brtrue IL_01d6
 
-				IL_0338: ldloc.s 9
-				IL_033a: ldc.r8 1
-				IL_0343: add
-				IL_0344: stloc.s 9
+			IL_01cd: pop
+			IL_01ce: ldloc.s 5
+			IL_01d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_01d5: throw
 
-				IL_0346: br IL_022f
+			IL_01d6: throw
+
+			IL_01d7: ldarg.0
+			IL_01d8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
+			IL_01dd: ldc.i4.1
+			IL_01de: newarr [System.Runtime]System.Object
+			IL_01e3: dup
+			IL_01e4: ldc.i4.0
+			IL_01e5: ldarg.0
+			IL_01e6: stelem.ref
+			IL_01e7: stloc.s 16
+			IL_01e9: ldloc.s 16
+			IL_01eb: ldarg.2
+			IL_01ec: ldloc.s 4
+			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01f3: stloc.s 6
+			IL_01f5: ldloc.s 6
+			IL_01f7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01fc: ldc.i4.0
+			IL_01fd: ceq
+			IL_01ff: stloc.s 17
+			IL_0201: ldloc.s 17
+			IL_0203: brfalse IL_0248
+
+			IL_0208: ldarg.3
+			IL_0209: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_020e: stloc.s 14
+			IL_0210: ldstr "Could not determine tag name for id '"
+			IL_0215: ldloc.s 14
+			IL_0217: call string [System.Runtime]System.String::Concat(string, string)
+			IL_021c: ldstr "'."
+			IL_0221: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0226: stloc.s 14
+			IL_0228: ldloc.s 14
+			IL_022a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_022f: stloc.s 7
+			IL_0231: ldloc.s 7
+			IL_0233: isinst [System.Runtime]System.Exception
+			IL_0238: dup
+			IL_0239: brtrue IL_0247
+
+			IL_023e: pop
+			IL_023f: ldloc.s 7
+			IL_0241: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0246: throw
+
+			IL_0247: throw
+
+			IL_0248: ldarg.0
+			IL_0249: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
+			IL_024e: ldc.i4.1
+			IL_024f: newarr [System.Runtime]System.Object
+			IL_0254: dup
+			IL_0255: ldc.i4.0
+			IL_0256: ldarg.0
+			IL_0257: stelem.ref
+			IL_0258: ldloc.s 6
+			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_025f: stloc.s 15
+			IL_0261: ldloc.s 15
+			IL_0263: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0268: stloc.s 14
+			IL_026a: ldstr "<\\/?"
+			IL_026f: ldloc.s 14
+			IL_0271: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0276: ldstr "\\b[^>]*>"
+			IL_027b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0280: stloc.s 14
+			IL_0282: ldloc.s 14
+			IL_0284: ldstr "gi"
+			IL_0289: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_028e: stloc.s 8
+			IL_0290: ldloc.s 8
+			IL_0292: ldstr "lastIndex"
+			IL_0297: ldloc.s 4
+			IL_0299: ldc.i4.1
+			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_029f: pop
+			IL_02a0: ldc.r8 0.0
+			IL_02a9: stloc.s 9
+			IL_02ab: ldc.r8 1
+			IL_02b4: neg
+			IL_02b5: stloc.s 18
+			IL_02b7: ldloc.s 18
+			IL_02b9: box [System.Runtime]System.Double
+			IL_02be: stloc.s 10
+			// loop start (head: IL_02c0)
+				IL_02c0: ldc.i4.1
+				IL_02c1: brfalse IL_0438
+
+				IL_02c6: ldloc.s 8
+				IL_02c8: ldstr "exec"
+				IL_02cd: ldarg.2
+				IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_02d3: stloc.s 11
+				IL_02d5: ldloc.s 11
+				IL_02d7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_02dc: ldc.i4.0
+				IL_02dd: ceq
+				IL_02df: stloc.s 17
+				IL_02e1: ldloc.s 17
+				IL_02e3: brfalse IL_02ed
+
+				IL_02e8: br IL_0438
+
+				IL_02ed: ldloc.s 11
+				IL_02ef: ldc.r8 0.0
+				IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_02fd: stloc.s 12
+				IL_02ff: ldloc.s 10
+				IL_0301: stloc.s 19
+				IL_0303: ldloc.s 19
+				IL_0305: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_030a: ldc.r8 0.0
+				IL_0313: clt
+				IL_0315: brfalse IL_032c
+
+				IL_031a: ldloc.s 11
+				IL_031c: ldstr "index"
+				IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0326: stloc.s 15
+				IL_0328: ldloc.s 15
+				IL_032a: stloc.s 10
+
+				IL_032c: ldloc.s 12
+				IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0333: stloc.s 15
+				IL_0335: ldc.i4.0
+				IL_0336: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_033b: brfalse IL_0364
+
+				IL_0340: ldloc.s 15
+				IL_0342: isinst [System.Runtime]System.String
+				IL_0347: dup
+				IL_0348: brfalse IL_0363
+
+				IL_034d: ldstr "</"
+				IL_0352: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+				IL_0357: box [System.Runtime]System.Boolean
+				IL_035c: stloc.s 15
+				IL_035e: br IL_0377
+
+				IL_0363: pop
+
+				IL_0364: ldloc.s 15
+				IL_0366: ldstr "startsWith"
+				IL_036b: ldstr "</"
+				IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0375: stloc.s 15
+
+				IL_0377: ldloc.s 15
+				IL_0379: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_037e: stloc.s 17
+				IL_0380: ldloc.s 17
+				IL_0382: brfalse IL_0425
+
+				IL_0387: ldloc.s 9
+				IL_0389: ldc.r8 1
+				IL_0392: sub
+				IL_0393: stloc.s 9
+				IL_0395: ldloc.s 9
+				IL_0397: stloc.s 18
+				IL_0399: ldloc.s 18
+				IL_039b: ldc.r8 0.0
+				IL_03a4: ceq
+				IL_03a6: brfalse IL_0420
+
+				IL_03ab: ldarg.2
+				IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_03b1: stloc.s 15
+				IL_03b3: ldloc.s 8
+				IL_03b5: ldstr "lastIndex"
+				IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_03bf: stloc.s 20
+				IL_03c1: ldc.i4.0
+				IL_03c2: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_03c7: brfalse IL_03ea
+
+				IL_03cc: ldloc.s 15
+				IL_03ce: isinst [System.Runtime]System.String
+				IL_03d3: dup
+				IL_03d4: brfalse IL_03e9
+
+				IL_03d9: ldloc.s 10
+				IL_03db: ldloc.s 20
+				IL_03dd: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+				IL_03e2: stloc.s 20
+				IL_03e4: br IL_03fc
+
+				IL_03e9: pop
+
+				IL_03ea: ldloc.s 15
+				IL_03ec: ldstr "substring"
+				IL_03f1: ldloc.s 10
+				IL_03f3: ldloc.s 20
+				IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_03fa: stloc.s 20
+
+				IL_03fc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0401: dup
+				IL_0402: ldstr "tagName"
+				IL_0407: ldloc.s 6
+				IL_0409: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_040e: dup
+				IL_040f: ldstr "html"
+				IL_0414: ldloc.s 20
+				IL_0416: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_041b: stloc.s 21
+				IL_041d: ldloc.s 21
+				IL_041f: ret
+
+				IL_0420: br IL_0433
+
+				IL_0425: ldloc.s 9
+				IL_0427: ldc.r8 1
+				IL_0430: add
+				IL_0431: stloc.s 9
+
+				IL_0433: br IL_02c0
 			// end loop
 
-			IL_034b: ldloc.s 6
-			IL_034d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0352: stloc.s 14
-			IL_0354: ldstr "Could not find a matching closing </"
-			IL_0359: ldloc.s 14
-			IL_035b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0360: ldstr "> for id '"
-			IL_0365: call string [System.Runtime]System.String::Concat(string, string)
-			IL_036a: ldarg.3
-			IL_036b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0370: stloc.s 14
-			IL_0372: ldloc.s 14
-			IL_0374: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0379: ldstr "'."
-			IL_037e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0383: stloc.s 14
-			IL_0385: ldloc.s 14
-			IL_0387: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_038c: stloc.s 13
-			IL_038e: ldloc.s 13
-			IL_0390: isinst [System.Runtime]System.Exception
-			IL_0395: dup
-			IL_0396: brtrue IL_03a4
+			IL_0438: ldloc.s 6
+			IL_043a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_043f: stloc.s 14
+			IL_0441: ldstr "Could not find a matching closing </"
+			IL_0446: ldloc.s 14
+			IL_0448: call string [System.Runtime]System.String::Concat(string, string)
+			IL_044d: ldstr "> for id '"
+			IL_0452: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0457: ldarg.3
+			IL_0458: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_045d: stloc.s 14
+			IL_045f: ldloc.s 14
+			IL_0461: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0466: ldstr "'."
+			IL_046b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0470: stloc.s 14
+			IL_0472: ldloc.s 14
+			IL_0474: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0479: stloc.s 13
+			IL_047b: ldloc.s 13
+			IL_047d: isinst [System.Runtime]System.Exception
+			IL_0482: dup
+			IL_0483: brtrue IL_0491
 
-			IL_039b: pop
-			IL_039c: ldloc.s 13
-			IL_039e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_03a3: throw
+			IL_0488: pop
+			IL_0489: ldloc.s 13
+			IL_048b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0490: throw
 
-			IL_03a4: throw
+			IL_0491: throw
 
-			IL_03a5: ldnull
-			IL_03a6: ret
+			IL_0492: ldnull
+			IL_0493: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -4592,7 +4768,7 @@
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
-			// Code size: 458 (0x1ca)
+			// Code size: 584 (0x248)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -4705,76 +4881,119 @@
 
 			IL_00e7: ldloc.3
 			IL_00e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ed: ldstr "indexOf"
-			IL_00f2: ldstr "#"
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00fc: stloc.s 4
-			IL_00fe: ldloc.s 4
-			IL_0100: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0105: ldc.r8 0.0
-			IL_010e: clt
-			IL_0110: ldc.i4.0
-			IL_0111: ceq
-			IL_0113: brfalse IL_0143
+			IL_00ed: stloc.s 10
+			IL_00ef: ldc.i4.0
+			IL_00f0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00f5: brfalse IL_0117
 
-			IL_0118: ldloc.3
-			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011e: ldstr "substring"
-			IL_0123: ldc.r8 0.0
-			IL_012c: box [System.Runtime]System.Double
-			IL_0131: ldloc.s 4
-			IL_0133: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0138: stloc.s 10
-			IL_013a: ldloc.s 10
-			IL_013c: stloc.s 5
-			IL_013e: br IL_0146
+			IL_00fa: ldloc.s 10
+			IL_00fc: castclass [System.Runtime]System.String
+			IL_0101: ldstr "#"
+			IL_0106: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_010b: box [System.Runtime]System.Double
+			IL_0110: stloc.s 4
+			IL_0112: br IL_012a
 
-			IL_0143: ldloc.3
-			IL_0144: stloc.s 5
+			IL_0117: ldloc.s 10
+			IL_0119: ldstr "indexOf"
+			IL_011e: ldstr "#"
+			IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0128: stloc.s 4
 
-			IL_0146: ldloc.s 4
-			IL_0148: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_014d: ldc.r8 0.0
-			IL_0156: clt
-			IL_0158: ldc.i4.0
-			IL_0159: ceq
-			IL_015b: brfalse IL_0193
+			IL_012a: ldloc.s 4
+			IL_012c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0131: ldc.r8 0.0
+			IL_013a: clt
+			IL_013c: ldc.i4.0
+			IL_013d: ceq
+			IL_013f: brfalse IL_01a1
 
-			IL_0160: ldloc.3
-			IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0166: stloc.s 10
-			IL_0168: ldloc.s 4
-			IL_016a: ldc.r8 1
-			IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0178: stloc.s 14
+			IL_0144: ldloc.3
+			IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014a: stloc.s 10
+			IL_014c: ldc.i4.0
+			IL_014d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0152: brfalse IL_017a
+
+			IL_0157: ldloc.s 10
+			IL_0159: castclass [System.Runtime]System.String
+			IL_015e: ldc.r8 0.0
+			IL_0167: box [System.Runtime]System.Double
+			IL_016c: ldloc.s 4
+			IL_016e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_0173: stloc.s 10
+			IL_0175: br IL_0198
+
 			IL_017a: ldloc.s 10
 			IL_017c: ldstr "substring"
-			IL_0181: ldloc.s 14
-			IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0188: stloc.s 10
-			IL_018a: ldloc.s 10
-			IL_018c: stloc.s 6
-			IL_018e: br IL_019a
+			IL_0181: ldc.r8 0.0
+			IL_018a: box [System.Runtime]System.Double
+			IL_018f: ldloc.s 4
+			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0196: stloc.s 10
 
-			IL_0193: ldstr ""
-			IL_0198: stloc.s 6
+			IL_0198: ldloc.s 10
+			IL_019a: stloc.s 5
+			IL_019c: br IL_01a4
 
-			IL_019a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_019f: dup
-			IL_01a0: ldstr "href"
-			IL_01a5: ldloc.3
-			IL_01a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01ab: dup
-			IL_01ac: ldstr "filePart"
-			IL_01b1: ldloc.s 5
-			IL_01b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01b8: dup
-			IL_01b9: ldstr "fragment"
-			IL_01be: ldloc.s 6
-			IL_01c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01c5: stloc.s 16
-			IL_01c7: ldloc.s 16
-			IL_01c9: ret
+			IL_01a1: ldloc.3
+			IL_01a2: stloc.s 5
+
+			IL_01a4: ldloc.s 4
+			IL_01a6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_01ab: ldc.r8 0.0
+			IL_01b4: clt
+			IL_01b6: ldc.i4.0
+			IL_01b7: ceq
+			IL_01b9: brfalse IL_0211
+
+			IL_01be: ldloc.3
+			IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c4: stloc.s 10
+			IL_01c6: ldloc.s 4
+			IL_01c8: ldc.r8 1
+			IL_01d1: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01d6: stloc.s 14
+			IL_01d8: ldc.i4.0
+			IL_01d9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01de: brfalse IL_01f8
+
+			IL_01e3: ldloc.s 10
+			IL_01e5: castclass [System.Runtime]System.String
+			IL_01ea: ldloc.s 14
+			IL_01ec: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_01f1: stloc.s 10
+			IL_01f3: br IL_0208
+
+			IL_01f8: ldloc.s 10
+			IL_01fa: ldstr "substring"
+			IL_01ff: ldloc.s 14
+			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0206: stloc.s 10
+
+			IL_0208: ldloc.s 10
+			IL_020a: stloc.s 6
+			IL_020c: br IL_0218
+
+			IL_0211: ldstr ""
+			IL_0216: stloc.s 6
+
+			IL_0218: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_021d: dup
+			IL_021e: ldstr "href"
+			IL_0223: ldloc.3
+			IL_0224: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0229: dup
+			IL_022a: ldstr "filePart"
+			IL_022f: ldloc.s 5
+			IL_0231: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0236: dup
+			IL_0237: ldstr "fragment"
+			IL_023c: ldloc.s 6
+			IL_023e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0243: stloc.s 16
+			IL_0245: ldloc.s 16
+			IL_0247: ret
 		} // end of method resolveSectionLinkFromMultipageIndexHtml::__js_call__
 
 	} // end of class resolveSectionLinkFromMultipageIndexHtml
@@ -5257,7 +5476,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 3007 (0xbbf)
+			// Code size: 3152 (0xc50)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -5286,8 +5505,8 @@
 				[23] bool,
 				[24] object,
 				[25] object,
-				[26] string,
-				[27] object,
+				[26] object,
+				[27] string,
 				[28] object,
 				[29] object,
 				[30] object,
@@ -5453,11 +5672,11 @@
 			IL_012d: dup
 			IL_012e: ldc.i4.s 25
 			IL_0130: ldelem.ref
-			IL_0131: castclass [System.Runtime]System.String
-			IL_0136: stloc.s 26
-			IL_0138: dup
-			IL_0139: ldc.i4.s 26
-			IL_013b: ldelem.ref
+			IL_0131: stloc.s 26
+			IL_0133: dup
+			IL_0134: ldc.i4.s 26
+			IL_0136: ldelem.ref
+			IL_0137: castclass [System.Runtime]System.String
 			IL_013c: stloc.s 27
 			IL_013e: dup
 			IL_013f: ldc.i4.s 27
@@ -5490,7 +5709,7 @@
 
 			IL_0172: ldloc.0
 			IL_0173: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0178: switch (IL_018d, IL_050b, IL_0765, IL_08f6)
+			IL_0178: switch (IL_018d, IL_054e, IL_07d1, IL_0987)
 
 			IL_018d: ldarg.0
 			IL_018e: ldc.i4.1
@@ -5684,978 +5903,1039 @@
 			IL_039d: ldloc.s 25
 			IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_03a4: stloc.s 22
-			IL_03a6: ldloc.s 22
-			IL_03a8: ldstr "trim"
-			IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_03b2: stloc.s 9
-			IL_03b4: ldstr ""
-			IL_03b9: stloc.s 10
-			IL_03bb: ldloc.1
-			IL_03bc: ldstr "auto"
-			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03c6: stloc.s 22
-			IL_03c8: ldloc.s 22
-			IL_03ca: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_03cf: stloc.s 23
-			IL_03d1: ldloc.s 23
-			IL_03d3: brfalse IL_07c3
+			IL_03a6: ldc.i4.0
+			IL_03a7: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_03ac: brfalse IL_03c4
 
-			IL_03d8: ldloc.1
-			IL_03d9: ldstr "indexUrl"
-			IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03e3: stloc.s 22
-			IL_03e5: ldloc.s 22
-			IL_03e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_03ec: stloc.s 22
-			IL_03ee: ldloc.s 22
-			IL_03f0: ldstr "trim"
-			IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_03fa: stloc.s 11
-			IL_03fc: ldarg.0
-			IL_03fd: ldc.i4.1
-			IL_03fe: ldelem.ref
-			IL_03ff: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0404: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0409: ldc.i4.1
-			IL_040a: newarr [System.Runtime]System.Object
-			IL_040f: dup
-			IL_0410: ldc.i4.0
-			IL_0411: ldarg.0
-			IL_0412: ldc.i4.1
-			IL_0413: ldelem.ref
-			IL_0414: stelem.ref
-			IL_0415: stloc.s 21
-			IL_0417: ldloc.s 21
-			IL_0419: ldloc.s 11
-			IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0420: stloc.s 22
-			IL_0422: ldloc.0
-			IL_0423: ldc.i4.1
-			IL_0424: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0429: ldloc.0
-			IL_042a: ldloc.s 22
-			IL_042c: ldarg.0
-			IL_042d: ldc.i4.1
-			IL_042e: ldloc.0
-			IL_042f: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0434: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0439: ldloc.0
-			IL_043a: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_043f: dup
-			IL_0440: ldc.i4.0
-			IL_0441: ldloc.1
-			IL_0442: stelem.ref
-			IL_0443: dup
-			IL_0444: ldc.i4.1
-			IL_0445: ldloc.2
-			IL_0446: stelem.ref
-			IL_0447: dup
-			IL_0448: ldc.i4.2
-			IL_0449: ldloc.3
-			IL_044a: stelem.ref
-			IL_044b: dup
-			IL_044c: ldc.i4.3
-			IL_044d: ldloc.s 4
-			IL_044f: stelem.ref
-			IL_0450: dup
-			IL_0451: ldc.i4.4
-			IL_0452: ldloc.s 5
-			IL_0454: stelem.ref
-			IL_0455: dup
-			IL_0456: ldc.i4.5
-			IL_0457: ldloc.s 6
-			IL_0459: stelem.ref
-			IL_045a: dup
-			IL_045b: ldc.i4.6
-			IL_045c: ldloc.s 7
-			IL_045e: stelem.ref
-			IL_045f: dup
-			IL_0460: ldc.i4.7
-			IL_0461: ldloc.s 8
-			IL_0463: stelem.ref
-			IL_0464: dup
-			IL_0465: ldc.i4.8
-			IL_0466: ldloc.s 9
-			IL_0468: stelem.ref
-			IL_0469: dup
-			IL_046a: ldc.i4.s 9
-			IL_046c: ldloc.s 10
-			IL_046e: stelem.ref
-			IL_046f: dup
-			IL_0470: ldc.i4.s 10
-			IL_0472: ldloc.s 11
-			IL_0474: stelem.ref
-			IL_0475: dup
-			IL_0476: ldc.i4.s 11
-			IL_0478: ldloc.s 12
-			IL_047a: stelem.ref
-			IL_047b: dup
-			IL_047c: ldc.i4.s 12
-			IL_047e: ldloc.s 13
-			IL_0480: stelem.ref
-			IL_0481: dup
-			IL_0482: ldc.i4.s 13
-			IL_0484: ldloc.s 14
-			IL_0486: stelem.ref
-			IL_0487: dup
-			IL_0488: ldc.i4.s 14
-			IL_048a: ldloc.s 15
-			IL_048c: stelem.ref
-			IL_048d: dup
-			IL_048e: ldc.i4.s 15
-			IL_0490: ldloc.s 16
+			IL_03b1: ldloc.s 22
+			IL_03b3: castclass [System.Runtime]System.String
+			IL_03b8: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_03bd: stloc.s 9
+			IL_03bf: br IL_03d2
+
+			IL_03c4: ldloc.s 22
+			IL_03c6: ldstr "trim"
+			IL_03cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_03d0: stloc.s 9
+
+			IL_03d2: ldstr ""
+			IL_03d7: stloc.s 10
+			IL_03d9: ldloc.1
+			IL_03da: ldstr "auto"
+			IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e4: stloc.s 22
+			IL_03e6: ldloc.s 22
+			IL_03e8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03ed: stloc.s 23
+			IL_03ef: ldloc.s 23
+			IL_03f1: brfalse IL_082f
+
+			IL_03f6: ldloc.1
+			IL_03f7: ldstr "indexUrl"
+			IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0401: stloc.s 22
+			IL_0403: ldloc.s 22
+			IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_040a: stloc.s 22
+			IL_040c: ldc.i4.0
+			IL_040d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0412: brfalse IL_0431
+
+			IL_0417: ldloc.s 22
+			IL_0419: isinst [System.Runtime]System.String
+			IL_041e: dup
+			IL_041f: brfalse IL_0430
+
+			IL_0424: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0429: stloc.s 11
+			IL_042b: br IL_043f
+
+			IL_0430: pop
+
+			IL_0431: ldloc.s 22
+			IL_0433: ldstr "trim"
+			IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_043d: stloc.s 11
+
+			IL_043f: ldarg.0
+			IL_0440: ldc.i4.1
+			IL_0441: ldelem.ref
+			IL_0442: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0447: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_044c: ldc.i4.1
+			IL_044d: newarr [System.Runtime]System.Object
+			IL_0452: dup
+			IL_0453: ldc.i4.0
+			IL_0454: ldarg.0
+			IL_0455: ldc.i4.1
+			IL_0456: ldelem.ref
+			IL_0457: stelem.ref
+			IL_0458: stloc.s 21
+			IL_045a: ldloc.s 21
+			IL_045c: ldloc.s 11
+			IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0463: stloc.s 22
+			IL_0465: ldloc.0
+			IL_0466: ldc.i4.1
+			IL_0467: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_046c: ldloc.0
+			IL_046d: ldloc.s 22
+			IL_046f: ldarg.0
+			IL_0470: ldc.i4.1
+			IL_0471: ldloc.0
+			IL_0472: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0477: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_047c: ldloc.0
+			IL_047d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0482: dup
+			IL_0483: ldc.i4.0
+			IL_0484: ldloc.1
+			IL_0485: stelem.ref
+			IL_0486: dup
+			IL_0487: ldc.i4.1
+			IL_0488: ldloc.2
+			IL_0489: stelem.ref
+			IL_048a: dup
+			IL_048b: ldc.i4.2
+			IL_048c: ldloc.3
+			IL_048d: stelem.ref
+			IL_048e: dup
+			IL_048f: ldc.i4.3
+			IL_0490: ldloc.s 4
 			IL_0492: stelem.ref
 			IL_0493: dup
-			IL_0494: ldc.i4.s 16
-			IL_0496: ldloc.s 17
-			IL_0498: stelem.ref
-			IL_0499: dup
-			IL_049a: ldc.i4.s 17
-			IL_049c: ldloc.s 18
-			IL_049e: stelem.ref
-			IL_049f: dup
-			IL_04a0: ldc.i4.s 18
-			IL_04a2: ldloc.s 19
-			IL_04a4: stelem.ref
-			IL_04a5: dup
-			IL_04a6: ldc.i4.s 19
-			IL_04a8: ldloc.s 20
-			IL_04aa: stelem.ref
-			IL_04ab: dup
-			IL_04ac: ldc.i4.s 20
-			IL_04ae: ldloc.s 21
-			IL_04b0: stelem.ref
-			IL_04b1: dup
-			IL_04b2: ldc.i4.s 21
-			IL_04b4: ldloc.s 22
-			IL_04b6: stelem.ref
-			IL_04b7: dup
-			IL_04b8: ldc.i4.s 22
-			IL_04ba: ldloc.s 23
-			IL_04bc: box [System.Runtime]System.Boolean
-			IL_04c1: stelem.ref
-			IL_04c2: dup
-			IL_04c3: ldc.i4.s 23
-			IL_04c5: ldloc.s 24
-			IL_04c7: stelem.ref
-			IL_04c8: dup
-			IL_04c9: ldc.i4.s 24
-			IL_04cb: ldloc.s 25
-			IL_04cd: stelem.ref
-			IL_04ce: dup
-			IL_04cf: ldc.i4.s 25
-			IL_04d1: ldloc.s 26
-			IL_04d3: stelem.ref
-			IL_04d4: dup
-			IL_04d5: ldc.i4.s 26
-			IL_04d7: ldloc.s 27
-			IL_04d9: stelem.ref
-			IL_04da: dup
-			IL_04db: ldc.i4.s 27
-			IL_04dd: ldloc.s 28
-			IL_04df: stelem.ref
-			IL_04e0: dup
-			IL_04e1: ldc.i4.s 28
-			IL_04e3: ldloc.s 29
-			IL_04e5: stelem.ref
-			IL_04e6: dup
-			IL_04e7: ldc.i4.s 29
-			IL_04e9: ldloc.s 30
-			IL_04eb: stelem.ref
-			IL_04ec: dup
-			IL_04ed: ldc.i4.s 30
-			IL_04ef: ldloc.s 31
-			IL_04f1: stelem.ref
-			IL_04f2: dup
-			IL_04f3: ldc.i4.s 31
-			IL_04f5: ldloc.s 32
-			IL_04f7: stelem.ref
-			IL_04f8: dup
-			IL_04f9: ldc.i4.s 32
-			IL_04fb: ldloc.s 33
-			IL_04fd: stelem.ref
-			IL_04fe: pop
-			IL_04ff: ldloc.0
-			IL_0500: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0505: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_050a: ret
+			IL_0494: ldc.i4.4
+			IL_0495: ldloc.s 5
+			IL_0497: stelem.ref
+			IL_0498: dup
+			IL_0499: ldc.i4.5
+			IL_049a: ldloc.s 6
+			IL_049c: stelem.ref
+			IL_049d: dup
+			IL_049e: ldc.i4.6
+			IL_049f: ldloc.s 7
+			IL_04a1: stelem.ref
+			IL_04a2: dup
+			IL_04a3: ldc.i4.7
+			IL_04a4: ldloc.s 8
+			IL_04a6: stelem.ref
+			IL_04a7: dup
+			IL_04a8: ldc.i4.8
+			IL_04a9: ldloc.s 9
+			IL_04ab: stelem.ref
+			IL_04ac: dup
+			IL_04ad: ldc.i4.s 9
+			IL_04af: ldloc.s 10
+			IL_04b1: stelem.ref
+			IL_04b2: dup
+			IL_04b3: ldc.i4.s 10
+			IL_04b5: ldloc.s 11
+			IL_04b7: stelem.ref
+			IL_04b8: dup
+			IL_04b9: ldc.i4.s 11
+			IL_04bb: ldloc.s 12
+			IL_04bd: stelem.ref
+			IL_04be: dup
+			IL_04bf: ldc.i4.s 12
+			IL_04c1: ldloc.s 13
+			IL_04c3: stelem.ref
+			IL_04c4: dup
+			IL_04c5: ldc.i4.s 13
+			IL_04c7: ldloc.s 14
+			IL_04c9: stelem.ref
+			IL_04ca: dup
+			IL_04cb: ldc.i4.s 14
+			IL_04cd: ldloc.s 15
+			IL_04cf: stelem.ref
+			IL_04d0: dup
+			IL_04d1: ldc.i4.s 15
+			IL_04d3: ldloc.s 16
+			IL_04d5: stelem.ref
+			IL_04d6: dup
+			IL_04d7: ldc.i4.s 16
+			IL_04d9: ldloc.s 17
+			IL_04db: stelem.ref
+			IL_04dc: dup
+			IL_04dd: ldc.i4.s 17
+			IL_04df: ldloc.s 18
+			IL_04e1: stelem.ref
+			IL_04e2: dup
+			IL_04e3: ldc.i4.s 18
+			IL_04e5: ldloc.s 19
+			IL_04e7: stelem.ref
+			IL_04e8: dup
+			IL_04e9: ldc.i4.s 19
+			IL_04eb: ldloc.s 20
+			IL_04ed: stelem.ref
+			IL_04ee: dup
+			IL_04ef: ldc.i4.s 20
+			IL_04f1: ldloc.s 21
+			IL_04f3: stelem.ref
+			IL_04f4: dup
+			IL_04f5: ldc.i4.s 21
+			IL_04f7: ldloc.s 22
+			IL_04f9: stelem.ref
+			IL_04fa: dup
+			IL_04fb: ldc.i4.s 22
+			IL_04fd: ldloc.s 23
+			IL_04ff: box [System.Runtime]System.Boolean
+			IL_0504: stelem.ref
+			IL_0505: dup
+			IL_0506: ldc.i4.s 23
+			IL_0508: ldloc.s 24
+			IL_050a: stelem.ref
+			IL_050b: dup
+			IL_050c: ldc.i4.s 24
+			IL_050e: ldloc.s 25
+			IL_0510: stelem.ref
+			IL_0511: dup
+			IL_0512: ldc.i4.s 25
+			IL_0514: ldloc.s 26
+			IL_0516: stelem.ref
+			IL_0517: dup
+			IL_0518: ldc.i4.s 26
+			IL_051a: ldloc.s 27
+			IL_051c: stelem.ref
+			IL_051d: dup
+			IL_051e: ldc.i4.s 27
+			IL_0520: ldloc.s 28
+			IL_0522: stelem.ref
+			IL_0523: dup
+			IL_0524: ldc.i4.s 28
+			IL_0526: ldloc.s 29
+			IL_0528: stelem.ref
+			IL_0529: dup
+			IL_052a: ldc.i4.s 29
+			IL_052c: ldloc.s 30
+			IL_052e: stelem.ref
+			IL_052f: dup
+			IL_0530: ldc.i4.s 30
+			IL_0532: ldloc.s 31
+			IL_0534: stelem.ref
+			IL_0535: dup
+			IL_0536: ldc.i4.s 31
+			IL_0538: ldloc.s 32
+			IL_053a: stelem.ref
+			IL_053b: dup
+			IL_053c: ldc.i4.s 32
+			IL_053e: ldloc.s 33
+			IL_0540: stelem.ref
+			IL_0541: pop
+			IL_0542: ldloc.0
+			IL_0543: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0548: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_054d: ret
 
-			IL_050b: ldloc.0
-			IL_050c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
-			IL_0511: stloc.s 12
-			IL_0513: ldarg.0
-			IL_0514: ldc.i4.1
-			IL_0515: ldelem.ref
-			IL_0516: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_051b: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
-			IL_0520: ldc.i4.1
-			IL_0521: newarr [System.Runtime]System.Object
-			IL_0526: dup
-			IL_0527: ldc.i4.0
-			IL_0528: ldarg.0
-			IL_0529: ldc.i4.1
-			IL_052a: ldelem.ref
-			IL_052b: stelem.ref
-			IL_052c: stloc.s 21
-			IL_052e: ldloc.1
-			IL_052f: ldstr "section"
-			IL_0534: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0539: stloc.s 22
-			IL_053b: ldloc.s 22
-			IL_053d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0542: stloc.s 22
-			IL_0544: ldloc.s 22
-			IL_0546: ldstr "trim"
-			IL_054b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0550: stloc.s 22
-			IL_0552: ldloc.s 21
-			IL_0554: ldloc.s 12
-			IL_0556: ldloc.s 22
-			IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_055d: stloc.s 13
-			IL_055f: ldloc.s 13
-			IL_0561: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0566: ldc.i4.0
-			IL_0567: ceq
-			IL_0569: stloc.s 23
-			IL_056b: ldloc.s 23
-			IL_056d: brfalse IL_05e9
+			IL_054e: ldloc.0
+			IL_054f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_0554: stloc.s 12
+			IL_0556: ldarg.0
+			IL_0557: ldc.i4.1
+			IL_0558: ldelem.ref
+			IL_0559: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_055e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
+			IL_0563: stloc.s 22
+			IL_0565: ldc.i4.1
+			IL_0566: newarr [System.Runtime]System.Object
+			IL_056b: dup
+			IL_056c: ldc.i4.0
+			IL_056d: ldarg.0
+			IL_056e: ldc.i4.1
+			IL_056f: ldelem.ref
+			IL_0570: stelem.ref
+			IL_0571: stloc.s 21
+			IL_0573: ldloc.1
+			IL_0574: ldstr "section"
+			IL_0579: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_057e: stloc.s 26
+			IL_0580: ldloc.s 26
+			IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0587: stloc.s 26
+			IL_0589: ldc.i4.0
+			IL_058a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_058f: brfalse IL_05ae
 
-			IL_0572: ldloc.1
-			IL_0573: ldstr "section"
-			IL_0578: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_057d: stloc.s 22
-			IL_057f: ldloc.s 22
-			IL_0581: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0586: stloc.s 26
-			IL_0588: ldstr "Could not find section '"
-			IL_058d: ldloc.s 26
-			IL_058f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0594: ldstr "' in multipage index: "
-			IL_0599: call string [System.Runtime]System.String::Concat(string, string)
-			IL_059e: ldloc.s 11
-			IL_05a0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05a5: stloc.s 26
-			IL_05a7: ldloc.s 26
-			IL_05a9: call string [System.Runtime]System.String::Concat(string, string)
-			IL_05ae: stloc.s 26
-			IL_05b0: ldloc.s 26
-			IL_05b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_05b7: stloc.s 14
-			IL_05b9: ldloc.0
-			IL_05ba: ldc.i4.m1
-			IL_05bb: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_05c0: ldloc.0
-			IL_05c1: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_05cb: ldarg.0
-			IL_05cc: ldc.i4.1
-			IL_05cd: newarr [System.Runtime]System.Object
-			IL_05d2: dup
-			IL_05d3: ldc.i4.0
-			IL_05d4: ldloc.s 14
-			IL_05d6: stelem.ref
-			IL_05d7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_05dc: pop
-			IL_05dd: ldloc.0
-			IL_05de: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_05e3: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_05e8: ret
+			IL_0594: ldloc.s 26
+			IL_0596: isinst [System.Runtime]System.String
+			IL_059b: dup
+			IL_059c: brfalse IL_05ad
 
-			IL_05e9: ldarg.0
-			IL_05ea: ldc.i4.1
-			IL_05eb: ldelem.ref
-			IL_05ec: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_05f1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_05f6: stloc.s 22
-			IL_05f8: ldloc.s 13
-			IL_05fa: ldstr "filePart"
-			IL_05ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0604: stloc.s 27
-			IL_0606: ldloc.s 27
-			IL_0608: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_060d: stloc.s 23
-			IL_060f: ldloc.s 23
-			IL_0611: brtrue IL_062d
+			IL_05a1: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_05a6: stloc.s 26
+			IL_05a8: br IL_05bc
 
-			IL_0616: ldloc.s 13
-			IL_0618: ldstr "href"
-			IL_061d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0622: stloc.s 28
-			IL_0624: ldloc.s 28
-			IL_0626: stloc.s 29
-			IL_0628: br IL_0631
+			IL_05ad: pop
 
-			IL_062d: ldloc.s 27
-			IL_062f: stloc.s 29
+			IL_05ae: ldloc.s 26
+			IL_05b0: ldstr "trim"
+			IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_05ba: stloc.s 26
 
-			IL_0631: ldloc.s 22
-			IL_0633: dup
-			IL_0634: ldloc.s 29
-			IL_0636: ldloc.s 11
-			IL_0638: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
-			IL_063d: stloc.s 22
-			IL_063f: ldloc.s 22
-			IL_0641: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0646: stloc.s 22
-			IL_0648: ldloc.s 22
-			IL_064a: ldstr "toString"
-			IL_064f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0654: stloc.s 15
-			IL_0656: ldarg.0
-			IL_0657: ldc.i4.1
-			IL_0658: ldelem.ref
-			IL_0659: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_065e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0663: ldc.i4.1
-			IL_0664: newarr [System.Runtime]System.Object
-			IL_0669: dup
-			IL_066a: ldc.i4.0
-			IL_066b: ldarg.0
-			IL_066c: ldc.i4.1
-			IL_066d: ldelem.ref
-			IL_066e: stelem.ref
-			IL_066f: stloc.s 21
-			IL_0671: ldloc.s 21
-			IL_0673: ldloc.s 15
-			IL_0675: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_067a: stloc.s 22
-			IL_067c: ldloc.0
-			IL_067d: ldc.i4.2
-			IL_067e: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0683: ldloc.0
-			IL_0684: ldloc.s 22
-			IL_0686: ldarg.0
-			IL_0687: ldc.i4.2
-			IL_0688: ldloc.0
-			IL_0689: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_068e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0693: ldloc.0
-			IL_0694: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0699: dup
-			IL_069a: ldc.i4.0
-			IL_069b: ldloc.1
-			IL_069c: stelem.ref
-			IL_069d: dup
-			IL_069e: ldc.i4.1
-			IL_069f: ldloc.2
-			IL_06a0: stelem.ref
-			IL_06a1: dup
-			IL_06a2: ldc.i4.2
-			IL_06a3: ldloc.3
-			IL_06a4: stelem.ref
-			IL_06a5: dup
-			IL_06a6: ldc.i4.3
-			IL_06a7: ldloc.s 4
-			IL_06a9: stelem.ref
-			IL_06aa: dup
-			IL_06ab: ldc.i4.4
-			IL_06ac: ldloc.s 5
-			IL_06ae: stelem.ref
-			IL_06af: dup
-			IL_06b0: ldc.i4.5
-			IL_06b1: ldloc.s 6
-			IL_06b3: stelem.ref
-			IL_06b4: dup
-			IL_06b5: ldc.i4.6
-			IL_06b6: ldloc.s 7
-			IL_06b8: stelem.ref
-			IL_06b9: dup
-			IL_06ba: ldc.i4.7
-			IL_06bb: ldloc.s 8
-			IL_06bd: stelem.ref
-			IL_06be: dup
-			IL_06bf: ldc.i4.8
-			IL_06c0: ldloc.s 9
-			IL_06c2: stelem.ref
-			IL_06c3: dup
-			IL_06c4: ldc.i4.s 9
-			IL_06c6: ldloc.s 10
-			IL_06c8: stelem.ref
-			IL_06c9: dup
-			IL_06ca: ldc.i4.s 10
-			IL_06cc: ldloc.s 11
-			IL_06ce: stelem.ref
-			IL_06cf: dup
-			IL_06d0: ldc.i4.s 11
-			IL_06d2: ldloc.s 12
-			IL_06d4: stelem.ref
+			IL_05bc: ldloc.s 22
+			IL_05be: ldloc.s 21
+			IL_05c0: ldloc.s 12
+			IL_05c2: ldloc.s 26
+			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05c9: stloc.s 13
+			IL_05cb: ldloc.s 13
+			IL_05cd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_05d2: ldc.i4.0
+			IL_05d3: ceq
+			IL_05d5: stloc.s 23
+			IL_05d7: ldloc.s 23
+			IL_05d9: brfalse IL_0655
+
+			IL_05de: ldloc.1
+			IL_05df: ldstr "section"
+			IL_05e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05e9: stloc.s 26
+			IL_05eb: ldloc.s 26
+			IL_05ed: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_05f2: stloc.s 27
+			IL_05f4: ldstr "Could not find section '"
+			IL_05f9: ldloc.s 27
+			IL_05fb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0600: ldstr "' in multipage index: "
+			IL_0605: call string [System.Runtime]System.String::Concat(string, string)
+			IL_060a: ldloc.s 11
+			IL_060c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0611: stloc.s 27
+			IL_0613: ldloc.s 27
+			IL_0615: call string [System.Runtime]System.String::Concat(string, string)
+			IL_061a: stloc.s 27
+			IL_061c: ldloc.s 27
+			IL_061e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0623: stloc.s 14
+			IL_0625: ldloc.0
+			IL_0626: ldc.i4.m1
+			IL_0627: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_062c: ldloc.0
+			IL_062d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0632: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0637: ldarg.0
+			IL_0638: ldc.i4.1
+			IL_0639: newarr [System.Runtime]System.Object
+			IL_063e: dup
+			IL_063f: ldc.i4.0
+			IL_0640: ldloc.s 14
+			IL_0642: stelem.ref
+			IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0648: pop
+			IL_0649: ldloc.0
+			IL_064a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_064f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0654: ret
+
+			IL_0655: ldarg.0
+			IL_0656: ldc.i4.1
+			IL_0657: ldelem.ref
+			IL_0658: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_065d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_0662: stloc.s 26
+			IL_0664: ldloc.s 13
+			IL_0666: ldstr "filePart"
+			IL_066b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0670: stloc.s 22
+			IL_0672: ldloc.s 22
+			IL_0674: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0679: stloc.s 23
+			IL_067b: ldloc.s 23
+			IL_067d: brtrue IL_0699
+
+			IL_0682: ldloc.s 13
+			IL_0684: ldstr "href"
+			IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_068e: stloc.s 28
+			IL_0690: ldloc.s 28
+			IL_0692: stloc.s 29
+			IL_0694: br IL_069d
+
+			IL_0699: ldloc.s 22
+			IL_069b: stloc.s 29
+
+			IL_069d: ldloc.s 26
+			IL_069f: dup
+			IL_06a0: ldloc.s 29
+			IL_06a2: ldloc.s 11
+			IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
+			IL_06a9: stloc.s 26
+			IL_06ab: ldloc.s 26
+			IL_06ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06b2: stloc.s 26
+			IL_06b4: ldloc.s 26
+			IL_06b6: ldstr "toString"
+			IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_06c0: stloc.s 15
+			IL_06c2: ldarg.0
+			IL_06c3: ldc.i4.1
+			IL_06c4: ldelem.ref
+			IL_06c5: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_06ca: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_06cf: ldc.i4.1
+			IL_06d0: newarr [System.Runtime]System.Object
 			IL_06d5: dup
-			IL_06d6: ldc.i4.s 12
-			IL_06d8: ldloc.s 13
+			IL_06d6: ldc.i4.0
+			IL_06d7: ldarg.0
+			IL_06d8: ldc.i4.1
+			IL_06d9: ldelem.ref
 			IL_06da: stelem.ref
-			IL_06db: dup
-			IL_06dc: ldc.i4.s 13
-			IL_06de: ldloc.s 14
-			IL_06e0: stelem.ref
-			IL_06e1: dup
-			IL_06e2: ldc.i4.s 14
-			IL_06e4: ldloc.s 15
-			IL_06e6: stelem.ref
-			IL_06e7: dup
-			IL_06e8: ldc.i4.s 15
-			IL_06ea: ldloc.s 16
-			IL_06ec: stelem.ref
-			IL_06ed: dup
-			IL_06ee: ldc.i4.s 16
-			IL_06f0: ldloc.s 17
-			IL_06f2: stelem.ref
-			IL_06f3: dup
-			IL_06f4: ldc.i4.s 17
-			IL_06f6: ldloc.s 18
-			IL_06f8: stelem.ref
-			IL_06f9: dup
-			IL_06fa: ldc.i4.s 18
-			IL_06fc: ldloc.s 19
-			IL_06fe: stelem.ref
-			IL_06ff: dup
-			IL_0700: ldc.i4.s 19
-			IL_0702: ldloc.s 20
-			IL_0704: stelem.ref
+			IL_06db: stloc.s 21
+			IL_06dd: ldloc.s 21
+			IL_06df: ldloc.s 15
+			IL_06e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_06e6: stloc.s 26
+			IL_06e8: ldloc.0
+			IL_06e9: ldc.i4.2
+			IL_06ea: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_06ef: ldloc.0
+			IL_06f0: ldloc.s 26
+			IL_06f2: ldarg.0
+			IL_06f3: ldc.i4.2
+			IL_06f4: ldloc.0
+			IL_06f5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_06fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_06ff: ldloc.0
+			IL_0700: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
 			IL_0705: dup
-			IL_0706: ldc.i4.s 20
-			IL_0708: ldloc.s 21
-			IL_070a: stelem.ref
-			IL_070b: dup
-			IL_070c: ldc.i4.s 21
-			IL_070e: ldloc.s 22
+			IL_0706: ldc.i4.0
+			IL_0707: ldloc.1
+			IL_0708: stelem.ref
+			IL_0709: dup
+			IL_070a: ldc.i4.1
+			IL_070b: ldloc.2
+			IL_070c: stelem.ref
+			IL_070d: dup
+			IL_070e: ldc.i4.2
+			IL_070f: ldloc.3
 			IL_0710: stelem.ref
 			IL_0711: dup
-			IL_0712: ldc.i4.s 22
-			IL_0714: ldloc.s 23
-			IL_0716: box [System.Runtime]System.Boolean
-			IL_071b: stelem.ref
-			IL_071c: dup
-			IL_071d: ldc.i4.s 23
-			IL_071f: ldloc.s 24
-			IL_0721: stelem.ref
-			IL_0722: dup
-			IL_0723: ldc.i4.s 24
-			IL_0725: ldloc.s 25
-			IL_0727: stelem.ref
-			IL_0728: dup
-			IL_0729: ldc.i4.s 25
-			IL_072b: ldloc.s 26
-			IL_072d: stelem.ref
-			IL_072e: dup
-			IL_072f: ldc.i4.s 26
-			IL_0731: ldloc.s 27
-			IL_0733: stelem.ref
-			IL_0734: dup
-			IL_0735: ldc.i4.s 27
-			IL_0737: ldloc.s 28
-			IL_0739: stelem.ref
-			IL_073a: dup
-			IL_073b: ldc.i4.s 28
-			IL_073d: ldloc.s 29
-			IL_073f: stelem.ref
-			IL_0740: dup
-			IL_0741: ldc.i4.s 29
-			IL_0743: ldloc.s 30
-			IL_0745: stelem.ref
-			IL_0746: dup
-			IL_0747: ldc.i4.s 30
-			IL_0749: ldloc.s 31
-			IL_074b: stelem.ref
-			IL_074c: dup
-			IL_074d: ldc.i4.s 31
-			IL_074f: ldloc.s 32
-			IL_0751: stelem.ref
-			IL_0752: dup
-			IL_0753: ldc.i4.s 32
-			IL_0755: ldloc.s 33
-			IL_0757: stelem.ref
-			IL_0758: pop
-			IL_0759: ldloc.0
-			IL_075a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_075f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0764: ret
+			IL_0712: ldc.i4.3
+			IL_0713: ldloc.s 4
+			IL_0715: stelem.ref
+			IL_0716: dup
+			IL_0717: ldc.i4.4
+			IL_0718: ldloc.s 5
+			IL_071a: stelem.ref
+			IL_071b: dup
+			IL_071c: ldc.i4.5
+			IL_071d: ldloc.s 6
+			IL_071f: stelem.ref
+			IL_0720: dup
+			IL_0721: ldc.i4.6
+			IL_0722: ldloc.s 7
+			IL_0724: stelem.ref
+			IL_0725: dup
+			IL_0726: ldc.i4.7
+			IL_0727: ldloc.s 8
+			IL_0729: stelem.ref
+			IL_072a: dup
+			IL_072b: ldc.i4.8
+			IL_072c: ldloc.s 9
+			IL_072e: stelem.ref
+			IL_072f: dup
+			IL_0730: ldc.i4.s 9
+			IL_0732: ldloc.s 10
+			IL_0734: stelem.ref
+			IL_0735: dup
+			IL_0736: ldc.i4.s 10
+			IL_0738: ldloc.s 11
+			IL_073a: stelem.ref
+			IL_073b: dup
+			IL_073c: ldc.i4.s 11
+			IL_073e: ldloc.s 12
+			IL_0740: stelem.ref
+			IL_0741: dup
+			IL_0742: ldc.i4.s 12
+			IL_0744: ldloc.s 13
+			IL_0746: stelem.ref
+			IL_0747: dup
+			IL_0748: ldc.i4.s 13
+			IL_074a: ldloc.s 14
+			IL_074c: stelem.ref
+			IL_074d: dup
+			IL_074e: ldc.i4.s 14
+			IL_0750: ldloc.s 15
+			IL_0752: stelem.ref
+			IL_0753: dup
+			IL_0754: ldc.i4.s 15
+			IL_0756: ldloc.s 16
+			IL_0758: stelem.ref
+			IL_0759: dup
+			IL_075a: ldc.i4.s 16
+			IL_075c: ldloc.s 17
+			IL_075e: stelem.ref
+			IL_075f: dup
+			IL_0760: ldc.i4.s 17
+			IL_0762: ldloc.s 18
+			IL_0764: stelem.ref
+			IL_0765: dup
+			IL_0766: ldc.i4.s 18
+			IL_0768: ldloc.s 19
+			IL_076a: stelem.ref
+			IL_076b: dup
+			IL_076c: ldc.i4.s 19
+			IL_076e: ldloc.s 20
+			IL_0770: stelem.ref
+			IL_0771: dup
+			IL_0772: ldc.i4.s 20
+			IL_0774: ldloc.s 21
+			IL_0776: stelem.ref
+			IL_0777: dup
+			IL_0778: ldc.i4.s 21
+			IL_077a: ldloc.s 22
+			IL_077c: stelem.ref
+			IL_077d: dup
+			IL_077e: ldc.i4.s 22
+			IL_0780: ldloc.s 23
+			IL_0782: box [System.Runtime]System.Boolean
+			IL_0787: stelem.ref
+			IL_0788: dup
+			IL_0789: ldc.i4.s 23
+			IL_078b: ldloc.s 24
+			IL_078d: stelem.ref
+			IL_078e: dup
+			IL_078f: ldc.i4.s 24
+			IL_0791: ldloc.s 25
+			IL_0793: stelem.ref
+			IL_0794: dup
+			IL_0795: ldc.i4.s 25
+			IL_0797: ldloc.s 26
+			IL_0799: stelem.ref
+			IL_079a: dup
+			IL_079b: ldc.i4.s 26
+			IL_079d: ldloc.s 27
+			IL_079f: stelem.ref
+			IL_07a0: dup
+			IL_07a1: ldc.i4.s 27
+			IL_07a3: ldloc.s 28
+			IL_07a5: stelem.ref
+			IL_07a6: dup
+			IL_07a7: ldc.i4.s 28
+			IL_07a9: ldloc.s 29
+			IL_07ab: stelem.ref
+			IL_07ac: dup
+			IL_07ad: ldc.i4.s 29
+			IL_07af: ldloc.s 30
+			IL_07b1: stelem.ref
+			IL_07b2: dup
+			IL_07b3: ldc.i4.s 30
+			IL_07b5: ldloc.s 31
+			IL_07b7: stelem.ref
+			IL_07b8: dup
+			IL_07b9: ldc.i4.s 31
+			IL_07bb: ldloc.s 32
+			IL_07bd: stelem.ref
+			IL_07be: dup
+			IL_07bf: ldc.i4.s 32
+			IL_07c1: ldloc.s 33
+			IL_07c3: stelem.ref
+			IL_07c4: pop
+			IL_07c5: ldloc.0
+			IL_07c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_07cb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_07d0: ret
 
-			IL_0765: ldloc.0
-			IL_0766: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_076b: stloc.s 22
-			IL_076d: ldloc.s 22
-			IL_076f: stloc.s 8
-			IL_0771: ldloc.s 15
-			IL_0773: stloc.s 22
-			IL_0775: ldloc.s 22
-			IL_0777: stloc.s 10
-			IL_0779: ldloc.s 9
-			IL_077b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0780: ldc.i4.0
-			IL_0781: ceq
-			IL_0783: stloc.s 23
-			IL_0785: ldloc.s 23
-			IL_0787: brfalse IL_07be
+			IL_07d1: ldloc.0
+			IL_07d2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_07d7: stloc.s 26
+			IL_07d9: ldloc.s 26
+			IL_07db: stloc.s 8
+			IL_07dd: ldloc.s 15
+			IL_07df: stloc.s 26
+			IL_07e1: ldloc.s 26
+			IL_07e3: stloc.s 10
+			IL_07e5: ldloc.s 9
+			IL_07e7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_07ec: ldc.i4.0
+			IL_07ed: ceq
+			IL_07ef: stloc.s 23
+			IL_07f1: ldloc.s 23
+			IL_07f3: brfalse IL_082a
 
-			IL_078c: ldloc.s 13
-			IL_078e: ldstr "fragment"
-			IL_0793: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0798: stloc.s 22
-			IL_079a: ldloc.s 22
-			IL_079c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_07a1: stloc.s 23
-			IL_07a3: ldloc.s 23
-			IL_07a5: brtrue IL_07b6
+			IL_07f8: ldloc.s 13
+			IL_07fa: ldstr "fragment"
+			IL_07ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0804: stloc.s 26
+			IL_0806: ldloc.s 26
+			IL_0808: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_080d: stloc.s 23
+			IL_080f: ldloc.s 23
+			IL_0811: brtrue IL_0822
 
-			IL_07aa: ldstr ""
-			IL_07af: stloc.s 30
-			IL_07b1: br IL_07ba
+			IL_0816: ldstr ""
+			IL_081b: stloc.s 30
+			IL_081d: br IL_0826
 
-			IL_07b6: ldloc.s 22
-			IL_07b8: stloc.s 30
+			IL_0822: ldloc.s 26
+			IL_0824: stloc.s 30
 
-			IL_07ba: ldloc.s 30
-			IL_07bc: stloc.s 9
+			IL_0826: ldloc.s 30
+			IL_0828: stloc.s 9
 
-			IL_07be: br IL_090a
+			IL_082a: br IL_099b
 
-			IL_07c3: ldloc.1
-			IL_07c4: ldstr "url"
-			IL_07c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_07ce: stloc.s 22
-			IL_07d0: ldloc.s 22
-			IL_07d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_07d7: stloc.s 22
-			IL_07d9: ldloc.s 22
-			IL_07db: ldstr "trim"
-			IL_07e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_07e5: stloc.s 16
-			IL_07e7: ldarg.0
-			IL_07e8: ldc.i4.1
-			IL_07e9: ldelem.ref
-			IL_07ea: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_07ef: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_07f4: ldc.i4.1
-			IL_07f5: newarr [System.Runtime]System.Object
-			IL_07fa: dup
-			IL_07fb: ldc.i4.0
-			IL_07fc: ldarg.0
-			IL_07fd: ldc.i4.1
-			IL_07fe: ldelem.ref
-			IL_07ff: stelem.ref
-			IL_0800: stloc.s 21
-			IL_0802: ldloc.s 21
-			IL_0804: ldloc.s 16
-			IL_0806: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_080b: stloc.s 22
-			IL_080d: ldloc.0
-			IL_080e: ldc.i4.3
-			IL_080f: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0814: ldloc.0
-			IL_0815: ldloc.s 22
-			IL_0817: ldarg.0
-			IL_0818: ldc.i4.3
-			IL_0819: ldloc.0
-			IL_081a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_081f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_0824: ldloc.0
-			IL_0825: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_082a: dup
-			IL_082b: ldc.i4.0
-			IL_082c: ldloc.1
-			IL_082d: stelem.ref
-			IL_082e: dup
-			IL_082f: ldc.i4.1
-			IL_0830: ldloc.2
-			IL_0831: stelem.ref
-			IL_0832: dup
-			IL_0833: ldc.i4.2
-			IL_0834: ldloc.3
-			IL_0835: stelem.ref
-			IL_0836: dup
-			IL_0837: ldc.i4.3
-			IL_0838: ldloc.s 4
-			IL_083a: stelem.ref
-			IL_083b: dup
-			IL_083c: ldc.i4.4
-			IL_083d: ldloc.s 5
-			IL_083f: stelem.ref
-			IL_0840: dup
-			IL_0841: ldc.i4.5
-			IL_0842: ldloc.s 6
-			IL_0844: stelem.ref
-			IL_0845: dup
-			IL_0846: ldc.i4.6
-			IL_0847: ldloc.s 7
-			IL_0849: stelem.ref
-			IL_084a: dup
-			IL_084b: ldc.i4.7
-			IL_084c: ldloc.s 8
-			IL_084e: stelem.ref
-			IL_084f: dup
-			IL_0850: ldc.i4.8
-			IL_0851: ldloc.s 9
-			IL_0853: stelem.ref
-			IL_0854: dup
-			IL_0855: ldc.i4.s 9
-			IL_0857: ldloc.s 10
-			IL_0859: stelem.ref
-			IL_085a: dup
-			IL_085b: ldc.i4.s 10
-			IL_085d: ldloc.s 11
-			IL_085f: stelem.ref
-			IL_0860: dup
-			IL_0861: ldc.i4.s 11
-			IL_0863: ldloc.s 12
-			IL_0865: stelem.ref
-			IL_0866: dup
-			IL_0867: ldc.i4.s 12
-			IL_0869: ldloc.s 13
-			IL_086b: stelem.ref
-			IL_086c: dup
-			IL_086d: ldc.i4.s 13
-			IL_086f: ldloc.s 14
-			IL_0871: stelem.ref
-			IL_0872: dup
-			IL_0873: ldc.i4.s 14
-			IL_0875: ldloc.s 15
-			IL_0877: stelem.ref
-			IL_0878: dup
-			IL_0879: ldc.i4.s 15
-			IL_087b: ldloc.s 16
-			IL_087d: stelem.ref
-			IL_087e: dup
-			IL_087f: ldc.i4.s 16
-			IL_0881: ldloc.s 17
-			IL_0883: stelem.ref
-			IL_0884: dup
-			IL_0885: ldc.i4.s 17
-			IL_0887: ldloc.s 18
-			IL_0889: stelem.ref
-			IL_088a: dup
-			IL_088b: ldc.i4.s 18
-			IL_088d: ldloc.s 19
-			IL_088f: stelem.ref
-			IL_0890: dup
-			IL_0891: ldc.i4.s 19
-			IL_0893: ldloc.s 20
-			IL_0895: stelem.ref
-			IL_0896: dup
-			IL_0897: ldc.i4.s 20
-			IL_0899: ldloc.s 21
-			IL_089b: stelem.ref
-			IL_089c: dup
-			IL_089d: ldc.i4.s 21
-			IL_089f: ldloc.s 22
-			IL_08a1: stelem.ref
-			IL_08a2: dup
-			IL_08a3: ldc.i4.s 22
-			IL_08a5: ldloc.s 23
-			IL_08a7: box [System.Runtime]System.Boolean
-			IL_08ac: stelem.ref
-			IL_08ad: dup
-			IL_08ae: ldc.i4.s 23
-			IL_08b0: ldloc.s 24
-			IL_08b2: stelem.ref
-			IL_08b3: dup
-			IL_08b4: ldc.i4.s 24
-			IL_08b6: ldloc.s 25
-			IL_08b8: stelem.ref
-			IL_08b9: dup
-			IL_08ba: ldc.i4.s 25
-			IL_08bc: ldloc.s 26
+			IL_082f: ldloc.1
+			IL_0830: ldstr "url"
+			IL_0835: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_083a: stloc.s 26
+			IL_083c: ldloc.s 26
+			IL_083e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0843: stloc.s 26
+			IL_0845: ldc.i4.0
+			IL_0846: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_084b: brfalse IL_086a
+
+			IL_0850: ldloc.s 26
+			IL_0852: isinst [System.Runtime]System.String
+			IL_0857: dup
+			IL_0858: brfalse IL_0869
+
+			IL_085d: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0862: stloc.s 16
+			IL_0864: br IL_0878
+
+			IL_0869: pop
+
+			IL_086a: ldloc.s 26
+			IL_086c: ldstr "trim"
+			IL_0871: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0876: stloc.s 16
+
+			IL_0878: ldarg.0
+			IL_0879: ldc.i4.1
+			IL_087a: ldelem.ref
+			IL_087b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0880: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_0885: ldc.i4.1
+			IL_0886: newarr [System.Runtime]System.Object
+			IL_088b: dup
+			IL_088c: ldc.i4.0
+			IL_088d: ldarg.0
+			IL_088e: ldc.i4.1
+			IL_088f: ldelem.ref
+			IL_0890: stelem.ref
+			IL_0891: stloc.s 21
+			IL_0893: ldloc.s 21
+			IL_0895: ldloc.s 16
+			IL_0897: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_089c: stloc.s 26
+			IL_089e: ldloc.0
+			IL_089f: ldc.i4.3
+			IL_08a0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08a5: ldloc.0
+			IL_08a6: ldloc.s 26
+			IL_08a8: ldarg.0
+			IL_08a9: ldc.i4.3
+			IL_08aa: ldloc.0
+			IL_08ab: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_08b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_08b5: ldloc.0
+			IL_08b6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_08bb: dup
+			IL_08bc: ldc.i4.0
+			IL_08bd: ldloc.1
 			IL_08be: stelem.ref
 			IL_08bf: dup
-			IL_08c0: ldc.i4.s 26
-			IL_08c2: ldloc.s 27
-			IL_08c4: stelem.ref
-			IL_08c5: dup
-			IL_08c6: ldc.i4.s 27
-			IL_08c8: ldloc.s 28
-			IL_08ca: stelem.ref
-			IL_08cb: dup
-			IL_08cc: ldc.i4.s 28
-			IL_08ce: ldloc.s 29
+			IL_08c0: ldc.i4.1
+			IL_08c1: ldloc.2
+			IL_08c2: stelem.ref
+			IL_08c3: dup
+			IL_08c4: ldc.i4.2
+			IL_08c5: ldloc.3
+			IL_08c6: stelem.ref
+			IL_08c7: dup
+			IL_08c8: ldc.i4.3
+			IL_08c9: ldloc.s 4
+			IL_08cb: stelem.ref
+			IL_08cc: dup
+			IL_08cd: ldc.i4.4
+			IL_08ce: ldloc.s 5
 			IL_08d0: stelem.ref
 			IL_08d1: dup
-			IL_08d2: ldc.i4.s 29
-			IL_08d4: ldloc.s 30
-			IL_08d6: stelem.ref
-			IL_08d7: dup
-			IL_08d8: ldc.i4.s 30
-			IL_08da: ldloc.s 31
-			IL_08dc: stelem.ref
-			IL_08dd: dup
-			IL_08de: ldc.i4.s 31
-			IL_08e0: ldloc.s 32
-			IL_08e2: stelem.ref
-			IL_08e3: dup
-			IL_08e4: ldc.i4.s 32
-			IL_08e6: ldloc.s 33
-			IL_08e8: stelem.ref
-			IL_08e9: pop
-			IL_08ea: ldloc.0
-			IL_08eb: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_08f0: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_08f5: ret
+			IL_08d2: ldc.i4.5
+			IL_08d3: ldloc.s 6
+			IL_08d5: stelem.ref
+			IL_08d6: dup
+			IL_08d7: ldc.i4.6
+			IL_08d8: ldloc.s 7
+			IL_08da: stelem.ref
+			IL_08db: dup
+			IL_08dc: ldc.i4.7
+			IL_08dd: ldloc.s 8
+			IL_08df: stelem.ref
+			IL_08e0: dup
+			IL_08e1: ldc.i4.8
+			IL_08e2: ldloc.s 9
+			IL_08e4: stelem.ref
+			IL_08e5: dup
+			IL_08e6: ldc.i4.s 9
+			IL_08e8: ldloc.s 10
+			IL_08ea: stelem.ref
+			IL_08eb: dup
+			IL_08ec: ldc.i4.s 10
+			IL_08ee: ldloc.s 11
+			IL_08f0: stelem.ref
+			IL_08f1: dup
+			IL_08f2: ldc.i4.s 11
+			IL_08f4: ldloc.s 12
+			IL_08f6: stelem.ref
+			IL_08f7: dup
+			IL_08f8: ldc.i4.s 12
+			IL_08fa: ldloc.s 13
+			IL_08fc: stelem.ref
+			IL_08fd: dup
+			IL_08fe: ldc.i4.s 13
+			IL_0900: ldloc.s 14
+			IL_0902: stelem.ref
+			IL_0903: dup
+			IL_0904: ldc.i4.s 14
+			IL_0906: ldloc.s 15
+			IL_0908: stelem.ref
+			IL_0909: dup
+			IL_090a: ldc.i4.s 15
+			IL_090c: ldloc.s 16
+			IL_090e: stelem.ref
+			IL_090f: dup
+			IL_0910: ldc.i4.s 16
+			IL_0912: ldloc.s 17
+			IL_0914: stelem.ref
+			IL_0915: dup
+			IL_0916: ldc.i4.s 17
+			IL_0918: ldloc.s 18
+			IL_091a: stelem.ref
+			IL_091b: dup
+			IL_091c: ldc.i4.s 18
+			IL_091e: ldloc.s 19
+			IL_0920: stelem.ref
+			IL_0921: dup
+			IL_0922: ldc.i4.s 19
+			IL_0924: ldloc.s 20
+			IL_0926: stelem.ref
+			IL_0927: dup
+			IL_0928: ldc.i4.s 20
+			IL_092a: ldloc.s 21
+			IL_092c: stelem.ref
+			IL_092d: dup
+			IL_092e: ldc.i4.s 21
+			IL_0930: ldloc.s 22
+			IL_0932: stelem.ref
+			IL_0933: dup
+			IL_0934: ldc.i4.s 22
+			IL_0936: ldloc.s 23
+			IL_0938: box [System.Runtime]System.Boolean
+			IL_093d: stelem.ref
+			IL_093e: dup
+			IL_093f: ldc.i4.s 23
+			IL_0941: ldloc.s 24
+			IL_0943: stelem.ref
+			IL_0944: dup
+			IL_0945: ldc.i4.s 24
+			IL_0947: ldloc.s 25
+			IL_0949: stelem.ref
+			IL_094a: dup
+			IL_094b: ldc.i4.s 25
+			IL_094d: ldloc.s 26
+			IL_094f: stelem.ref
+			IL_0950: dup
+			IL_0951: ldc.i4.s 26
+			IL_0953: ldloc.s 27
+			IL_0955: stelem.ref
+			IL_0956: dup
+			IL_0957: ldc.i4.s 27
+			IL_0959: ldloc.s 28
+			IL_095b: stelem.ref
+			IL_095c: dup
+			IL_095d: ldc.i4.s 28
+			IL_095f: ldloc.s 29
+			IL_0961: stelem.ref
+			IL_0962: dup
+			IL_0963: ldc.i4.s 29
+			IL_0965: ldloc.s 30
+			IL_0967: stelem.ref
+			IL_0968: dup
+			IL_0969: ldc.i4.s 30
+			IL_096b: ldloc.s 31
+			IL_096d: stelem.ref
+			IL_096e: dup
+			IL_096f: ldc.i4.s 31
+			IL_0971: ldloc.s 32
+			IL_0973: stelem.ref
+			IL_0974: dup
+			IL_0975: ldc.i4.s 32
+			IL_0977: ldloc.s 33
+			IL_0979: stelem.ref
+			IL_097a: pop
+			IL_097b: ldloc.0
+			IL_097c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0981: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0986: ret
 
-			IL_08f6: ldloc.0
-			IL_08f7: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_08fc: stloc.s 22
-			IL_08fe: ldloc.s 22
-			IL_0900: stloc.s 8
-			IL_0902: ldloc.s 16
-			IL_0904: stloc.s 22
-			IL_0906: ldloc.s 22
-			IL_0908: stloc.s 10
+			IL_0987: ldloc.0
+			IL_0988: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_098d: stloc.s 26
+			IL_098f: ldloc.s 26
+			IL_0991: stloc.s 8
+			IL_0993: ldloc.s 16
+			IL_0995: stloc.s 26
+			IL_0997: ldloc.s 26
+			IL_0999: stloc.s 10
 
-			IL_090a: ldloc.s 9
-			IL_090c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0911: ldc.i4.0
-			IL_0912: ceq
-			IL_0914: stloc.s 23
-			IL_0916: ldloc.s 23
-			IL_0918: brfalse IL_0984
+			IL_099b: ldloc.s 9
+			IL_099d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_09a2: ldc.i4.0
+			IL_09a3: ceq
+			IL_09a5: stloc.s 23
+			IL_09a7: ldloc.s 23
+			IL_09a9: brfalse IL_0a15
 
-			IL_091d: ldloc.1
-			IL_091e: ldstr "section"
-			IL_0923: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0928: stloc.s 22
-			IL_092a: ldloc.s 22
-			IL_092c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0931: stloc.s 26
-			IL_0933: ldstr "Could not infer an element id for section '"
-			IL_0938: ldloc.s 26
-			IL_093a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_093f: ldstr "'. Try passing --id sec-... explicitly."
-			IL_0944: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0949: stloc.s 26
-			IL_094b: ldloc.s 26
-			IL_094d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0952: stloc.s 17
-			IL_0954: ldloc.0
-			IL_0955: ldc.i4.m1
-			IL_0956: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_095b: ldloc.0
-			IL_095c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0961: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0966: ldarg.0
-			IL_0967: ldc.i4.1
-			IL_0968: newarr [System.Runtime]System.Object
-			IL_096d: dup
-			IL_096e: ldc.i4.0
-			IL_096f: ldloc.s 17
-			IL_0971: stelem.ref
-			IL_0972: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0977: pop
-			IL_0978: ldloc.0
-			IL_0979: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_097e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0983: ret
+			IL_09ae: ldloc.1
+			IL_09af: ldstr "section"
+			IL_09b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09b9: stloc.s 26
+			IL_09bb: ldloc.s 26
+			IL_09bd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_09c2: stloc.s 27
+			IL_09c4: ldstr "Could not infer an element id for section '"
+			IL_09c9: ldloc.s 27
+			IL_09cb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09d0: ldstr "'. Try passing --id sec-... explicitly."
+			IL_09d5: call string [System.Runtime]System.String::Concat(string, string)
+			IL_09da: stloc.s 27
+			IL_09dc: ldloc.s 27
+			IL_09de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_09e3: stloc.s 17
+			IL_09e5: ldloc.0
+			IL_09e6: ldc.i4.m1
+			IL_09e7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_09ec: ldloc.0
+			IL_09ed: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_09f7: ldarg.0
+			IL_09f8: ldc.i4.1
+			IL_09f9: newarr [System.Runtime]System.Object
+			IL_09fe: dup
+			IL_09ff: ldc.i4.0
+			IL_0a00: ldloc.s 17
+			IL_0a02: stelem.ref
+			IL_0a03: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0a08: pop
+			IL_0a09: ldloc.0
+			IL_0a0a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a0f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0a14: ret
 
-			IL_0984: ldarg.0
-			IL_0985: ldc.i4.1
-			IL_0986: ldelem.ref
-			IL_0987: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_098c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
-			IL_0991: ldc.i4.1
-			IL_0992: newarr [System.Runtime]System.Object
-			IL_0997: dup
-			IL_0998: ldc.i4.0
-			IL_0999: ldarg.0
-			IL_099a: ldc.i4.1
-			IL_099b: ldelem.ref
-			IL_099c: stelem.ref
-			IL_099d: stloc.s 21
-			IL_099f: ldloc.s 21
-			IL_09a1: ldloc.s 8
-			IL_09a3: ldloc.s 9
-			IL_09a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_09aa: stloc.s 18
-			IL_09ac: ldarg.0
-			IL_09ad: ldc.i4.1
-			IL_09ae: ldelem.ref
-			IL_09af: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_09b4: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_09b9: stloc.s 31
-			IL_09bb: ldstr "process"
-			IL_09c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_09c5: stloc.s 22
-			IL_09c7: ldloc.s 22
-			IL_09c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_09ce: stloc.s 22
-			IL_09d0: ldloc.s 22
-			IL_09d2: ldstr "cwd"
-			IL_09d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_09dc: stloc.s 22
-			IL_09de: ldloc.1
-			IL_09df: ldstr "outFile"
-			IL_09e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09e9: stloc.s 27
-			IL_09eb: ldloc.s 31
-			IL_09ed: ldc.i4.2
-			IL_09ee: newarr [System.Runtime]System.Object
-			IL_09f3: dup
-			IL_09f4: ldc.i4.0
-			IL_09f5: ldloc.s 22
-			IL_09f7: stelem.ref
-			IL_09f8: dup
-			IL_09f9: ldc.i4.1
-			IL_09fa: ldloc.s 27
-			IL_09fc: stelem.ref
-			IL_09fd: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0a02: stloc.s 19
-			IL_0a04: ldarg.0
-			IL_0a05: ldc.i4.1
-			IL_0a06: ldelem.ref
-			IL_0a07: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a0c: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
-			IL_0a11: ldc.i4.1
-			IL_0a12: newarr [System.Runtime]System.Object
-			IL_0a17: dup
-			IL_0a18: ldc.i4.0
-			IL_0a19: ldarg.0
-			IL_0a1a: ldc.i4.1
-			IL_0a1b: ldelem.ref
-			IL_0a1c: stelem.ref
-			IL_0a1d: stloc.s 21
-			IL_0a1f: ldloc.s 18
-			IL_0a21: ldstr "html"
-			IL_0a26: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a2b: stloc.s 27
-			IL_0a2d: ldloc.1
-			IL_0a2e: ldstr "section"
-			IL_0a33: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a38: stloc.s 22
-			IL_0a3a: ldloc.s 22
-			IL_0a3c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0a41: stloc.s 26
-			IL_0a43: ldstr "ECMA-262 "
-			IL_0a48: ldloc.s 26
-			IL_0a4a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0a4f: stloc.s 26
-			IL_0a51: ldloc.s 21
-			IL_0a53: ldloc.s 27
-			IL_0a55: ldloc.s 26
-			IL_0a57: ldloc.s 10
-			IL_0a59: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0a5e: stloc.s 20
-			IL_0a60: ldarg.0
-			IL_0a61: ldc.i4.1
-			IL_0a62: ldelem.ref
-			IL_0a63: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a68: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0a6d: stloc.s 32
-			IL_0a6f: ldloc.s 32
-			IL_0a71: ldloc.s 19
-			IL_0a73: ldloc.s 20
-			IL_0a75: ldstr "utf8"
-			IL_0a7a: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_0a7f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0a84: stloc.s 33
-			IL_0a86: ldarg.0
-			IL_0a87: ldc.i4.1
-			IL_0a88: ldelem.ref
-			IL_0a89: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a8e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0a93: ldc.i4.1
-			IL_0a94: newarr [System.Runtime]System.Object
-			IL_0a99: dup
-			IL_0a9a: ldc.i4.0
-			IL_0a9b: ldarg.0
-			IL_0a9c: ldc.i4.1
-			IL_0a9d: ldelem.ref
-			IL_0a9e: stelem.ref
-			IL_0a9f: stloc.s 21
-			IL_0aa1: ldloc.1
-			IL_0aa2: ldstr "section"
-			IL_0aa7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0aac: stloc.s 27
-			IL_0aae: ldloc.s 27
-			IL_0ab0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ab5: stloc.s 26
-			IL_0ab7: ldstr "Extracted section "
-			IL_0abc: ldloc.s 26
-			IL_0abe: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ac3: ldstr " (id="
-			IL_0ac8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0acd: ldloc.s 9
-			IL_0acf: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ad4: stloc.s 26
-			IL_0ad6: ldloc.s 26
-			IL_0ad8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0add: ldstr ", tag="
-			IL_0ae2: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ae7: ldloc.s 18
-			IL_0ae9: ldstr "tagName"
-			IL_0aee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0af3: stloc.s 27
-			IL_0af5: ldloc.s 27
-			IL_0af7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0afc: stloc.s 26
-			IL_0afe: ldloc.s 26
-			IL_0b00: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b05: ldstr ") -> "
-			IL_0b0a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b0f: ldloc.s 19
-			IL_0b11: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b16: stloc.s 26
-			IL_0b18: ldloc.s 26
-			IL_0b1a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b1f: stloc.s 26
-			IL_0b21: ldloc.s 21
-			IL_0b23: ldloc.s 26
-			IL_0b25: ldloc.s 19
-			IL_0b27: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b2c: stloc.s 27
-			IL_0b2e: ldloc.s 33
-			IL_0b30: ldloc.s 27
-			IL_0b32: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0b37: pop
-			IL_0b38: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0b3d: stloc.s 33
-			IL_0b3f: ldarg.0
-			IL_0b40: ldc.i4.1
-			IL_0b41: ldelem.ref
-			IL_0b42: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b47: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0b4c: stloc.s 27
-			IL_0b4e: ldc.i4.1
-			IL_0b4f: newarr [System.Runtime]System.Object
-			IL_0b54: dup
-			IL_0b55: ldc.i4.0
-			IL_0b56: ldarg.0
-			IL_0b57: ldc.i4.1
-			IL_0b58: ldelem.ref
-			IL_0b59: stelem.ref
-			IL_0b5a: stloc.s 21
-			IL_0b5c: ldarg.0
-			IL_0b5d: ldc.i4.1
-			IL_0b5e: ldelem.ref
-			IL_0b5f: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b64: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0b69: stloc.s 32
-			IL_0b6b: ldloc.s 32
-			IL_0b6d: ldloc.s 19
-			IL_0b6f: ldstr "utf8"
-			IL_0b74: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0b79: stloc.s 22
-			IL_0b7b: ldloc.s 27
-			IL_0b7d: ldloc.s 21
-			IL_0b7f: ldloc.s 22
-			IL_0b81: ldloc.s 19
-			IL_0b83: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0b88: stloc.s 22
-			IL_0b8a: ldloc.s 33
-			IL_0b8c: ldloc.s 22
-			IL_0b8e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0b93: pop
-			IL_0b94: ldloc.0
-			IL_0b95: ldc.i4.m1
-			IL_0b96: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0b9b: ldloc.0
-			IL_0b9c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0ba1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0ba6: ldarg.0
-			IL_0ba7: ldc.i4.1
-			IL_0ba8: newarr [System.Runtime]System.Object
-			IL_0bad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0bb2: pop
-			IL_0bb3: ldloc.0
-			IL_0bb4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0bb9: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0bbe: ret
+			IL_0a15: ldarg.0
+			IL_0a16: ldc.i4.1
+			IL_0a17: ldelem.ref
+			IL_0a18: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a1d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
+			IL_0a22: ldc.i4.1
+			IL_0a23: newarr [System.Runtime]System.Object
+			IL_0a28: dup
+			IL_0a29: ldc.i4.0
+			IL_0a2a: ldarg.0
+			IL_0a2b: ldc.i4.1
+			IL_0a2c: ldelem.ref
+			IL_0a2d: stelem.ref
+			IL_0a2e: stloc.s 21
+			IL_0a30: ldloc.s 21
+			IL_0a32: ldloc.s 8
+			IL_0a34: ldloc.s 9
+			IL_0a36: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0a3b: stloc.s 18
+			IL_0a3d: ldarg.0
+			IL_0a3e: ldc.i4.1
+			IL_0a3f: ldelem.ref
+			IL_0a40: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a45: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_0a4a: stloc.s 31
+			IL_0a4c: ldstr "process"
+			IL_0a51: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a56: stloc.s 26
+			IL_0a58: ldloc.s 26
+			IL_0a5a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a5f: stloc.s 26
+			IL_0a61: ldloc.s 26
+			IL_0a63: ldstr "cwd"
+			IL_0a68: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0a6d: stloc.s 26
+			IL_0a6f: ldloc.1
+			IL_0a70: ldstr "outFile"
+			IL_0a75: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0a7a: stloc.s 22
+			IL_0a7c: ldloc.s 31
+			IL_0a7e: ldc.i4.2
+			IL_0a7f: newarr [System.Runtime]System.Object
+			IL_0a84: dup
+			IL_0a85: ldc.i4.0
+			IL_0a86: ldloc.s 26
+			IL_0a88: stelem.ref
+			IL_0a89: dup
+			IL_0a8a: ldc.i4.1
+			IL_0a8b: ldloc.s 22
+			IL_0a8d: stelem.ref
+			IL_0a8e: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0a93: stloc.s 19
+			IL_0a95: ldarg.0
+			IL_0a96: ldc.i4.1
+			IL_0a97: ldelem.ref
+			IL_0a98: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a9d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
+			IL_0aa2: ldc.i4.1
+			IL_0aa3: newarr [System.Runtime]System.Object
+			IL_0aa8: dup
+			IL_0aa9: ldc.i4.0
+			IL_0aaa: ldarg.0
+			IL_0aab: ldc.i4.1
+			IL_0aac: ldelem.ref
+			IL_0aad: stelem.ref
+			IL_0aae: stloc.s 21
+			IL_0ab0: ldloc.s 18
+			IL_0ab2: ldstr "html"
+			IL_0ab7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0abc: stloc.s 22
+			IL_0abe: ldloc.1
+			IL_0abf: ldstr "section"
+			IL_0ac4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ac9: stloc.s 26
+			IL_0acb: ldloc.s 26
+			IL_0acd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ad2: stloc.s 27
+			IL_0ad4: ldstr "ECMA-262 "
+			IL_0ad9: ldloc.s 27
+			IL_0adb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ae0: stloc.s 27
+			IL_0ae2: ldloc.s 21
+			IL_0ae4: ldloc.s 22
+			IL_0ae6: ldloc.s 27
+			IL_0ae8: ldloc.s 10
+			IL_0aea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0aef: stloc.s 20
+			IL_0af1: ldarg.0
+			IL_0af2: ldc.i4.1
+			IL_0af3: ldelem.ref
+			IL_0af4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0af9: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0afe: stloc.s 32
+			IL_0b00: ldloc.s 32
+			IL_0b02: ldloc.s 19
+			IL_0b04: ldloc.s 20
+			IL_0b06: ldstr "utf8"
+			IL_0b0b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_0b10: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0b15: stloc.s 33
+			IL_0b17: ldarg.0
+			IL_0b18: ldc.i4.1
+			IL_0b19: ldelem.ref
+			IL_0b1a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b1f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0b24: ldc.i4.1
+			IL_0b25: newarr [System.Runtime]System.Object
+			IL_0b2a: dup
+			IL_0b2b: ldc.i4.0
+			IL_0b2c: ldarg.0
+			IL_0b2d: ldc.i4.1
+			IL_0b2e: ldelem.ref
+			IL_0b2f: stelem.ref
+			IL_0b30: stloc.s 21
+			IL_0b32: ldloc.1
+			IL_0b33: ldstr "section"
+			IL_0b38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b3d: stloc.s 22
+			IL_0b3f: ldloc.s 22
+			IL_0b41: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b46: stloc.s 27
+			IL_0b48: ldstr "Extracted section "
+			IL_0b4d: ldloc.s 27
+			IL_0b4f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b54: ldstr " (id="
+			IL_0b59: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b5e: ldloc.s 9
+			IL_0b60: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b65: stloc.s 27
+			IL_0b67: ldloc.s 27
+			IL_0b69: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b6e: ldstr ", tag="
+			IL_0b73: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b78: ldloc.s 18
+			IL_0b7a: ldstr "tagName"
+			IL_0b7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b84: stloc.s 22
+			IL_0b86: ldloc.s 22
+			IL_0b88: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b8d: stloc.s 27
+			IL_0b8f: ldloc.s 27
+			IL_0b91: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b96: ldstr ") -> "
+			IL_0b9b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ba0: ldloc.s 19
+			IL_0ba2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0ba7: stloc.s 27
+			IL_0ba9: ldloc.s 27
+			IL_0bab: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0bb0: stloc.s 27
+			IL_0bb2: ldloc.s 21
+			IL_0bb4: ldloc.s 27
+			IL_0bb6: ldloc.s 19
+			IL_0bb8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0bbd: stloc.s 22
+			IL_0bbf: ldloc.s 33
+			IL_0bc1: ldloc.s 22
+			IL_0bc3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0bc8: pop
+			IL_0bc9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0bce: stloc.s 33
+			IL_0bd0: ldarg.0
+			IL_0bd1: ldc.i4.1
+			IL_0bd2: ldelem.ref
+			IL_0bd3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0bd8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0bdd: stloc.s 22
+			IL_0bdf: ldc.i4.1
+			IL_0be0: newarr [System.Runtime]System.Object
+			IL_0be5: dup
+			IL_0be6: ldc.i4.0
+			IL_0be7: ldarg.0
+			IL_0be8: ldc.i4.1
+			IL_0be9: ldelem.ref
+			IL_0bea: stelem.ref
+			IL_0beb: stloc.s 21
+			IL_0bed: ldarg.0
+			IL_0bee: ldc.i4.1
+			IL_0bef: ldelem.ref
+			IL_0bf0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0bf5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0bfa: stloc.s 32
+			IL_0bfc: ldloc.s 32
+			IL_0bfe: ldloc.s 19
+			IL_0c00: ldstr "utf8"
+			IL_0c05: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0c0a: stloc.s 26
+			IL_0c0c: ldloc.s 22
+			IL_0c0e: ldloc.s 21
+			IL_0c10: ldloc.s 26
+			IL_0c12: ldloc.s 19
+			IL_0c14: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0c19: stloc.s 26
+			IL_0c1b: ldloc.s 33
+			IL_0c1d: ldloc.s 26
+			IL_0c1f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0c24: pop
+			IL_0c25: ldloc.0
+			IL_0c26: ldc.i4.m1
+			IL_0c27: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0c2c: ldloc.0
+			IL_0c2d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c32: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0c37: ldarg.0
+			IL_0c38: ldc.i4.1
+			IL_0c39: newarr [System.Runtime]System.Object
+			IL_0c3e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0c43: pop
+			IL_0c44: ldloc.0
+			IL_0c45: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c4a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0c4f: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_ModernFlags_Basic.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_RegExp_ModernFlags_Basic.verified.txt
@@ -116,7 +116,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 815 (0x32f)
+		// Code size: 850 (0x352)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.IntrinsicCallables_RegExp_ModernFlags_Basic/Scope,
@@ -290,7 +290,7 @@
 			IL_01e7: ldstr "no-error"
 			IL_01ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 			IL_01f1: pop
-			IL_01f2: leave IL_02ab
+			IL_01f2: leave IL_02ce
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -339,83 +339,95 @@
 			IL_0260: ldloc.s 12
 			IL_0262: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 			IL_0267: stloc.s 12
-			IL_0269: ldloc.s 12
-			IL_026b: ldstr "indexOf"
-			IL_0270: ldstr "v"
-			IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_027a: stloc.s 10
-			IL_027c: ldloc.s 10
-			IL_027e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0283: ldc.r8 0.0
-			IL_028c: clt
-			IL_028e: ldc.i4.0
-			IL_028f: ceq
-			IL_0291: stloc.s 13
-			IL_0293: ldloc.s 13
-			IL_0295: box [System.Runtime]System.Boolean
-			IL_029a: stloc.s 14
-			IL_029c: ldloc.s 9
-			IL_029e: ldloc.s 14
-			IL_02a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02a5: pop
-			IL_02a6: leave IL_02ab
+			IL_0269: ldc.i4.0
+			IL_026a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_026f: brfalse IL_028c
+
+			IL_0274: ldloc.s 12
+			IL_0276: ldstr "v"
+			IL_027b: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0280: box [System.Runtime]System.Double
+			IL_0285: stloc.s 10
+			IL_0287: br IL_029f
+
+			IL_028c: ldloc.s 12
+			IL_028e: ldstr "indexOf"
+			IL_0293: ldstr "v"
+			IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_029d: stloc.s 10
+
+			IL_029f: ldloc.s 10
+			IL_02a1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_02a6: ldc.r8 0.0
+			IL_02af: clt
+			IL_02b1: ldc.i4.0
+			IL_02b2: ceq
+			IL_02b4: stloc.s 13
+			IL_02b6: ldloc.s 13
+			IL_02b8: box [System.Runtime]System.Boolean
+			IL_02bd: stloc.s 14
+			IL_02bf: ldloc.s 9
+			IL_02c1: ldloc.s 14
+			IL_02c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02c8: pop
+			IL_02c9: leave IL_02ce
 		} // end handler
 		.try
 		{
-			IL_02ab: nop
-			IL_02ac: ldstr "a"
-			IL_02b1: ldstr "gg"
-			IL_02b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_02bb: pop
-			IL_02bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02c1: stloc.s 9
-			IL_02c3: ldloc.s 9
-			IL_02c5: ldstr "no-error"
-			IL_02ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_02cf: pop
-			IL_02d0: leave IL_032b
+			IL_02ce: nop
+			IL_02cf: ldstr "a"
+			IL_02d4: ldstr "gg"
+			IL_02d9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_02de: pop
+			IL_02df: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02e4: stloc.s 9
+			IL_02e6: ldloc.s 9
+			IL_02e8: ldstr "no-error"
+			IL_02ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02f2: pop
+			IL_02f3: leave IL_034e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02d5: stloc.s 5
-			IL_02d7: ldloc.s 5
-			IL_02d9: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02de: dup
-			IL_02df: brtrue IL_02f5
+			IL_02f8: stloc.s 5
+			IL_02fa: ldloc.s 5
+			IL_02fc: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0301: dup
+			IL_0302: brtrue IL_0318
 
-			IL_02e4: pop
-			IL_02e5: ldloc.s 5
-			IL_02e7: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02ec: dup
-			IL_02ed: brtrue IL_0301
+			IL_0307: pop
+			IL_0308: ldloc.s 5
+			IL_030a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_030f: dup
+			IL_0310: brtrue IL_0324
 
-			IL_02f2: pop
-			IL_02f3: rethrow
+			IL_0315: pop
+			IL_0316: rethrow
 
-			IL_02f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_02fa: stloc.s 6
-			IL_02fc: br IL_0303
+			IL_0318: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_031d: stloc.s 6
+			IL_031f: br IL_0326
 
-			IL_0301: stloc.s 6
+			IL_0324: stloc.s 6
 
-			IL_0303: ldloc.s 6
-			IL_0305: stloc.s 7
-			IL_0307: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_030c: stloc.s 9
-			IL_030e: ldloc.s 7
-			IL_0310: ldstr "name"
-			IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_031a: stloc.s 10
-			IL_031c: ldloc.s 9
-			IL_031e: ldloc.s 10
-			IL_0320: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0325: pop
-			IL_0326: leave IL_032b
+			IL_0326: ldloc.s 6
+			IL_0328: stloc.s 7
+			IL_032a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_032f: stloc.s 9
+			IL_0331: ldloc.s 7
+			IL_0333: ldstr "name"
+			IL_0338: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_033d: stloc.s 10
+			IL_033f: ldloc.s 9
+			IL_0341: ldloc.s 10
+			IL_0343: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0348: pop
+			IL_0349: leave IL_034e
 		} // end handler
 
-		IL_032b: ldnull
-		IL_032c: stloc.s 8
-		IL_032e: ret
+		IL_034e: ldnull
+		IL_034f: stloc.s 8
+		IL_0351: ret
 	} // end of method IntrinsicCallables_RegExp_ModernFlags_Basic::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_RegExp_ModernFlags_Basic

--- a/tests/Jroc.Tests/IntrinsicPrototypeEpochTests.cs
+++ b/tests/Jroc.Tests/IntrinsicPrototypeEpochTests.cs
@@ -203,6 +203,34 @@ public sealed class IntrinsicPrototypeEpochTests
             });
     }
 
+    [Fact]
+    public void GuardedStringTrimFastPathAllocatesNothing()
+    {
+        WithRealm(
+            () =>
+            {
+                _ = GlobalThis.globalThis;
+                object receiver = "value";
+                object? result = null;
+                for (var index = 0; index < 32; index++)
+                {
+                    result = GuardedTrim(receiver);
+                }
+
+                var before =
+                    GC.GetAllocatedBytesForCurrentThread();
+                for (var index = 0; index < 10_000; index++)
+                {
+                    result = GuardedTrim(receiver);
+                }
+                var allocated =
+                    GC.GetAllocatedBytesForCurrentThread() - before;
+
+                GC.KeepAlive(result);
+                Assert.Equal(0, allocated);
+            });
+    }
+
     private static void AssertAdvances(Action mutation)
     {
         var before = IntrinsicPrototypeEpochs.Read(
@@ -255,6 +283,18 @@ public sealed class IntrinsicPrototypeEpochTests
         {
             services.OwningRealm!.Agent.Cluster.Dispose();
         }
+    }
+
+    private static object? GuardedTrim(object receiver)
+    {
+        if (IntrinsicPrototypeEpochs.IsPristine(
+                IntrinsicPrototypeFamily.String)
+            && receiver is string input)
+        {
+            return JavaScriptRuntime.String.Trim(input);
+        }
+
+        return ObjectRuntime.CallMember0(receiver, "trim");
     }
 
     private sealed class EpochFunction : JsFunctionObject

--- a/tests/Jroc.Tests/LIRIntrinsicNormalizationTests.cs
+++ b/tests/Jroc.Tests/LIRIntrinsicNormalizationTests.cs
@@ -60,6 +60,112 @@ public sealed class LIRIntrinsicNormalizationTests
     }
 
     [Fact]
+    public void Normalize_Rewrites_ProvenStringMemberCall_ToGuardedIntrinsic()
+    {
+        var body = new MethodBodyIR();
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(string)));
+        var argument = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        body.Instructions.Add(
+            new LIRCallMember1(receiver, "charAt", argument, result));
+
+        LIRIntrinsicNormalization.Normalize(body, new ClassRegistry());
+
+        var guarded = Assert.IsType<LIRCallGuardedStringIntrinsic>(
+            body.Instructions[0]);
+        Assert.True(guarded.ReceiverIsProvenString);
+        Assert.Equal("charAt", guarded.MemberName);
+        Assert.Equal(nameof(JavaScriptRuntime.String.CharAt), guarded.IntrinsicMethodName);
+        Assert.Equal(
+            [typeof(string), typeof(object)],
+            guarded.IntrinsicParameterTypes);
+        Assert.Equal(typeof(string), guarded.IntrinsicReturnClrType);
+        Assert.Equal(LIRGuardedStringFallbackResultConversion.None, guarded.FallbackResultConversion);
+        Assert.Equal(ValueStorageKind.Reference, body.TempStorages[result.Index].Kind);
+        Assert.Equal(typeof(object), body.TempStorages[result.Index].ClrType);
+    }
+
+    [Fact]
+    public void Normalize_Rewrites_UncertainStringMemberCall_WithReceiverTypeTest()
+    {
+        var body = new MethodBodyIR();
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        body.Instructions.Add(new LIRCallMember0(receiver, "trim", result));
+
+        LIRIntrinsicNormalization.Normalize(body, new ClassRegistry());
+
+        var guarded = Assert.IsType<LIRCallGuardedStringIntrinsic>(
+            body.Instructions[0]);
+        Assert.False(guarded.ReceiverIsProvenString);
+        Assert.Equal("trim", guarded.MemberName);
+        Assert.Empty(guarded.Arguments);
+    }
+
+    [Fact]
+    public void Normalize_DoesNotAddStringGuard_ForKnownNonStringReceiver()
+    {
+        var body = new MethodBodyIR();
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(JavaScriptRuntime.Array)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        body.Instructions.Add(new LIRCallMember0(receiver, "trim", result));
+
+        LIRIntrinsicNormalization.Normalize(body, new ClassRegistry());
+
+        Assert.IsType<LIRCallMember0>(body.Instructions[0]);
+    }
+
+    [Fact]
+    public void Normalize_Fuses_CharCodeAtNumberConversion_IntoGuardedIntrinsic()
+    {
+        var body = new MethodBodyIR();
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var index = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.UnboxedValue, typeof(double)));
+        var callResult = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var numberResult = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.UnboxedValue, typeof(double)));
+        body.Instructions.Add(
+            new LIRCallMember1(receiver, "charCodeAt", index, callResult));
+        body.Instructions.Add(
+            new LIRConvertToNumber(callResult, numberResult));
+
+        LIRIntrinsicNormalization.Normalize(body, new ClassRegistry());
+
+        var guarded = Assert.IsType<LIRCallGuardedStringIntrinsic>(
+            Assert.Single(body.Instructions));
+        Assert.False(guarded.ReceiverIsProvenString);
+        Assert.Equal(
+            LIRGuardedStringFallbackResultConversion.ToNumber,
+            guarded.FallbackResultConversion);
+        Assert.Equal(typeof(double), guarded.IntrinsicReturnClrType);
+        Assert.Equal(ValueStorageKind.UnboxedValue, body.TempStorages[numberResult.Index].Kind);
+        Assert.Equal(typeof(double), body.TempStorages[numberResult.Index].ClrType);
+    }
+
+    [Fact]
     public void Normalize_Rewrites_SetItem_To_Int32ArrayElementSet_WhenReceiverProvenViaCopyAndOperandsAreDouble()
     {
         var classRegistry = new ClassRegistry();

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -3091,7 +3091,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 899 (0x383)
+		// Code size: 950 (0x3b6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope,
@@ -3193,134 +3193,134 @@
 		IL_011b: stloc.s 5
 		IL_011d: ldloc.s 5
 		IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0124: ldstr "includes"
-		IL_0129: ldstr "verbose"
-		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0133: stloc.s 5
-		IL_0135: ldloc.1
-		IL_0136: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
-		IL_013b: ldloc.s 5
-		IL_013d: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_verbose(object)
-		IL_0142: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_0147: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_014c: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_0151: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0156: stloc.s 8
-		IL_0158: ldloc.s 8
-		IL_015a: ldstr "prototype"
-		IL_015f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0164: stloc.s 5
-		IL_0166: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_016b: stloc.s 9
-		IL_016d: ldloc.s 5
-		IL_016f: ldstr "setBitTrue"
-		IL_0174: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject::.ctor()
-		IL_0179: ldc.i4.1
-		IL_017a: conv.r8
-		IL_017b: ldstr "setBitTrue"
-		IL_0180: ldc.i4.1
-		IL_0181: ldc.i4.1
-		IL_0182: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0187: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject>(!!0)
-		IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0191: pop
-		IL_0192: ldc.i4.1
-		IL_0193: newarr [System.Runtime]System.Object
-		IL_0198: dup
-		IL_0199: ldc.i4.0
-		IL_019a: ldloc.0
-		IL_019b: stelem.ref
-		IL_019c: stloc.s 9
-		IL_019e: ldloc.s 5
-		IL_01a0: ldstr "setBitsTrue"
-		IL_01a5: ldloc.s 9
-		IL_01a7: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject::.ctor(object[])
-		IL_01ac: ldc.i4.3
+		IL_0124: stloc.s 5
+		IL_0126: ldc.i4.0
+		IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_012c: brfalse IL_0155
+
+		IL_0131: ldloc.s 5
+		IL_0133: isinst [System.Runtime]System.String
+		IL_0138: dup
+		IL_0139: brfalse IL_0154
+
+		IL_013e: ldstr "verbose"
+		IL_0143: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_0148: box [System.Runtime]System.Boolean
+		IL_014d: stloc.s 5
+		IL_014f: br IL_0168
+
+		IL_0154: pop
+
+		IL_0155: ldloc.s 5
+		IL_0157: ldstr "includes"
+		IL_015c: ldstr "verbose"
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0166: stloc.s 5
+
+		IL_0168: ldloc.1
+		IL_0169: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
+		IL_016e: ldloc.s 5
+		IL_0170: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_verbose(object)
+		IL_0175: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+		IL_017a: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_017f: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+		IL_0184: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0189: stloc.s 8
+		IL_018b: ldloc.s 8
+		IL_018d: ldstr "prototype"
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0197: stloc.s 5
+		IL_0199: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_019e: stloc.s 9
+		IL_01a0: ldloc.s 5
+		IL_01a2: ldstr "setBitTrue"
+		IL_01a7: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject::.ctor()
+		IL_01ac: ldc.i4.1
 		IL_01ad: conv.r8
-		IL_01ae: ldstr "setBitsTrue"
+		IL_01ae: ldstr "setBitTrue"
 		IL_01b3: ldc.i4.1
 		IL_01b4: ldc.i4.1
-		IL_01b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject>(!!0)
+		IL_01b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject>(!!0)
 		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_01c4: pop
-		IL_01c5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01ca: stloc.s 9
-		IL_01cc: ldloc.s 5
-		IL_01ce: ldstr "testBitTrue"
-		IL_01d3: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject::.ctor()
-		IL_01d8: ldc.i4.1
-		IL_01d9: conv.r8
-		IL_01da: ldstr "testBitTrue"
-		IL_01df: ldc.i4.1
-		IL_01e0: ldc.i4.1
-		IL_01e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject>(!!0)
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01f0: pop
-		IL_01f1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01f6: stloc.s 9
-		IL_01f8: ldloc.s 5
-		IL_01fa: ldstr "searchBitFalse"
-		IL_01ff: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject::.ctor()
-		IL_0204: ldc.i4.1
-		IL_0205: conv.r8
-		IL_0206: ldstr "searchBitFalse"
+		IL_01c5: ldc.i4.1
+		IL_01c6: newarr [System.Runtime]System.Object
+		IL_01cb: dup
+		IL_01cc: ldc.i4.0
+		IL_01cd: ldloc.0
+		IL_01ce: stelem.ref
+		IL_01cf: stloc.s 9
+		IL_01d1: ldloc.s 5
+		IL_01d3: ldstr "setBitsTrue"
+		IL_01d8: ldloc.s 9
+		IL_01da: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject::.ctor(object[])
+		IL_01df: ldc.i4.3
+		IL_01e0: conv.r8
+		IL_01e1: ldstr "setBitsTrue"
+		IL_01e6: ldc.i4.1
+		IL_01e7: ldc.i4.1
+		IL_01e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject>(!!0)
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01f7: pop
+		IL_01f8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01fd: stloc.s 9
+		IL_01ff: ldloc.s 5
+		IL_0201: ldstr "testBitTrue"
+		IL_0206: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject::.ctor()
 		IL_020b: ldc.i4.1
-		IL_020c: ldc.i4.1
-		IL_020d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject>(!!0)
-		IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_021c: pop
-		IL_021d: ldc.i4.1
-		IL_021e: newarr [System.Runtime]System.Object
-		IL_0223: dup
-		IL_0224: ldc.i4.0
-		IL_0225: ldloc.0
-		IL_0226: stelem.ref
-		IL_0227: stloc.s 9
-		IL_0229: ldloc.s 9
-		IL_022b: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
-		IL_0230: ldloc.s 8
-		IL_0232: ldloc.s 9
-		IL_0234: ldc.i4.1
-		IL_0235: conv.r8
-		IL_0236: ldc.i4.0
-		IL_0237: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_023c: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_ctor/FunctionObject
-		IL_0241: stloc.s 10
-		IL_0243: ldloc.0
-		IL_0244: ldloc.s 10
-		IL_0246: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
-		IL_024b: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0250: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0255: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_025a: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_025f: stloc.s 8
-		IL_0261: ldloc.s 8
-		IL_0263: ldstr "prototype"
-		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_026d: stloc.s 5
-		IL_026f: ldc.i4.1
-		IL_0270: newarr [System.Runtime]System.Object
-		IL_0275: dup
-		IL_0276: ldc.i4.0
-		IL_0277: ldloc.0
-		IL_0278: stelem.ref
-		IL_0279: stloc.s 9
-		IL_027b: ldloc.s 5
-		IL_027d: ldstr "runSieve"
-		IL_0282: ldloc.s 9
-		IL_0284: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject::.ctor(object[])
-		IL_0289: ldc.i4.0
-		IL_028a: conv.r8
-		IL_028b: ldstr "runSieve"
-		IL_0290: ldc.i4.1
-		IL_0291: ldc.i4.1
-		IL_0292: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0297: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject>(!!0)
-		IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02a1: pop
+		IL_020c: conv.r8
+		IL_020d: ldstr "testBitTrue"
+		IL_0212: ldc.i4.1
+		IL_0213: ldc.i4.1
+		IL_0214: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0219: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject>(!!0)
+		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0223: pop
+		IL_0224: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0229: stloc.s 9
+		IL_022b: ldloc.s 5
+		IL_022d: ldstr "searchBitFalse"
+		IL_0232: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject::.ctor()
+		IL_0237: ldc.i4.1
+		IL_0238: conv.r8
+		IL_0239: ldstr "searchBitFalse"
+		IL_023e: ldc.i4.1
+		IL_023f: ldc.i4.1
+		IL_0240: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0245: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject>(!!0)
+		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_024f: pop
+		IL_0250: ldc.i4.1
+		IL_0251: newarr [System.Runtime]System.Object
+		IL_0256: dup
+		IL_0257: ldc.i4.0
+		IL_0258: ldloc.0
+		IL_0259: stelem.ref
+		IL_025a: stloc.s 9
+		IL_025c: ldloc.s 9
+		IL_025e: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
+		IL_0263: ldloc.s 8
+		IL_0265: ldloc.s 9
+		IL_0267: ldc.i4.1
+		IL_0268: conv.r8
+		IL_0269: ldc.i4.0
+		IL_026a: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_026f: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_ctor/FunctionObject
+		IL_0274: stloc.s 10
+		IL_0276: ldloc.0
+		IL_0277: ldloc.s 10
+		IL_0279: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
+		IL_027e: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_0283: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0288: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_028d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0292: stloc.s 8
+		IL_0294: ldloc.s 8
+		IL_0296: ldstr "prototype"
+		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02a0: stloc.s 5
 		IL_02a2: ldc.i4.1
 		IL_02a3: newarr [System.Runtime]System.Object
 		IL_02a8: dup
@@ -3329,16 +3329,16 @@
 		IL_02ab: stelem.ref
 		IL_02ac: stloc.s 9
 		IL_02ae: ldloc.s 5
-		IL_02b0: ldstr "countPrimes"
+		IL_02b0: ldstr "runSieve"
 		IL_02b5: ldloc.s 9
-		IL_02b7: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject::.ctor(object[])
+		IL_02b7: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject::.ctor(object[])
 		IL_02bc: ldc.i4.0
 		IL_02bd: conv.r8
-		IL_02be: ldstr "countPrimes"
+		IL_02be: ldstr "runSieve"
 		IL_02c3: ldc.i4.1
 		IL_02c4: ldc.i4.1
-		IL_02c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02ca: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject>(!!0)
+		IL_02c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02ca: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject>(!!0)
 		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_02d4: pop
 		IL_02d5: ldc.i4.1
@@ -3349,16 +3349,16 @@
 		IL_02de: stelem.ref
 		IL_02df: stloc.s 9
 		IL_02e1: ldloc.s 5
-		IL_02e3: ldstr "getPrimes"
+		IL_02e3: ldstr "countPrimes"
 		IL_02e8: ldloc.s 9
-		IL_02ea: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject::.ctor(object[])
+		IL_02ea: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject::.ctor(object[])
 		IL_02ef: ldc.i4.0
 		IL_02f0: conv.r8
-		IL_02f1: ldstr "getPrimes"
+		IL_02f1: ldstr "countPrimes"
 		IL_02f6: ldc.i4.1
 		IL_02f7: ldc.i4.1
-		IL_02f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject>(!!0)
+		IL_02f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject>(!!0)
 		IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0307: pop
 		IL_0308: ldc.i4.1
@@ -3369,16 +3369,16 @@
 		IL_0311: stelem.ref
 		IL_0312: stloc.s 9
 		IL_0314: ldloc.s 5
-		IL_0316: ldstr "validatePrimeCount"
+		IL_0316: ldstr "getPrimes"
 		IL_031b: ldloc.s 9
-		IL_031d: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject::.ctor(object[])
-		IL_0322: ldc.i4.1
+		IL_031d: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject::.ctor(object[])
+		IL_0322: ldc.i4.0
 		IL_0323: conv.r8
-		IL_0324: ldstr "validatePrimeCount"
+		IL_0324: ldstr "getPrimes"
 		IL_0329: ldc.i4.1
 		IL_032a: ldc.i4.1
-		IL_032b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0330: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject>(!!0)
+		IL_032b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0330: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject>(!!0)
 		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_033a: pop
 		IL_033b: ldc.i4.1
@@ -3388,32 +3388,52 @@
 		IL_0343: ldloc.0
 		IL_0344: stelem.ref
 		IL_0345: stloc.s 9
-		IL_0347: ldloc.s 9
-		IL_0349: ldc.i4.0
-		IL_034a: ldelem.ref
-		IL_034b: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_0350: ldloc.s 9
-		IL_0352: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object[])
-		IL_0357: ldloc.s 8
-		IL_0359: ldloc.s 9
-		IL_035b: ldc.i4.1
-		IL_035c: conv.r8
-		IL_035d: ldc.i4.0
-		IL_035e: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0363: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject
-		IL_0368: stloc.s 11
-		IL_036a: ldloc.0
-		IL_036b: ldloc.s 11
-		IL_036d: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
-		IL_0372: nop
-		IL_0373: nop
-		IL_0374: ldloc.0
-		IL_0375: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_037a: ldnull
-		IL_037b: ldloc.1
-		IL_037c: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
-		IL_0381: pop
-		IL_0382: ret
+		IL_0347: ldloc.s 5
+		IL_0349: ldstr "validatePrimeCount"
+		IL_034e: ldloc.s 9
+		IL_0350: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject::.ctor(object[])
+		IL_0355: ldc.i4.1
+		IL_0356: conv.r8
+		IL_0357: ldstr "validatePrimeCount"
+		IL_035c: ldc.i4.1
+		IL_035d: ldc.i4.1
+		IL_035e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0363: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject>(!!0)
+		IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_036d: pop
+		IL_036e: ldc.i4.1
+		IL_036f: newarr [System.Runtime]System.Object
+		IL_0374: dup
+		IL_0375: ldc.i4.0
+		IL_0376: ldloc.0
+		IL_0377: stelem.ref
+		IL_0378: stloc.s 9
+		IL_037a: ldloc.s 9
+		IL_037c: ldc.i4.0
+		IL_037d: ldelem.ref
+		IL_037e: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_0383: ldloc.s 9
+		IL_0385: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object[])
+		IL_038a: ldloc.s 8
+		IL_038c: ldloc.s 9
+		IL_038e: ldc.i4.1
+		IL_038f: conv.r8
+		IL_0390: ldc.i4.0
+		IL_0391: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_0396: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject
+		IL_039b: stloc.s 11
+		IL_039d: ldloc.0
+		IL_039e: ldloc.s 11
+		IL_03a0: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
+		IL_03a5: nop
+		IL_03a6: nop
+		IL_03a7: ldloc.0
+		IL_03a8: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_03ad: ldnull
+		IL_03ae: ldloc.1
+		IL_03af: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
+		IL_03b4: pop
+		IL_03b5: ret
 	} // end of method Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes::__js_module_init__
 
 } // end of class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_ExecFileSync_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_ExecFileSync_Basic.verified.txt
@@ -78,7 +78,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 682 (0x2aa)
+		// Code size: 784 (0x310)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_ChildProcess_ExecFileSync_Basic/Scope,
@@ -178,167 +178,207 @@
 		IL_00d2: stloc.s 17
 		IL_00d4: ldloc.s 7
 		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00db: ldstr "indexOf"
-		IL_00e0: ldstr "hello"
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ea: stloc.s 14
-		IL_00ec: ldloc.s 14
-		IL_00ee: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_00f3: ldc.r8 0.0
-		IL_00fc: clt
-		IL_00fe: ldc.i4.0
-		IL_00ff: ceq
-		IL_0101: stloc.s 18
-		IL_0103: ldloc.s 18
-		IL_0105: box [System.Runtime]System.Boolean
-		IL_010a: stloc.s 19
-		IL_010c: ldloc.s 17
-		IL_010e: ldstr "stdout contains hello:"
-		IL_0113: ldloc.s 19
-		IL_0115: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_011a: pop
+		IL_00db: stloc.s 14
+		IL_00dd: ldc.i4.0
+		IL_00de: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_00e3: brfalse IL_010c
+
+		IL_00e8: ldloc.s 14
+		IL_00ea: isinst [System.Runtime]System.String
+		IL_00ef: dup
+		IL_00f0: brfalse IL_010b
+
+		IL_00f5: ldstr "hello"
+		IL_00fa: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_00ff: box [System.Runtime]System.Double
+		IL_0104: stloc.s 14
+		IL_0106: br IL_011f
+
+		IL_010b: pop
+
+		IL_010c: ldloc.s 14
+		IL_010e: ldstr "indexOf"
+		IL_0113: ldstr "hello"
+		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011d: stloc.s 14
+
+		IL_011f: ldloc.s 14
+		IL_0121: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0126: ldc.r8 0.0
+		IL_012f: clt
+		IL_0131: ldc.i4.0
+		IL_0132: ceq
+		IL_0134: stloc.s 18
+		IL_0136: ldloc.s 18
+		IL_0138: box [System.Runtime]System.Boolean
+		IL_013d: stloc.s 19
+		IL_013f: ldloc.s 17
+		IL_0141: ldstr "stdout contains hello:"
+		IL_0146: ldloc.s 19
+		IL_0148: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_014d: pop
 		.try
 		{
-			IL_011b: nop
-			IL_011c: ldloc.2
-			IL_011d: brfalse IL_0149
+			IL_014e: nop
+			IL_014f: ldloc.2
+			IL_0150: brfalse IL_017c
 
-			IL_0122: ldc.i4.2
-			IL_0123: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0128: dup
-			IL_0129: ldstr "/c"
-			IL_012e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0133: dup
-			IL_0134: ldstr "exit 5"
-			IL_0139: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_013e: stloc.s 15
-			IL_0140: ldloc.s 15
-			IL_0142: stloc.s 8
-			IL_0144: br IL_016b
+			IL_0155: ldc.i4.2
+			IL_0156: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_015b: dup
+			IL_015c: ldstr "/c"
+			IL_0161: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0166: dup
+			IL_0167: ldstr "exit 5"
+			IL_016c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0171: stloc.s 15
+			IL_0173: ldloc.s 15
+			IL_0175: stloc.s 8
+			IL_0177: br IL_019e
 
-			IL_0149: ldc.i4.2
-			IL_014a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_014f: dup
-			IL_0150: ldstr "-c"
-			IL_0155: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_015a: dup
-			IL_015b: ldstr "exit 5"
-			IL_0160: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0165: stloc.s 15
-			IL_0167: ldloc.s 15
-			IL_0169: stloc.s 8
+			IL_017c: ldc.i4.2
+			IL_017d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0182: dup
+			IL_0183: ldstr "-c"
+			IL_0188: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_018d: dup
+			IL_018e: ldstr "exit 5"
+			IL_0193: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0198: stloc.s 15
+			IL_019a: ldloc.s 15
+			IL_019c: stloc.s 8
 
-			IL_016b: ldloc.s 8
-			IL_016d: stloc.s 9
-			IL_016f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0174: dup
-			IL_0175: ldstr "encoding"
-			IL_017a: ldstr "utf8"
-			IL_017f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0184: stloc.s 16
-			IL_0186: ldloc.1
-			IL_0187: ldstr "execFileSync"
-			IL_018c: ldloc.s 4
-			IL_018e: ldloc.s 9
-			IL_0190: ldloc.s 16
-			IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_0197: pop
-			IL_0198: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_019d: stloc.s 17
-			IL_019f: ldloc.s 17
-			IL_01a1: ldstr "expected error not thrown"
-			IL_01a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01ab: pop
-			IL_01ac: leave IL_02a6
+			IL_019e: ldloc.s 8
+			IL_01a0: stloc.s 9
+			IL_01a2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01a7: dup
+			IL_01a8: ldstr "encoding"
+			IL_01ad: ldstr "utf8"
+			IL_01b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01b7: stloc.s 16
+			IL_01b9: ldloc.1
+			IL_01ba: ldstr "execFileSync"
+			IL_01bf: ldloc.s 4
+			IL_01c1: ldloc.s 9
+			IL_01c3: ldloc.s 16
+			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_01ca: pop
+			IL_01cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01d0: stloc.s 17
+			IL_01d2: ldloc.s 17
+			IL_01d4: ldstr "expected error not thrown"
+			IL_01d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01de: pop
+			IL_01df: leave IL_030c
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_01b1: stloc.s 10
-			IL_01b3: ldloc.s 10
-			IL_01b5: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_01ba: dup
-			IL_01bb: brtrue IL_01d1
+			IL_01e4: stloc.s 10
+			IL_01e6: ldloc.s 10
+			IL_01e8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_01ed: dup
+			IL_01ee: brtrue IL_0204
 
-			IL_01c0: pop
-			IL_01c1: ldloc.s 10
-			IL_01c3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_01c8: dup
-			IL_01c9: brtrue IL_01dd
+			IL_01f3: pop
+			IL_01f4: ldloc.s 10
+			IL_01f6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_01fb: dup
+			IL_01fc: brtrue IL_0210
 
-			IL_01ce: pop
-			IL_01cf: rethrow
+			IL_0201: pop
+			IL_0202: rethrow
 
-			IL_01d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_01d6: stloc.s 11
-			IL_01d8: br IL_01df
+			IL_0204: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0209: stloc.s 11
+			IL_020b: br IL_0212
 
-			IL_01dd: stloc.s 11
+			IL_0210: stloc.s 11
 
-			IL_01df: ldloc.s 11
-			IL_01e1: stloc.s 12
-			IL_01e3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01e8: stloc.s 17
-			IL_01ea: ldloc.s 17
-			IL_01ec: ldstr "throws on non-zero:"
-			IL_01f1: ldc.i4.1
-			IL_01f2: box [System.Runtime]System.Boolean
-			IL_01f7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_01fc: pop
-			IL_01fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0202: stloc.s 17
-			IL_0204: ldloc.s 12
-			IL_0206: ldstr "status"
-			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0210: stloc.s 14
-			IL_0212: ldloc.s 17
-			IL_0214: ldstr "status:"
-			IL_0219: ldloc.s 14
-			IL_021b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0220: pop
-			IL_0221: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0226: stloc.s 17
-			IL_0228: ldloc.s 12
-			IL_022a: ldstr "code"
-			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0234: stloc.s 14
-			IL_0236: ldloc.s 17
-			IL_0238: ldstr "code:"
-			IL_023d: ldloc.s 14
-			IL_023f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0244: pop
-			IL_0245: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_024a: stloc.s 17
-			IL_024c: ldloc.s 12
-			IL_024e: ldstr "message"
-			IL_0253: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0258: stloc.s 14
-			IL_025a: ldloc.s 14
-			IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0261: ldstr "indexOf"
-			IL_0266: ldstr "exit code 5"
-			IL_026b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0270: stloc.s 14
-			IL_0272: ldloc.s 14
-			IL_0274: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0279: ldc.r8 0.0
-			IL_0282: clt
-			IL_0284: ldc.i4.0
-			IL_0285: ceq
-			IL_0287: stloc.s 18
-			IL_0289: ldloc.s 18
-			IL_028b: box [System.Runtime]System.Boolean
-			IL_0290: stloc.s 19
-			IL_0292: ldloc.s 17
-			IL_0294: ldstr "message has exit code:"
-			IL_0299: ldloc.s 19
-			IL_029b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_02a0: pop
-			IL_02a1: leave IL_02a6
+			IL_0212: ldloc.s 11
+			IL_0214: stloc.s 12
+			IL_0216: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_021b: stloc.s 17
+			IL_021d: ldloc.s 17
+			IL_021f: ldstr "throws on non-zero:"
+			IL_0224: ldc.i4.1
+			IL_0225: box [System.Runtime]System.Boolean
+			IL_022a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_022f: pop
+			IL_0230: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0235: stloc.s 17
+			IL_0237: ldloc.s 12
+			IL_0239: ldstr "status"
+			IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0243: stloc.s 14
+			IL_0245: ldloc.s 17
+			IL_0247: ldstr "status:"
+			IL_024c: ldloc.s 14
+			IL_024e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0253: pop
+			IL_0254: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0259: stloc.s 17
+			IL_025b: ldloc.s 12
+			IL_025d: ldstr "code"
+			IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0267: stloc.s 14
+			IL_0269: ldloc.s 17
+			IL_026b: ldstr "code:"
+			IL_0270: ldloc.s 14
+			IL_0272: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0277: pop
+			IL_0278: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_027d: stloc.s 17
+			IL_027f: ldloc.s 12
+			IL_0281: ldstr "message"
+			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_028b: stloc.s 14
+			IL_028d: ldloc.s 14
+			IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0294: stloc.s 14
+			IL_0296: ldc.i4.0
+			IL_0297: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_029c: brfalse IL_02c5
+
+			IL_02a1: ldloc.s 14
+			IL_02a3: isinst [System.Runtime]System.String
+			IL_02a8: dup
+			IL_02a9: brfalse IL_02c4
+
+			IL_02ae: ldstr "exit code 5"
+			IL_02b3: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_02b8: box [System.Runtime]System.Double
+			IL_02bd: stloc.s 14
+			IL_02bf: br IL_02d8
+
+			IL_02c4: pop
+
+			IL_02c5: ldloc.s 14
+			IL_02c7: ldstr "indexOf"
+			IL_02cc: ldstr "exit code 5"
+			IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02d6: stloc.s 14
+
+			IL_02d8: ldloc.s 14
+			IL_02da: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_02df: ldc.r8 0.0
+			IL_02e8: clt
+			IL_02ea: ldc.i4.0
+			IL_02eb: ceq
+			IL_02ed: stloc.s 18
+			IL_02ef: ldloc.s 18
+			IL_02f1: box [System.Runtime]System.Boolean
+			IL_02f6: stloc.s 19
+			IL_02f8: ldloc.s 17
+			IL_02fa: ldstr "message has exit code:"
+			IL_02ff: ldloc.s 19
+			IL_0301: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0306: pop
+			IL_0307: leave IL_030c
 		} // end handler
 
-		IL_02a6: ldnull
-		IL_02a7: stloc.s 13
-		IL_02a9: ret
+		IL_030c: ldnull
+		IL_030d: stloc.s 13
+		IL_030f: ret
 	} // end of method Require_ChildProcess_ExecFileSync_Basic::__js_module_init__
 
 } // end of class Modules.Require_ChildProcess_ExecFileSync_Basic

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_ExecFile_NonZero.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_ExecFile_NonZero.verified.txt
@@ -132,7 +132,7 @@
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
 			// Header size: 12
-			// Code size: 375 (0x177)
+			// Code size: 422 (0x1a6)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -218,7 +218,7 @@
 			IL_00a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_00a5: stloc.1
 			IL_00a6: ldloc.1
-			IL_00a7: brfalse IL_00f2
+			IL_00a7: brfalse IL_0121
 
 			IL_00ac: ldarg.2
 			IL_00ad: ldstr "message"
@@ -226,71 +226,91 @@
 			IL_00b7: stloc.3
 			IL_00b8: ldloc.3
 			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00be: ldstr "indexOf"
-			IL_00c3: ldstr "exit code 7"
-			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00cd: stloc.3
-			IL_00ce: ldloc.3
-			IL_00cf: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00d4: ldc.r8 0.0
-			IL_00dd: clt
-			IL_00df: ldc.i4.0
-			IL_00e0: ceq
-			IL_00e2: stloc.1
-			IL_00e3: ldloc.1
-			IL_00e4: box [System.Runtime]System.Boolean
-			IL_00e9: stloc.2
-			IL_00ea: ldloc.2
-			IL_00eb: stloc.s 7
-			IL_00ed: br IL_00f5
+			IL_00be: stloc.3
+			IL_00bf: ldc.i4.0
+			IL_00c0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00c5: brfalse IL_00ec
 
-			IL_00f2: ldarg.2
-			IL_00f3: stloc.s 7
+			IL_00ca: ldloc.3
+			IL_00cb: isinst [System.Runtime]System.String
+			IL_00d0: dup
+			IL_00d1: brfalse IL_00eb
 
-			IL_00f5: ldloc.0
-			IL_00f6: ldstr "message has exit code:"
-			IL_00fb: ldloc.s 7
-			IL_00fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0102: pop
-			IL_0103: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0108: stloc.0
-			IL_0109: ldarg.3
-			IL_010a: ldstr "length"
-			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0114: stloc.3
-			IL_0115: ldloc.0
-			IL_0116: ldstr "stdout length:"
-			IL_011b: ldloc.3
-			IL_011c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0121: pop
-			IL_0122: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0127: stloc.0
-			IL_0128: ldarg.s stderr
-			IL_012a: ldstr "length"
-			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0134: stloc.3
-			IL_0135: ldloc.0
-			IL_0136: ldstr "stderr length:"
-			IL_013b: ldloc.3
-			IL_013c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0141: pop
-			IL_0142: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0147: stloc.0
-			IL_0148: ldarg.0
-			IL_0149: ldfld object Modules.Require_ChildProcess_ExecFile_NonZero/Scope::child
-			IL_014e: ldstr "Cannot access 'child' before initialization"
-			IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_015d: ldstr "kill"
-			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0167: stloc.3
-			IL_0168: ldloc.0
-			IL_0169: ldstr "kill after callback:"
-			IL_016e: ldloc.3
-			IL_016f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0174: pop
-			IL_0175: ldnull
-			IL_0176: ret
+			IL_00d6: ldstr "exit code 7"
+			IL_00db: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_00e0: box [System.Runtime]System.Double
+			IL_00e5: stloc.3
+			IL_00e6: br IL_00fd
+
+			IL_00eb: pop
+
+			IL_00ec: ldloc.3
+			IL_00ed: ldstr "indexOf"
+			IL_00f2: ldstr "exit code 7"
+			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00fc: stloc.3
+
+			IL_00fd: ldloc.3
+			IL_00fe: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0103: ldc.r8 0.0
+			IL_010c: clt
+			IL_010e: ldc.i4.0
+			IL_010f: ceq
+			IL_0111: stloc.1
+			IL_0112: ldloc.1
+			IL_0113: box [System.Runtime]System.Boolean
+			IL_0118: stloc.2
+			IL_0119: ldloc.2
+			IL_011a: stloc.s 7
+			IL_011c: br IL_0124
+
+			IL_0121: ldarg.2
+			IL_0122: stloc.s 7
+
+			IL_0124: ldloc.0
+			IL_0125: ldstr "message has exit code:"
+			IL_012a: ldloc.s 7
+			IL_012c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0131: pop
+			IL_0132: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0137: stloc.0
+			IL_0138: ldarg.3
+			IL_0139: ldstr "length"
+			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0143: stloc.3
+			IL_0144: ldloc.0
+			IL_0145: ldstr "stdout length:"
+			IL_014a: ldloc.3
+			IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0150: pop
+			IL_0151: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0156: stloc.0
+			IL_0157: ldarg.s stderr
+			IL_0159: ldstr "length"
+			IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0163: stloc.3
+			IL_0164: ldloc.0
+			IL_0165: ldstr "stderr length:"
+			IL_016a: ldloc.3
+			IL_016b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0170: pop
+			IL_0171: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0176: stloc.0
+			IL_0177: ldarg.0
+			IL_0178: ldfld object Modules.Require_ChildProcess_ExecFile_NonZero/Scope::child
+			IL_017d: ldstr "Cannot access 'child' before initialization"
+			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_018c: ldstr "kill"
+			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0196: stloc.3
+			IL_0197: ldloc.0
+			IL_0198: ldstr "kill after callback:"
+			IL_019d: ldloc.3
+			IL_019e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_01a3: pop
+			IL_01a4: ldnull
+			IL_01a5: ret
 		} // end of method ArrowFunction_L11C49::__js_call__
 
 	} // end of class ArrowFunction_L11C49

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Exec_Callback.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Exec_Callback.verified.txt
@@ -132,7 +132,7 @@
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
 			// Header size: 12
-			// Code size: 160 (0xa0)
+			// Code size: 197 (0xc5)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -160,42 +160,60 @@
 			IL_002c: stloc.0
 			IL_002d: ldarg.3
 			IL_002e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0033: ldstr "trim"
-			IL_0038: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_003d: stloc.3
-			IL_003e: ldloc.0
-			IL_003f: ldstr "stdout:"
-			IL_0044: ldloc.3
-			IL_0045: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_004a: pop
-			IL_004b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0050: stloc.0
-			IL_0051: ldarg.s stderr
-			IL_0053: ldstr "length"
-			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_005d: stloc.3
-			IL_005e: ldloc.0
-			IL_005f: ldstr "stderr length:"
-			IL_0064: ldloc.3
-			IL_0065: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_006a: pop
-			IL_006b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0070: stloc.0
-			IL_0071: ldarg.0
-			IL_0072: ldfld object Modules.Require_ChildProcess_Exec_Callback/Scope::child
-			IL_0077: ldstr "Cannot access 'child' before initialization"
-			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0086: ldstr "kill"
-			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0090: stloc.3
-			IL_0091: ldloc.0
-			IL_0092: ldstr "kill after callback:"
-			IL_0097: ldloc.3
-			IL_0098: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_009d: pop
-			IL_009e: ldnull
-			IL_009f: ret
+			IL_0033: stloc.3
+			IL_0034: ldc.i4.0
+			IL_0035: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_003a: brfalse IL_0057
+
+			IL_003f: ldloc.3
+			IL_0040: isinst [System.Runtime]System.String
+			IL_0045: dup
+			IL_0046: brfalse IL_0056
+
+			IL_004b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0050: stloc.3
+			IL_0051: br IL_0063
+
+			IL_0056: pop
+
+			IL_0057: ldloc.3
+			IL_0058: ldstr "trim"
+			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0062: stloc.3
+
+			IL_0063: ldloc.0
+			IL_0064: ldstr "stdout:"
+			IL_0069: ldloc.3
+			IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_006f: pop
+			IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0075: stloc.0
+			IL_0076: ldarg.s stderr
+			IL_0078: ldstr "length"
+			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0082: stloc.3
+			IL_0083: ldloc.0
+			IL_0084: ldstr "stderr length:"
+			IL_0089: ldloc.3
+			IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_008f: pop
+			IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0095: stloc.0
+			IL_0096: ldarg.0
+			IL_0097: ldfld object Modules.Require_ChildProcess_Exec_Callback/Scope::child
+			IL_009c: ldstr "Cannot access 'child' before initialization"
+			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ab: ldstr "kill"
+			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_00b5: stloc.3
+			IL_00b6: ldloc.0
+			IL_00b7: ldstr "kill after callback:"
+			IL_00bc: ldloc.3
+			IL_00bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00c2: pop
+			IL_00c3: ldnull
+			IL_00c4: ret
 		} // end of method ArrowFunction_L9C42::__js_call__
 
 	} // end of class ArrowFunction_L9C42

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Exec_Callback_Function_Objects.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Exec_Callback_Function_Objects.verified.txt
@@ -406,7 +406,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 153 (0x99)
+			// Code size: 188 (0xbc)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -444,35 +444,51 @@
 			IL_0040: ldarg.3
 			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_0046: stloc.1
-			IL_0047: ldloc.1
-			IL_0048: ldstr "trim"
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0052: stloc.1
-			IL_0053: ldstr "async-stdout:"
-			IL_0058: ldloc.1
-			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_005e: stloc.s 5
-			IL_0060: ldloc.2
-			IL_0061: ldloc.s 5
-			IL_0063: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0068: pop
-			IL_0069: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_006e: stloc.2
-			IL_006f: ldarg.s stderr
-			IL_0071: ldstr "length"
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_007b: stloc.1
-			IL_007c: ldstr "async-stderr:"
-			IL_0081: ldloc.1
-			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0087: stloc.s 5
-			IL_0089: ldloc.2
-			IL_008a: ldloc.s 5
-			IL_008c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0091: pop
-			IL_0092: ldnull
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-			IL_0098: ret
+			IL_0047: ldc.i4.0
+			IL_0048: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_004d: brfalse IL_006a
+
+			IL_0052: ldloc.1
+			IL_0053: isinst [System.Runtime]System.String
+			IL_0058: dup
+			IL_0059: brfalse IL_0069
+
+			IL_005e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0063: stloc.1
+			IL_0064: br IL_0076
+
+			IL_0069: pop
+
+			IL_006a: ldloc.1
+			IL_006b: ldstr "trim"
+			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0075: stloc.1
+
+			IL_0076: ldstr "async-stdout:"
+			IL_007b: ldloc.1
+			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0081: stloc.s 5
+			IL_0083: ldloc.2
+			IL_0084: ldloc.s 5
+			IL_0086: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_008b: pop
+			IL_008c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0091: stloc.2
+			IL_0092: ldarg.s stderr
+			IL_0094: ldstr "length"
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_009e: stloc.1
+			IL_009f: ldstr "async-stderr:"
+			IL_00a4: ldloc.1
+			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00aa: stloc.s 5
+			IL_00ac: ldloc.2
+			IL_00ad: ldloc.s 5
+			IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00b4: pop
+			IL_00b5: ldnull
+			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+			IL_00bb: ret
 		} // end of method asyncCallback::__js_call__
 
 	} // end of class asyncCallback

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Kill_And_Env.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Kill_And_Env.verified.txt
@@ -682,7 +682,7 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 120 (0x78)
+			// Code size: 157 (0x9d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -725,16 +725,34 @@
 			IL_0053: ldarg.0
 			IL_0054: ldfld object Modules.Require_ChildProcess_Fork_Kill_And_Env/Scope::stderr
 			IL_0059: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_005e: ldstr "trim"
-			IL_0063: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0068: stloc.3
-			IL_0069: ldloc.0
-			IL_006a: ldstr "stderr:"
-			IL_006f: ldloc.3
-			IL_0070: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0075: pop
-			IL_0076: ldnull
-			IL_0077: ret
+			IL_005e: stloc.3
+			IL_005f: ldc.i4.0
+			IL_0060: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0065: brfalse IL_0082
+
+			IL_006a: ldloc.3
+			IL_006b: isinst [System.Runtime]System.String
+			IL_0070: dup
+			IL_0071: brfalse IL_0081
+
+			IL_0076: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_007b: stloc.3
+			IL_007c: br IL_008e
+
+			IL_0081: pop
+
+			IL_0082: ldloc.3
+			IL_0083: ldstr "trim"
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_008d: stloc.3
+
+			IL_008e: ldloc.0
+			IL_008f: ldstr "stderr:"
+			IL_0094: ldloc.3
+			IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_009a: pop
+			IL_009b: ldnull
+			IL_009c: ret
 		} // end of method ArrowFunction_L40C19::__js_call__
 
 	} // end of class ArrowFunction_L40C19

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_MessagePassing.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_MessagePassing.verified.txt
@@ -1057,7 +1057,7 @@
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
 			// Header size: 12
-			// Code size: 265 (0x109)
+			// Code size: 339 (0x153)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -1140,29 +1140,65 @@
 			IL_00bb: ldarg.0
 			IL_00bc: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stdout
 			IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c6: ldstr "trim"
-			IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_00d0: stloc.1
-			IL_00d1: ldloc.0
-			IL_00d2: ldstr "stdout:"
-			IL_00d7: ldloc.1
-			IL_00d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_00dd: pop
-			IL_00de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00e3: stloc.0
-			IL_00e4: ldarg.0
-			IL_00e5: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stderr
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ef: ldstr "trim"
-			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_00f9: stloc.1
-			IL_00fa: ldloc.0
-			IL_00fb: ldstr "stderr:"
-			IL_0100: ldloc.1
-			IL_0101: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0106: pop
-			IL_0107: ldnull
-			IL_0108: ret
+			IL_00c6: stloc.1
+			IL_00c7: ldc.i4.0
+			IL_00c8: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00cd: brfalse IL_00ea
+
+			IL_00d2: ldloc.1
+			IL_00d3: isinst [System.Runtime]System.String
+			IL_00d8: dup
+			IL_00d9: brfalse IL_00e9
+
+			IL_00de: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_00e3: stloc.1
+			IL_00e4: br IL_00f6
+
+			IL_00e9: pop
+
+			IL_00ea: ldloc.1
+			IL_00eb: ldstr "trim"
+			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_00f5: stloc.1
+
+			IL_00f6: ldloc.0
+			IL_00f7: ldstr "stdout:"
+			IL_00fc: ldloc.1
+			IL_00fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0102: pop
+			IL_0103: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0108: stloc.0
+			IL_0109: ldarg.0
+			IL_010a: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stderr
+			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0114: stloc.1
+			IL_0115: ldc.i4.0
+			IL_0116: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_011b: brfalse IL_0138
+
+			IL_0120: ldloc.1
+			IL_0121: isinst [System.Runtime]System.String
+			IL_0126: dup
+			IL_0127: brfalse IL_0137
+
+			IL_012c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0131: stloc.1
+			IL_0132: br IL_0144
+
+			IL_0137: pop
+
+			IL_0138: ldloc.1
+			IL_0139: ldstr "trim"
+			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0143: stloc.1
+
+			IL_0144: ldloc.0
+			IL_0145: ldstr "stderr:"
+			IL_014a: ldloc.1
+			IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0150: pop
+			IL_0151: ldnull
+			IL_0152: ret
 		} // end of method ArrowFunction_L63C19::__js_call__
 
 	} // end of class ArrowFunction_L63C19

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
@@ -594,7 +594,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 222 (0xde)
+				// Code size: 316 (0x13c)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -618,77 +618,117 @@
 				IL_001c: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
 				IL_0021: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stdout
 				IL_0026: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_002b: ldstr "indexOf"
-				IL_0030: ldstr "silent child stdout"
-				IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_003a: stloc.1
-				IL_003b: ldloc.1
-				IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0041: ldc.r8 0.0
-				IL_004a: clt
-				IL_004c: ldc.i4.0
-				IL_004d: ceq
-				IL_004f: stloc.2
-				IL_0050: ldloc.2
-				IL_0051: box [System.Runtime]System.Boolean
-				IL_0056: stloc.3
-				IL_0057: ldloc.0
-				IL_0058: ldstr "silent true stdout marker:"
-				IL_005d: ldloc.3
-				IL_005e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_0063: pop
-				IL_0064: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0069: stloc.0
-				IL_006a: ldarg.0
-				IL_006b: ldc.i4.1
-				IL_006c: ldelem.ref
-				IL_006d: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
-				IL_0072: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stderr
-				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_007c: ldstr "indexOf"
-				IL_0081: ldstr "silent child stderr"
-				IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_008b: stloc.1
-				IL_008c: ldloc.1
-				IL_008d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0092: ldc.r8 0.0
-				IL_009b: clt
-				IL_009d: ldc.i4.0
-				IL_009e: ceq
-				IL_00a0: stloc.2
-				IL_00a1: ldloc.2
-				IL_00a2: box [System.Runtime]System.Boolean
-				IL_00a7: stloc.3
-				IL_00a8: ldloc.0
-				IL_00a9: ldstr "silent true stderr marker:"
-				IL_00ae: ldloc.3
-				IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_00b4: pop
-				IL_00b5: ldarg.0
-				IL_00b6: ldc.i4.0
-				IL_00b7: ldelem.ref
-				IL_00b8: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
-				IL_00bd: ldfld object Modules.Require_ChildProcess_Fork_Silent/Scope::runSilentFalse
-				IL_00c2: stloc.1
-				IL_00c3: ldloc.1
-				IL_00c4: ldc.i4.2
-				IL_00c5: newarr [System.Runtime]System.Object
-				IL_00ca: dup
-				IL_00cb: ldc.i4.0
-				IL_00cc: ldarg.0
-				IL_00cd: ldc.i4.0
-				IL_00ce: ldelem.ref
-				IL_00cf: stelem.ref
-				IL_00d0: dup
-				IL_00d1: ldc.i4.1
-				IL_00d2: ldarg.0
-				IL_00d3: ldc.i4.1
-				IL_00d4: ldelem.ref
-				IL_00d5: stelem.ref
-				IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_00db: pop
-				IL_00dc: ldnull
-				IL_00dd: ret
+				IL_002b: stloc.1
+				IL_002c: ldc.i4.0
+				IL_002d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0032: brfalse IL_0059
+
+				IL_0037: ldloc.1
+				IL_0038: isinst [System.Runtime]System.String
+				IL_003d: dup
+				IL_003e: brfalse IL_0058
+
+				IL_0043: ldstr "silent child stdout"
+				IL_0048: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+				IL_004d: box [System.Runtime]System.Double
+				IL_0052: stloc.1
+				IL_0053: br IL_006a
+
+				IL_0058: pop
+
+				IL_0059: ldloc.1
+				IL_005a: ldstr "indexOf"
+				IL_005f: ldstr "silent child stdout"
+				IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0069: stloc.1
+
+				IL_006a: ldloc.1
+				IL_006b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0070: ldc.r8 0.0
+				IL_0079: clt
+				IL_007b: ldc.i4.0
+				IL_007c: ceq
+				IL_007e: stloc.2
+				IL_007f: ldloc.2
+				IL_0080: box [System.Runtime]System.Boolean
+				IL_0085: stloc.3
+				IL_0086: ldloc.0
+				IL_0087: ldstr "silent true stdout marker:"
+				IL_008c: ldloc.3
+				IL_008d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_0092: pop
+				IL_0093: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0098: stloc.0
+				IL_0099: ldarg.0
+				IL_009a: ldc.i4.1
+				IL_009b: ldelem.ref
+				IL_009c: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
+				IL_00a1: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stderr
+				IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00ab: stloc.1
+				IL_00ac: ldc.i4.0
+				IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_00b2: brfalse IL_00d9
+
+				IL_00b7: ldloc.1
+				IL_00b8: isinst [System.Runtime]System.String
+				IL_00bd: dup
+				IL_00be: brfalse IL_00d8
+
+				IL_00c3: ldstr "silent child stderr"
+				IL_00c8: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+				IL_00cd: box [System.Runtime]System.Double
+				IL_00d2: stloc.1
+				IL_00d3: br IL_00ea
+
+				IL_00d8: pop
+
+				IL_00d9: ldloc.1
+				IL_00da: ldstr "indexOf"
+				IL_00df: ldstr "silent child stderr"
+				IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00e9: stloc.1
+
+				IL_00ea: ldloc.1
+				IL_00eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00f0: ldc.r8 0.0
+				IL_00f9: clt
+				IL_00fb: ldc.i4.0
+				IL_00fc: ceq
+				IL_00fe: stloc.2
+				IL_00ff: ldloc.2
+				IL_0100: box [System.Runtime]System.Boolean
+				IL_0105: stloc.3
+				IL_0106: ldloc.0
+				IL_0107: ldstr "silent true stderr marker:"
+				IL_010c: ldloc.3
+				IL_010d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_0112: pop
+				IL_0113: ldarg.0
+				IL_0114: ldc.i4.0
+				IL_0115: ldelem.ref
+				IL_0116: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
+				IL_011b: ldfld object Modules.Require_ChildProcess_Fork_Silent/Scope::runSilentFalse
+				IL_0120: stloc.1
+				IL_0121: ldloc.1
+				IL_0122: ldc.i4.2
+				IL_0123: newarr [System.Runtime]System.Object
+				IL_0128: dup
+				IL_0129: ldc.i4.0
+				IL_012a: ldarg.0
+				IL_012b: ldc.i4.0
+				IL_012c: ldelem.ref
+				IL_012d: stelem.ref
+				IL_012e: dup
+				IL_012f: ldc.i4.1
+				IL_0130: ldarg.0
+				IL_0131: ldc.i4.1
+				IL_0132: ldelem.ref
+				IL_0133: stelem.ref
+				IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_0139: pop
+				IL_013a: ldnull
+				IL_013b: ret
 			} // end of method ArrowFunction_L31C23::__js_call__
 
 		} // end of class ArrowFunction_L31C23

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Unsupported_Options.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Unsupported_Options.verified.txt
@@ -192,7 +192,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1104 (0x450)
+		// Code size: 1257 (0x4e9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_ChildProcess_Fork_Unsupported_Options/Scope,
@@ -249,7 +249,7 @@
 			IL_0037: ldloc.s 22
 			IL_0039: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::fork(object, object, object)
 			IL_003e: pop
-			IL_003f: leave IL_00d1
+			IL_003f: leave IL_0104
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -284,349 +284,409 @@
 			IL_0083: stloc.s 24
 			IL_0085: ldloc.s 24
 			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_008c: ldstr "indexOf"
-			IL_0091: ldstr "detached child processes"
-			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_009b: stloc.s 24
-			IL_009d: ldloc.s 24
-			IL_009f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00a4: ldc.r8 0.0
-			IL_00ad: clt
-			IL_00af: ldc.i4.0
-			IL_00b0: ceq
-			IL_00b2: stloc.s 25
-			IL_00b4: ldloc.s 25
-			IL_00b6: box [System.Runtime]System.Boolean
-			IL_00bb: stloc.s 26
-			IL_00bd: ldloc.s 23
-			IL_00bf: ldstr "detached error:"
-			IL_00c4: ldloc.s 26
-			IL_00c6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_00cb: pop
-			IL_00cc: leave IL_00d1
+			IL_008c: stloc.s 24
+			IL_008e: ldc.i4.0
+			IL_008f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0094: brfalse IL_00bd
+
+			IL_0099: ldloc.s 24
+			IL_009b: isinst [System.Runtime]System.String
+			IL_00a0: dup
+			IL_00a1: brfalse IL_00bc
+
+			IL_00a6: ldstr "detached child processes"
+			IL_00ab: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_00b0: box [System.Runtime]System.Double
+			IL_00b5: stloc.s 24
+			IL_00b7: br IL_00d0
+
+			IL_00bc: pop
+
+			IL_00bd: ldloc.s 24
+			IL_00bf: ldstr "indexOf"
+			IL_00c4: ldstr "detached child processes"
+			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00ce: stloc.s 24
+
+			IL_00d0: ldloc.s 24
+			IL_00d2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00d7: ldc.r8 0.0
+			IL_00e0: clt
+			IL_00e2: ldc.i4.0
+			IL_00e3: ceq
+			IL_00e5: stloc.s 25
+			IL_00e7: ldloc.s 25
+			IL_00e9: box [System.Runtime]System.Boolean
+			IL_00ee: stloc.s 26
+			IL_00f0: ldloc.s 23
+			IL_00f2: ldstr "detached error:"
+			IL_00f7: ldloc.s 26
+			IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00fe: pop
+			IL_00ff: leave IL_0104
 		} // end handler
 		.try
 		{
-			IL_00d1: nop
-			IL_00d2: ldc.i4.0
-			IL_00d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00d8: stloc.s 21
-			IL_00da: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_00df: dup
-			IL_00e0: ldstr "serialization"
-			IL_00e5: ldstr "advanced"
-			IL_00ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_00ef: stloc.s 22
-			IL_00f1: ldloc.1
-			IL_00f2: ldstr "./Require_ChildProcess_Fork_MessagePassing_Child"
-			IL_00f7: ldloc.s 21
-			IL_00f9: ldloc.s 22
-			IL_00fb: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::fork(object, object, object)
-			IL_0100: pop
-			IL_0101: leave IL_0199
+			IL_0104: nop
+			IL_0105: ldc.i4.0
+			IL_0106: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_010b: stloc.s 21
+			IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0112: dup
+			IL_0113: ldstr "serialization"
+			IL_0118: ldstr "advanced"
+			IL_011d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0122: stloc.s 22
+			IL_0124: ldloc.1
+			IL_0125: ldstr "./Require_ChildProcess_Fork_MessagePassing_Child"
+			IL_012a: ldloc.s 21
+			IL_012c: ldloc.s 22
+			IL_012e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::fork(object, object, object)
+			IL_0133: pop
+			IL_0134: leave IL_01ff
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0106: stloc.s 5
-			IL_0108: ldloc.s 5
-			IL_010a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_010f: dup
-			IL_0110: brtrue IL_0126
+			IL_0139: stloc.s 5
+			IL_013b: ldloc.s 5
+			IL_013d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0142: dup
+			IL_0143: brtrue IL_0159
 
-			IL_0115: pop
-			IL_0116: ldloc.s 5
-			IL_0118: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_011d: dup
-			IL_011e: brtrue IL_0132
+			IL_0148: pop
+			IL_0149: ldloc.s 5
+			IL_014b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0150: dup
+			IL_0151: brtrue IL_0165
 
-			IL_0123: pop
-			IL_0124: rethrow
+			IL_0156: pop
+			IL_0157: rethrow
 
-			IL_0126: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_012b: stloc.s 6
-			IL_012d: br IL_0134
+			IL_0159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_015e: stloc.s 6
+			IL_0160: br IL_0167
 
-			IL_0132: stloc.s 6
+			IL_0165: stloc.s 6
 
-			IL_0134: ldloc.s 6
-			IL_0136: stloc.s 7
-			IL_0138: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_013d: stloc.s 23
-			IL_013f: ldloc.s 7
-			IL_0141: ldstr "message"
-			IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_014b: stloc.s 24
-			IL_014d: ldloc.s 24
-			IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0154: ldstr "indexOf"
-			IL_0159: ldstr "JSON message serialization"
-			IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0163: stloc.s 24
-			IL_0165: ldloc.s 24
-			IL_0167: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_016c: ldc.r8 0.0
-			IL_0175: clt
-			IL_0177: ldc.i4.0
-			IL_0178: ceq
-			IL_017a: stloc.s 25
-			IL_017c: ldloc.s 25
-			IL_017e: box [System.Runtime]System.Boolean
-			IL_0183: stloc.s 26
-			IL_0185: ldloc.s 23
-			IL_0187: ldstr "serialization error:"
-			IL_018c: ldloc.s 26
-			IL_018e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0193: pop
-			IL_0194: leave IL_0199
+			IL_0167: ldloc.s 6
+			IL_0169: stloc.s 7
+			IL_016b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0170: stloc.s 23
+			IL_0172: ldloc.s 7
+			IL_0174: ldstr "message"
+			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_017e: stloc.s 24
+			IL_0180: ldloc.s 24
+			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0187: stloc.s 24
+			IL_0189: ldc.i4.0
+			IL_018a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_018f: brfalse IL_01b8
+
+			IL_0194: ldloc.s 24
+			IL_0196: isinst [System.Runtime]System.String
+			IL_019b: dup
+			IL_019c: brfalse IL_01b7
+
+			IL_01a1: ldstr "JSON message serialization"
+			IL_01a6: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_01ab: box [System.Runtime]System.Double
+			IL_01b0: stloc.s 24
+			IL_01b2: br IL_01cb
+
+			IL_01b7: pop
+
+			IL_01b8: ldloc.s 24
+			IL_01ba: ldstr "indexOf"
+			IL_01bf: ldstr "JSON message serialization"
+			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01c9: stloc.s 24
+
+			IL_01cb: ldloc.s 24
+			IL_01cd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_01d2: ldc.r8 0.0
+			IL_01db: clt
+			IL_01dd: ldc.i4.0
+			IL_01de: ceq
+			IL_01e0: stloc.s 25
+			IL_01e2: ldloc.s 25
+			IL_01e4: box [System.Runtime]System.Boolean
+			IL_01e9: stloc.s 26
+			IL_01eb: ldloc.s 23
+			IL_01ed: ldstr "serialization error:"
+			IL_01f2: ldloc.s 26
+			IL_01f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_01f9: pop
+			IL_01fa: leave IL_01ff
 		} // end handler
 		.try
 		{
-			IL_0199: nop
-			IL_019a: ldstr "process"
-			IL_019f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01a4: ldstr "platform"
-			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ae: stloc.s 24
-			IL_01b0: ldloc.s 24
-			IL_01b2: ldstr "win32"
-			IL_01b7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01bc: stloc.s 8
-			IL_01be: ldloc.s 8
-			IL_01c0: brfalse IL_01d1
+			IL_01ff: nop
+			IL_0200: ldstr "process"
+			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_020a: ldstr "platform"
+			IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0214: stloc.s 24
+			IL_0216: ldloc.s 24
+			IL_0218: ldstr "win32"
+			IL_021d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0222: stloc.s 8
+			IL_0224: ldloc.s 8
+			IL_0226: brfalse IL_0237
 
-			IL_01c5: ldstr "cmd.exe"
-			IL_01ca: stloc.s 9
-			IL_01cc: br IL_01d8
+			IL_022b: ldstr "cmd.exe"
+			IL_0230: stloc.s 9
+			IL_0232: br IL_023e
 
-			IL_01d1: ldstr "/bin/sh"
-			IL_01d6: stloc.s 9
+			IL_0237: ldstr "/bin/sh"
+			IL_023c: stloc.s 9
 
-			IL_01d8: ldloc.s 8
-			IL_01da: brfalse IL_021c
+			IL_023e: ldloc.s 8
+			IL_0240: brfalse IL_0282
 
-			IL_01df: ldc.i4.4
-			IL_01e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_01e5: dup
-			IL_01e6: ldstr "/d"
-			IL_01eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01f0: dup
-			IL_01f1: ldstr "/s"
-			IL_01f6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_01fb: dup
-			IL_01fc: ldstr "/c"
-			IL_0201: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0206: dup
-			IL_0207: ldstr "exit /b 0"
-			IL_020c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0211: stloc.s 21
-			IL_0213: ldloc.s 21
-			IL_0215: stloc.s 10
-			IL_0217: br IL_023e
+			IL_0245: ldc.i4.4
+			IL_0246: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_024b: dup
+			IL_024c: ldstr "/d"
+			IL_0251: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0256: dup
+			IL_0257: ldstr "/s"
+			IL_025c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0261: dup
+			IL_0262: ldstr "/c"
+			IL_0267: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_026c: dup
+			IL_026d: ldstr "exit /b 0"
+			IL_0272: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0277: stloc.s 21
+			IL_0279: ldloc.s 21
+			IL_027b: stloc.s 10
+			IL_027d: br IL_02a4
 
-			IL_021c: ldc.i4.2
-			IL_021d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0222: dup
-			IL_0223: ldstr "-c"
-			IL_0228: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_022d: dup
-			IL_022e: ldstr "exit 0"
-			IL_0233: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0238: stloc.s 21
-			IL_023a: ldloc.s 21
-			IL_023c: stloc.s 10
+			IL_0282: ldc.i4.2
+			IL_0283: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0288: dup
+			IL_0289: ldstr "-c"
+			IL_028e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0293: dup
+			IL_0294: ldstr "exit 0"
+			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_029e: stloc.s 21
+			IL_02a0: ldloc.s 21
+			IL_02a2: stloc.s 10
 
-			IL_023e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0243: dup
-			IL_0244: ldstr "stdio"
-			IL_0249: ldc.i4.4
-			IL_024a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_024f: dup
-			IL_0250: ldstr "pipe"
-			IL_0255: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_025a: dup
-			IL_025b: ldstr "pipe"
-			IL_0260: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0265: dup
-			IL_0266: ldstr "pipe"
-			IL_026b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0270: dup
-			IL_0271: ldstr "ipc"
-			IL_0276: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_027b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0280: stloc.s 22
-			IL_0282: ldloc.1
-			IL_0283: ldstr "spawn"
-			IL_0288: ldloc.s 9
-			IL_028a: ldloc.s 10
-			IL_028c: ldloc.s 22
-			IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_0293: pop
-			IL_0294: leave IL_02ea
+			IL_02a4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02a9: dup
+			IL_02aa: ldstr "stdio"
+			IL_02af: ldc.i4.4
+			IL_02b0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02b5: dup
+			IL_02b6: ldstr "pipe"
+			IL_02bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02c0: dup
+			IL_02c1: ldstr "pipe"
+			IL_02c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02cb: dup
+			IL_02cc: ldstr "pipe"
+			IL_02d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02d6: dup
+			IL_02d7: ldstr "ipc"
+			IL_02dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_02e6: stloc.s 22
+			IL_02e8: ldloc.1
+			IL_02e9: ldstr "spawn"
+			IL_02ee: ldloc.s 9
+			IL_02f0: ldloc.s 10
+			IL_02f2: ldloc.s 22
+			IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_02f9: pop
+			IL_02fa: leave IL_0350
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0299: stloc.s 11
-			IL_029b: ldloc.s 11
-			IL_029d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_02a2: dup
-			IL_02a3: brtrue IL_02b9
+			IL_02ff: stloc.s 11
+			IL_0301: ldloc.s 11
+			IL_0303: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0308: dup
+			IL_0309: brtrue IL_031f
 
-			IL_02a8: pop
-			IL_02a9: ldloc.s 11
-			IL_02ab: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_02b0: dup
-			IL_02b1: brtrue IL_02c5
+			IL_030e: pop
+			IL_030f: ldloc.s 11
+			IL_0311: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0316: dup
+			IL_0317: brtrue IL_032b
 
-			IL_02b6: pop
-			IL_02b7: rethrow
+			IL_031c: pop
+			IL_031d: rethrow
 
-			IL_02b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_02be: stloc.s 12
-			IL_02c0: br IL_02c7
+			IL_031f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0324: stloc.s 12
+			IL_0326: br IL_032d
 
-			IL_02c5: stloc.s 12
+			IL_032b: stloc.s 12
 
-			IL_02c7: ldloc.s 12
-			IL_02c9: stloc.s 13
-			IL_02cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02d0: stloc.s 23
-			IL_02d2: ldloc.s 23
-			IL_02d4: ldstr "spawn ipc error:"
-			IL_02d9: ldc.i4.1
-			IL_02da: box [System.Runtime]System.Boolean
-			IL_02df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_02e4: pop
-			IL_02e5: leave IL_02ea
+			IL_032d: ldloc.s 12
+			IL_032f: stloc.s 13
+			IL_0331: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0336: stloc.s 23
+			IL_0338: ldloc.s 23
+			IL_033a: ldstr "spawn ipc error:"
+			IL_033f: ldc.i4.1
+			IL_0340: box [System.Runtime]System.Boolean
+			IL_0345: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_034a: pop
+			IL_034b: leave IL_0350
 		} // end handler
 		.try
 		{
-			IL_02ea: nop
-			IL_02eb: ldstr "process"
-			IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_02f5: ldstr "platform"
-			IL_02fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_02ff: stloc.s 24
-			IL_0301: ldloc.s 24
-			IL_0303: ldstr "win32"
-			IL_0308: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_030d: stloc.s 14
-			IL_030f: ldloc.s 14
-			IL_0311: brfalse IL_0322
+			IL_0350: nop
+			IL_0351: ldstr "process"
+			IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_035b: ldstr "platform"
+			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0365: stloc.s 24
+			IL_0367: ldloc.s 24
+			IL_0369: ldstr "win32"
+			IL_036e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0373: stloc.s 14
+			IL_0375: ldloc.s 14
+			IL_0377: brfalse IL_0388
 
-			IL_0316: ldstr "cmd.exe"
-			IL_031b: stloc.s 15
-			IL_031d: br IL_0329
+			IL_037c: ldstr "cmd.exe"
+			IL_0381: stloc.s 15
+			IL_0383: br IL_038f
 
-			IL_0322: ldstr "/bin/sh"
-			IL_0327: stloc.s 15
+			IL_0388: ldstr "/bin/sh"
+			IL_038d: stloc.s 15
 
-			IL_0329: ldloc.s 14
-			IL_032b: brfalse IL_036d
+			IL_038f: ldloc.s 14
+			IL_0391: brfalse IL_03d3
 
-			IL_0330: ldc.i4.4
-			IL_0331: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0336: dup
-			IL_0337: ldstr "/d"
-			IL_033c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0341: dup
-			IL_0342: ldstr "/s"
-			IL_0347: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_034c: dup
-			IL_034d: ldstr "/c"
-			IL_0352: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0357: dup
-			IL_0358: ldstr "exit /b 0"
-			IL_035d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0362: stloc.s 21
-			IL_0364: ldloc.s 21
-			IL_0366: stloc.s 16
-			IL_0368: br IL_038f
+			IL_0396: ldc.i4.4
+			IL_0397: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_039c: dup
+			IL_039d: ldstr "/d"
+			IL_03a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03a7: dup
+			IL_03a8: ldstr "/s"
+			IL_03ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03b2: dup
+			IL_03b3: ldstr "/c"
+			IL_03b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03bd: dup
+			IL_03be: ldstr "exit /b 0"
+			IL_03c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03c8: stloc.s 21
+			IL_03ca: ldloc.s 21
+			IL_03cc: stloc.s 16
+			IL_03ce: br IL_03f5
 
-			IL_036d: ldc.i4.2
-			IL_036e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0373: dup
-			IL_0374: ldstr "-c"
-			IL_0379: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_037e: dup
-			IL_037f: ldstr "exit 0"
-			IL_0384: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0389: stloc.s 21
-			IL_038b: ldloc.s 21
-			IL_038d: stloc.s 16
+			IL_03d3: ldc.i4.2
+			IL_03d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_03d9: dup
+			IL_03da: ldstr "-c"
+			IL_03df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03e4: dup
+			IL_03e5: ldstr "exit 0"
+			IL_03ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03ef: stloc.s 21
+			IL_03f1: ldloc.s 21
+			IL_03f3: stloc.s 16
 
-			IL_038f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0394: dup
-			IL_0395: ldstr "detached"
-			IL_039a: ldc.i4.1
-			IL_039b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_03a0: stloc.s 22
-			IL_03a2: ldloc.1
-			IL_03a3: ldstr "spawn"
-			IL_03a8: ldloc.s 15
-			IL_03aa: ldloc.s 16
-			IL_03ac: ldloc.s 22
-			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_03b3: pop
-			IL_03b4: leave IL_044c
+			IL_03f5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_03fa: dup
+			IL_03fb: ldstr "detached"
+			IL_0400: ldc.i4.1
+			IL_0401: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0406: stloc.s 22
+			IL_0408: ldloc.1
+			IL_0409: ldstr "spawn"
+			IL_040e: ldloc.s 15
+			IL_0410: ldloc.s 16
+			IL_0412: ldloc.s 22
+			IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_0419: pop
+			IL_041a: leave IL_04e5
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03b9: stloc.s 17
-			IL_03bb: ldloc.s 17
-			IL_03bd: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03c2: dup
-			IL_03c3: brtrue IL_03d9
+			IL_041f: stloc.s 17
+			IL_0421: ldloc.s 17
+			IL_0423: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0428: dup
+			IL_0429: brtrue IL_043f
 
-			IL_03c8: pop
-			IL_03c9: ldloc.s 17
-			IL_03cb: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03d0: dup
-			IL_03d1: brtrue IL_03e5
+			IL_042e: pop
+			IL_042f: ldloc.s 17
+			IL_0431: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0436: dup
+			IL_0437: brtrue IL_044b
 
-			IL_03d6: pop
-			IL_03d7: rethrow
+			IL_043c: pop
+			IL_043d: rethrow
 
-			IL_03d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03de: stloc.s 18
-			IL_03e0: br IL_03e7
+			IL_043f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0444: stloc.s 18
+			IL_0446: br IL_044d
 
-			IL_03e5: stloc.s 18
+			IL_044b: stloc.s 18
 
-			IL_03e7: ldloc.s 18
-			IL_03e9: stloc.s 19
-			IL_03eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03f0: stloc.s 23
-			IL_03f2: ldloc.s 19
-			IL_03f4: ldstr "message"
-			IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03fe: stloc.s 24
-			IL_0400: ldloc.s 24
-			IL_0402: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0407: ldstr "indexOf"
-			IL_040c: ldstr "detached child processes"
-			IL_0411: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0416: stloc.s 24
-			IL_0418: ldloc.s 24
-			IL_041a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_041f: ldc.r8 0.0
-			IL_0428: clt
-			IL_042a: ldc.i4.0
-			IL_042b: ceq
-			IL_042d: stloc.s 25
-			IL_042f: ldloc.s 25
-			IL_0431: box [System.Runtime]System.Boolean
-			IL_0436: stloc.s 26
-			IL_0438: ldloc.s 23
-			IL_043a: ldstr "spawn detached error:"
-			IL_043f: ldloc.s 26
-			IL_0441: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0446: pop
-			IL_0447: leave IL_044c
+			IL_044d: ldloc.s 18
+			IL_044f: stloc.s 19
+			IL_0451: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0456: stloc.s 23
+			IL_0458: ldloc.s 19
+			IL_045a: ldstr "message"
+			IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0464: stloc.s 24
+			IL_0466: ldloc.s 24
+			IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_046d: stloc.s 24
+			IL_046f: ldc.i4.0
+			IL_0470: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0475: brfalse IL_049e
+
+			IL_047a: ldloc.s 24
+			IL_047c: isinst [System.Runtime]System.String
+			IL_0481: dup
+			IL_0482: brfalse IL_049d
+
+			IL_0487: ldstr "detached child processes"
+			IL_048c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0491: box [System.Runtime]System.Double
+			IL_0496: stloc.s 24
+			IL_0498: br IL_04b1
+
+			IL_049d: pop
+
+			IL_049e: ldloc.s 24
+			IL_04a0: ldstr "indexOf"
+			IL_04a5: ldstr "detached child processes"
+			IL_04aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_04af: stloc.s 24
+
+			IL_04b1: ldloc.s 24
+			IL_04b3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_04b8: ldc.r8 0.0
+			IL_04c1: clt
+			IL_04c3: ldc.i4.0
+			IL_04c4: ceq
+			IL_04c6: stloc.s 25
+			IL_04c8: ldloc.s 25
+			IL_04ca: box [System.Runtime]System.Boolean
+			IL_04cf: stloc.s 26
+			IL_04d1: ldloc.s 23
+			IL_04d3: ldstr "spawn detached error:"
+			IL_04d8: ldloc.s 26
+			IL_04da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_04df: pop
+			IL_04e0: leave IL_04e5
 		} // end handler
 
-		IL_044c: ldnull
-		IL_044d: stloc.s 20
-		IL_044f: ret
+		IL_04e5: ldnull
+		IL_04e6: stloc.s 20
+		IL_04e8: ret
 	} // end of method Require_ChildProcess_Fork_Unsupported_Options::__js_module_init__
 
 } // end of class Modules.Require_ChildProcess_Fork_Unsupported_Options

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Spawn_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Spawn_Basic.verified.txt
@@ -511,7 +511,7 @@
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
 			// Header size: 12
-			// Code size: 139 (0x8b)
+			// Code size: 176 (0xb0)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -530,41 +530,59 @@
 			IL_0019: ldarg.0
 			IL_001a: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stdout
 			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0024: ldstr "trim"
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_002e: stloc.1
-			IL_002f: ldloc.0
-			IL_0030: ldstr "stdout:"
-			IL_0035: ldloc.1
-			IL_0036: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_003b: pop
-			IL_003c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0041: stloc.0
-			IL_0042: ldarg.0
-			IL_0043: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stderr
-			IL_0048: ldstr "length"
-			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0052: stloc.1
-			IL_0053: ldloc.0
-			IL_0054: ldstr "stderr length:"
-			IL_0059: ldloc.1
-			IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_005f: pop
-			IL_0060: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0065: stloc.0
-			IL_0066: ldarg.0
-			IL_0067: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
-			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0071: ldstr "kill"
-			IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_007b: stloc.1
-			IL_007c: ldloc.0
-			IL_007d: ldstr "kill after close:"
-			IL_0082: ldloc.1
-			IL_0083: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0088: pop
-			IL_0089: ldnull
-			IL_008a: ret
+			IL_0024: stloc.1
+			IL_0025: ldc.i4.0
+			IL_0026: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_002b: brfalse IL_0048
+
+			IL_0030: ldloc.1
+			IL_0031: isinst [System.Runtime]System.String
+			IL_0036: dup
+			IL_0037: brfalse IL_0047
+
+			IL_003c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0041: stloc.1
+			IL_0042: br IL_0054
+
+			IL_0047: pop
+
+			IL_0048: ldloc.1
+			IL_0049: ldstr "trim"
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0053: stloc.1
+
+			IL_0054: ldloc.0
+			IL_0055: ldstr "stdout:"
+			IL_005a: ldloc.1
+			IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0060: pop
+			IL_0061: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0066: stloc.0
+			IL_0067: ldarg.0
+			IL_0068: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stderr
+			IL_006d: ldstr "length"
+			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0077: stloc.1
+			IL_0078: ldloc.0
+			IL_0079: ldstr "stderr length:"
+			IL_007e: ldloc.1
+			IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0084: pop
+			IL_0085: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_008a: stloc.0
+			IL_008b: ldarg.0
+			IL_008c: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
+			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0096: ldstr "kill"
+			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_00a0: stloc.1
+			IL_00a1: ldloc.0
+			IL_00a2: ldstr "kill after close:"
+			IL_00a7: ldloc.1
+			IL_00a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00ad: pop
+			IL_00ae: ldnull
+			IL_00af: ret
 		} // end of method ArrowFunction_L29C19::__js_call__
 
 	} // end of class ArrowFunction_L29C19

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_MissingDir_Rejects.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Readdir_MissingDir_Rejects.verified.txt
@@ -214,7 +214,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 64 (0x40)
+			// Code size: 97 (0x61)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -234,18 +234,30 @@
 			IL_0019: ldloc.2
 			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 			IL_001f: stloc.2
-			IL_0020: ldloc.2
-			IL_0021: ldstr "startsWith"
-			IL_0026: ldstr "ENOENT:"
-			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0030: stloc.1
-			IL_0031: ldloc.0
-			IL_0032: ldstr "Is ENOENT:"
-			IL_0037: ldloc.1
-			IL_0038: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_003d: pop
-			IL_003e: ldnull
-			IL_003f: ret
+			IL_0020: ldc.i4.0
+			IL_0021: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0026: brfalse IL_0041
+
+			IL_002b: ldloc.2
+			IL_002c: ldstr "ENOENT:"
+			IL_0031: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+			IL_0036: box [System.Runtime]System.Boolean
+			IL_003b: stloc.1
+			IL_003c: br IL_0052
+
+			IL_0041: ldloc.2
+			IL_0042: ldstr "startsWith"
+			IL_0047: ldstr "ENOENT:"
+			IL_004c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0051: stloc.1
+
+			IL_0052: ldloc.0
+			IL_0053: ldstr "Is ENOENT:"
+			IL_0058: ldloc.1
+			IL_0059: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_005e: pop
+			IL_005f: ldnull
+			IL_0060: ret
 		} // end of method ArrowFunction_L12C12::__js_call__
 
 	} // end of class ArrowFunction_L12C12

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Realpath.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Realpath.verified.txt
@@ -120,7 +120,7 @@
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
 			// Header size: 12
-			// Code size: 181 (0xb5)
+			// Code size: 228 (0xe4)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -154,48 +154,68 @@
 			IL_003d: stloc.0
 			IL_003e: ldarg.2
 			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0044: ldstr "includes"
-			IL_0049: ldstr "test-realpath.txt"
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0053: stloc.1
-			IL_0054: ldloc.0
-			IL_0055: ldstr "Contains filename:"
-			IL_005a: ldloc.1
-			IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0060: pop
-			IL_0061: ldarg.0
-			IL_0062: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.FSPromises_Realpath/Scope::require
-			IL_0067: stloc.s 4
-			IL_0069: ldloc.s 4
-			IL_006b: ldstr "fs"
-			IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule>(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object)
-			IL_0075: stloc.s 5
-			IL_0077: ldarg.0
-			IL_0078: ldfld object Modules.FSPromises_Realpath/Scope::testFile
-			IL_007d: stloc.1
-			IL_007e: ldloc.s 5
-			IL_0080: ldstr "rmSync"
-			IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_008a: brtrue IL_009c
+			IL_0044: stloc.1
+			IL_0045: ldc.i4.0
+			IL_0046: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_004b: brfalse IL_0072
 
-			IL_008f: ldloc.s 5
-			IL_0091: ldloc.1
-			IL_0092: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object)
-			IL_0097: br IL_00b3
+			IL_0050: ldloc.1
+			IL_0051: isinst [System.Runtime]System.String
+			IL_0056: dup
+			IL_0057: brfalse IL_0071
 
-			IL_009c: ldloc.s 5
-			IL_009e: ldstr "rmSync"
-			IL_00a3: ldc.i4.1
-			IL_00a4: newarr [System.Runtime]System.Object
-			IL_00a9: dup
-			IL_00aa: ldc.i4.0
-			IL_00ab: ldloc.1
-			IL_00ac: stelem.ref
-			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_00b2: pop
+			IL_005c: ldstr "test-realpath.txt"
+			IL_0061: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_0066: box [System.Runtime]System.Boolean
+			IL_006b: stloc.1
+			IL_006c: br IL_0083
 
-			IL_00b3: ldnull
-			IL_00b4: ret
+			IL_0071: pop
+
+			IL_0072: ldloc.1
+			IL_0073: ldstr "includes"
+			IL_0078: ldstr "test-realpath.txt"
+			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0082: stloc.1
+
+			IL_0083: ldloc.0
+			IL_0084: ldstr "Contains filename:"
+			IL_0089: ldloc.1
+			IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_008f: pop
+			IL_0090: ldarg.0
+			IL_0091: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.FSPromises_Realpath/Scope::require
+			IL_0096: stloc.s 4
+			IL_0098: ldloc.s 4
+			IL_009a: ldstr "fs"
+			IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule>(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object)
+			IL_00a4: stloc.s 5
+			IL_00a6: ldarg.0
+			IL_00a7: ldfld object Modules.FSPromises_Realpath/Scope::testFile
+			IL_00ac: stloc.1
+			IL_00ad: ldloc.s 5
+			IL_00af: ldstr "rmSync"
+			IL_00b4: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_00b9: brtrue IL_00cb
+
+			IL_00be: ldloc.s 5
+			IL_00c0: ldloc.1
+			IL_00c1: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object)
+			IL_00c6: br IL_00e2
+
+			IL_00cb: ldloc.s 5
+			IL_00cd: ldstr "rmSync"
+			IL_00d2: ldc.i4.1
+			IL_00d3: newarr [System.Runtime]System.Object
+			IL_00d8: dup
+			IL_00d9: ldc.i4.0
+			IL_00da: ldloc.1
+			IL_00db: stelem.ref
+			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_00e1: pop
+
+			IL_00e2: ldnull
+			IL_00e3: ret
 		} // end of method ArrowFunction_L8C28::__js_call__
 
 	} // end of class ArrowFunction_L8C28

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_UnlinkSync_ReleaseCleanup.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_UnlinkSync_ReleaseCleanup.verified.txt
@@ -118,7 +118,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 692 (0x2b4)
+		// Code size: 794 (0x31a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FS_UnlinkSync_ReleaseCleanup/Scope,
@@ -314,7 +314,7 @@
 				IL_01d9: ldloc.1
 				IL_01da: ldloc.s 6
 				IL_01dc: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::unlinkSync(object)
-				IL_01e1: leave IL_0281
+				IL_01e1: leave IL_02e7
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -349,53 +349,93 @@
 				IL_022b: stloc.s 12
 				IL_022d: ldloc.s 12
 				IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0234: ldstr "includes"
-				IL_0239: ldstr "ENOENT:"
-				IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0243: stloc.s 12
-				IL_0245: ldloc.s 10
-				IL_0247: ldstr "message"
-				IL_024c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0251: stloc.s 17
-				IL_0253: ldloc.s 17
-				IL_0255: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_025a: ldstr "includes"
-				IL_025f: ldstr "pr-body.md"
-				IL_0264: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0269: stloc.s 17
-				IL_026b: ldloc.s 16
-				IL_026d: ldstr "MissingError:"
-				IL_0272: ldloc.s 12
-				IL_0274: ldloc.s 17
-				IL_0276: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-				IL_027b: pop
-				IL_027c: leave IL_0281
+				IL_0234: stloc.s 12
+				IL_0236: ldc.i4.0
+				IL_0237: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_023c: brfalse IL_0265
+
+				IL_0241: ldloc.s 12
+				IL_0243: isinst [System.Runtime]System.String
+				IL_0248: dup
+				IL_0249: brfalse IL_0264
+
+				IL_024e: ldstr "ENOENT:"
+				IL_0253: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+				IL_0258: box [System.Runtime]System.Boolean
+				IL_025d: stloc.s 12
+				IL_025f: br IL_0278
+
+				IL_0264: pop
+
+				IL_0265: ldloc.s 12
+				IL_0267: ldstr "includes"
+				IL_026c: ldstr "ENOENT:"
+				IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0276: stloc.s 12
+
+				IL_0278: ldloc.s 10
+				IL_027a: ldstr "message"
+				IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0284: stloc.s 17
+				IL_0286: ldloc.s 17
+				IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_028d: stloc.s 17
+				IL_028f: ldc.i4.0
+				IL_0290: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0295: brfalse IL_02be
+
+				IL_029a: ldloc.s 17
+				IL_029c: isinst [System.Runtime]System.String
+				IL_02a1: dup
+				IL_02a2: brfalse IL_02bd
+
+				IL_02a7: ldstr "pr-body.md"
+				IL_02ac: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+				IL_02b1: box [System.Runtime]System.Boolean
+				IL_02b6: stloc.s 17
+				IL_02b8: br IL_02d1
+
+				IL_02bd: pop
+
+				IL_02be: ldloc.s 17
+				IL_02c0: ldstr "includes"
+				IL_02c5: ldstr "pr-body.md"
+				IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_02cf: stloc.s 17
+
+				IL_02d1: ldloc.s 16
+				IL_02d3: ldstr "MissingError:"
+				IL_02d8: ldloc.s 12
+				IL_02da: ldloc.s 17
+				IL_02dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+				IL_02e1: pop
+				IL_02e2: leave IL_02e7
 			} // end handler
 
-			IL_0281: leave IL_02b0
+			IL_02e7: leave IL_0316
 		} // end .try
 		finally
 		{
-			IL_0286: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_028b: dup
-			IL_028c: ldstr "recursive"
-			IL_0291: ldc.i4.1
-			IL_0292: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0297: dup
-			IL_0298: ldstr "force"
-			IL_029d: ldc.i4.1
-			IL_029e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02a3: stloc.s 15
-			IL_02a5: ldloc.1
-			IL_02a6: ldloc.s 5
-			IL_02a8: ldloc.s 15
-			IL_02aa: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_02af: endfinally
+			IL_02ec: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02f1: dup
+			IL_02f2: ldstr "recursive"
+			IL_02f7: ldc.i4.1
+			IL_02f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_02fd: dup
+			IL_02fe: ldstr "force"
+			IL_0303: ldc.i4.1
+			IL_0304: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0309: stloc.s 15
+			IL_030b: ldloc.1
+			IL_030c: ldloc.s 5
+			IL_030e: ldloc.s 15
+			IL_0310: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_0315: endfinally
 		} // end handler
 
-		IL_02b0: ldnull
-		IL_02b1: stloc.s 11
-		IL_02b3: ret
+		IL_0316: ldnull
+		IL_0317: stloc.s 11
+		IL_0319: ret
 	} // end of method FS_UnlinkSync_ReleaseCleanup::__js_module_init__
 
 } // end of class Modules.FS_UnlinkSync_ReleaseCleanup

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_CreateServer_Get_Loopback.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_CreateServer_Get_Loopback.verified.txt
@@ -144,7 +144,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 275 (0x113)
+			// Code size: 322 (0x142)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -195,57 +195,77 @@
 			IL_0069: stloc.1
 			IL_006a: ldloc.1
 			IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0070: ldstr "indexOf"
-			IL_0075: ldstr "127.0.0.1:"
-			IL_007a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_007f: stloc.1
-			IL_0080: ldloc.1
-			IL_0081: ldc.r8 0.0
-			IL_008a: box [System.Runtime]System.Double
-			IL_008f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0094: stloc.3
-			IL_0095: ldloc.3
-			IL_0096: box [System.Runtime]System.Boolean
-			IL_009b: stloc.s 4
-			IL_009d: ldstr "req host:"
-			IL_00a2: ldloc.s 4
-			IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00a9: stloc.2
-			IL_00aa: ldloc.0
-			IL_00ab: ldloc.2
-			IL_00ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00b1: pop
-			IL_00b2: ldarg.2
-			IL_00b3: ldstr "statusCode"
-			IL_00b8: ldc.r8 201
-			IL_00c1: ldc.i4.1
-			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_00c7: pop
-			IL_00c8: ldarg.2
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ce: ldstr "setHeader"
-			IL_00d3: ldstr "X-Answer"
-			IL_00d8: ldstr "42"
-			IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00e2: pop
-			IL_00e3: ldarg.2
-			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e9: stloc.1
-			IL_00ea: ldarg.1
-			IL_00eb: ldstr "url"
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00f5: stloc.s 5
-			IL_00f7: ldstr "hello:"
-			IL_00fc: ldloc.s 5
-			IL_00fe: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0103: stloc.2
-			IL_0104: ldloc.1
-			IL_0105: ldstr "end"
-			IL_010a: ldloc.2
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0110: pop
-			IL_0111: ldnull
-			IL_0112: ret
+			IL_0070: stloc.1
+			IL_0071: ldc.i4.0
+			IL_0072: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0077: brfalse IL_009e
+
+			IL_007c: ldloc.1
+			IL_007d: isinst [System.Runtime]System.String
+			IL_0082: dup
+			IL_0083: brfalse IL_009d
+
+			IL_0088: ldstr "127.0.0.1:"
+			IL_008d: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0092: box [System.Runtime]System.Double
+			IL_0097: stloc.1
+			IL_0098: br IL_00af
+
+			IL_009d: pop
+
+			IL_009e: ldloc.1
+			IL_009f: ldstr "indexOf"
+			IL_00a4: ldstr "127.0.0.1:"
+			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00ae: stloc.1
+
+			IL_00af: ldloc.1
+			IL_00b0: ldc.r8 0.0
+			IL_00b9: box [System.Runtime]System.Double
+			IL_00be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00c3: stloc.3
+			IL_00c4: ldloc.3
+			IL_00c5: box [System.Runtime]System.Boolean
+			IL_00ca: stloc.s 4
+			IL_00cc: ldstr "req host:"
+			IL_00d1: ldloc.s 4
+			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00d8: stloc.2
+			IL_00d9: ldloc.0
+			IL_00da: ldloc.2
+			IL_00db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00e0: pop
+			IL_00e1: ldarg.2
+			IL_00e2: ldstr "statusCode"
+			IL_00e7: ldc.r8 201
+			IL_00f0: ldc.i4.1
+			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_00f6: pop
+			IL_00f7: ldarg.2
+			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00fd: ldstr "setHeader"
+			IL_0102: ldstr "X-Answer"
+			IL_0107: ldstr "42"
+			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0111: pop
+			IL_0112: ldarg.2
+			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0118: stloc.1
+			IL_0119: ldarg.1
+			IL_011a: ldstr "url"
+			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0124: stloc.s 5
+			IL_0126: ldstr "hello:"
+			IL_012b: ldloc.s 5
+			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0132: stloc.2
+			IL_0133: ldloc.1
+			IL_0134: ldstr "end"
+			IL_0139: ldloc.2
+			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_013f: pop
+			IL_0140: ldnull
+			IL_0141: ret
 		} // end of method FunctionExpression_server::__js_call__
 
 	} // end of class FunctionExpression_server

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Post_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Post_Basic.verified.txt
@@ -339,7 +339,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 414 (0x19e)
+				// Code size: 451 (0x1c3)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -482,16 +482,34 @@
 				IL_0175: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
 				IL_017a: ldfld object Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::body
 				IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0184: ldstr "toUpperCase"
-				IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_018e: stloc.3
-				IL_018f: ldloc.1
-				IL_0190: ldstr "end"
-				IL_0195: ldloc.3
-				IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_019b: pop
-				IL_019c: ldnull
-				IL_019d: ret
+				IL_0184: stloc.3
+				IL_0185: ldc.i4.0
+				IL_0186: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_018b: brfalse IL_01a8
+
+				IL_0190: ldloc.3
+				IL_0191: isinst [System.Runtime]System.String
+				IL_0196: dup
+				IL_0197: brfalse IL_01a7
+
+				IL_019c: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+				IL_01a1: stloc.3
+				IL_01a2: br IL_01b4
+
+				IL_01a7: pop
+
+				IL_01a8: ldloc.3
+				IL_01a9: ldstr "toUpperCase"
+				IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_01b3: stloc.3
+
+				IL_01b4: ldloc.1
+				IL_01b5: ldstr "end"
+				IL_01ba: ldloc.3
+				IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01c0: pop
+				IL_01c1: ldnull
+				IL_01c2: ret
 			} // end of method FunctionExpression_server_L13C16::__js_call__
 
 		} // end of class FunctionExpression_server_L13C16

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_AllowHalfOpen_Delayed_Response.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_AllowHalfOpen_Delayed_Response.verified.txt
@@ -350,7 +350,7 @@
 						01 00 02 00 00 00 00 00
 					)
 					// Header size: 12
-					// Code size: 125 (0x7d)
+					// Code size: 162 (0xa2)
 					.maxstack 8
 					.locals init (
 						[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -390,20 +390,38 @@
 					IL_0048: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
 					IL_004d: ldfld object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::received
 					IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-					IL_0057: ldstr "toUpperCase"
-					IL_005c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_0061: stloc.3
-					IL_0062: ldstr "delayed:"
-					IL_0067: ldloc.3
-					IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_006d: stloc.2
-					IL_006e: ldloc.1
-					IL_006f: ldstr "end"
-					IL_0074: ldloc.2
-					IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_0057: stloc.3
+					IL_0058: ldc.i4.0
+					IL_0059: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+					IL_005e: brfalse IL_007b
+
+					IL_0063: ldloc.3
+					IL_0064: isinst [System.Runtime]System.String
+					IL_0069: dup
+					IL_006a: brfalse IL_007a
+
+					IL_006f: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+					IL_0074: stloc.3
+					IL_0075: br IL_0087
+
 					IL_007a: pop
-					IL_007b: ldnull
-					IL_007c: ret
+
+					IL_007b: ldloc.3
+					IL_007c: ldstr "toUpperCase"
+					IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_0086: stloc.3
+
+					IL_0087: ldstr "delayed:"
+					IL_008c: ldloc.3
+					IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_0092: stloc.2
+					IL_0093: ldloc.1
+					IL_0094: ldstr "end"
+					IL_0099: ldloc.2
+					IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_009f: pop
+					IL_00a0: ldnull
+					IL_00a1: ret
 				} // end of method FunctionExpression_server::__js_call__
 
 			} // end of class FunctionExpression_server

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_Connect_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_Connect_Basic.verified.txt
@@ -346,7 +346,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 144 (0x90)
+				// Code size: 181 (0xb5)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -384,29 +384,47 @@
 				IL_003e: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
 				IL_0043: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::received
 				IL_0048: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_004d: ldstr "toUpperCase"
-				IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_0057: stloc.3
-				IL_0058: ldstr "pong:"
-				IL_005d: ldloc.3
-				IL_005e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0063: stloc.2
-				IL_0064: ldloc.1
-				IL_0065: ldstr "write"
-				IL_006a: ldloc.2
-				IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_004d: stloc.3
+				IL_004e: ldc.i4.0
+				IL_004f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0054: brfalse IL_0071
+
+				IL_0059: ldloc.3
+				IL_005a: isinst [System.Runtime]System.String
+				IL_005f: dup
+				IL_0060: brfalse IL_0070
+
+				IL_0065: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+				IL_006a: stloc.3
+				IL_006b: br IL_007d
+
 				IL_0070: pop
-				IL_0071: ldarg.0
-				IL_0072: ldc.i4.1
-				IL_0073: ldelem.ref
-				IL_0074: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
-				IL_0079: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::socket
-				IL_007e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0083: ldstr "end"
-				IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_008d: pop
-				IL_008e: ldnull
-				IL_008f: ret
+
+				IL_0071: ldloc.3
+				IL_0072: ldstr "toUpperCase"
+				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_007c: stloc.3
+
+				IL_007d: ldstr "pong:"
+				IL_0082: ldloc.3
+				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0088: stloc.2
+				IL_0089: ldloc.1
+				IL_008a: ldstr "write"
+				IL_008f: ldloc.2
+				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0095: pop
+				IL_0096: ldarg.0
+				IL_0097: ldc.i4.1
+				IL_0098: ldelem.ref
+				IL_0099: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
+				IL_009e: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::socket
+				IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00a8: ldstr "end"
+				IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_00b2: pop
+				IL_00b3: ldnull
+				IL_00b4: ret
 			} // end of method FunctionExpression_server_L12C19::__js_call__
 
 		} // end of class FunctionExpression_server_L12C19

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Transform_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Transform_Basic.verified.txt
@@ -156,7 +156,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 49 (0x31)
+			// Code size: 86 (0x56)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -170,16 +170,34 @@
 			IL_0010: stloc.0
 			IL_0011: ldarg.2
 			IL_0012: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0017: ldstr "toUpperCase"
-			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0021: stloc.1
-			IL_0022: ldloc.0
-			IL_0023: ldstr "push"
-			IL_0028: ldloc.1
-			IL_0029: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_002e: pop
-			IL_002f: ldnull
-			IL_0030: ret
+			IL_0017: stloc.1
+			IL_0018: ldc.i4.0
+			IL_0019: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_001e: brfalse IL_003b
+
+			IL_0023: ldloc.1
+			IL_0024: isinst [System.Runtime]System.String
+			IL_0029: dup
+			IL_002a: brfalse IL_003a
+
+			IL_002f: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+			IL_0034: stloc.1
+			IL_0035: br IL_0047
+
+			IL_003a: pop
+
+			IL_003b: ldloc.1
+			IL_003c: ldstr "toUpperCase"
+			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0046: stloc.1
+
+			IL_0047: ldloc.0
+			IL_0048: ldstr "push"
+			IL_004d: ldloc.1
+			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0053: pop
+			IL_0054: ldnull
+			IL_0055: ret
 		} // end of method FunctionExpression_L9C23::__js_call__
 
 	} // end of class FunctionExpression_L9C23

--- a/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_File_Helpers.verified.txt
+++ b/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_File_Helpers.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 393 (0x189)
+		// Code size: 597 (0x255)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Url_File_Helpers/Scope,
@@ -81,97 +81,177 @@
 		IL_0054: stloc.s 5
 		IL_0056: ldloc.s 5
 		IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_005d: ldstr "startsWith"
-		IL_0062: ldstr "file://"
-		IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_006c: stloc.s 5
-		IL_006e: ldloc.s 4
-		IL_0070: ldstr "href file:"
-		IL_0075: ldloc.s 5
-		IL_0077: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_007c: pop
-		IL_007d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0082: stloc.s 4
-		IL_0084: ldloc.2
-		IL_0085: ldstr "pathname"
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_008f: stloc.s 5
-		IL_0091: ldloc.s 5
-		IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0098: ldstr "indexOf"
-		IL_009d: ldstr "folder%20with%20space"
-		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a7: stloc.s 5
-		IL_00a9: ldloc.s 5
-		IL_00ab: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_00b0: ldc.r8 0.0
-		IL_00b9: clt
-		IL_00bb: ldc.i4.0
-		IL_00bc: ceq
-		IL_00be: stloc.s 6
-		IL_00c0: ldloc.s 6
-		IL_00c2: box [System.Runtime]System.Boolean
-		IL_00c7: stloc.s 7
-		IL_00c9: ldloc.s 4
-		IL_00cb: ldstr "pathname escaped:"
-		IL_00d0: ldloc.s 7
-		IL_00d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00d7: pop
-		IL_00d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00dd: stloc.s 4
-		IL_00df: ldloc.1
-		IL_00e0: ldloc.2
-		IL_00e1: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
-		IL_00e6: stloc.s 5
-		IL_00e8: ldloc.s 5
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ef: ldstr "indexOf"
-		IL_00f4: ldstr "folder with space"
-		IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00fe: stloc.s 5
-		IL_0100: ldloc.s 5
-		IL_0102: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0107: ldc.r8 0.0
-		IL_0110: clt
-		IL_0112: ldc.i4.0
-		IL_0113: ceq
-		IL_0115: stloc.s 6
-		IL_0117: ldloc.s 6
-		IL_0119: box [System.Runtime]System.Boolean
-		IL_011e: stloc.s 7
-		IL_0120: ldloc.s 4
-		IL_0122: ldstr "roundtrip contains:"
-		IL_0127: ldloc.s 7
-		IL_0129: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_012e: pop
-		IL_012f: ldloc.1
-		IL_0130: ldstr "file:///var/example.txt"
-		IL_0135: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
-		IL_013a: stloc.3
-		IL_013b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0140: stloc.s 4
-		IL_0142: ldloc.3
-		IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0148: ldstr "indexOf"
-		IL_014d: ldstr "example.txt"
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0157: stloc.s 5
-		IL_0159: ldloc.s 5
-		IL_015b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0160: ldc.r8 0.0
-		IL_0169: clt
-		IL_016b: ldc.i4.0
-		IL_016c: ceq
-		IL_016e: stloc.s 6
-		IL_0170: ldloc.s 6
-		IL_0172: box [System.Runtime]System.Boolean
-		IL_0177: stloc.s 7
-		IL_0179: ldloc.s 4
-		IL_017b: ldstr "from string suffix:"
-		IL_0180: ldloc.s 7
-		IL_0182: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0187: pop
-		IL_0188: ret
+		IL_005d: stloc.s 5
+		IL_005f: ldc.i4.0
+		IL_0060: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0065: brfalse IL_008e
+
+		IL_006a: ldloc.s 5
+		IL_006c: isinst [System.Runtime]System.String
+		IL_0071: dup
+		IL_0072: brfalse IL_008d
+
+		IL_0077: ldstr "file://"
+		IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+		IL_0081: box [System.Runtime]System.Boolean
+		IL_0086: stloc.s 5
+		IL_0088: br IL_00a1
+
+		IL_008d: pop
+
+		IL_008e: ldloc.s 5
+		IL_0090: ldstr "startsWith"
+		IL_0095: ldstr "file://"
+		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_009f: stloc.s 5
+
+		IL_00a1: ldloc.s 4
+		IL_00a3: ldstr "href file:"
+		IL_00a8: ldloc.s 5
+		IL_00aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00af: pop
+		IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b5: stloc.s 4
+		IL_00b7: ldloc.2
+		IL_00b8: ldstr "pathname"
+		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00c2: stloc.s 5
+		IL_00c4: ldloc.s 5
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00cb: stloc.s 5
+		IL_00cd: ldc.i4.0
+		IL_00ce: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_00d3: brfalse IL_00fc
+
+		IL_00d8: ldloc.s 5
+		IL_00da: isinst [System.Runtime]System.String
+		IL_00df: dup
+		IL_00e0: brfalse IL_00fb
+
+		IL_00e5: ldstr "folder%20with%20space"
+		IL_00ea: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_00ef: box [System.Runtime]System.Double
+		IL_00f4: stloc.s 5
+		IL_00f6: br IL_010f
+
+		IL_00fb: pop
+
+		IL_00fc: ldloc.s 5
+		IL_00fe: ldstr "indexOf"
+		IL_0103: ldstr "folder%20with%20space"
+		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_010d: stloc.s 5
+
+		IL_010f: ldloc.s 5
+		IL_0111: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0116: ldc.r8 0.0
+		IL_011f: clt
+		IL_0121: ldc.i4.0
+		IL_0122: ceq
+		IL_0124: stloc.s 6
+		IL_0126: ldloc.s 6
+		IL_0128: box [System.Runtime]System.Boolean
+		IL_012d: stloc.s 7
+		IL_012f: ldloc.s 4
+		IL_0131: ldstr "pathname escaped:"
+		IL_0136: ldloc.s 7
+		IL_0138: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_013d: pop
+		IL_013e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0143: stloc.s 4
+		IL_0145: ldloc.1
+		IL_0146: ldloc.2
+		IL_0147: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
+		IL_014c: stloc.s 5
+		IL_014e: ldloc.s 5
+		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0155: stloc.s 5
+		IL_0157: ldc.i4.0
+		IL_0158: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_015d: brfalse IL_0186
+
+		IL_0162: ldloc.s 5
+		IL_0164: isinst [System.Runtime]System.String
+		IL_0169: dup
+		IL_016a: brfalse IL_0185
+
+		IL_016f: ldstr "folder with space"
+		IL_0174: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_0179: box [System.Runtime]System.Double
+		IL_017e: stloc.s 5
+		IL_0180: br IL_0199
+
+		IL_0185: pop
+
+		IL_0186: ldloc.s 5
+		IL_0188: ldstr "indexOf"
+		IL_018d: ldstr "folder with space"
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0197: stloc.s 5
+
+		IL_0199: ldloc.s 5
+		IL_019b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_01a0: ldc.r8 0.0
+		IL_01a9: clt
+		IL_01ab: ldc.i4.0
+		IL_01ac: ceq
+		IL_01ae: stloc.s 6
+		IL_01b0: ldloc.s 6
+		IL_01b2: box [System.Runtime]System.Boolean
+		IL_01b7: stloc.s 7
+		IL_01b9: ldloc.s 4
+		IL_01bb: ldstr "roundtrip contains:"
+		IL_01c0: ldloc.s 7
+		IL_01c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_01c7: pop
+		IL_01c8: ldloc.1
+		IL_01c9: ldstr "file:///var/example.txt"
+		IL_01ce: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
+		IL_01d3: stloc.3
+		IL_01d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01d9: stloc.s 4
+		IL_01db: ldloc.3
+		IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01e1: stloc.s 5
+		IL_01e3: ldc.i4.0
+		IL_01e4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_01e9: brfalse IL_0212
+
+		IL_01ee: ldloc.s 5
+		IL_01f0: isinst [System.Runtime]System.String
+		IL_01f5: dup
+		IL_01f6: brfalse IL_0211
+
+		IL_01fb: ldstr "example.txt"
+		IL_0200: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_0205: box [System.Runtime]System.Double
+		IL_020a: stloc.s 5
+		IL_020c: br IL_0225
+
+		IL_0211: pop
+
+		IL_0212: ldloc.s 5
+		IL_0214: ldstr "indexOf"
+		IL_0219: ldstr "example.txt"
+		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0223: stloc.s 5
+
+		IL_0225: ldloc.s 5
+		IL_0227: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_022c: ldc.r8 0.0
+		IL_0235: clt
+		IL_0237: ldc.i4.0
+		IL_0238: ceq
+		IL_023a: stloc.s 6
+		IL_023c: ldloc.s 6
+		IL_023e: box [System.Runtime]System.Boolean
+		IL_0243: stloc.s 7
+		IL_0245: ldloc.s 4
+		IL_0247: ldstr "from string suffix:"
+		IL_024c: ldloc.s 7
+		IL_024e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0253: pop
+		IL_0254: ret
 	} // end of method Require_Url_File_Helpers::__js_module_init__
 
 } // end of class Modules.Require_Url_File_Helpers

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_DestructuredParameterInference_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_DestructuredParameterInference_Parity.verified.txt
@@ -405,7 +405,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 179 (0xb3)
+		// Code size: 226 (0xe2)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_DestructuredParameterInference_Parity/Scope,
@@ -450,20 +450,40 @@
 		IL_0086: stloc.2
 		IL_0087: ldloc.2
 		IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_008d: ldstr "includes"
-		IL_0092: ldstr "verbose"
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009c: stloc.2
-		IL_009d: ldloc.1
-		IL_009e: castclass Modules.ObjectLiteral_DestructuredParameterInference_Parity/ObjectLiterals/L1C14_config
-		IL_00a3: ldloc.2
-		IL_00a4: callvirt instance void Modules.ObjectLiteral_DestructuredParameterInference_Parity/ObjectLiterals/L1C14_config::set_verbose(object)
-		IL_00a9: nop
-		IL_00aa: ldnull
-		IL_00ab: ldloc.1
-		IL_00ac: call object Modules.ObjectLiteral_DestructuredParameterInference_Parity/ArrowFunction_L11C14::__js_call__(object, object)
-		IL_00b1: pop
-		IL_00b2: ret
+		IL_008d: stloc.2
+		IL_008e: ldc.i4.0
+		IL_008f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0094: brfalse IL_00bb
+
+		IL_0099: ldloc.2
+		IL_009a: isinst [System.Runtime]System.String
+		IL_009f: dup
+		IL_00a0: brfalse IL_00ba
+
+		IL_00a5: ldstr "verbose"
+		IL_00aa: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_00af: box [System.Runtime]System.Boolean
+		IL_00b4: stloc.2
+		IL_00b5: br IL_00cc
+
+		IL_00ba: pop
+
+		IL_00bb: ldloc.2
+		IL_00bc: ldstr "includes"
+		IL_00c1: ldstr "verbose"
+		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00cb: stloc.2
+
+		IL_00cc: ldloc.1
+		IL_00cd: castclass Modules.ObjectLiteral_DestructuredParameterInference_Parity/ObjectLiterals/L1C14_config
+		IL_00d2: ldloc.2
+		IL_00d3: callvirt instance void Modules.ObjectLiteral_DestructuredParameterInference_Parity/ObjectLiterals/L1C14_config::set_verbose(object)
+		IL_00d8: nop
+		IL_00d9: ldnull
+		IL_00da: ldloc.1
+		IL_00db: call object Modules.ObjectLiteral_DestructuredParameterInference_Parity/ArrowFunction_L11C14::__js_call__(object, object)
+		IL_00e0: pop
+		IL_00e1: ret
 	} // end of method ObjectLiteral_DestructuredParameterInference_Parity::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_DestructuredParameterInference_Parity

--- a/tests/Jroc.Tests/String/JavaScript/String_PrototypeMethodOverrides.js
+++ b/tests/Jroc.Tests/String/JavaScript/String_PrototypeMethodOverrides.js
@@ -1,5 +1,16 @@
 "use strict";
 
+function callTrim(value) {
+    return value.trim();
+}
+
+console.log(callTrim("  uncertain  "));
+console.log(callTrim({
+    trim: function () {
+        return "object-fallback";
+    }
+}));
+
 var originalCharAt = String.prototype.charAt;
 String.prototype.charAt = function (index) {
     return "replaced-" + index;
@@ -34,6 +45,15 @@ if (originalObjectToUpperCase === undefined) {
     Object.prototype.toUpperCase = originalObjectToUpperCase;
 }
 
+var originalIncludes = String.prototype.includes;
+delete String.prototype.includes;
+try {
+    "abc".includes("a");
+} catch (error) {
+    console.log(error.name);
+}
+String.prototype.includes = originalIncludes;
+
 var originalStartsWith = String.prototype.startsWith;
 String.prototype.startsWith = function (prefix) {
     return "alias-" + prefix;
@@ -42,3 +62,11 @@ var startsWith = "abc".startsWith;
 console.log(startsWith.call("abc", "a"));
 console.log(startsWith.apply("abc", ["b"]));
 String.prototype.startsWith = originalStartsWith;
+
+var originalCharCodeAt = String.prototype.charCodeAt;
+String.prototype.charCodeAt = function () {
+    return "41.9";
+};
+console.log(Math.floor("A".charCodeAt(0)));
+console.log(+"A".charCodeAt(0));
+String.prototype.charCodeAt = originalCharCodeAt;

--- a/tests/Jroc.Tests/String/Snapshots/ExecutionTests.String_PrototypeMethodOverrides.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/ExecutionTests.String_PrototypeMethodOverrides.verified.txt
@@ -1,6 +1,11 @@
-﻿replaced-1
+﻿uncertain
+object-fallback
+replaced-1
 trim-getter
 accessor-result
 inherited
+TypeError
 alias-a
 alias-b
+41
+41.9

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharAt_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharAt_Basic.verified.txt
@@ -78,7 +78,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 611 (0x263)
+		// Code size: 911 (0x38f)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_CharAt_Basic/Scope,
@@ -104,196 +104,304 @@
 		IL_000c: stloc.1
 		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0012: stloc.s 7
-		IL_0014: ldloc.1
-		IL_0015: ldstr "charAt"
-		IL_001a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_001f: stloc.s 8
-		IL_0021: ldloc.s 7
-		IL_0023: ldloc.s 8
-		IL_0025: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_002a: pop
-		IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0030: stloc.s 7
-		IL_0032: ldloc.1
-		IL_0033: ldstr "charAt"
-		IL_0038: ldc.r8 1
-		IL_0041: box [System.Runtime]System.Double
-		IL_0046: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_004b: stloc.s 8
-		IL_004d: ldloc.s 7
-		IL_004f: ldloc.s 8
-		IL_0051: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0056: pop
-		IL_0057: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_005c: stloc.s 7
-		IL_005e: ldloc.1
-		IL_005f: ldstr "charAt"
-		IL_0064: ldc.r8 4
-		IL_006d: box [System.Runtime]System.Double
-		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0077: stloc.s 8
-		IL_0079: ldloc.s 7
-		IL_007b: ldloc.s 8
-		IL_007d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0082: pop
-		IL_0083: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0088: stloc.s 7
-		IL_008a: ldloc.1
-		IL_008b: ldstr "charAt"
-		IL_0090: ldc.r8 5
-		IL_0099: box [System.Runtime]System.Double
-		IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a3: stloc.s 8
-		IL_00a5: ldloc.s 8
-		IL_00a7: ldstr ""
-		IL_00ac: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00b1: stloc.s 9
-		IL_00b3: ldloc.s 9
-		IL_00b5: box [System.Runtime]System.Boolean
-		IL_00ba: stloc.s 10
-		IL_00bc: ldloc.s 7
-		IL_00be: ldloc.s 10
-		IL_00c0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c5: pop
-		IL_00c6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00cb: stloc.s 7
-		IL_00cd: ldc.r8 1
-		IL_00d6: neg
-		IL_00d7: stloc.s 11
-		IL_00d9: ldloc.s 11
-		IL_00db: box [System.Runtime]System.Double
-		IL_00e0: stloc.s 12
-		IL_00e2: ldloc.1
-		IL_00e3: ldstr "charAt"
-		IL_00e8: ldloc.s 12
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ef: stloc.s 8
-		IL_00f1: ldloc.s 8
-		IL_00f3: ldstr ""
-		IL_00f8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00fd: stloc.s 9
-		IL_00ff: ldloc.s 9
-		IL_0101: box [System.Runtime]System.Boolean
-		IL_0106: stloc.s 10
-		IL_0108: ldloc.s 7
-		IL_010a: ldloc.s 10
-		IL_010c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0111: pop
+		IL_0014: ldc.i4.0
+		IL_0015: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_001a: brfalse IL_002c
+
+		IL_001f: ldloc.1
+		IL_0020: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string)
+		IL_0025: stloc.s 8
+		IL_0027: br IL_0039
+
+		IL_002c: ldloc.1
+		IL_002d: ldstr "charAt"
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0037: stloc.s 8
+
+		IL_0039: ldloc.s 7
+		IL_003b: ldloc.s 8
+		IL_003d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0042: pop
+		IL_0043: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0048: stloc.s 7
+		IL_004a: ldc.i4.0
+		IL_004b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0050: brfalse IL_0070
+
+		IL_0055: ldloc.1
+		IL_0056: ldc.r8 1
+		IL_005f: box [System.Runtime]System.Double
+		IL_0064: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_0069: stloc.s 8
+		IL_006b: br IL_008b
+
+		IL_0070: ldloc.1
+		IL_0071: ldstr "charAt"
+		IL_0076: ldc.r8 1
+		IL_007f: box [System.Runtime]System.Double
+		IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0089: stloc.s 8
+
+		IL_008b: ldloc.s 7
+		IL_008d: ldloc.s 8
+		IL_008f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0094: pop
+		IL_0095: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009a: stloc.s 7
+		IL_009c: ldc.i4.0
+		IL_009d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_00a2: brfalse IL_00c2
+
+		IL_00a7: ldloc.1
+		IL_00a8: ldc.r8 4
+		IL_00b1: box [System.Runtime]System.Double
+		IL_00b6: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_00bb: stloc.s 8
+		IL_00bd: br IL_00dd
+
+		IL_00c2: ldloc.1
+		IL_00c3: ldstr "charAt"
+		IL_00c8: ldc.r8 4
+		IL_00d1: box [System.Runtime]System.Double
+		IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00db: stloc.s 8
+
+		IL_00dd: ldloc.s 7
+		IL_00df: ldloc.s 8
+		IL_00e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e6: pop
+		IL_00e7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ec: stloc.s 7
+		IL_00ee: ldc.i4.0
+		IL_00ef: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_00f4: brfalse IL_0114
+
+		IL_00f9: ldloc.1
+		IL_00fa: ldc.r8 5
+		IL_0103: box [System.Runtime]System.Double
+		IL_0108: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_010d: stloc.s 8
+		IL_010f: br IL_012f
+
+		IL_0114: ldloc.1
+		IL_0115: ldstr "charAt"
+		IL_011a: ldc.r8 5
+		IL_0123: box [System.Runtime]System.Double
+		IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_012d: stloc.s 8
+
+		IL_012f: ldloc.s 8
+		IL_0131: ldstr ""
+		IL_0136: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_013b: stloc.s 9
+		IL_013d: ldloc.s 9
+		IL_013f: box [System.Runtime]System.Boolean
+		IL_0144: stloc.s 10
+		IL_0146: ldloc.s 7
+		IL_0148: ldloc.s 10
+		IL_014a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_014f: pop
+		IL_0150: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0155: stloc.s 7
+		IL_0157: ldc.r8 1
+		IL_0160: neg
+		IL_0161: stloc.s 11
+		IL_0163: ldloc.s 11
+		IL_0165: box [System.Runtime]System.Double
+		IL_016a: stloc.s 12
+		IL_016c: ldc.i4.0
+		IL_016d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0172: brfalse IL_0186
+
+		IL_0177: ldloc.1
+		IL_0178: ldloc.s 12
+		IL_017a: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_017f: stloc.s 8
+		IL_0181: br IL_0195
+
+		IL_0186: ldloc.1
+		IL_0187: ldstr "charAt"
+		IL_018c: ldloc.s 12
+		IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0193: stloc.s 8
+
+		IL_0195: ldloc.s 8
+		IL_0197: ldstr ""
+		IL_019c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_01a1: stloc.s 9
+		IL_01a3: ldloc.s 9
+		IL_01a5: box [System.Runtime]System.Boolean
+		IL_01aa: stloc.s 10
+		IL_01ac: ldloc.s 7
+		IL_01ae: ldloc.s 10
+		IL_01b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01b5: pop
 		.try
 		{
-			IL_0112: nop
-			IL_0113: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0118: stloc.s 7
-			IL_011a: ldc.r8 1
-			IL_0123: box [System.Runtime]System.Double
-			IL_0128: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
-			IL_012d: stloc.s 13
-			IL_012f: ldloc.1
-			IL_0130: ldstr "charAt"
-			IL_0135: ldloc.s 13
-			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_013c: stloc.s 8
-			IL_013e: ldloc.s 7
-			IL_0140: ldloc.s 8
-			IL_0142: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0147: pop
-			IL_0148: leave IL_01e0
+			IL_01b6: nop
+			IL_01b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01bc: stloc.s 7
+			IL_01be: ldc.r8 1
+			IL_01c7: box [System.Runtime]System.Double
+			IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.BigInt::Call(object)
+			IL_01d1: stloc.s 13
+			IL_01d3: ldc.i4.0
+			IL_01d4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01d9: brfalse IL_01ed
+
+			IL_01de: ldloc.1
+			IL_01df: ldloc.s 13
+			IL_01e1: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+			IL_01e6: stloc.s 8
+			IL_01e8: br IL_01fc
+
+			IL_01ed: ldloc.1
+			IL_01ee: ldstr "charAt"
+			IL_01f3: ldloc.s 13
+			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01fa: stloc.s 8
+
+			IL_01fc: ldloc.s 7
+			IL_01fe: ldloc.s 8
+			IL_0200: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0205: pop
+			IL_0206: leave IL_029e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_014d: stloc.2
-			IL_014e: ldloc.2
-			IL_014f: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0154: dup
-			IL_0155: brtrue IL_016a
+			IL_020b: stloc.2
+			IL_020c: ldloc.2
+			IL_020d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0212: dup
+			IL_0213: brtrue IL_0228
 
-			IL_015a: pop
-			IL_015b: ldloc.2
-			IL_015c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0161: dup
-			IL_0162: brtrue IL_0175
+			IL_0218: pop
+			IL_0219: ldloc.2
+			IL_021a: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_021f: dup
+			IL_0220: brtrue IL_0233
 
-			IL_0167: pop
-			IL_0168: rethrow
+			IL_0225: pop
+			IL_0226: rethrow
 
-			IL_016a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_016f: stloc.3
-			IL_0170: br IL_0176
+			IL_0228: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_022d: stloc.3
+			IL_022e: br IL_0234
 
-			IL_0175: stloc.3
+			IL_0233: stloc.3
 
-			IL_0176: ldloc.3
-			IL_0177: stloc.s 4
-			IL_0179: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_017e: stloc.s 7
-			IL_0180: ldloc.s 7
-			IL_0182: ldstr "bigint threw:"
-			IL_0187: ldc.i4.1
-			IL_0188: box [System.Runtime]System.Boolean
-			IL_018d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0192: pop
-			IL_0193: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0198: stloc.s 7
-			IL_019a: ldloc.s 4
-			IL_019c: ldstr "name"
-			IL_01a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01a6: stloc.s 8
-			IL_01a8: ldloc.s 7
-			IL_01aa: ldstr "bigint name:"
-			IL_01af: ldloc.s 8
-			IL_01b1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_01b6: pop
-			IL_01b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01bc: stloc.s 7
-			IL_01be: ldloc.s 4
-			IL_01c0: ldstr "message"
-			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ca: stloc.s 8
-			IL_01cc: ldloc.s 7
-			IL_01ce: ldstr "bigint message:"
-			IL_01d3: ldloc.s 8
-			IL_01d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_01da: pop
-			IL_01db: leave IL_01e0
+			IL_0234: ldloc.3
+			IL_0235: stloc.s 4
+			IL_0237: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_023c: stloc.s 7
+			IL_023e: ldloc.s 7
+			IL_0240: ldstr "bigint threw:"
+			IL_0245: ldc.i4.1
+			IL_0246: box [System.Runtime]System.Boolean
+			IL_024b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0250: pop
+			IL_0251: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0256: stloc.s 7
+			IL_0258: ldloc.s 4
+			IL_025a: ldstr "name"
+			IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0264: stloc.s 8
+			IL_0266: ldloc.s 7
+			IL_0268: ldstr "bigint name:"
+			IL_026d: ldloc.s 8
+			IL_026f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0274: pop
+			IL_0275: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_027a: stloc.s 7
+			IL_027c: ldloc.s 4
+			IL_027e: ldstr "message"
+			IL_0283: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0288: stloc.s 8
+			IL_028a: ldloc.s 7
+			IL_028c: ldstr "bigint message:"
+			IL_0291: ldloc.s 8
+			IL_0293: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0298: pop
+			IL_0299: leave IL_029e
 		} // end handler
 
-		IL_01e0: ldstr "String"
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01ea: stloc.s 8
-		IL_01ec: ldloc.s 8
-		IL_01ee: dup
-		IL_01ef: ldstr "world"
-		IL_01f4: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_01f9: stloc.s 5
-		IL_01fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0200: stloc.s 7
-		IL_0202: ldloc.s 5
-		IL_0204: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0209: ldstr "charAt"
-		IL_020e: ldc.r8 0.0
-		IL_0217: box [System.Runtime]System.Double
-		IL_021c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0221: stloc.s 8
-		IL_0223: ldloc.s 7
-		IL_0225: ldloc.s 8
-		IL_0227: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_022c: pop
-		IL_022d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0232: stloc.s 7
-		IL_0234: ldloc.s 5
-		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_023b: ldstr "charAt"
-		IL_0240: ldc.r8 2
-		IL_0249: box [System.Runtime]System.Double
-		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0253: stloc.s 8
-		IL_0255: ldloc.s 7
-		IL_0257: ldloc.s 8
-		IL_0259: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_025e: pop
-		IL_025f: ldnull
-		IL_0260: stloc.s 6
-		IL_0262: ret
+		IL_029e: ldstr "String"
+		IL_02a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02a8: stloc.s 8
+		IL_02aa: ldloc.s 8
+		IL_02ac: dup
+		IL_02ad: ldstr "world"
+		IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_02b7: stloc.s 5
+		IL_02b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02be: stloc.s 7
+		IL_02c0: ldloc.s 5
+		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_02c7: stloc.s 8
+		IL_02c9: ldc.i4.0
+		IL_02ca: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_02cf: brfalse IL_02fc
+
+		IL_02d4: ldloc.s 8
+		IL_02d6: isinst [System.Runtime]System.String
+		IL_02db: dup
+		IL_02dc: brfalse IL_02fb
+
+		IL_02e1: ldc.r8 0.0
+		IL_02ea: box [System.Runtime]System.Double
+		IL_02ef: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_02f4: stloc.s 8
+		IL_02f6: br IL_0318
+
+		IL_02fb: pop
+
+		IL_02fc: ldloc.s 8
+		IL_02fe: ldstr "charAt"
+		IL_0303: ldc.r8 0.0
+		IL_030c: box [System.Runtime]System.Double
+		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0316: stloc.s 8
+
+		IL_0318: ldloc.s 7
+		IL_031a: ldloc.s 8
+		IL_031c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0321: pop
+		IL_0322: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0327: stloc.s 7
+		IL_0329: ldloc.s 5
+		IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0330: stloc.s 8
+		IL_0332: ldc.i4.0
+		IL_0333: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0338: brfalse IL_0365
+
+		IL_033d: ldloc.s 8
+		IL_033f: isinst [System.Runtime]System.String
+		IL_0344: dup
+		IL_0345: brfalse IL_0364
+
+		IL_034a: ldc.r8 2
+		IL_0353: box [System.Runtime]System.Double
+		IL_0358: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_035d: stloc.s 8
+		IL_035f: br IL_0381
+
+		IL_0364: pop
+
+		IL_0365: ldloc.s 8
+		IL_0367: ldstr "charAt"
+		IL_036c: ldc.r8 2
+		IL_0375: box [System.Runtime]System.Double
+		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_037f: stloc.s 8
+
+		IL_0381: ldloc.s 7
+		IL_0383: ldloc.s 8
+		IL_0385: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_038a: pop
+		IL_038b: ldnull
+		IL_038c: stloc.s 6
+		IL_038e: ret
 	} // end of method String_CharAt_Basic::__js_module_init__
 
 } // end of class Modules.String_CharAt_Basic

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharCodeAt_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharCodeAt_Basic.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 96 (0x60)
+		// Code size: 188 (0xbc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_CharCodeAt_Basic/Scope,
@@ -51,29 +51,55 @@
 		IL_0006: nop
 		IL_0007: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_000c: stloc.1
-		IL_000d: ldstr "A"
-		IL_0012: ldstr "charCodeAt"
-		IL_0017: ldc.r8 0.0
-		IL_0020: box [System.Runtime]System.Double
-		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_002a: stloc.2
-		IL_002b: ldloc.1
-		IL_002c: ldloc.2
-		IL_002d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0032: pop
-		IL_0033: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0038: stloc.1
-		IL_0039: ldstr "ABC"
-		IL_003e: ldstr "charCodeAt"
-		IL_0043: ldc.r8 2
-		IL_004c: box [System.Runtime]System.Double
-		IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0056: stloc.2
-		IL_0057: ldloc.1
-		IL_0058: ldloc.2
-		IL_0059: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_005e: pop
-		IL_005f: ret
+		IL_000d: ldc.i4.0
+		IL_000e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0013: brfalse IL_003b
+
+		IL_0018: ldstr "A"
+		IL_001d: ldc.r8 0.0
+		IL_0026: box [System.Runtime]System.Double
+		IL_002b: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_0030: box [System.Runtime]System.Double
+		IL_0035: stloc.2
+		IL_0036: br IL_0059
+
+		IL_003b: ldstr "A"
+		IL_0040: ldstr "charCodeAt"
+		IL_0045: ldc.r8 0.0
+		IL_004e: box [System.Runtime]System.Double
+		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0058: stloc.2
+
+		IL_0059: ldloc.1
+		IL_005a: ldloc.2
+		IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0060: pop
+		IL_0061: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0066: stloc.1
+		IL_0067: ldc.i4.0
+		IL_0068: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_006d: brfalse IL_0095
+
+		IL_0072: ldstr "ABC"
+		IL_0077: ldc.r8 2
+		IL_0080: box [System.Runtime]System.Double
+		IL_0085: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_008a: box [System.Runtime]System.Double
+		IL_008f: stloc.2
+		IL_0090: br IL_00b3
+
+		IL_0095: ldstr "ABC"
+		IL_009a: ldstr "charCodeAt"
+		IL_009f: ldc.r8 2
+		IL_00a8: box [System.Runtime]System.Double
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b2: stloc.2
+
+		IL_00b3: ldloc.1
+		IL_00b4: ldloc.2
+		IL_00b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ba: pop
+		IL_00bb: ret
 	} // end of method String_CharCodeAt_Basic::__js_module_init__
 
 } // end of class Modules.String_CharCodeAt_Basic

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_ExplicitReceiverAbi.verified.txt
@@ -210,7 +210,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1221 (0x4c5)
+		// Code size: 1321 (0x529)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_ExplicitReceiverAbi/Scope,
@@ -402,209 +402,236 @@
 		IL_023e: ldloc.s 10
 		IL_0240: box [System.Runtime]System.Double
 		IL_0245: stloc.s 11
-		IL_0247: ldstr "abcdef"
-		IL_024c: ldstr "substr"
-		IL_0251: ldloc.s 11
-		IL_0253: ldc.r8 2
-		IL_025c: box [System.Runtime]System.Double
-		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0266: stloc.s 8
-		IL_0268: ldloc.s 6
-		IL_026a: ldloc.s 8
-		IL_026c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0271: pop
-		IL_0272: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0277: stloc.s 6
-		IL_0279: ldstr "String"
-		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0283: ldstr "prototype"
-		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_028d: stloc.s 8
-		IL_028f: ldloc.s 8
-		IL_0291: ldstr "trimLeft"
-		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_029b: stloc.s 8
-		IL_029d: ldstr "String"
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a7: ldstr "prototype"
-		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b1: stloc.s 7
-		IL_02b3: ldloc.s 7
-		IL_02b5: ldstr "trimStart"
-		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02bf: stloc.s 7
-		IL_02c1: ldloc.s 8
-		IL_02c3: ldloc.s 7
-		IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_02ca: stloc.s 12
-		IL_02cc: ldloc.s 12
-		IL_02ce: box [System.Runtime]System.Boolean
-		IL_02d3: stloc.s 13
-		IL_02d5: ldloc.s 6
-		IL_02d7: ldloc.s 13
-		IL_02d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02de: pop
-		IL_02df: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02e4: stloc.s 6
-		IL_02e6: ldstr "String"
-		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02f0: ldstr "prototype"
-		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02fa: stloc.s 7
-		IL_02fc: ldloc.s 7
-		IL_02fe: ldstr "trimRight"
-		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0308: stloc.s 7
-		IL_030a: ldstr "String"
-		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0314: ldstr "prototype"
-		IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_031e: stloc.s 8
-		IL_0320: ldloc.s 8
-		IL_0322: ldstr "trimEnd"
-		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_032c: stloc.s 8
-		IL_032e: ldloc.s 7
-		IL_0330: ldloc.s 8
-		IL_0332: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0337: stloc.s 12
-		IL_0339: ldloc.s 12
-		IL_033b: box [System.Runtime]System.Boolean
-		IL_0340: stloc.s 13
-		IL_0342: ldloc.s 6
-		IL_0344: ldloc.s 13
-		IL_0346: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_034b: pop
+		IL_0247: ldc.i4.0
+		IL_0248: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_024d: brfalse IL_0273
+
+		IL_0252: ldstr "abcdef"
+		IL_0257: ldloc.s 11
+		IL_0259: ldc.r8 2
+		IL_0262: box [System.Runtime]System.Double
+		IL_0267: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object, object)
+		IL_026c: stloc.s 8
+		IL_026e: br IL_0294
+
+		IL_0273: ldstr "abcdef"
+		IL_0278: ldstr "substr"
+		IL_027d: ldloc.s 11
+		IL_027f: ldc.r8 2
+		IL_0288: box [System.Runtime]System.Double
+		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0292: stloc.s 8
+
+		IL_0294: ldloc.s 6
+		IL_0296: ldloc.s 8
+		IL_0298: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_029d: pop
+		IL_029e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02a3: stloc.s 6
+		IL_02a5: ldstr "String"
+		IL_02aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02af: ldstr "prototype"
+		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02b9: stloc.s 8
+		IL_02bb: ldloc.s 8
+		IL_02bd: ldstr "trimLeft"
+		IL_02c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02c7: stloc.s 8
+		IL_02c9: ldstr "String"
+		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02d3: ldstr "prototype"
+		IL_02d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02dd: stloc.s 7
+		IL_02df: ldloc.s 7
+		IL_02e1: ldstr "trimStart"
+		IL_02e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02eb: stloc.s 7
+		IL_02ed: ldloc.s 8
+		IL_02ef: ldloc.s 7
+		IL_02f1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02f6: stloc.s 12
+		IL_02f8: ldloc.s 12
+		IL_02fa: box [System.Runtime]System.Boolean
+		IL_02ff: stloc.s 13
+		IL_0301: ldloc.s 6
+		IL_0303: ldloc.s 13
+		IL_0305: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_030a: pop
+		IL_030b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0310: stloc.s 6
+		IL_0312: ldstr "String"
+		IL_0317: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_031c: ldstr "prototype"
+		IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0326: stloc.s 7
+		IL_0328: ldloc.s 7
+		IL_032a: ldstr "trimRight"
+		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0334: stloc.s 7
+		IL_0336: ldstr "String"
+		IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0340: ldstr "prototype"
+		IL_0345: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_034a: stloc.s 8
+		IL_034c: ldloc.s 8
+		IL_034e: ldstr "trimEnd"
+		IL_0353: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0358: stloc.s 8
+		IL_035a: ldloc.s 7
+		IL_035c: ldloc.s 8
+		IL_035e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0363: stloc.s 12
+		IL_0365: ldloc.s 12
+		IL_0367: box [System.Runtime]System.Boolean
+		IL_036c: stloc.s 13
+		IL_036e: ldloc.s 6
+		IL_0370: ldloc.s 13
+		IL_0372: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0377: pop
 		.try
 		{
-			IL_034c: nop
-			IL_034d: ldstr "String"
-			IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0357: ldstr "prototype"
-			IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0361: stloc.s 8
-			IL_0363: ldloc.s 8
-			IL_0365: ldstr "trim"
-			IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_036f: stloc.s 8
-			IL_0371: ldloc.s 8
-			IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0378: ldstr "call"
-			IL_037d: ldc.i4.0
-			IL_037e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0388: pop
-			IL_0389: leave IL_03f2
+			IL_0378: nop
+			IL_0379: ldstr "String"
+			IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0383: ldstr "prototype"
+			IL_0388: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_038d: stloc.s 8
+			IL_038f: ldloc.s 8
+			IL_0391: ldstr "trim"
+			IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_039b: stloc.s 8
+			IL_039d: ldloc.s 8
+			IL_039f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03a4: ldstr "call"
+			IL_03a9: ldc.i4.0
+			IL_03aa: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_03af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03b4: pop
+			IL_03b5: leave IL_041e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_038e: stloc.1
-			IL_038f: ldloc.1
-			IL_0390: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0395: dup
-			IL_0396: brtrue IL_03ab
+			IL_03ba: stloc.1
+			IL_03bb: ldloc.1
+			IL_03bc: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03c1: dup
+			IL_03c2: brtrue IL_03d7
 
-			IL_039b: pop
-			IL_039c: ldloc.1
-			IL_039d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03a2: dup
-			IL_03a3: brtrue IL_03b6
+			IL_03c7: pop
+			IL_03c8: ldloc.1
+			IL_03c9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03ce: dup
+			IL_03cf: brtrue IL_03e2
 
-			IL_03a8: pop
-			IL_03a9: rethrow
+			IL_03d4: pop
+			IL_03d5: rethrow
 
-			IL_03ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03b0: stloc.2
-			IL_03b1: br IL_03b7
+			IL_03d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03dc: stloc.2
+			IL_03dd: br IL_03e3
 
-			IL_03b6: stloc.2
+			IL_03e2: stloc.2
 
-			IL_03b7: ldloc.2
-			IL_03b8: stloc.3
-			IL_03b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03be: stloc.s 6
-			IL_03c0: ldloc.3
-			IL_03c1: stloc.s 8
-			IL_03c3: ldstr "TypeError"
-			IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_03cd: stloc.s 7
-			IL_03cf: ldloc.s 8
-			IL_03d1: ldloc.s 7
-			IL_03d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_03d8: stloc.s 12
-			IL_03da: ldloc.s 12
-			IL_03dc: box [System.Runtime]System.Boolean
-			IL_03e1: stloc.s 13
-			IL_03e3: ldloc.s 6
-			IL_03e5: ldloc.s 13
-			IL_03e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03ec: pop
-			IL_03ed: leave IL_03f2
+			IL_03e3: ldloc.2
+			IL_03e4: stloc.3
+			IL_03e5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03ea: stloc.s 6
+			IL_03ec: ldloc.3
+			IL_03ed: stloc.s 8
+			IL_03ef: ldstr "TypeError"
+			IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03f9: stloc.s 7
+			IL_03fb: ldloc.s 8
+			IL_03fd: ldloc.s 7
+			IL_03ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0404: stloc.s 12
+			IL_0406: ldloc.s 12
+			IL_0408: box [System.Runtime]System.Boolean
+			IL_040d: stloc.s 13
+			IL_040f: ldloc.s 6
+			IL_0411: ldloc.s 13
+			IL_0413: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0418: pop
+			IL_0419: leave IL_041e
 		} // end handler
 
-		IL_03f2: ldstr "String"
-		IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03fc: ldstr "prototype"
-		IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0406: stloc.s 7
-		IL_0408: ldloc.s 7
-		IL_040a: ldstr "slice"
-		IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0414: stloc.s 4
-		IL_0416: ldstr "String"
-		IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0420: ldstr "prototype"
-		IL_0425: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_042a: stloc.s 7
-		IL_042c: ldc.i4.1
-		IL_042d: newarr [System.Runtime]System.Object
-		IL_0432: dup
-		IL_0433: ldc.i4.0
-		IL_0434: ldloc.0
-		IL_0435: stelem.ref
-		IL_0436: stloc.s 14
-		IL_0438: newobj instance void Modules.String_ExplicitReceiverAbi/FunctionExpression_L19C25/FunctionObject::.ctor()
-		IL_043d: ldc.i4.0
-		IL_043e: conv.r8
-		IL_043f: ldstr ""
-		IL_0444: ldc.i4.0
-		IL_0445: ldc.i4.1
-		IL_0446: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_ExplicitReceiverAbi/FunctionExpression_L19C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_044b: stloc.s 15
-		IL_044d: ldloc.s 7
-		IL_044f: ldstr "slice"
-		IL_0454: ldloc.s 15
-		IL_0456: ldc.i4.1
-		IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_045c: pop
-		IL_045d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0462: stloc.s 6
-		IL_0464: ldstr "abcdef"
-		IL_0469: ldstr "slice"
-		IL_046e: ldc.r8 1
-		IL_0477: box [System.Runtime]System.Double
-		IL_047c: ldc.r8 4
-		IL_0485: box [System.Runtime]System.Double
-		IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_048f: stloc.s 7
-		IL_0491: ldloc.s 6
-		IL_0493: ldloc.s 7
-		IL_0495: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_049a: pop
-		IL_049b: ldstr "String"
-		IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04a5: ldstr "prototype"
-		IL_04aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04af: stloc.s 7
-		IL_04b1: ldloc.s 7
-		IL_04b3: ldstr "slice"
-		IL_04b8: ldloc.s 4
-		IL_04ba: ldc.i4.1
-		IL_04bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_04c0: pop
-		IL_04c1: ldnull
-		IL_04c2: stloc.s 5
-		IL_04c4: ret
+		IL_041e: ldstr "String"
+		IL_0423: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0428: ldstr "prototype"
+		IL_042d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0432: stloc.s 7
+		IL_0434: ldloc.s 7
+		IL_0436: ldstr "slice"
+		IL_043b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0440: stloc.s 4
+		IL_0442: ldstr "String"
+		IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_044c: ldstr "prototype"
+		IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0456: stloc.s 7
+		IL_0458: ldc.i4.1
+		IL_0459: newarr [System.Runtime]System.Object
+		IL_045e: dup
+		IL_045f: ldc.i4.0
+		IL_0460: ldloc.0
+		IL_0461: stelem.ref
+		IL_0462: stloc.s 14
+		IL_0464: newobj instance void Modules.String_ExplicitReceiverAbi/FunctionExpression_L19C25/FunctionObject::.ctor()
+		IL_0469: ldc.i4.0
+		IL_046a: conv.r8
+		IL_046b: ldstr ""
+		IL_0470: ldc.i4.0
+		IL_0471: ldc.i4.1
+		IL_0472: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_ExplicitReceiverAbi/FunctionExpression_L19C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0477: stloc.s 15
+		IL_0479: ldloc.s 7
+		IL_047b: ldstr "slice"
+		IL_0480: ldloc.s 15
+		IL_0482: ldc.i4.1
+		IL_0483: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0488: pop
+		IL_0489: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_048e: stloc.s 6
+		IL_0490: ldc.i4.0
+		IL_0491: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0496: brfalse IL_04c8
+
+		IL_049b: ldstr "abcdef"
+		IL_04a0: ldc.r8 1
+		IL_04a9: box [System.Runtime]System.Double
+		IL_04ae: ldc.r8 4
+		IL_04b7: box [System.Runtime]System.Double
+		IL_04bc: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+		IL_04c1: stloc.s 7
+		IL_04c3: br IL_04f5
+
+		IL_04c8: ldstr "abcdef"
+		IL_04cd: ldstr "slice"
+		IL_04d2: ldc.r8 1
+		IL_04db: box [System.Runtime]System.Double
+		IL_04e0: ldc.r8 4
+		IL_04e9: box [System.Runtime]System.Double
+		IL_04ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_04f3: stloc.s 7
+
+		IL_04f5: ldloc.s 6
+		IL_04f7: ldloc.s 7
+		IL_04f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04fe: pop
+		IL_04ff: ldstr "String"
+		IL_0504: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0509: ldstr "prototype"
+		IL_050e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0513: stloc.s 7
+		IL_0515: ldloc.s 7
+		IL_0517: ldstr "slice"
+		IL_051c: ldloc.s 4
+		IL_051e: ldc.i4.1
+		IL_051f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0524: pop
+		IL_0525: ldnull
+		IL_0526: stloc.s 5
+		IL_0528: ret
 	} // end of method String_ExplicitReceiverAbi::__js_module_init__
 
 } // end of class Modules.String_ExplicitReceiverAbi

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_FromCharCode_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_FromCharCode_Basic.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 382 (0x17e)
+		// Code size: 470 (0x1d6)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_FromCharCode_Basic/Scope,
@@ -132,37 +132,63 @@
 		IL_0105: ldloc.s 4
 		IL_0107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 		IL_010c: stloc.s 4
-		IL_010e: ldloc.s 4
-		IL_0110: ldstr "charCodeAt"
-		IL_0115: ldc.r8 0.0
-		IL_011e: box [System.Runtime]System.Double
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0128: stloc.s 5
-		IL_012a: ldloc.2
-		IL_012b: ldloc.s 5
-		IL_012d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0132: pop
-		IL_0133: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0138: stloc.2
-		IL_0139: ldc.r8 1
-		IL_0142: neg
-		IL_0143: box [System.Runtime]System.Double
-		IL_0148: call string [JavaScriptRuntime]JavaScriptRuntime.String::FromCharCode(object)
-		IL_014d: stloc.s 4
-		IL_014f: ldloc.s 4
-		IL_0151: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-		IL_0156: stloc.s 4
-		IL_0158: ldloc.s 4
-		IL_015a: ldstr "charCodeAt"
-		IL_015f: ldc.r8 0.0
-		IL_0168: box [System.Runtime]System.Double
-		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0172: stloc.s 5
-		IL_0174: ldloc.2
-		IL_0175: ldloc.s 5
-		IL_0177: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_017c: pop
-		IL_017d: ret
+		IL_010e: ldc.i4.0
+		IL_010f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0114: brfalse IL_013a
+
+		IL_0119: ldloc.s 4
+		IL_011b: ldc.r8 0.0
+		IL_0124: box [System.Runtime]System.Double
+		IL_0129: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_012e: box [System.Runtime]System.Double
+		IL_0133: stloc.s 5
+		IL_0135: br IL_0156
+
+		IL_013a: ldloc.s 4
+		IL_013c: ldstr "charCodeAt"
+		IL_0141: ldc.r8 0.0
+		IL_014a: box [System.Runtime]System.Double
+		IL_014f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0154: stloc.s 5
+
+		IL_0156: ldloc.2
+		IL_0157: ldloc.s 5
+		IL_0159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_015e: pop
+		IL_015f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0164: stloc.2
+		IL_0165: ldc.r8 1
+		IL_016e: neg
+		IL_016f: box [System.Runtime]System.Double
+		IL_0174: call string [JavaScriptRuntime]JavaScriptRuntime.String::FromCharCode(object)
+		IL_0179: stloc.s 4
+		IL_017b: ldloc.s 4
+		IL_017d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+		IL_0182: stloc.s 4
+		IL_0184: ldc.i4.0
+		IL_0185: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_018a: brfalse IL_01b0
+
+		IL_018f: ldloc.s 4
+		IL_0191: ldc.r8 0.0
+		IL_019a: box [System.Runtime]System.Double
+		IL_019f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_01a4: box [System.Runtime]System.Double
+		IL_01a9: stloc.s 5
+		IL_01ab: br IL_01cc
+
+		IL_01b0: ldloc.s 4
+		IL_01b2: ldstr "charCodeAt"
+		IL_01b7: ldc.r8 0.0
+		IL_01c0: box [System.Runtime]System.Double
+		IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ca: stloc.s 5
+
+		IL_01cc: ldloc.2
+		IL_01cd: ldloc.s 5
+		IL_01cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d4: pop
+		IL_01d5: ret
 	} // end of method String_FromCharCode_Basic::__js_module_init__
 
 } // end of class Modules.String_FromCharCode_Basic

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_LastIndexOf_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_LastIndexOf_Basic.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 341 (0x155)
+		// Code size: 663 (0x297)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_LastIndexOf_Basic/Scope,
@@ -56,108 +56,213 @@
 		IL_000c: stloc.1
 		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0012: stloc.2
-		IL_0013: ldloc.1
-		IL_0014: ldstr "lastIndexOf"
-		IL_0019: ldstr "a"
-		IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0023: stloc.3
-		IL_0024: ldloc.2
-		IL_0025: ldloc.3
-		IL_0026: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_002b: pop
-		IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0031: stloc.2
-		IL_0032: ldloc.1
-		IL_0033: ldstr "lastIndexOf"
-		IL_0038: ldstr "a"
-		IL_003d: ldc.r8 2
-		IL_0046: box [System.Runtime]System.Double
-		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0050: stloc.3
-		IL_0051: ldloc.2
-		IL_0052: ldloc.3
-		IL_0053: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0058: pop
-		IL_0059: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_005e: stloc.2
-		IL_005f: ldc.r8 1
-		IL_0068: neg
-		IL_0069: stloc.s 4
-		IL_006b: ldloc.s 4
+		IL_0013: ldc.i4.0
+		IL_0014: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0019: brfalse IL_0034
+
+		IL_001e: ldloc.1
+		IL_001f: ldstr "a"
+		IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+		IL_0029: box [System.Runtime]System.Double
+		IL_002e: stloc.3
+		IL_002f: br IL_0045
+
+		IL_0034: ldloc.1
+		IL_0035: ldstr "lastIndexOf"
+		IL_003a: ldstr "a"
+		IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0044: stloc.3
+
+		IL_0045: ldloc.2
+		IL_0046: ldloc.3
+		IL_0047: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_004c: pop
+		IL_004d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0052: stloc.2
+		IL_0053: ldc.i4.0
+		IL_0054: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0059: brfalse IL_0082
+
+		IL_005e: ldloc.1
+		IL_005f: ldstr "a"
+		IL_0064: ldc.r8 2
 		IL_006d: box [System.Runtime]System.Double
-		IL_0072: stloc.s 5
-		IL_0074: ldloc.1
-		IL_0075: ldstr "lastIndexOf"
-		IL_007a: ldstr "a"
-		IL_007f: ldloc.s 5
-		IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0086: stloc.3
-		IL_0087: ldloc.2
-		IL_0088: ldloc.3
-		IL_0089: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_008e: pop
-		IL_008f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0094: stloc.2
-		IL_0095: ldloc.1
-		IL_0096: ldstr "lastIndexOf"
-		IL_009b: ldstr "a"
-		IL_00a0: ldc.r8 99
-		IL_00a9: box [System.Runtime]System.Double
-		IL_00ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_00b3: stloc.3
-		IL_00b4: ldloc.2
-		IL_00b5: ldloc.3
-		IL_00b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00bb: pop
-		IL_00bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c1: stloc.2
-		IL_00c2: ldloc.1
-		IL_00c3: ldstr "lastIndexOf"
-		IL_00c8: ldstr ""
-		IL_00cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00d2: stloc.3
-		IL_00d3: ldloc.2
-		IL_00d4: ldloc.3
-		IL_00d5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00da: pop
-		IL_00db: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00e0: stloc.2
-		IL_00e1: ldloc.1
-		IL_00e2: ldstr "lastIndexOf"
-		IL_00e7: ldstr ""
-		IL_00ec: ldc.r8 2
-		IL_00f5: box [System.Runtime]System.Double
-		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_00ff: stloc.3
-		IL_0100: ldloc.2
-		IL_0101: ldloc.3
-		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0107: pop
-		IL_0108: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010d: stloc.2
-		IL_010e: ldloc.1
-		IL_010f: ldstr "lastIndexOf"
-		IL_0114: ldstr "ab"
-		IL_0119: ldc.r8 1
+		IL_0072: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_0077: box [System.Runtime]System.Double
+		IL_007c: stloc.3
+		IL_007d: br IL_00a1
+
+		IL_0082: ldloc.1
+		IL_0083: ldstr "lastIndexOf"
+		IL_0088: ldstr "a"
+		IL_008d: ldc.r8 2
+		IL_0096: box [System.Runtime]System.Double
+		IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_00a0: stloc.3
+
+		IL_00a1: ldloc.2
+		IL_00a2: ldloc.3
+		IL_00a3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a8: pop
+		IL_00a9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ae: stloc.2
+		IL_00af: ldc.r8 1
+		IL_00b8: neg
+		IL_00b9: stloc.s 4
+		IL_00bb: ldloc.s 4
+		IL_00bd: box [System.Runtime]System.Double
+		IL_00c2: stloc.s 5
+		IL_00c4: ldc.i4.0
+		IL_00c5: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_00ca: brfalse IL_00e7
+
+		IL_00cf: ldloc.1
+		IL_00d0: ldstr "a"
+		IL_00d5: ldloc.s 5
+		IL_00d7: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_00dc: box [System.Runtime]System.Double
+		IL_00e1: stloc.3
+		IL_00e2: br IL_00fa
+
+		IL_00e7: ldloc.1
+		IL_00e8: ldstr "lastIndexOf"
+		IL_00ed: ldstr "a"
+		IL_00f2: ldloc.s 5
+		IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_00f9: stloc.3
+
+		IL_00fa: ldloc.2
+		IL_00fb: ldloc.3
+		IL_00fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0101: pop
+		IL_0102: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0107: stloc.2
+		IL_0108: ldc.i4.0
+		IL_0109: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_010e: brfalse IL_0137
+
+		IL_0113: ldloc.1
+		IL_0114: ldstr "a"
+		IL_0119: ldc.r8 99
 		IL_0122: box [System.Runtime]System.Double
-		IL_0127: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_012c: stloc.3
-		IL_012d: ldloc.2
-		IL_012e: ldloc.3
-		IL_012f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0134: pop
-		IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_013a: stloc.2
-		IL_013b: ldloc.1
-		IL_013c: ldstr "lastIndexOf"
-		IL_0141: ldstr "z"
-		IL_0146: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_014b: stloc.3
-		IL_014c: ldloc.2
-		IL_014d: ldloc.3
-		IL_014e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0153: pop
-		IL_0154: ret
+		IL_0127: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_012c: box [System.Runtime]System.Double
+		IL_0131: stloc.3
+		IL_0132: br IL_0156
+
+		IL_0137: ldloc.1
+		IL_0138: ldstr "lastIndexOf"
+		IL_013d: ldstr "a"
+		IL_0142: ldc.r8 99
+		IL_014b: box [System.Runtime]System.Double
+		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0155: stloc.3
+
+		IL_0156: ldloc.2
+		IL_0157: ldloc.3
+		IL_0158: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_015d: pop
+		IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0163: stloc.2
+		IL_0164: ldc.i4.0
+		IL_0165: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_016a: brfalse IL_0185
+
+		IL_016f: ldloc.1
+		IL_0170: ldstr ""
+		IL_0175: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+		IL_017a: box [System.Runtime]System.Double
+		IL_017f: stloc.3
+		IL_0180: br IL_0196
+
+		IL_0185: ldloc.1
+		IL_0186: ldstr "lastIndexOf"
+		IL_018b: ldstr ""
+		IL_0190: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0195: stloc.3
+
+		IL_0196: ldloc.2
+		IL_0197: ldloc.3
+		IL_0198: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_019d: pop
+		IL_019e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a3: stloc.2
+		IL_01a4: ldc.i4.0
+		IL_01a5: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_01aa: brfalse IL_01d3
+
+		IL_01af: ldloc.1
+		IL_01b0: ldstr ""
+		IL_01b5: ldc.r8 2
+		IL_01be: box [System.Runtime]System.Double
+		IL_01c3: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_01c8: box [System.Runtime]System.Double
+		IL_01cd: stloc.3
+		IL_01ce: br IL_01f2
+
+		IL_01d3: ldloc.1
+		IL_01d4: ldstr "lastIndexOf"
+		IL_01d9: ldstr ""
+		IL_01de: ldc.r8 2
+		IL_01e7: box [System.Runtime]System.Double
+		IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_01f1: stloc.3
+
+		IL_01f2: ldloc.2
+		IL_01f3: ldloc.3
+		IL_01f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01f9: pop
+		IL_01fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01ff: stloc.2
+		IL_0200: ldc.i4.0
+		IL_0201: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0206: brfalse IL_022f
+
+		IL_020b: ldloc.1
+		IL_020c: ldstr "ab"
+		IL_0211: ldc.r8 1
+		IL_021a: box [System.Runtime]System.Double
+		IL_021f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+		IL_0224: box [System.Runtime]System.Double
+		IL_0229: stloc.3
+		IL_022a: br IL_024e
+
+		IL_022f: ldloc.1
+		IL_0230: ldstr "lastIndexOf"
+		IL_0235: ldstr "ab"
+		IL_023a: ldc.r8 1
+		IL_0243: box [System.Runtime]System.Double
+		IL_0248: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_024d: stloc.3
+
+		IL_024e: ldloc.2
+		IL_024f: ldloc.3
+		IL_0250: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0255: pop
+		IL_0256: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_025b: stloc.2
+		IL_025c: ldc.i4.0
+		IL_025d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0262: brfalse IL_027d
+
+		IL_0267: ldloc.1
+		IL_0268: ldstr "z"
+		IL_026d: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+		IL_0272: box [System.Runtime]System.Double
+		IL_0277: stloc.3
+		IL_0278: br IL_028e
+
+		IL_027d: ldloc.1
+		IL_027e: ldstr "lastIndexOf"
+		IL_0283: ldstr "z"
+		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_028d: stloc.3
+
+		IL_028e: ldloc.2
+		IL_028f: ldloc.3
+		IL_0290: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0295: pop
+		IL_0296: ret
 	} // end of method String_LastIndexOf_Basic::__js_module_init__
 
 } // end of class Modules.String_LastIndexOf_Basic

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_Arity2_Substring.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_Arity2_Substring.verified.txt
@@ -38,12 +38,12 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 63 (0x3f)
+		// Code size: 119 (0x77)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_MemberCall_Arity2_Substring/Scope,
 			[1] string,
-			[2] string,
+			[2] object,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
 
@@ -52,20 +52,35 @@
 		IL_0006: nop
 		IL_0007: ldstr "hello"
 		IL_000c: stloc.1
-		IL_000d: ldloc.1
-		IL_000e: ldc.r8 1
-		IL_0017: box [System.Runtime]System.Double
-		IL_001c: ldc.r8 3
-		IL_0025: box [System.Runtime]System.Double
-		IL_002a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-		IL_002f: stloc.2
-		IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0035: stloc.3
-		IL_0036: ldloc.3
-		IL_0037: ldloc.2
-		IL_0038: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_003d: pop
-		IL_003e: ret
+		IL_000d: ldc.i4.0
+		IL_000e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0013: brfalse IL_0040
+
+		IL_0018: ldloc.1
+		IL_0019: ldc.r8 1
+		IL_0022: box [System.Runtime]System.Double
+		IL_0027: ldc.r8 3
+		IL_0030: box [System.Runtime]System.Double
+		IL_0035: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+		IL_003a: stloc.2
+		IL_003b: br IL_0068
+
+		IL_0040: ldloc.1
+		IL_0041: ldstr "substring"
+		IL_0046: ldc.r8 1
+		IL_004f: box [System.Runtime]System.Double
+		IL_0054: ldc.r8 3
+		IL_005d: box [System.Runtime]System.Double
+		IL_0062: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0067: stloc.2
+
+		IL_0068: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006d: stloc.3
+		IL_006e: ldloc.3
+		IL_006f: ldloc.2
+		IL_0070: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0075: pop
+		IL_0076: ret
 	} // end of method String_MemberCall_Arity2_Substring::__js_module_init__
 
 } // end of class Modules.String_MemberCall_Arity2_Substring

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_FastPath_CommonMethods.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_FastPath_CommonMethods.verified.txt
@@ -139,7 +139,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 575 (0x23f)
+			// Code size: 1067 (0x42b)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -152,200 +152,370 @@
 			IL_0006: ldarg.1
 			IL_0007: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
 			IL_000c: stloc.1
-			IL_000d: ldloc.1
-			IL_000e: ldstr "charCodeAt"
-			IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0018: stloc.2
-			IL_0019: ldloc.0
-			IL_001a: ldloc.2
-			IL_001b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0020: pop
-			IL_0021: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0026: stloc.0
-			IL_0027: ldarg.1
-			IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_002d: stloc.1
-			IL_002e: ldloc.1
-			IL_002f: ldstr "charCodeAt"
-			IL_0034: ldc.r8 1
-			IL_003d: box [System.Runtime]System.Double
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0047: stloc.2
-			IL_0048: ldloc.0
-			IL_0049: ldloc.2
-			IL_004a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_004f: pop
-			IL_0050: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0055: stloc.0
-			IL_0056: ldarg.1
-			IL_0057: ldc.r8 1
-			IL_0060: box [System.Runtime]System.Double
-			IL_0065: ldc.r8 4
-			IL_006e: box [System.Runtime]System.Double
-			IL_0073: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_0078: stloc.1
-			IL_0079: ldloc.0
-			IL_007a: ldloc.1
-			IL_007b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0080: pop
-			IL_0081: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0086: stloc.0
-			IL_0087: ldarg.1
-			IL_0088: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_008d: stloc.1
-			IL_008e: ldloc.1
-			IL_008f: ldstr "slice"
-			IL_0094: ldc.r8 2
-			IL_009d: box [System.Runtime]System.Double
-			IL_00a2: ldc.r8 5
-			IL_00ab: box [System.Runtime]System.Double
-			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00b5: stloc.2
-			IL_00b6: ldloc.0
-			IL_00b7: ldloc.2
-			IL_00b8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00bd: pop
-			IL_00be: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00c3: stloc.0
-			IL_00c4: ldarg.1
-			IL_00c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_00ca: stloc.1
-			IL_00cb: ldloc.1
-			IL_00cc: ldstr "indexOf"
-			IL_00d1: ldstr "cd"
-			IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00db: stloc.2
-			IL_00dc: ldloc.0
-			IL_00dd: ldloc.2
-			IL_00de: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00e3: pop
-			IL_00e4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_00e9: stloc.0
-			IL_00ea: ldarg.1
-			IL_00eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_00f0: stloc.1
-			IL_00f1: ldloc.1
-			IL_00f2: ldstr "indexOf"
-			IL_00f7: ldstr "cd"
-			IL_00fc: ldc.r8 3
-			IL_0105: box [System.Runtime]System.Double
-			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_010f: stloc.2
-			IL_0110: ldloc.0
-			IL_0111: ldloc.2
-			IL_0112: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0117: pop
-			IL_0118: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_011d: stloc.0
-			IL_011e: ldarg.1
-			IL_011f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_0124: stloc.1
-			IL_0125: ldloc.1
-			IL_0126: ldstr "startsWith"
-			IL_012b: ldstr "ab"
-			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0135: stloc.2
-			IL_0136: ldloc.0
-			IL_0137: ldloc.2
-			IL_0138: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_013d: pop
-			IL_013e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0143: stloc.0
-			IL_0144: ldarg.1
-			IL_0145: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_014a: stloc.1
-			IL_014b: ldloc.1
-			IL_014c: ldstr "startsWith"
-			IL_0151: ldstr "bc"
-			IL_0156: ldc.r8 1
-			IL_015f: box [System.Runtime]System.Double
-			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0169: stloc.2
-			IL_016a: ldloc.0
-			IL_016b: ldloc.2
-			IL_016c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0171: pop
-			IL_0172: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0177: stloc.0
-			IL_0178: ldarg.1
-			IL_0179: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_017e: stloc.1
-			IL_017f: ldloc.1
-			IL_0180: ldstr "includes"
-			IL_0185: ldstr "de"
-			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_018f: stloc.2
-			IL_0190: ldloc.0
-			IL_0191: ldloc.2
-			IL_0192: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0197: pop
-			IL_0198: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_019d: stloc.0
-			IL_019e: ldarg.1
-			IL_019f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_01a4: stloc.1
-			IL_01a5: ldloc.1
-			IL_01a6: ldstr "trim"
-			IL_01ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_01b0: stloc.2
-			IL_01b1: ldloc.0
-			IL_01b2: ldloc.2
-			IL_01b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01b8: pop
-			IL_01b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01be: stloc.0
-			IL_01bf: ldarg.1
-			IL_01c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_01c5: stloc.1
-			IL_01c6: ldloc.1
-			IL_01c7: ldstr "trimStart"
-			IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_01d1: stloc.2
-			IL_01d2: ldloc.0
-			IL_01d3: ldloc.2
-			IL_01d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01d9: pop
-			IL_01da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01df: stloc.0
-			IL_01e0: ldarg.1
-			IL_01e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_01e6: stloc.1
-			IL_01e7: ldloc.1
-			IL_01e8: ldstr "trimEnd"
-			IL_01ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_01f2: stloc.2
-			IL_01f3: ldloc.0
-			IL_01f4: ldloc.2
-			IL_01f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01fa: pop
-			IL_01fb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0200: stloc.0
-			IL_0201: ldarg.1
-			IL_0202: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_0207: stloc.1
-			IL_0208: ldloc.1
-			IL_0209: ldstr "trimLeft"
-			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0213: stloc.2
-			IL_0214: ldloc.0
-			IL_0215: ldloc.2
-			IL_0216: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_021b: pop
-			IL_021c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0221: stloc.0
-			IL_0222: ldarg.1
-			IL_0223: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
-			IL_0228: stloc.1
-			IL_0229: ldloc.1
-			IL_022a: ldstr "trimRight"
-			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0234: stloc.2
-			IL_0235: ldloc.0
-			IL_0236: ldloc.2
-			IL_0237: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_023c: pop
-			IL_023d: ldnull
-			IL_023e: ret
+			IL_000d: ldc.i4.0
+			IL_000e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0013: brfalse IL_0029
+
+			IL_0018: ldloc.1
+			IL_0019: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string)
+			IL_001e: box [System.Runtime]System.Double
+			IL_0023: stloc.2
+			IL_0024: br IL_0035
+
+			IL_0029: ldloc.1
+			IL_002a: ldstr "charCodeAt"
+			IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0034: stloc.2
+
+			IL_0035: ldloc.0
+			IL_0036: ldloc.2
+			IL_0037: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_003c: pop
+			IL_003d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0042: stloc.0
+			IL_0043: ldarg.1
+			IL_0044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0049: stloc.1
+			IL_004a: ldc.i4.0
+			IL_004b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0050: brfalse IL_0074
+
+			IL_0055: ldloc.1
+			IL_0056: ldc.r8 1
+			IL_005f: box [System.Runtime]System.Double
+			IL_0064: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+			IL_0069: box [System.Runtime]System.Double
+			IL_006e: stloc.2
+			IL_006f: br IL_008e
+
+			IL_0074: ldloc.1
+			IL_0075: ldstr "charCodeAt"
+			IL_007a: ldc.r8 1
+			IL_0083: box [System.Runtime]System.Double
+			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_008d: stloc.2
+
+			IL_008e: ldloc.0
+			IL_008f: ldloc.2
+			IL_0090: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0095: pop
+			IL_0096: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_009b: stloc.0
+			IL_009c: ldarg.1
+			IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_00a2: stloc.1
+			IL_00a3: ldc.i4.0
+			IL_00a4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00a9: brfalse IL_00d6
+
+			IL_00ae: ldloc.1
+			IL_00af: ldc.r8 1
+			IL_00b8: box [System.Runtime]System.Double
+			IL_00bd: ldc.r8 4
+			IL_00c6: box [System.Runtime]System.Double
+			IL_00cb: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_00d0: stloc.2
+			IL_00d1: br IL_00fe
+
+			IL_00d6: ldloc.1
+			IL_00d7: ldstr "substring"
+			IL_00dc: ldc.r8 1
+			IL_00e5: box [System.Runtime]System.Double
+			IL_00ea: ldc.r8 4
+			IL_00f3: box [System.Runtime]System.Double
+			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00fd: stloc.2
+
+			IL_00fe: ldloc.0
+			IL_00ff: ldloc.2
+			IL_0100: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0105: pop
+			IL_0106: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_010b: stloc.0
+			IL_010c: ldarg.1
+			IL_010d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0112: stloc.1
+			IL_0113: ldc.i4.0
+			IL_0114: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0119: brfalse IL_0146
+
+			IL_011e: ldloc.1
+			IL_011f: ldc.r8 2
+			IL_0128: box [System.Runtime]System.Double
+			IL_012d: ldc.r8 5
+			IL_0136: box [System.Runtime]System.Double
+			IL_013b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+			IL_0140: stloc.2
+			IL_0141: br IL_016e
+
+			IL_0146: ldloc.1
+			IL_0147: ldstr "slice"
+			IL_014c: ldc.r8 2
+			IL_0155: box [System.Runtime]System.Double
+			IL_015a: ldc.r8 5
+			IL_0163: box [System.Runtime]System.Double
+			IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_016d: stloc.2
+
+			IL_016e: ldloc.0
+			IL_016f: ldloc.2
+			IL_0170: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0175: pop
+			IL_0176: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_017b: stloc.0
+			IL_017c: ldarg.1
+			IL_017d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0182: stloc.1
+			IL_0183: ldc.i4.0
+			IL_0184: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0189: brfalse IL_01a4
+
+			IL_018e: ldloc.1
+			IL_018f: ldstr "cd"
+			IL_0194: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0199: box [System.Runtime]System.Double
+			IL_019e: stloc.2
+			IL_019f: br IL_01b5
+
+			IL_01a4: ldloc.1
+			IL_01a5: ldstr "indexOf"
+			IL_01aa: ldstr "cd"
+			IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01b4: stloc.2
+
+			IL_01b5: ldloc.0
+			IL_01b6: ldloc.2
+			IL_01b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01bc: pop
+			IL_01bd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01c2: stloc.0
+			IL_01c3: ldarg.1
+			IL_01c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_01c9: stloc.1
+			IL_01ca: ldc.i4.0
+			IL_01cb: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01d0: brfalse IL_01f9
+
+			IL_01d5: ldloc.1
+			IL_01d6: ldstr "cd"
+			IL_01db: ldc.r8 3
+			IL_01e4: box [System.Runtime]System.Double
+			IL_01e9: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string, object)
+			IL_01ee: box [System.Runtime]System.Double
+			IL_01f3: stloc.2
+			IL_01f4: br IL_0218
+
+			IL_01f9: ldloc.1
+			IL_01fa: ldstr "indexOf"
+			IL_01ff: ldstr "cd"
+			IL_0204: ldc.r8 3
+			IL_020d: box [System.Runtime]System.Double
+			IL_0212: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0217: stloc.2
+
+			IL_0218: ldloc.0
+			IL_0219: ldloc.2
+			IL_021a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_021f: pop
+			IL_0220: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0225: stloc.0
+			IL_0226: ldarg.1
+			IL_0227: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_022c: stloc.1
+			IL_022d: ldc.i4.0
+			IL_022e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0233: brfalse IL_024e
+
+			IL_0238: ldloc.1
+			IL_0239: ldstr "ab"
+			IL_023e: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+			IL_0243: box [System.Runtime]System.Boolean
+			IL_0248: stloc.2
+			IL_0249: br IL_025f
+
+			IL_024e: ldloc.1
+			IL_024f: ldstr "startsWith"
+			IL_0254: ldstr "ab"
+			IL_0259: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_025e: stloc.2
+
+			IL_025f: ldloc.0
+			IL_0260: ldloc.2
+			IL_0261: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0266: pop
+			IL_0267: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_026c: stloc.0
+			IL_026d: ldarg.1
+			IL_026e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0273: stloc.1
+			IL_0274: ldc.i4.0
+			IL_0275: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_027a: brfalse IL_02a3
+
+			IL_027f: ldloc.1
+			IL_0280: ldstr "bc"
+			IL_0285: ldc.r8 1
+			IL_028e: box [System.Runtime]System.Double
+			IL_0293: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, object, object)
+			IL_0298: box [System.Runtime]System.Boolean
+			IL_029d: stloc.2
+			IL_029e: br IL_02c2
+
+			IL_02a3: ldloc.1
+			IL_02a4: ldstr "startsWith"
+			IL_02a9: ldstr "bc"
+			IL_02ae: ldc.r8 1
+			IL_02b7: box [System.Runtime]System.Double
+			IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_02c1: stloc.2
+
+			IL_02c2: ldloc.0
+			IL_02c3: ldloc.2
+			IL_02c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_02c9: pop
+			IL_02ca: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02cf: stloc.0
+			IL_02d0: ldarg.1
+			IL_02d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_02d6: stloc.1
+			IL_02d7: ldc.i4.0
+			IL_02d8: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_02dd: brfalse IL_02f8
+
+			IL_02e2: ldloc.1
+			IL_02e3: ldstr "de"
+			IL_02e8: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_02ed: box [System.Runtime]System.Boolean
+			IL_02f2: stloc.2
+			IL_02f3: br IL_0309
+
+			IL_02f8: ldloc.1
+			IL_02f9: ldstr "includes"
+			IL_02fe: ldstr "de"
+			IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0308: stloc.2
+
+			IL_0309: ldloc.0
+			IL_030a: ldloc.2
+			IL_030b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0310: pop
+			IL_0311: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0316: stloc.0
+			IL_0317: ldarg.1
+			IL_0318: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_031d: stloc.1
+			IL_031e: ldc.i4.0
+			IL_031f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0324: brfalse IL_0335
+
+			IL_0329: ldloc.1
+			IL_032a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_032f: stloc.2
+			IL_0330: br IL_0341
+
+			IL_0335: ldloc.1
+			IL_0336: ldstr "trim"
+			IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0340: stloc.2
+
+			IL_0341: ldloc.0
+			IL_0342: ldloc.2
+			IL_0343: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0348: pop
+			IL_0349: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_034e: stloc.0
+			IL_034f: ldarg.1
+			IL_0350: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_0355: stloc.1
+			IL_0356: ldc.i4.0
+			IL_0357: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_035c: brfalse IL_036d
+
+			IL_0361: ldloc.1
+			IL_0362: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimStart(string)
+			IL_0367: stloc.2
+			IL_0368: br IL_0379
+
+			IL_036d: ldloc.1
+			IL_036e: ldstr "trimStart"
+			IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0378: stloc.2
+
+			IL_0379: ldloc.0
+			IL_037a: ldloc.2
+			IL_037b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0380: pop
+			IL_0381: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0386: stloc.0
+			IL_0387: ldarg.1
+			IL_0388: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_038d: stloc.1
+			IL_038e: ldc.i4.0
+			IL_038f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0394: brfalse IL_03a5
+
+			IL_0399: ldloc.1
+			IL_039a: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimEnd(string)
+			IL_039f: stloc.2
+			IL_03a0: br IL_03b1
+
+			IL_03a5: ldloc.1
+			IL_03a6: ldstr "trimEnd"
+			IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_03b0: stloc.2
+
+			IL_03b1: ldloc.0
+			IL_03b2: ldloc.2
+			IL_03b3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03b8: pop
+			IL_03b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03be: stloc.0
+			IL_03bf: ldarg.1
+			IL_03c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_03c5: stloc.1
+			IL_03c6: ldc.i4.0
+			IL_03c7: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_03cc: brfalse IL_03dd
+
+			IL_03d1: ldloc.1
+			IL_03d2: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimLeft(string)
+			IL_03d7: stloc.2
+			IL_03d8: br IL_03e9
+
+			IL_03dd: ldloc.1
+			IL_03de: ldstr "trimLeft"
+			IL_03e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_03e8: stloc.2
+
+			IL_03e9: ldloc.0
+			IL_03ea: ldloc.2
+			IL_03eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03f0: pop
+			IL_03f1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03f6: stloc.0
+			IL_03f7: ldarg.1
+			IL_03f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [System.Runtime]System.String>(!!0)
+			IL_03fd: stloc.1
+			IL_03fe: ldc.i4.0
+			IL_03ff: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0404: brfalse IL_0415
+
+			IL_0409: ldloc.1
+			IL_040a: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimRight(string)
+			IL_040f: stloc.2
+			IL_0410: br IL_0421
+
+			IL_0415: ldloc.1
+			IL_0416: ldstr "trimRight"
+			IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0420: stloc.2
+
+			IL_0421: ldloc.0
+			IL_0422: ldloc.2
+			IL_0423: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0428: pop
+			IL_0429: ldnull
+			IL_042a: ret
 		} // end of method runCommon::__js_call__
 
 	} // end of class runCommon
@@ -388,7 +558,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 283 (0x11b)
+		// Code size: 479 (0x1df)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_MemberCall_FastPath_CommonMethods/Scope,
@@ -426,75 +596,145 @@
 		IL_0039: pop
 		IL_003a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_003f: stloc.3
-		IL_0040: ldstr "  x  "
-		IL_0045: ldstr "trim"
-		IL_004a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_004f: stloc.s 4
-		IL_0051: ldloc.3
-		IL_0052: ldloc.s 4
-		IL_0054: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0059: pop
-		IL_005a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_005f: stloc.3
-		IL_0060: ldstr "  x  "
-		IL_0065: ldstr "trimStart"
-		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_006f: stloc.s 4
-		IL_0071: ldloc.3
-		IL_0072: ldloc.s 4
-		IL_0074: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0079: pop
-		IL_007a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_007f: stloc.3
-		IL_0080: ldstr "x  "
-		IL_0085: ldstr "trimEnd"
-		IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_008f: stloc.s 4
-		IL_0091: ldloc.3
-		IL_0092: ldloc.s 4
-		IL_0094: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0099: pop
-		IL_009a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_009f: stloc.3
-		IL_00a0: ldstr "  x  "
-		IL_00a5: ldstr "trimLeft"
-		IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00af: stloc.s 4
-		IL_00b1: ldloc.3
-		IL_00b2: ldloc.s 4
-		IL_00b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b9: pop
-		IL_00ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00bf: stloc.3
-		IL_00c0: ldstr "x  "
-		IL_00c5: ldstr "trimRight"
-		IL_00ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00cf: stloc.s 4
-		IL_00d1: ldloc.3
-		IL_00d2: ldloc.s 4
-		IL_00d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d9: pop
-		IL_00da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00df: stloc.3
-		IL_00e0: ldstr "A"
-		IL_00e5: ldstr "toLowerCase"
-		IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00ef: stloc.s 4
-		IL_00f1: ldloc.3
-		IL_00f2: ldloc.s 4
-		IL_00f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00f9: pop
-		IL_00fa: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00ff: stloc.3
-		IL_0100: ldstr "a"
-		IL_0105: ldstr "toUpperCase"
-		IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_010f: stloc.s 4
-		IL_0111: ldloc.3
-		IL_0112: ldloc.s 4
-		IL_0114: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0119: pop
-		IL_011a: ret
+		IL_0040: ldc.i4.0
+		IL_0041: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0046: brfalse IL_005c
+
+		IL_004b: ldstr "  x  "
+		IL_0050: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+		IL_0055: stloc.s 4
+		IL_0057: br IL_006d
+
+		IL_005c: ldstr "  x  "
+		IL_0061: ldstr "trim"
+		IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_006b: stloc.s 4
+
+		IL_006d: ldloc.3
+		IL_006e: ldloc.s 4
+		IL_0070: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0075: pop
+		IL_0076: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007b: stloc.3
+		IL_007c: ldc.i4.0
+		IL_007d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0082: brfalse IL_0098
+
+		IL_0087: ldstr "  x  "
+		IL_008c: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimStart(string)
+		IL_0091: stloc.s 4
+		IL_0093: br IL_00a9
+
+		IL_0098: ldstr "  x  "
+		IL_009d: ldstr "trimStart"
+		IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00a7: stloc.s 4
+
+		IL_00a9: ldloc.3
+		IL_00aa: ldloc.s 4
+		IL_00ac: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b1: pop
+		IL_00b2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00b7: stloc.3
+		IL_00b8: ldc.i4.0
+		IL_00b9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_00be: brfalse IL_00d4
+
+		IL_00c3: ldstr "x  "
+		IL_00c8: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimEnd(string)
+		IL_00cd: stloc.s 4
+		IL_00cf: br IL_00e5
+
+		IL_00d4: ldstr "x  "
+		IL_00d9: ldstr "trimEnd"
+		IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00e3: stloc.s 4
+
+		IL_00e5: ldloc.3
+		IL_00e6: ldloc.s 4
+		IL_00e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ed: pop
+		IL_00ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00f3: stloc.3
+		IL_00f4: ldc.i4.0
+		IL_00f5: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_00fa: brfalse IL_0110
+
+		IL_00ff: ldstr "  x  "
+		IL_0104: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimLeft(string)
+		IL_0109: stloc.s 4
+		IL_010b: br IL_0121
+
+		IL_0110: ldstr "  x  "
+		IL_0115: ldstr "trimLeft"
+		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_011f: stloc.s 4
+
+		IL_0121: ldloc.3
+		IL_0122: ldloc.s 4
+		IL_0124: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0129: pop
+		IL_012a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_012f: stloc.3
+		IL_0130: ldc.i4.0
+		IL_0131: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0136: brfalse IL_014c
+
+		IL_013b: ldstr "x  "
+		IL_0140: call string [JavaScriptRuntime]JavaScriptRuntime.String::TrimRight(string)
+		IL_0145: stloc.s 4
+		IL_0147: br IL_015d
+
+		IL_014c: ldstr "x  "
+		IL_0151: ldstr "trimRight"
+		IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_015b: stloc.s 4
+
+		IL_015d: ldloc.3
+		IL_015e: ldloc.s 4
+		IL_0160: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0165: pop
+		IL_0166: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_016b: stloc.3
+		IL_016c: ldc.i4.0
+		IL_016d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0172: brfalse IL_0188
+
+		IL_0177: ldstr "A"
+		IL_017c: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
+		IL_0181: stloc.s 4
+		IL_0183: br IL_0199
+
+		IL_0188: ldstr "A"
+		IL_018d: ldstr "toLowerCase"
+		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0197: stloc.s 4
+
+		IL_0199: ldloc.3
+		IL_019a: ldloc.s 4
+		IL_019c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01a1: pop
+		IL_01a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a7: stloc.3
+		IL_01a8: ldc.i4.0
+		IL_01a9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_01ae: brfalse IL_01c4
+
+		IL_01b3: ldstr "a"
+		IL_01b8: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+		IL_01bd: stloc.s 4
+		IL_01bf: br IL_01d5
+
+		IL_01c4: ldstr "a"
+		IL_01c9: ldstr "toUpperCase"
+		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01d3: stloc.s 4
+
+		IL_01d5: ldloc.3
+		IL_01d6: ldloc.s 4
+		IL_01d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01dd: pop
+		IL_01de: ret
 	} // end of method String_MemberCall_FastPath_CommonMethods::__js_module_init__
 
 } // end of class Modules.String_MemberCall_FastPath_CommonMethods

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_NewApis_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_NewApis_Basic.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 879 (0x36f)
+		// Code size: 939 (0x3ab)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_NewApis_Basic/Scope,
@@ -285,16 +285,37 @@
 		IL_0342: stloc.s 4
 		IL_0344: ldloc.s 4
 		IL_0346: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_034b: ldstr "charCodeAt"
-		IL_0350: ldc.r8 1
-		IL_0359: box [System.Runtime]System.Double
-		IL_035e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0363: stloc.s 4
-		IL_0365: ldloc.1
-		IL_0366: ldloc.s 4
-		IL_0368: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_036d: pop
-		IL_036e: ret
+		IL_034b: stloc.s 4
+		IL_034d: ldc.i4.0
+		IL_034e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0353: brfalse IL_0385
+
+		IL_0358: ldloc.s 4
+		IL_035a: isinst [System.Runtime]System.String
+		IL_035f: dup
+		IL_0360: brfalse IL_0384
+
+		IL_0365: ldc.r8 1
+		IL_036e: box [System.Runtime]System.Double
+		IL_0373: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_0378: box [System.Runtime]System.Double
+		IL_037d: stloc.s 4
+		IL_037f: br IL_03a1
+
+		IL_0384: pop
+
+		IL_0385: ldloc.s 4
+		IL_0387: ldstr "charCodeAt"
+		IL_038c: ldc.r8 1
+		IL_0395: box [System.Runtime]System.Double
+		IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_039f: stloc.s 4
+
+		IL_03a1: ldloc.1
+		IL_03a2: ldloc.s 4
+		IL_03a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03a9: pop
+		IL_03aa: ret
 	} // end of method String_NewApis_Basic::__js_module_init__
 
 } // end of class Modules.String_NewApis_Basic

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_PrototypeMethodOverrides.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_PrototypeMethodOverrides.verified.txt
@@ -7,7 +7,7 @@
 	extends [System.Runtime]System.Object
 {
 	// Nested Types
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L4C26
+	.class nested public auto ansi abstract sealed beforefieldinit callTrim
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -82,7 +82,7 @@
 				IL_0001: ldarg.2
 				IL_0002: ldc.i4.0
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0008: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L4C26::__js_call__(object, object)
+				IL_0008: call object Modules.String_PrototypeMethodOverrides/callTrim::__js_call__(object, object)
 				IL_000d: ret
 			} // end of method FunctionObject::CallCore
 
@@ -101,7 +101,304 @@
 				IL_0001: ldarg.2
 				IL_0002: ldc.i4.0
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0008: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L4C26::__js_call__(object, object)
+				IL_0008: call object Modules.String_PrototypeMethodOverrides/callTrim::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 56 (0x38)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0006: stloc.0
+			IL_0007: ldc.i4.0
+			IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_000d: brfalse IL_002a
+
+			IL_0012: ldloc.0
+			IL_0013: isinst [System.Runtime]System.String
+			IL_0018: dup
+			IL_0019: brfalse IL_0029
+
+			IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0023: stloc.0
+			IL_0024: br IL_0036
+
+			IL_0029: pop
+
+			IL_002a: ldloc.0
+			IL_002b: ldstr "trim"
+			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0035: stloc.0
+
+			IL_0036: ldloc.0
+			IL_0037: ret
+		} // end of method callTrim::__js_call__
+
+	} // end of class callTrim
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L9C10
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L9C10::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L9C10::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 6 (0x6)
+			.maxstack 8
+
+			IL_0000: ldstr "object-fallback"
+			IL_0005: ret
+		} // end of method FunctionExpression_L9C10::__js_call__
+
+	} // end of class FunctionExpression_L9C10
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L15C26
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L15C26::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L15C26::__js_call__(object, object)
 				IL_000d: ret
 			} // end of method FunctionObject::ConstructBodyCore
 
@@ -149,15 +446,15 @@
 			IL_000b: stloc.0
 			IL_000c: ldloc.0
 			IL_000d: ret
-		} // end of method FunctionExpression_L4C26::__js_call__
+		} // end of method FunctionExpression_L15C26::__js_call__
 
-	} // end of class FunctionExpression_L4C26
+	} // end of class FunctionExpression_L15C26
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L13C9
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L24C9
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L15C15
+		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L26C15
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
@@ -229,7 +526,7 @@
 					.maxstack 8
 
 					IL_0000: ldnull
-					IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L13C9/FunctionExpression_L15C15::__js_call__(object)
+					IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/FunctionExpression_L26C15::__js_call__(object)
 					IL_0006: ret
 				} // end of method FunctionObject::CallCore
 
@@ -245,7 +542,7 @@
 					.maxstack 8
 
 					IL_0000: ldarg.3
-					IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L13C9/FunctionExpression_L15C15::__js_call__(object)
+					IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/FunctionExpression_L26C15::__js_call__(object)
 					IL_0006: ret
 				} // end of method FunctionObject::ConstructBodyCore
 
@@ -285,9 +582,9 @@
 
 				IL_0000: ldstr "accessor-result"
 				IL_0005: ret
-			} // end of method FunctionExpression_L15C15::__js_call__
+			} // end of method FunctionExpression_L26C15::__js_call__
 
-		} // end of class FunctionExpression_L15C15
+		} // end of class FunctionExpression_L26C15
 
 		.class nested public auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
@@ -357,7 +654,7 @@
 				.maxstack 8
 
 				IL_0000: ldnull
-				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L13C9::__js_call__(object)
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::CallCore
 
@@ -373,7 +670,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.3
-				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L13C9::__js_call__(object)
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::ConstructBodyCore
 
@@ -411,13 +708,13 @@
 			// Code size: 52 (0x34)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L13C9/Scope,
+				[0] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/Scope,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 				[2] object[],
-				[3] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L13C9/FunctionExpression_L15C15/FunctionObject
+				[3] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/FunctionExpression_L26C15/FunctionObject
 			)
 
-			IL_0000: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L13C9/Scope::.ctor()
+			IL_0000: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_000b: stloc.1
@@ -427,21 +724,21 @@
 			IL_0017: pop
 			IL_0018: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_001d: stloc.2
-			IL_001e: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L13C9/FunctionExpression_L15C15/FunctionObject::.ctor()
+			IL_001e: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/FunctionExpression_L26C15/FunctionObject::.ctor()
 			IL_0023: ldc.i4.0
 			IL_0024: conv.r8
 			IL_0025: ldstr ""
 			IL_002a: ldc.i4.0
 			IL_002b: ldc.i4.1
-			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L13C9/FunctionExpression_L15C15/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/FunctionExpression_L26C15/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0031: stloc.3
 			IL_0032: ldloc.3
 			IL_0033: ret
-		} // end of method FunctionExpression_L13C9::__js_call__
+		} // end of method FunctionExpression_L24C9::__js_call__
 
-	} // end of class FunctionExpression_L13C9
+	} // end of class FunctionExpression_L24C9
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L26C31
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L37C31
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -513,7 +810,7 @@
 				.maxstack 8
 
 				IL_0000: ldnull
-				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L26C31::__js_call__(object)
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L37C31::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::CallCore
 
@@ -529,7 +826,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.3
-				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L26C31::__js_call__(object)
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L37C31::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::ConstructBodyCore
 
@@ -569,11 +866,11 @@
 
 			IL_0000: ldstr "inherited"
 			IL_0005: ret
-		} // end of method FunctionExpression_L26C31::__js_call__
+		} // end of method FunctionExpression_L37C31::__js_call__
 
-	} // end of class FunctionExpression_L26C31
+	} // end of class FunctionExpression_L37C31
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L38C30
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L58C30
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -648,7 +945,7 @@
 				IL_0001: ldarg.2
 				IL_0002: ldc.i4.0
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0008: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L38C30::__js_call__(object, object)
+				IL_0008: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L58C30::__js_call__(object, object)
 				IL_000d: ret
 			} // end of method FunctionObject::CallCore
 
@@ -667,7 +964,7 @@
 				IL_0001: ldarg.2
 				IL_0002: ldc.i4.0
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0008: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L38C30::__js_call__(object, object)
+				IL_0008: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L58C30::__js_call__(object, object)
 				IL_000d: ret
 			} // end of method FunctionObject::ConstructBodyCore
 
@@ -715,15 +1012,151 @@
 			IL_000b: stloc.0
 			IL_000c: ldloc.0
 			IL_000d: ret
-		} // end of method FunctionExpression_L38C30::__js_call__
+		} // end of method FunctionExpression_L58C30::__js_call__
 
-	} // end of class FunctionExpression_L38C30
+	} // end of class FunctionExpression_L58C30
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L67C30
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L67C30::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L67C30::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 6 (0x6)
+			.maxstack 8
+
+			IL_0000: ldstr "41.9"
+			IL_0005: ret
+		} // end of method FunctionExpression_L67C30::__js_call__
+
+	} // end of class FunctionExpression_L67C30
 
 	.class nested public auto ansi beforefieldinit Scope
 		extends [System.Runtime]System.Object
 	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 19 53 63 6f 70 65 20 63 61 6c 6c 54 72 69
+			6d 3d 7b 63 61 6c 6c 54 72 69 6d 7d 00 00
+		)
 		// Nested Types
-		.class nested public auto ansi beforefieldinit Block_L31C45
+		.class nested public auto ansi beforefieldinit Block_L42C45
 			extends [System.Runtime]System.Object
 		{
 			// Methods
@@ -738,11 +1171,11 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Block_L31C45::.ctor
+			} // end of method Block_L42C45::.ctor
 
-		} // end of class Block_L31C45
+		} // end of class Block_L42C45
 
-		.class nested public auto ansi beforefieldinit Block_L33C7
+		.class nested public auto ansi beforefieldinit Block_L44C7
 			extends [System.Runtime]System.Object
 		{
 			// Methods
@@ -757,10 +1190,51 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Block_L33C7::.ctor
+			} // end of method Block_L44C7::.ctor
 
-		} // end of class Block_L33C7
+		} // end of class Block_L44C7
 
+		.class nested public auto ansi beforefieldinit Block_L50C4
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L50C4::.ctor
+
+		} // end of class Block_L50C4
+
+		.class nested public auto ansi beforefieldinit Block_L52C16
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L52C16::.ctor
+
+		} // end of class Block_L52C16
+
+
+		// Fields
+		.field public object callTrim
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -790,342 +1264,642 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1025 (0x401)
+		// Code size: 1902 (0x76e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_PrototypeMethodOverrides/Scope,
-			[1] object,
+			[1] class Modules.String_PrototypeMethodOverrides/callTrim/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
 			[5] object,
 			[6] object,
-			[7] object,
-			[8] object[],
-			[9] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L4C26/FunctionObject,
-			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[11] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L13C9/FunctionObject,
-			[12] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[13] bool,
-			[14] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L26C31/FunctionObject,
-			[15] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L38C30/FunctionObject,
-			[16] class [JavaScriptRuntime]JavaScriptRuntime.Array
+			[7] class [System.Runtime]System.Exception,
+			[8] object,
+			[9] object,
+			[10] object,
+			[11] object,
+			[12] object,
+			[13] object,
+			[14] object[],
+			[15] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[16] object,
+			[17] object[],
+			[18] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L9C10/FunctionObject,
+			[19] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[20] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L15C26/FunctionObject,
+			[21] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/FunctionObject,
+			[22] bool,
+			[23] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L37C31/FunctionObject,
+			[24] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L58C30/FunctionObject,
+			[25] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[26] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L67C30/FunctionObject,
+			[27] object,
+			[28] float64
 		)
 
 		IL_0000: newobj instance void Modules.String_PrototypeMethodOverrides/Scope::.ctor()
 		IL_0005: stloc.0
-		IL_0006: nop
-		IL_0007: ldstr "String"
-		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0011: ldstr "prototype"
-		IL_0016: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_001b: stloc.s 7
-		IL_001d: ldloc.s 7
-		IL_001f: ldstr "charAt"
-		IL_0024: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0029: stloc.1
-		IL_002a: ldstr "String"
-		IL_002f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0034: ldstr "prototype"
-		IL_0039: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_003e: stloc.s 7
-		IL_0040: ldc.i4.1
-		IL_0041: newarr [System.Runtime]System.Object
-		IL_0046: dup
-		IL_0047: ldc.i4.0
-		IL_0048: ldloc.0
-		IL_0049: stelem.ref
-		IL_004a: stloc.s 8
-		IL_004c: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L4C26/FunctionObject::.ctor()
-		IL_0051: ldc.i4.1
-		IL_0052: conv.r8
-		IL_0053: ldstr ""
-		IL_0058: ldc.i4.0
-		IL_0059: ldc.i4.1
-		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L4C26/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_005f: stloc.s 9
-		IL_0061: ldloc.s 7
-		IL_0063: ldstr "charAt"
-		IL_0068: ldloc.s 9
-		IL_006a: ldc.i4.1
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0070: pop
-		IL_0071: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0076: stloc.s 10
-		IL_0078: ldstr "abc"
-		IL_007d: ldstr "charAt"
-		IL_0082: ldc.r8 1
-		IL_008b: box [System.Runtime]System.Double
-		IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0095: stloc.s 7
-		IL_0097: ldloc.s 10
-		IL_0099: ldloc.s 7
-		IL_009b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a0: pop
-		IL_00a1: ldstr "String"
-		IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00ab: ldstr "prototype"
-		IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00b5: stloc.s 7
-		IL_00b7: ldloc.s 7
-		IL_00b9: ldstr "charAt"
-		IL_00be: ldloc.1
-		IL_00bf: ldc.i4.1
-		IL_00c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_00c5: pop
-		IL_00c6: ldstr "String"
-		IL_00cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d0: ldstr "prototype"
-		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00da: stloc.s 7
-		IL_00dc: ldloc.s 7
-		IL_00de: ldstr "trim"
-		IL_00e3: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_00e8: stloc.2
-		IL_00e9: ldstr "String"
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00f3: ldstr "prototype"
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00fd: stloc.s 7
-		IL_00ff: ldc.i4.1
-		IL_0100: newarr [System.Runtime]System.Object
-		IL_0105: dup
-		IL_0106: ldc.i4.0
-		IL_0107: ldloc.0
-		IL_0108: stelem.ref
-		IL_0109: stloc.s 8
-		IL_010b: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L13C9/FunctionObject::.ctor()
-		IL_0110: ldc.i4.0
-		IL_0111: conv.r8
-		IL_0112: ldstr ""
-		IL_0117: ldc.i4.0
-		IL_0118: ldc.i4.1
-		IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L13C9/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_011e: stloc.s 11
-		IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0125: dup
-		IL_0126: ldstr "configurable"
-		IL_012b: ldc.i4.1
-		IL_012c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0131: dup
-		IL_0132: ldstr "get"
-		IL_0137: ldloc.s 11
-		IL_0139: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_013e: stloc.s 12
-		IL_0140: ldloc.s 7
-		IL_0142: ldstr "trim"
-		IL_0147: ldloc.s 12
-		IL_0149: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_014e: pop
-		IL_014f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0154: stloc.s 10
-		IL_0156: ldstr " abc "
-		IL_015b: ldstr "trim"
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0165: stloc.s 7
-		IL_0167: ldloc.s 10
-		IL_0169: ldloc.s 7
-		IL_016b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0170: pop
-		IL_0171: ldstr "String"
-		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_017b: ldstr "prototype"
-		IL_0180: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0185: stloc.s 7
-		IL_0187: ldloc.s 7
-		IL_0189: ldstr "trim"
-		IL_018e: ldloc.2
-		IL_018f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_0194: pop
-		IL_0195: ldstr "String"
-		IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_019f: ldstr "prototype"
-		IL_01a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a9: stloc.s 7
-		IL_01ab: ldloc.s 7
-		IL_01ad: ldstr "toUpperCase"
-		IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01b7: stloc.3
-		IL_01b8: ldstr "Object"
-		IL_01bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01c2: ldstr "prototype"
-		IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01cc: stloc.s 7
-		IL_01ce: ldloc.s 7
-		IL_01d0: ldstr "toUpperCase"
-		IL_01d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01da: stloc.s 4
-		IL_01dc: ldstr "String"
-		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01e6: ldstr "prototype"
-		IL_01eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01f0: stloc.s 7
-		IL_01f2: ldloc.s 7
-		IL_01f4: ldstr "toUpperCase"
-		IL_01f9: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_01fe: stloc.s 13
-		IL_0200: ldstr "Object"
-		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_020a: ldstr "prototype"
-		IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0214: stloc.s 7
-		IL_0216: ldc.i4.1
-		IL_0217: newarr [System.Runtime]System.Object
-		IL_021c: dup
-		IL_021d: ldc.i4.0
-		IL_021e: ldloc.0
-		IL_021f: stelem.ref
-		IL_0220: stloc.s 8
-		IL_0222: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L26C31/FunctionObject::.ctor()
-		IL_0227: ldc.i4.0
-		IL_0228: conv.r8
-		IL_0229: ldstr ""
-		IL_022e: ldc.i4.0
-		IL_022f: ldc.i4.1
-		IL_0230: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L26C31/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0235: stloc.s 14
-		IL_0237: ldloc.s 7
-		IL_0239: ldstr "toUpperCase"
-		IL_023e: ldloc.s 14
-		IL_0240: ldc.i4.1
-		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0246: pop
-		IL_0247: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_024c: stloc.s 10
-		IL_024e: ldstr "abc"
-		IL_0253: ldstr "toUpperCase"
-		IL_0258: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_025d: stloc.s 7
-		IL_025f: ldloc.s 10
-		IL_0261: ldloc.s 7
-		IL_0263: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0268: pop
-		IL_0269: ldstr "String"
-		IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0273: ldstr "prototype"
-		IL_0278: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_027d: stloc.s 7
-		IL_027f: ldloc.s 7
-		IL_0281: ldstr "toUpperCase"
-		IL_0286: ldloc.3
-		IL_0287: ldc.i4.1
-		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_028d: pop
-		IL_028e: ldloc.s 4
-		IL_0290: stloc.s 7
-		IL_0292: ldloc.s 7
-		IL_0294: ldnull
-		IL_0295: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_029a: stloc.s 13
-		IL_029c: ldloc.s 13
-		IL_029e: brfalse IL_02cc
+		IL_0006: ldc.i4.1
+		IL_0007: newarr [System.Runtime]System.Object
+		IL_000c: dup
+		IL_000d: ldc.i4.0
+		IL_000e: ldloc.0
+		IL_000f: stelem.ref
+		IL_0010: stloc.s 14
+		IL_0012: newobj instance void Modules.String_PrototypeMethodOverrides/callTrim/FunctionObject::.ctor()
+		IL_0017: ldc.i4.1
+		IL_0018: conv.r8
+		IL_0019: ldstr "callTrim"
+		IL_001e: ldc.i4.0
+		IL_001f: ldc.i4.1
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/callTrim/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: stloc.1
+		IL_0026: nop
+		IL_0027: nop
+		IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_002d: stloc.s 15
+		IL_002f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0034: stloc.s 14
+		IL_0036: ldloc.1
+		IL_0037: ldloc.s 14
+		IL_0039: ldstr "  uncertain  "
+		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0043: stloc.s 16
+		IL_0045: ldloc.s 15
+		IL_0047: ldloc.s 16
+		IL_0049: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_004e: pop
+		IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0054: stloc.s 15
+		IL_0056: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_005b: stloc.s 14
+		IL_005d: ldc.i4.1
+		IL_005e: newarr [System.Runtime]System.Object
+		IL_0063: dup
+		IL_0064: ldc.i4.0
+		IL_0065: ldloc.0
+		IL_0066: stelem.ref
+		IL_0067: stloc.s 17
+		IL_0069: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L9C10/FunctionObject::.ctor()
+		IL_006e: ldc.i4.0
+		IL_006f: conv.r8
+		IL_0070: ldstr ""
+		IL_0075: ldc.i4.0
+		IL_0076: ldc.i4.1
+		IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L9C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_007c: stloc.s 18
+		IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0083: dup
+		IL_0084: ldstr "trim"
+		IL_0089: ldloc.s 18
+		IL_008b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0090: stloc.s 19
+		IL_0092: ldloc.1
+		IL_0093: ldloc.s 14
+		IL_0095: ldloc.s 19
+		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_009c: stloc.s 16
+		IL_009e: ldloc.s 15
+		IL_00a0: ldloc.s 16
+		IL_00a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a7: pop
+		IL_00a8: ldstr "String"
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00b2: ldstr "prototype"
+		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00bc: stloc.s 16
+		IL_00be: ldloc.s 16
+		IL_00c0: ldstr "charAt"
+		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ca: stloc.2
+		IL_00cb: ldstr "String"
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00d5: ldstr "prototype"
+		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00df: stloc.s 16
+		IL_00e1: ldc.i4.1
+		IL_00e2: newarr [System.Runtime]System.Object
+		IL_00e7: dup
+		IL_00e8: ldc.i4.0
+		IL_00e9: ldloc.0
+		IL_00ea: stelem.ref
+		IL_00eb: stloc.s 14
+		IL_00ed: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L15C26/FunctionObject::.ctor()
+		IL_00f2: ldc.i4.1
+		IL_00f3: conv.r8
+		IL_00f4: ldstr ""
+		IL_00f9: ldc.i4.0
+		IL_00fa: ldc.i4.1
+		IL_00fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L15C26/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0100: stloc.s 20
+		IL_0102: ldloc.s 16
+		IL_0104: ldstr "charAt"
+		IL_0109: ldloc.s 20
+		IL_010b: ldc.i4.1
+		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0111: pop
+		IL_0112: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0117: stloc.s 15
+		IL_0119: ldc.i4.0
+		IL_011a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_011f: brfalse IL_0143
 
-		IL_02a3: ldstr "Object"
-		IL_02a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02ad: ldstr "prototype"
-		IL_02b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b7: stloc.s 7
-		IL_02b9: ldloc.s 7
-		IL_02bb: ldstr "toUpperCase"
-		IL_02c0: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_02c5: stloc.s 13
-		IL_02c7: br IL_02f2
+		IL_0124: ldstr "abc"
+		IL_0129: ldc.r8 1
+		IL_0132: box [System.Runtime]System.Double
+		IL_0137: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_013c: stloc.s 16
+		IL_013e: br IL_0162
 
-		IL_02cc: ldstr "Object"
-		IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02d6: ldstr "prototype"
-		IL_02db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02e0: stloc.s 7
-		IL_02e2: ldloc.s 7
-		IL_02e4: ldstr "toUpperCase"
-		IL_02e9: ldloc.s 4
-		IL_02eb: ldc.i4.1
-		IL_02ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_02f1: pop
+		IL_0143: ldstr "abc"
+		IL_0148: ldstr "charAt"
+		IL_014d: ldc.r8 1
+		IL_0156: box [System.Runtime]System.Double
+		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0160: stloc.s 16
 
-		IL_02f2: ldstr "String"
-		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02fc: ldstr "prototype"
-		IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0306: stloc.s 7
-		IL_0308: ldloc.s 7
-		IL_030a: ldstr "startsWith"
-		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0314: stloc.s 5
-		IL_0316: ldstr "String"
-		IL_031b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0320: ldstr "prototype"
-		IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_032a: stloc.s 7
-		IL_032c: ldc.i4.1
-		IL_032d: newarr [System.Runtime]System.Object
-		IL_0332: dup
-		IL_0333: ldc.i4.0
-		IL_0334: ldloc.0
-		IL_0335: stelem.ref
-		IL_0336: stloc.s 8
-		IL_0338: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L38C30/FunctionObject::.ctor()
-		IL_033d: ldc.i4.1
-		IL_033e: conv.r8
-		IL_033f: ldstr ""
-		IL_0344: ldc.i4.0
-		IL_0345: ldc.i4.1
-		IL_0346: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L38C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_034b: stloc.s 15
-		IL_034d: ldloc.s 7
-		IL_034f: ldstr "startsWith"
-		IL_0354: ldloc.s 15
-		IL_0356: ldc.i4.1
-		IL_0357: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_035c: pop
-		IL_035d: ldstr "abc"
-		IL_0362: ldstr "startsWith"
-		IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_036c: stloc.s 6
-		IL_036e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0373: stloc.s 10
-		IL_0375: ldloc.s 6
-		IL_0377: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_037c: ldstr "call"
-		IL_0381: ldstr "abc"
-		IL_0386: ldstr "a"
-		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0390: stloc.s 7
-		IL_0392: ldloc.s 10
-		IL_0394: ldloc.s 7
-		IL_0396: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_039b: pop
-		IL_039c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03a1: stloc.s 10
-		IL_03a3: ldloc.s 6
-		IL_03a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03aa: ldc.i4.1
-		IL_03ab: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_03b0: dup
-		IL_03b1: ldstr "b"
-		IL_03b6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_03bb: stloc.s 16
-		IL_03bd: ldstr "apply"
-		IL_03c2: ldstr "abc"
-		IL_03c7: ldloc.s 16
-		IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03ce: stloc.s 7
-		IL_03d0: ldloc.s 10
-		IL_03d2: ldloc.s 7
-		IL_03d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03d9: pop
-		IL_03da: ldstr "String"
-		IL_03df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03e4: ldstr "prototype"
-		IL_03e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03ee: stloc.s 7
-		IL_03f0: ldloc.s 7
-		IL_03f2: ldstr "startsWith"
-		IL_03f7: ldloc.s 5
-		IL_03f9: ldc.i4.1
-		IL_03fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_03ff: pop
-		IL_0400: ret
+		IL_0162: ldloc.s 15
+		IL_0164: ldloc.s 16
+		IL_0166: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_016b: pop
+		IL_016c: ldstr "String"
+		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0176: ldstr "prototype"
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0180: stloc.s 16
+		IL_0182: ldloc.s 16
+		IL_0184: ldstr "charAt"
+		IL_0189: ldloc.2
+		IL_018a: ldc.i4.1
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0190: pop
+		IL_0191: ldstr "String"
+		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_019b: ldstr "prototype"
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01a5: stloc.s 16
+		IL_01a7: ldloc.s 16
+		IL_01a9: ldstr "trim"
+		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_01b3: stloc.3
+		IL_01b4: ldstr "String"
+		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01be: ldstr "prototype"
+		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c8: stloc.s 16
+		IL_01ca: ldc.i4.1
+		IL_01cb: newarr [System.Runtime]System.Object
+		IL_01d0: dup
+		IL_01d1: ldc.i4.0
+		IL_01d2: ldloc.0
+		IL_01d3: stelem.ref
+		IL_01d4: stloc.s 14
+		IL_01d6: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/FunctionObject::.ctor()
+		IL_01db: ldc.i4.0
+		IL_01dc: conv.r8
+		IL_01dd: ldstr ""
+		IL_01e2: ldc.i4.0
+		IL_01e3: ldc.i4.1
+		IL_01e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01e9: stloc.s 21
+		IL_01eb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01f0: dup
+		IL_01f1: ldstr "configurable"
+		IL_01f6: ldc.i4.1
+		IL_01f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_01fc: dup
+		IL_01fd: ldstr "get"
+		IL_0202: ldloc.s 21
+		IL_0204: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0209: stloc.s 19
+		IL_020b: ldloc.s 16
+		IL_020d: ldstr "trim"
+		IL_0212: ldloc.s 19
+		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_0219: pop
+		IL_021a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_021f: stloc.s 15
+		IL_0221: ldc.i4.0
+		IL_0222: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0227: brfalse IL_023d
+
+		IL_022c: ldstr " abc "
+		IL_0231: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+		IL_0236: stloc.s 16
+		IL_0238: br IL_024e
+
+		IL_023d: ldstr " abc "
+		IL_0242: ldstr "trim"
+		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_024c: stloc.s 16
+
+		IL_024e: ldloc.s 15
+		IL_0250: ldloc.s 16
+		IL_0252: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0257: pop
+		IL_0258: ldstr "String"
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0262: ldstr "prototype"
+		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_026c: stloc.s 16
+		IL_026e: ldloc.s 16
+		IL_0270: ldstr "trim"
+		IL_0275: ldloc.3
+		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_027b: pop
+		IL_027c: ldstr "String"
+		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0286: ldstr "prototype"
+		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0290: stloc.s 16
+		IL_0292: ldloc.s 16
+		IL_0294: ldstr "toUpperCase"
+		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_029e: stloc.s 4
+		IL_02a0: ldstr "Object"
+		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02aa: ldstr "prototype"
+		IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02b4: stloc.s 16
+		IL_02b6: ldloc.s 16
+		IL_02b8: ldstr "toUpperCase"
+		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02c2: stloc.s 5
+		IL_02c4: ldstr "String"
+		IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02ce: ldstr "prototype"
+		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02d8: stloc.s 16
+		IL_02da: ldloc.s 16
+		IL_02dc: ldstr "toUpperCase"
+		IL_02e1: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_02e6: stloc.s 22
+		IL_02e8: ldstr "Object"
+		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02f2: ldstr "prototype"
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02fc: stloc.s 16
+		IL_02fe: ldc.i4.1
+		IL_02ff: newarr [System.Runtime]System.Object
+		IL_0304: dup
+		IL_0305: ldc.i4.0
+		IL_0306: ldloc.0
+		IL_0307: stelem.ref
+		IL_0308: stloc.s 14
+		IL_030a: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L37C31/FunctionObject::.ctor()
+		IL_030f: ldc.i4.0
+		IL_0310: conv.r8
+		IL_0311: ldstr ""
+		IL_0316: ldc.i4.0
+		IL_0317: ldc.i4.1
+		IL_0318: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L37C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_031d: stloc.s 23
+		IL_031f: ldloc.s 16
+		IL_0321: ldstr "toUpperCase"
+		IL_0326: ldloc.s 23
+		IL_0328: ldc.i4.1
+		IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_032e: pop
+		IL_032f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0334: stloc.s 15
+		IL_0336: ldc.i4.0
+		IL_0337: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_033c: brfalse IL_0352
+
+		IL_0341: ldstr "abc"
+		IL_0346: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+		IL_034b: stloc.s 16
+		IL_034d: br IL_0363
+
+		IL_0352: ldstr "abc"
+		IL_0357: ldstr "toUpperCase"
+		IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0361: stloc.s 16
+
+		IL_0363: ldloc.s 15
+		IL_0365: ldloc.s 16
+		IL_0367: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_036c: pop
+		IL_036d: ldstr "String"
+		IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0377: ldstr "prototype"
+		IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0381: stloc.s 16
+		IL_0383: ldloc.s 16
+		IL_0385: ldstr "toUpperCase"
+		IL_038a: ldloc.s 4
+		IL_038c: ldc.i4.1
+		IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0392: pop
+		IL_0393: ldloc.s 5
+		IL_0395: stloc.s 16
+		IL_0397: ldloc.s 16
+		IL_0399: ldnull
+		IL_039a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_039f: stloc.s 22
+		IL_03a1: ldloc.s 22
+		IL_03a3: brfalse IL_03d1
+
+		IL_03a8: ldstr "Object"
+		IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03b2: ldstr "prototype"
+		IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03bc: stloc.s 16
+		IL_03be: ldloc.s 16
+		IL_03c0: ldstr "toUpperCase"
+		IL_03c5: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_03ca: stloc.s 22
+		IL_03cc: br IL_03f7
+
+		IL_03d1: ldstr "Object"
+		IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03db: ldstr "prototype"
+		IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03e5: stloc.s 16
+		IL_03e7: ldloc.s 16
+		IL_03e9: ldstr "toUpperCase"
+		IL_03ee: ldloc.s 5
+		IL_03f0: ldc.i4.1
+		IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_03f6: pop
+
+		IL_03f7: ldstr "String"
+		IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0401: ldstr "prototype"
+		IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_040b: stloc.s 16
+		IL_040d: ldloc.s 16
+		IL_040f: ldstr "includes"
+		IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0419: stloc.s 6
+		IL_041b: ldstr "String"
+		IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0425: ldstr "prototype"
+		IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_042f: stloc.s 16
+		IL_0431: ldloc.s 16
+		IL_0433: ldstr "includes"
+		IL_0438: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_043d: stloc.s 22
+		.try
+		{
+			IL_043f: nop
+			IL_0440: ldc.i4.0
+			IL_0441: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0446: brfalse IL_0460
+
+			IL_044b: ldstr "abc"
+			IL_0450: ldstr "a"
+			IL_0455: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_045a: pop
+			IL_045b: br IL_0475
+
+			IL_0460: ldstr "abc"
+			IL_0465: ldstr "includes"
+			IL_046a: ldstr "a"
+			IL_046f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0474: pop
+
+			IL_0475: leave IL_04d0
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_047a: stloc.s 7
+			IL_047c: ldloc.s 7
+			IL_047e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0483: dup
+			IL_0484: brtrue IL_049a
+
+			IL_0489: pop
+			IL_048a: ldloc.s 7
+			IL_048c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0491: dup
+			IL_0492: brtrue IL_04a6
+
+			IL_0497: pop
+			IL_0498: rethrow
+
+			IL_049a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_049f: stloc.s 8
+			IL_04a1: br IL_04a8
+
+			IL_04a6: stloc.s 8
+
+			IL_04a8: ldloc.s 8
+			IL_04aa: stloc.s 9
+			IL_04ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04b1: stloc.s 15
+			IL_04b3: ldloc.s 9
+			IL_04b5: ldstr "name"
+			IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04bf: stloc.s 16
+			IL_04c1: ldloc.s 15
+			IL_04c3: ldloc.s 16
+			IL_04c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04ca: pop
+			IL_04cb: leave IL_04d0
+		} // end handler
+
+		IL_04d0: ldstr "String"
+		IL_04d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04da: ldstr "prototype"
+		IL_04df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04e4: stloc.s 16
+		IL_04e6: ldloc.s 16
+		IL_04e8: ldstr "includes"
+		IL_04ed: ldloc.s 6
+		IL_04ef: ldc.i4.1
+		IL_04f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_04f5: pop
+		IL_04f6: ldstr "String"
+		IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0500: ldstr "prototype"
+		IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_050a: stloc.s 16
+		IL_050c: ldloc.s 16
+		IL_050e: ldstr "startsWith"
+		IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0518: stloc.s 10
+		IL_051a: ldstr "String"
+		IL_051f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0524: ldstr "prototype"
+		IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_052e: stloc.s 16
+		IL_0530: ldc.i4.1
+		IL_0531: newarr [System.Runtime]System.Object
+		IL_0536: dup
+		IL_0537: ldc.i4.0
+		IL_0538: ldloc.0
+		IL_0539: stelem.ref
+		IL_053a: stloc.s 14
+		IL_053c: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L58C30/FunctionObject::.ctor()
+		IL_0541: ldc.i4.1
+		IL_0542: conv.r8
+		IL_0543: ldstr ""
+		IL_0548: ldc.i4.0
+		IL_0549: ldc.i4.1
+		IL_054a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L58C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_054f: stloc.s 24
+		IL_0551: ldloc.s 16
+		IL_0553: ldstr "startsWith"
+		IL_0558: ldloc.s 24
+		IL_055a: ldc.i4.1
+		IL_055b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0560: pop
+		IL_0561: ldstr "abc"
+		IL_0566: ldstr "startsWith"
+		IL_056b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0570: stloc.s 11
+		IL_0572: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0577: stloc.s 15
+		IL_0579: ldloc.s 11
+		IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0580: ldstr "call"
+		IL_0585: ldstr "abc"
+		IL_058a: ldstr "a"
+		IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0594: stloc.s 16
+		IL_0596: ldloc.s 15
+		IL_0598: ldloc.s 16
+		IL_059a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_059f: pop
+		IL_05a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05a5: stloc.s 15
+		IL_05a7: ldloc.s 11
+		IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_05ae: ldc.i4.1
+		IL_05af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_05b4: dup
+		IL_05b5: ldstr "b"
+		IL_05ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_05bf: stloc.s 25
+		IL_05c1: ldstr "apply"
+		IL_05c6: ldstr "abc"
+		IL_05cb: ldloc.s 25
+		IL_05cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_05d2: stloc.s 16
+		IL_05d4: ldloc.s 15
+		IL_05d6: ldloc.s 16
+		IL_05d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_05dd: pop
+		IL_05de: ldstr "String"
+		IL_05e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05e8: ldstr "prototype"
+		IL_05ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05f2: stloc.s 16
+		IL_05f4: ldloc.s 16
+		IL_05f6: ldstr "startsWith"
+		IL_05fb: ldloc.s 10
+		IL_05fd: ldc.i4.1
+		IL_05fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0603: pop
+		IL_0604: ldstr "String"
+		IL_0609: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_060e: ldstr "prototype"
+		IL_0613: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0618: stloc.s 16
+		IL_061a: ldloc.s 16
+		IL_061c: ldstr "charCodeAt"
+		IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0626: stloc.s 12
+		IL_0628: ldstr "String"
+		IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0632: ldstr "prototype"
+		IL_0637: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_063c: stloc.s 16
+		IL_063e: ldc.i4.1
+		IL_063f: newarr [System.Runtime]System.Object
+		IL_0644: dup
+		IL_0645: ldc.i4.0
+		IL_0646: ldloc.0
+		IL_0647: stelem.ref
+		IL_0648: stloc.s 14
+		IL_064a: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L67C30/FunctionObject::.ctor()
+		IL_064f: ldc.i4.0
+		IL_0650: conv.r8
+		IL_0651: ldstr ""
+		IL_0656: ldc.i4.0
+		IL_0657: ldc.i4.1
+		IL_0658: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L67C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_065d: stloc.s 26
+		IL_065f: ldloc.s 16
+		IL_0661: ldstr "charCodeAt"
+		IL_0666: ldloc.s 26
+		IL_0668: ldc.i4.1
+		IL_0669: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_066e: pop
+		IL_066f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0674: stloc.s 15
+		IL_0676: ldc.i4.0
+		IL_0677: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_067c: brfalse IL_06a5
+
+		IL_0681: ldstr "A"
+		IL_0686: ldc.r8 0.0
+		IL_068f: box [System.Runtime]System.Double
+		IL_0694: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_0699: box [System.Runtime]System.Double
+		IL_069e: stloc.s 16
+		IL_06a0: br IL_06c4
+
+		IL_06a5: ldstr "A"
+		IL_06aa: ldstr "charCodeAt"
+		IL_06af: ldc.r8 0.0
+		IL_06b8: box [System.Runtime]System.Double
+		IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_06c2: stloc.s 16
+
+		IL_06c4: ldloc.s 16
+		IL_06c6: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
+		IL_06cb: box [System.Runtime]System.Double
+		IL_06d0: stloc.s 27
+		IL_06d2: ldloc.s 15
+		IL_06d4: ldloc.s 27
+		IL_06d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_06db: pop
+		IL_06dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06e1: stloc.s 15
+		IL_06e3: ldc.i4.0
+		IL_06e4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_06e9: brfalse IL_070d
+
+		IL_06ee: ldstr "A"
+		IL_06f3: ldc.r8 0.0
+		IL_06fc: box [System.Runtime]System.Double
+		IL_0701: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_0706: stloc.s 28
+		IL_0708: br IL_0731
+
+		IL_070d: ldstr "A"
+		IL_0712: ldstr "charCodeAt"
+		IL_0717: ldc.r8 0.0
+		IL_0720: box [System.Runtime]System.Double
+		IL_0725: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_072a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_072f: stloc.s 28
+
+		IL_0731: ldloc.s 28
+		IL_0733: box [System.Runtime]System.Double
+		IL_0738: stloc.s 27
+		IL_073a: ldloc.s 15
+		IL_073c: ldloc.s 27
+		IL_073e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0743: pop
+		IL_0744: ldstr "String"
+		IL_0749: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_074e: ldstr "prototype"
+		IL_0753: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0758: stloc.s 16
+		IL_075a: ldloc.s 16
+		IL_075c: ldstr "charCodeAt"
+		IL_0761: ldloc.s 12
+		IL_0763: ldc.i4.1
+		IL_0764: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0769: pop
+		IL_076a: ldnull
+		IL_076b: stloc.s 13
+		IL_076d: ret
 	} // end of method String_PrototypeMethodOverrides::__js_module_init__
 
 } // end of class Modules.String_PrototypeMethodOverrides

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Regex_Empty.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Regex_Empty.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 762 (0x2fa)
+		// Code size: 882 (0x372)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Split_Regex_Empty/Scope,
@@ -191,82 +191,124 @@
 		IL_01dc: stloc.s 8
 		IL_01de: ldloc.s 8
 		IL_01e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e5: ldstr "charCodeAt"
-		IL_01ea: ldc.r8 0.0
-		IL_01f3: box [System.Runtime]System.Double
-		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01fd: stloc.s 8
-		IL_01ff: ldloc.s 7
-		IL_0201: ldloc.s 8
-		IL_0203: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0208: pop
-		IL_0209: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_020e: stloc.s 7
-		IL_0210: ldloc.s 4
-		IL_0212: ldc.r8 1
-		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0220: stloc.s 8
-		IL_0222: ldloc.s 8
-		IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0229: ldstr "charCodeAt"
-		IL_022e: ldc.r8 0.0
-		IL_0237: box [System.Runtime]System.Double
-		IL_023c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0241: stloc.s 8
-		IL_0243: ldloc.s 7
-		IL_0245: ldloc.s 8
-		IL_0247: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_024c: pop
-		IL_024d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0252: stloc.s 7
-		IL_0254: ldloc.s 4
-		IL_0256: ldc.r8 2
-		IL_025f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0264: stloc.s 8
-		IL_0266: ldloc.s 7
-		IL_0268: ldloc.s 8
-		IL_026a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_026f: pop
-		IL_0270: ldstr "(?:)"
-		IL_0275: ldstr "u"
-		IL_027a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_027f: stloc.s 6
-		IL_0281: ldstr "\ud83d\ude00a"
-		IL_0286: ldstr "split"
-		IL_028b: ldloc.s 6
-		IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0292: stloc.s 5
-		IL_0294: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0299: stloc.s 7
-		IL_029b: ldloc.s 5
-		IL_029d: ldstr "length"
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02a7: stloc.s 8
-		IL_02a9: ldloc.s 7
-		IL_02ab: ldloc.s 8
-		IL_02ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02b2: pop
-		IL_02b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02b8: stloc.s 7
-		IL_02ba: ldloc.s 5
-		IL_02bc: ldc.r8 0.0
-		IL_02c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02ca: stloc.s 8
-		IL_02cc: ldloc.s 7
-		IL_02ce: ldloc.s 8
-		IL_02d0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02d5: pop
-		IL_02d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02db: stloc.s 7
-		IL_02dd: ldloc.s 5
-		IL_02df: ldc.r8 1
-		IL_02e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02ed: stloc.s 8
-		IL_02ef: ldloc.s 7
-		IL_02f1: ldloc.s 8
-		IL_02f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02f8: pop
-		IL_02f9: ret
+		IL_01e5: stloc.s 8
+		IL_01e7: ldc.i4.0
+		IL_01e8: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_01ed: brfalse IL_021f
+
+		IL_01f2: ldloc.s 8
+		IL_01f4: isinst [System.Runtime]System.String
+		IL_01f9: dup
+		IL_01fa: brfalse IL_021e
+
+		IL_01ff: ldc.r8 0.0
+		IL_0208: box [System.Runtime]System.Double
+		IL_020d: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_0212: box [System.Runtime]System.Double
+		IL_0217: stloc.s 8
+		IL_0219: br IL_023b
+
+		IL_021e: pop
+
+		IL_021f: ldloc.s 8
+		IL_0221: ldstr "charCodeAt"
+		IL_0226: ldc.r8 0.0
+		IL_022f: box [System.Runtime]System.Double
+		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0239: stloc.s 8
+
+		IL_023b: ldloc.s 7
+		IL_023d: ldloc.s 8
+		IL_023f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0244: pop
+		IL_0245: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_024a: stloc.s 7
+		IL_024c: ldloc.s 4
+		IL_024e: ldc.r8 1
+		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_025c: stloc.s 8
+		IL_025e: ldloc.s 8
+		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0265: stloc.s 8
+		IL_0267: ldc.i4.0
+		IL_0268: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_026d: brfalse IL_029f
+
+		IL_0272: ldloc.s 8
+		IL_0274: isinst [System.Runtime]System.String
+		IL_0279: dup
+		IL_027a: brfalse IL_029e
+
+		IL_027f: ldc.r8 0.0
+		IL_0288: box [System.Runtime]System.Double
+		IL_028d: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_0292: box [System.Runtime]System.Double
+		IL_0297: stloc.s 8
+		IL_0299: br IL_02bb
+
+		IL_029e: pop
+
+		IL_029f: ldloc.s 8
+		IL_02a1: ldstr "charCodeAt"
+		IL_02a6: ldc.r8 0.0
+		IL_02af: box [System.Runtime]System.Double
+		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02b9: stloc.s 8
+
+		IL_02bb: ldloc.s 7
+		IL_02bd: ldloc.s 8
+		IL_02bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02c4: pop
+		IL_02c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02ca: stloc.s 7
+		IL_02cc: ldloc.s 4
+		IL_02ce: ldc.r8 2
+		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_02dc: stloc.s 8
+		IL_02de: ldloc.s 7
+		IL_02e0: ldloc.s 8
+		IL_02e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02e7: pop
+		IL_02e8: ldstr "(?:)"
+		IL_02ed: ldstr "u"
+		IL_02f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_02f7: stloc.s 6
+		IL_02f9: ldstr "\ud83d\ude00a"
+		IL_02fe: ldstr "split"
+		IL_0303: ldloc.s 6
+		IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_030a: stloc.s 5
+		IL_030c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0311: stloc.s 7
+		IL_0313: ldloc.s 5
+		IL_0315: ldstr "length"
+		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_031f: stloc.s 8
+		IL_0321: ldloc.s 7
+		IL_0323: ldloc.s 8
+		IL_0325: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_032a: pop
+		IL_032b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0330: stloc.s 7
+		IL_0332: ldloc.s 5
+		IL_0334: ldc.r8 0.0
+		IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0342: stloc.s 8
+		IL_0344: ldloc.s 7
+		IL_0346: ldloc.s 8
+		IL_0348: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_034d: pop
+		IL_034e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0353: stloc.s 7
+		IL_0355: ldloc.s 5
+		IL_0357: ldc.r8 1
+		IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0365: stloc.s 8
+		IL_0367: ldloc.s 7
+		IL_0369: ldloc.s 8
+		IL_036b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0370: pop
+		IL_0371: ret
 	} // end of method String_Split_Regex_Empty::__js_module_init__
 
 } // end of class Modules.String_Split_Regex_Empty

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_Basic.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 43 (0x2b)
+		// Code size: 80 (0x50)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_StartsWith_Basic/Scope,
@@ -51,16 +51,28 @@
 		IL_0006: nop
 		IL_0007: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_000c: stloc.1
-		IL_000d: ldstr "abc"
-		IL_0012: ldstr "startsWith"
-		IL_0017: ldstr "ab"
-		IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0021: stloc.2
-		IL_0022: ldloc.1
-		IL_0023: ldloc.2
-		IL_0024: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0029: pop
-		IL_002a: ret
+		IL_000d: ldc.i4.0
+		IL_000e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0013: brfalse IL_0032
+
+		IL_0018: ldstr "abc"
+		IL_001d: ldstr "ab"
+		IL_0022: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+		IL_0027: box [System.Runtime]System.Boolean
+		IL_002c: stloc.2
+		IL_002d: br IL_0047
+
+		IL_0032: ldstr "abc"
+		IL_0037: ldstr "startsWith"
+		IL_003c: ldstr "ab"
+		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0046: stloc.2
+
+		IL_0047: ldloc.1
+		IL_0048: ldloc.2
+		IL_0049: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_004e: pop
+		IL_004f: ret
 	} // end of method String_StartsWith_Basic::__js_module_init__
 
 } // end of class Modules.String_StartsWith_Basic

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_NestedParam.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_NestedParam.verified.txt
@@ -161,7 +161,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 32 (0x20)
+				// Code size: 75 (0x4b)
 				.maxstack 8
 				.locals init (
 					[0] object
@@ -173,12 +173,32 @@
 				IL_0003: castclass Modules.String_StartsWith_NestedParam/outer/Scope
 				IL_0008: ldfld object Modules.String_StartsWith_NestedParam/outer/Scope::s
 				IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0012: ldstr "startsWith"
-				IL_0017: ldarg.2
-				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_001d: stloc.0
+				IL_0012: stloc.0
+				IL_0013: ldc.i4.0
+				IL_0014: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0019: brfalse IL_003c
+
 				IL_001e: ldloc.0
-				IL_001f: ret
+				IL_001f: isinst [System.Runtime]System.String
+				IL_0024: dup
+				IL_0025: brfalse IL_003b
+
+				IL_002a: ldarg.2
+				IL_002b: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+				IL_0030: box [System.Runtime]System.Boolean
+				IL_0035: stloc.0
+				IL_0036: br IL_0049
+
+				IL_003b: pop
+
+				IL_003c: ldloc.0
+				IL_003d: ldstr "startsWith"
+				IL_0042: ldarg.2
+				IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0048: stloc.0
+
+				IL_0049: ldloc.0
+				IL_004a: ret
 			} // end of method inner::__js_call__
 
 		} // end of class inner

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Substring.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Substring.verified.txt
@@ -38,13 +38,15 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 197 (0xc5)
+		// Code size: 403 (0x193)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Substring/Scope,
 			[1] string,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[3] string
+			[3] object,
+			[4] float64,
+			[5] object
 		)
 
 		IL_0000: newobj instance void Modules.String_Substring/Scope::.ctor()
@@ -54,56 +56,117 @@
 		IL_000c: stloc.1
 		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0012: stloc.2
-		IL_0013: ldloc.1
-		IL_0014: ldc.r8 1
-		IL_001d: box [System.Runtime]System.Double
-		IL_0022: ldc.r8 4
-		IL_002b: box [System.Runtime]System.Double
-		IL_0030: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-		IL_0035: stloc.3
-		IL_0036: ldloc.2
-		IL_0037: ldloc.3
-		IL_0038: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_003d: pop
-		IL_003e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0043: stloc.2
-		IL_0044: ldloc.1
-		IL_0045: ldc.r8 4
-		IL_004e: box [System.Runtime]System.Double
-		IL_0053: ldc.r8 1
-		IL_005c: box [System.Runtime]System.Double
-		IL_0061: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-		IL_0066: stloc.3
-		IL_0067: ldloc.2
-		IL_0068: ldloc.3
-		IL_0069: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_006e: pop
-		IL_006f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0074: stloc.2
-		IL_0075: ldloc.1
-		IL_0076: ldc.r8 2
-		IL_007f: neg
-		IL_0080: box [System.Runtime]System.Double
-		IL_0085: ldc.r8 2
-		IL_008e: box [System.Runtime]System.Double
-		IL_0093: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-		IL_0098: stloc.3
-		IL_0099: ldloc.2
-		IL_009a: ldloc.3
-		IL_009b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a0: pop
-		IL_00a1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00a6: stloc.2
-		IL_00a7: ldloc.1
-		IL_00a8: ldc.r8 2
-		IL_00b1: box [System.Runtime]System.Double
-		IL_00b6: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-		IL_00bb: stloc.3
-		IL_00bc: ldloc.2
-		IL_00bd: ldloc.3
-		IL_00be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c3: pop
-		IL_00c4: ret
+		IL_0013: ldc.i4.0
+		IL_0014: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0019: brfalse IL_0046
+
+		IL_001e: ldloc.1
+		IL_001f: ldc.r8 1
+		IL_0028: box [System.Runtime]System.Double
+		IL_002d: ldc.r8 4
+		IL_0036: box [System.Runtime]System.Double
+		IL_003b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+		IL_0040: stloc.3
+		IL_0041: br IL_006e
+
+		IL_0046: ldloc.1
+		IL_0047: ldstr "substring"
+		IL_004c: ldc.r8 1
+		IL_0055: box [System.Runtime]System.Double
+		IL_005a: ldc.r8 4
+		IL_0063: box [System.Runtime]System.Double
+		IL_0068: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_006d: stloc.3
+
+		IL_006e: ldloc.2
+		IL_006f: ldloc.3
+		IL_0070: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0075: pop
+		IL_0076: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_007b: stloc.2
+		IL_007c: ldc.i4.0
+		IL_007d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0082: brfalse IL_00af
+
+		IL_0087: ldloc.1
+		IL_0088: ldc.r8 4
+		IL_0091: box [System.Runtime]System.Double
+		IL_0096: ldc.r8 1
+		IL_009f: box [System.Runtime]System.Double
+		IL_00a4: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+		IL_00a9: stloc.3
+		IL_00aa: br IL_00d7
+
+		IL_00af: ldloc.1
+		IL_00b0: ldstr "substring"
+		IL_00b5: ldc.r8 4
+		IL_00be: box [System.Runtime]System.Double
+		IL_00c3: ldc.r8 1
+		IL_00cc: box [System.Runtime]System.Double
+		IL_00d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_00d6: stloc.3
+
+		IL_00d7: ldloc.2
+		IL_00d8: ldloc.3
+		IL_00d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00de: pop
+		IL_00df: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00e4: stloc.2
+		IL_00e5: ldc.r8 2
+		IL_00ee: neg
+		IL_00ef: stloc.s 4
+		IL_00f1: ldloc.s 4
+		IL_00f3: box [System.Runtime]System.Double
+		IL_00f8: stloc.s 5
+		IL_00fa: ldc.i4.0
+		IL_00fb: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0100: brfalse IL_0121
+
+		IL_0105: ldloc.1
+		IL_0106: ldloc.s 5
+		IL_0108: ldc.r8 2
+		IL_0111: box [System.Runtime]System.Double
+		IL_0116: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+		IL_011b: stloc.3
+		IL_011c: br IL_013d
+
+		IL_0121: ldloc.1
+		IL_0122: ldstr "substring"
+		IL_0127: ldloc.s 5
+		IL_0129: ldc.r8 2
+		IL_0132: box [System.Runtime]System.Double
+		IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_013c: stloc.3
+
+		IL_013d: ldloc.2
+		IL_013e: ldloc.3
+		IL_013f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0144: pop
+		IL_0145: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_014a: stloc.2
+		IL_014b: ldc.i4.0
+		IL_014c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0151: brfalse IL_0170
+
+		IL_0156: ldloc.1
+		IL_0157: ldc.r8 2
+		IL_0160: box [System.Runtime]System.Double
+		IL_0165: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+		IL_016a: stloc.3
+		IL_016b: br IL_018a
+
+		IL_0170: ldloc.1
+		IL_0171: ldstr "substring"
+		IL_0176: ldc.r8 2
+		IL_017f: box [System.Runtime]System.Double
+		IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0189: stloc.3
+
+		IL_018a: ldloc.2
+		IL_018b: ldloc.3
+		IL_018c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0191: pop
+		IL_0192: ret
 	} // end of method String_Substring::__js_module_init__
 
 } // end of class Modules.String_Substring

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_ToLowerCase_ToUpperCase_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_ToLowerCase_ToUpperCase_Basic.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 68 (0x44)
+		// Code size: 122 (0x7a)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_ToLowerCase_ToUpperCase_Basic/Scope,
@@ -51,25 +51,45 @@
 		IL_0006: nop
 		IL_0007: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_000c: stloc.1
-		IL_000d: ldstr "AbC"
-		IL_0012: ldstr "toLowerCase"
-		IL_0017: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_001c: stloc.2
-		IL_001d: ldloc.1
-		IL_001e: ldloc.2
-		IL_001f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0024: pop
-		IL_0025: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_002a: stloc.1
-		IL_002b: ldstr "AbC"
-		IL_0030: ldstr "toUpperCase"
-		IL_0035: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_003a: stloc.2
-		IL_003b: ldloc.1
-		IL_003c: ldloc.2
-		IL_003d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0042: pop
-		IL_0043: ret
+		IL_000d: ldc.i4.0
+		IL_000e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0013: brfalse IL_0028
+
+		IL_0018: ldstr "AbC"
+		IL_001d: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
+		IL_0022: stloc.2
+		IL_0023: br IL_0038
+
+		IL_0028: ldstr "AbC"
+		IL_002d: ldstr "toLowerCase"
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0037: stloc.2
+
+		IL_0038: ldloc.1
+		IL_0039: ldloc.2
+		IL_003a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_003f: pop
+		IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0045: stloc.1
+		IL_0046: ldc.i4.0
+		IL_0047: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_004c: brfalse IL_0061
+
+		IL_0051: ldstr "AbC"
+		IL_0056: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+		IL_005b: stloc.2
+		IL_005c: br IL_0071
+
+		IL_0061: ldstr "AbC"
+		IL_0066: ldstr "toUpperCase"
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0070: stloc.2
+
+		IL_0071: ldloc.1
+		IL_0072: ldloc.2
+		IL_0073: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0078: pop
+		IL_0079: ret
 	} // end of method String_ToLowerCase_ToUpperCase_Basic::__js_module_init__
 
 } // end of class Modules.String_ToLowerCase_ToUpperCase_Basic

--- a/tests/performance/Benchmarks/GuardedStringIntrinsicBenchmarks.cs
+++ b/tests/performance/Benchmarks/GuardedStringIntrinsicBenchmarks.cs
@@ -1,0 +1,71 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Order;
+using JavaScriptRuntime;
+
+namespace Benchmarks;
+
+[MemoryDiagnoser]
+[ShortRunJob]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+[HideColumns("Error", "StdDev")]
+public class GuardedStringIntrinsicBenchmarks
+{
+    private const string Receiver = "value";
+    private const string MethodName = "trim";
+    private readonly object _uncertainReceiver = Receiver;
+    private RuntimeAgentCluster? _cluster;
+    private IDisposable? _scope;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        _cluster = services.OwningRealm!.Agent.Cluster;
+        var context = RuntimeExecutionContext.GetOrCreate(services);
+        _scope = context.EnterAsRoot();
+        _ = GlobalThis.globalThis;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _scope?.Dispose();
+        _cluster?.Dispose();
+    }
+
+    [Benchmark(
+        Baseline = true,
+        Description = "CallMember0 String.trim")]
+    public object? GenericCallMember()
+        => ObjectRuntime.CallMember0(Receiver, MethodName);
+
+    [Benchmark(Description = "Guarded proven String.trim")]
+    public object? GuardedProvenString()
+    {
+        if (IntrinsicPrototypeEpochs.IsPristine(
+                IntrinsicPrototypeFamily.String))
+        {
+            return JavaScriptRuntime.String.Trim(Receiver);
+        }
+
+        return ObjectRuntime.CallMember0(Receiver, MethodName);
+    }
+
+    [Benchmark(Description = "Guarded uncertain String.trim")]
+    public object? GuardedUncertainReceiver()
+    {
+        if (IntrinsicPrototypeEpochs.IsPristine(
+                IntrinsicPrototypeFamily.String)
+            && _uncertainReceiver is string input)
+        {
+            return JavaScriptRuntime.String.Trim(input);
+        }
+
+        return ObjectRuntime.CallMember0(
+            _uncertainReceiver,
+            MethodName);
+    }
+}

--- a/tests/performance/Benchmarks/Program.cs
+++ b/tests/performance/Benchmarks/Program.cs
@@ -70,6 +70,12 @@ else
             args: programArgs.Skip(1).ToArray());
         SetExitCodeFromSummaries([summary]);
     }
+    else if (programArgs.Length > 0 && programArgs[0] == "--guarded-string-intrinsics")
+    {
+        var summary = BenchmarkRunner.Run<GuardedStringIntrinsicBenchmarks>(
+            args: programArgs.Skip(1).ToArray());
+        SetExitCodeFromSummaries([summary]);
+    }
 #if SOURCE_JROC_PROJECTS
     else if (programArgs.Length > 0 && programArgs[0] == "--shape-storage")
     {
@@ -151,6 +157,7 @@ Console.WriteLine("  dotnet run -c Release --callable-abi # Compare function-obj
 Console.WriteLine("  dotnet run -c Release --builtin-invocation # Measure representative runtime-owned built-in adapters");
 Console.WriteLine("  dotnet run -c Release --async-context # Compare disabled and enabled async-context overhead");
 Console.WriteLine("  dotnet run -c Release --intrinsic-epochs # Measure realm-owned intrinsic epoch guards");
+Console.WriteLine("  dotnet run -c Release --guarded-string-intrinsics # Compare guarded String helpers with generic lookup");
 Console.WriteLine("  dotnet run -c Release --callable-arity-analysis # Measure benchmark/runtime call-site arities");
 Console.WriteLine("  dotnet run -c Release -- --dromaeo # Run Dromaeo execution benchmarks");
 Console.WriteLine("  dotnet run -c Release -- --kracken --scenario audio-oscillator # Run one Kraken scenario");


### PR DESCRIPTION
## Summary

- replace unguarded String early binding with realm-epoch-guarded AOT intrinsic calls
- use a cheap receiver type test at uncertain sites and preserve the exact `ObjectRuntime.CallMember0..5` fallback
- retain post-fallback numeric coercion for fused `charCodeAt` paths and keep known non-String receivers on their existing lowering
- add override, accessor, deletion, uncertain-receiver, cross-realm, allocation, benchmark, and generated-IL coverage

## Design

`LIRCallGuardedStringIntrinsic` evaluates and materializes the original receiver and arguments before checking `IntrinsicPrototypeEpochs.IsPristine(String)`. Proven String receivers call the fixed-arity runtime helper directly; uncertain receivers additionally pass an `isinst string` check. Any failed guard executes ordinary member lookup and invocation with the original member name, receiver, and arguments.

The uncommon fallback is emitted as internal control flow while the scheduler keeps uncertain receivers materialized. String-returning fast paths require no boxing or allocation, and the fused `charCodeAt` numeric path applies `TypeUtilities.ToNumber` only after the generic fallback.

## Benchmarks

| Operation | Mean | Allocated |
| --- | ---: | ---: |
| Guarded proven `String.trim` | 7.835 ns | 0 B |
| Guarded uncertain receiver | 8.069 ns | 0 B |
| Generic `ObjectRuntime.CallMember0` | 193.275 ns | 88 B |

## Validation

- `dotnet build jroc.sln --no-restore`
- `dotnet build tests/performance/Benchmarks/Benchmarks.csproj --no-restore`
- 73 focused String execution, LIR normalization, epoch, allocation, and realm-isolation tests
- all 1,047 generator snapshot tests
- targeted `built-ins/String/prototype/**` test262: 573 passed, 1 skipped
- focused BenchmarkDotNet ShortRun with three iterations

Closes #1891
