### PR TITLE
perf(compiler): propagate flow-sensitive receiver candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   observed reference types, invalidate across opaque property access and
   unsupported LIR barriers, and reject host-exposed callable summaries. They
   now drive guarded Array and typed-array fixed-arity calls with exact generic
-  fallback, while object-literal shapes and generated user-class metadata keep
+  fallback only at natural-loop sites, avoiding guard/fallback IL expansion at
+  cold calls. Object-literal shapes and generated user-class metadata keep
   their existing specialized identity domains.
 - perf(runtime): add realm-owned Array and typed-array prototype mutation
   epochs. Their compiler guards also reject own member overrides and custom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-- perf(compiler): retain flow-sensitive receiver candidate sets across
+- compiler: record receiver candidate sets across
   assignments and captured/deferred closures (issue #1898). Candidates keep
-  guarded String specialization available without treating an object-typed
-  field as a proven string, so all non-string and prototype-mutated paths
-  retain their exact generic fallback.
+  primitive strings distinct from boxed String objects and remain
+  analysis-only until representation-compatible guarded specialization is
+  available.
 - perf(compiler): emit realm-epoch-guarded fixed-arity String intrinsic calls
   with exact `CallMember0..5` fallbacks (issue #1891). Proven receivers skip
   the type test, uncertain receivers use `isinst string`, and the guarded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- perf(compiler): retain flow-sensitive receiver candidate sets across
+  assignments and captured/deferred closures (issue #1898). Candidates keep
+  guarded String specialization available without treating an object-typed
+  field as a proven string, so all non-string and prototype-mutated paths
+  retain their exact generic fallback.
 - perf(compiler): emit realm-epoch-guarded fixed-arity String intrinsic calls
   with exact `CallMember0..5` fallbacks (issue #1891). Proven receivers skip
   the type test, uncertain receivers use `isinst string`, and the guarded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   field writes. Direct-only callable summaries now propagate candidate unions
   through parameters, stable returns, and ordering-proven captured closure
   entries (issue #1898). Facts distinguish unknown/non-candidate paths from
-  observed reference types and remain analysis-only until representation-
-  compatible guarded specialization is available.
+  observed reference types, invalidate across opaque property access and
+  unsupported LIR barriers, and reject host-exposed callable summaries. They
+  remain analysis-only until representation-compatible guarded specialization
+  is available.
 - perf(compiler): emit realm-epoch-guarded fixed-arity String intrinsic calls
   with exact `CallMember0..5` fallbacks (issue #1891). Proven receivers skip
   the type test, uncertain receivers use `isinst string`, and the guarded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- perf(compiler/runtime): consume String receiver candidates for loop-hot
+  numeric element reads with exact generic fallback, and extend guarded String
+  method calls to safe same-realm boxed Strings (issue #1898). Five hot reads
+  in `dromaeo-object-string` now use the specialized element helper; three
+  local post-change runs averaged about 1.1% faster than the pre-change run,
+  while the focused boxed-String guard improved 183.714 ns / 32 B to
+  34.894 ns / 0 B.
 - compiler: record receiver candidate sets across assignments and
   captured/deferred closures, then compute per-program-point receiver facts
   across SSA copies, mutable slots, branches, loop back edges, and captured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- perf(compiler): run receiver candidate inference once after core type
+  convergence and skip full receiver-flow solving unless an eligible
+  specialization has a backward-reachable candidate source (issue #1898).
+  This removes an approximately 11% compile-time regression on the 466 KB
+  `ai-astar-data.js` control while preserving broad opt-in diagnostics and
+  byte-identical optimized Dromaeo IL.
 - perf(compiler/runtime): consume String receiver candidates for loop-hot
   numeric element reads with exact generic fallback, and extend guarded String
   method calls to safe same-realm boxed Strings (issue #1898). Five hot reads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   unsupported LIR barriers, and reject host-exposed callable summaries. They
   now drive guarded Array and typed-array fixed-arity calls with exact generic
   fallback only at natural-loop sites, avoiding guard/fallback IL expansion at
-  cold calls. Object-literal shapes and generated user-class metadata keep
-  their existing specialized identity domains.
+  cold calls. Verbose and diagnostic-file output explain receiver fact merges,
+  invalidations, retained candidates, and guarded-versus-cold specialization
+  decisions without tracing overhead in normal compilation. Object-literal
+  shapes and generated user-class metadata keep their existing specialized
+  identity domains.
 - perf(runtime): add realm-owned Array and typed-array prototype mutation
   epochs. Their compiler guards also reject own member overrides and custom
   per-instance prototype chains before calling runtime instance methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 - compiler: record receiver candidate sets across assignments and
   captured/deferred closures, then compute per-program-point receiver facts
   across SSA copies, mutable slots, branches, loop back edges, and captured
-  field writes (issue #1898). Facts distinguish unknown/non-candidate paths
-  from observed reference types and remain analysis-only until
-  representation-compatible guarded specialization is available.
+  field writes. Direct-only callable summaries now propagate candidate unions
+  through parameters, stable returns, and ordering-proven captured closure
+  entries (issue #1898). Facts distinguish unknown/non-candidate paths from
+  observed reference types and remain analysis-only until representation-
+  compatible guarded specialization is available.
 - perf(compiler): emit realm-epoch-guarded fixed-arity String intrinsic calls
   with exact `CallMember0..5` fallbacks (issue #1891). Proven receivers skip
   the type test, uncertain receivers use `isinst string`, and the guarded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
-- compiler: record receiver candidate sets across
-  assignments and captured/deferred closures (issue #1898). Candidates keep
-  primitive strings distinct from boxed String objects and remain
-  analysis-only until representation-compatible guarded specialization is
-  available.
+- compiler: record receiver candidate sets across assignments and
+  captured/deferred closures, then compute per-program-point receiver facts
+  across SSA copies, mutable slots, branches, loop back edges, and captured
+  field writes (issue #1898). Facts distinguish unknown/non-candidate paths
+  from observed reference types and remain analysis-only until
+  representation-compatible guarded specialization is available.
 - perf(compiler): emit realm-epoch-guarded fixed-arity String intrinsic calls
   with exact `CallMember0..5` fallbacks (issue #1891). Proven receivers skip
   the type test, uncertain receivers use `isinst string`, and the guarded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,12 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   entries (issue #1898). Facts distinguish unknown/non-candidate paths from
   observed reference types, invalidate across opaque property access and
   unsupported LIR barriers, and reject host-exposed callable summaries. They
-  remain analysis-only until representation-compatible guarded specialization
-  is available.
+  now drive guarded Array and typed-array fixed-arity calls with exact generic
+  fallback, while object-literal shapes and generated user-class metadata keep
+  their existing specialized identity domains.
+- perf(runtime): add realm-owned Array and typed-array prototype mutation
+  epochs. Their compiler guards also reject own member overrides and custom
+  per-instance prototype chains before calling runtime instance methods.
 - perf(compiler): emit realm-epoch-guarded fixed-arity String intrinsic calls
   with exact `CallMember0..5` fallbacks (issue #1891). Proven receivers skip
   the type test, uncertain receivers use `isinst string`, and the guarded

--- a/docs/compiler/GuardedStringIntrinsicCalls.md
+++ b/docs/compiler/GuardedStringIntrinsicCalls.md
@@ -60,6 +60,31 @@ JavaScript addition coerces that object to a primitive.
 Candidate sets also retain Array and typed-array observations for future
 guarded specializations, but do not affect their lowering today.
 
+### Per-program-point facts
+
+After final LIR normalization and variable-slot coalescing, the compiler runs a
+forward fixed-point analysis over the method control-flow graph. It tracks
+receiver candidates separately for SSA temps, mutable variable slots,
+parameters, and captured scope fields. Plain assignments are strong updates;
+branch joins and loop back edges union the incoming candidates until the graph
+stabilizes.
+
+To bound compile-time and memory cost, facts are materialized only for the
+backward slice rooted at dynamic receiver operands. The slice follows copies,
+object coercions, parameter loads/stores, mutable slots, and captured field
+loads/stores, so receiver-relevant dependencies are retained without recording
+unrelated method state.
+
+Each recorded fact distinguishes explicitly observed candidate CLR types from
+non-candidate values and unconstrained values. This preserves uncertainty at
+joins instead of treating a candidate seen on one path as proof for every path.
+The facts are available before instruction operands and after instruction
+definitions, including phi-like LIR temps written by copies in multiple
+branches. Calls and suspension points conservatively invalidate captured field
+facts, and control leaving a protected region with a `finally` invalidates
+mutable facts rather than assuming the handler has no relevant writes. The
+facts remain analysis-only and do not change generated IL.
+
 ## Current specialization surface
 
 The initial allowlist matches the previously supported String early-binding

--- a/docs/compiler/GuardedStringIntrinsicCalls.md
+++ b/docs/compiler/GuardedStringIntrinsicCalls.md
@@ -81,9 +81,13 @@ joins instead of treating a candidate seen on one path as proof for every path.
 The facts are available before instruction operands and after instruction
 definitions, including phi-like LIR temps written by copies in multiple
 branches. Calls and suspension points conservatively invalidate captured field
-facts, and control leaving a protected region with a `finally` invalidates
-mutable facts rather than assuming the handler has no relevant writes. The
-facts remain analysis-only and do not change generated IL.
+facts. Dynamic property reads and writes do the same because an accessor can
+run an escaping closure that mutates captured state. An unclassified LIR
+instruction invalidates every mutable location, and control leaving a protected
+region with a `finally` does likewise rather than assuming the handler has no
+relevant writes. Plain heap mutation does not invalidate a local binding's
+receiver type because changing an object does not replace the binding value.
+The facts remain analysis-only and do not change generated IL.
 
 ### Interprocedural summaries
 
@@ -100,7 +104,9 @@ binding or be immediately preceded in the same statement list by the captured
 binding's assignment. If that ordering proof is unavailable, the closure
 entry remains unknown. Unknown callbacks, exported/aliased callables, optional
 calls, spread calls, async functions, generators, and invocation-context-
-dependent functions do not contribute interprocedural receiver facts.
+dependent functions do not contribute interprocedural receiver facts. Direct
+ESM declaration exports are classified as escaping even when the export syntax
+contains no separate identifier read.
 
 ## Current specialization surface
 

--- a/docs/compiler/GuardedStringIntrinsicCalls.md
+++ b/docs/compiler/GuardedStringIntrinsicCalls.md
@@ -113,6 +113,23 @@ This gate does not change existing proven-Array direct calls or the guarded
 String contract. It controls the code-size expansion introduced when the
 post-flow receiver specialization selects a guarded fast path.
 
+### Diagnostics
+
+Pass `-v` or `--diagnostic-file <path>` to explain receiver-flow decisions.
+`[ReceiverFlow]` records identify the compiled scope and final-LIR instruction,
+then report:
+
+- branch/loop merges with each predecessor fact and the joined result;
+- mutable facts invalidated by calls, accessors, suspension, scope replacement,
+  `finally` exits, or unsupported barriers;
+- candidate facts retained at dynamic receiver sites;
+- specialization candidates, loop depth, whether the receiver type is proven,
+  and the resulting `guarded` or `retained-generic(cold)` action.
+
+Events are emitted in deterministic instruction/kind/message order. Diagnostics
+are collected only when one of these established channels is enabled, so normal
+compilation does not allocate trace records or format diagnostic messages.
+
 ### Interprocedural summaries
 
 Statically proven direct-only callables also receive receiver summaries for

--- a/docs/compiler/GuardedStringIntrinsicCalls.md
+++ b/docs/compiler/GuardedStringIntrinsicCalls.md
@@ -24,12 +24,19 @@ The generated fast path:
 1. validates
    `IntrinsicPrototypeEpochs.IsPristine(IntrinsicPrototypeFamily.String)`;
 2. performs `isinst string` when the receiver type is uncertain;
-3. calls the exact fixed-arity String helper.
+3. if that check fails, accepts a boxed String only when it has the current
+   realm's exact `String.prototype`, no own override for the called member, and
+   an intact string-valued `[[StringData]]` slot;
+4. calls the exact fixed-arity String helper.
 
 The cold path executes the original `ObjectRuntime.CallMember0..5` operation
 with the original receiver and arguments. Argument expressions are evaluated
 before the guard, so both branches preserve JavaScript evaluation order and
 coercion behavior.
+
+Boxed Strings with a custom prototype, own assignment or descriptor override,
+or a prototype from another realm take the exact generic fallback. Prototype
+epoch invalidation also bypasses both primitive and boxed fast paths.
 
 The compiler keeps result storage as `object` when an override can return an
 arbitrary value. The `charCodeAt` plus `ToNumber` fusion is the current
@@ -109,9 +116,10 @@ block appear loop-hot. The analysis is lazy: methods pay its cost only after
 the receiver specialization pass finds an otherwise eligible Array or
 typed-array call.
 
-This gate does not change existing proven-Array direct calls or the guarded
-String contract. It controls the code-size expansion introduced when the
-post-flow receiver specialization selects a guarded fast path.
+This gate does not change existing proven-Array direct calls or guarded String
+method calls. It controls the code-size expansion introduced when post-flow
+receiver specialization selects a guarded method or numeric String-index fast
+path.
 
 ### Diagnostics
 
@@ -161,6 +169,14 @@ The String allowlist matches the previously supported early-binding surface:
 A call is specialized only when a fixed-arity helper preserves each argument's
 existing representation. Otherwise the original generic call remains.
 
+Numeric element reads on String candidates also have a loop-gated fast path.
+For an in-range canonical integer index on a primitive String, it returns the
+cached one-character string directly. A non-String receiver, non-canonical
+index, or out-of-range index executes the original `ObjectRuntime.GetItem`
+operation, preserving inherited numeric properties and other dynamic behavior.
+Candidate evidence authorizes this checked helper but is never treated as
+proof.
+
 Array specialization currently covers `push`, `unshift`, `pop`, `shift`,
 `slice`, and `splice`. Typed-array specialization covers `at`, `includes`,
 `indexOf`, `lastIndexOf`, `join`, and `reverse`. Their fast paths require a
@@ -193,12 +209,36 @@ The guard removes about 96% of the generic dispatch time in this focused case
 and eliminates its steady-state allocation. The uncertain receiver type test
 adds about 0.2 ns while retaining the complete generic fallback.
 
+The 2026-08-21 ShortRun added a focused boxed-String control:
+
+| Path | Mean | Allocated |
+| --- | ---: | ---: |
+| Guarded String-object `trim` | 34.894 ns | 0 B |
+| Generic `CallMember0` String-object `trim` | 183.714 ns | 32 B |
+
+Both rows used N=3. This is causal microbenchmark evidence for the boxed
+receiver arm, not an end-to-end application result.
+
 The 2026-08-19 local DefaultJob run of `dromaeo-object-string` on .NET
 10.0.11 measured JROC execution at 22.03 ms (N=13) with 44.24 MB allocated
 per module load. Compiling that exact fixture before and after receiver
 candidate tracking produced the same 22,528-byte module assembly. String
 candidate tracking remains code-generation-neutral until a later
 specialization consumes its final-LIR fact.
+
+On 2026-08-21, the exact `dromaeo-object-string` fixture provided the
+end-to-end item-8 control. Before the numeric-index specialization, one
+DefaultJob run measured 20.426 ms mean / 20.359 ms median (N=19). Three
+post-change runs measured 20.190, 20.273, and 20.165 ms means (N=18, 15, and
+17), averaging 20.210 ms; their medians averaged 20.255 ms. This is about a
+1.1% mean and 0.5% median improvement, but the single baseline and small effect
+make the end-to-end result noise-sensitive. Generated IL confirms the causal
+change: five hot numeric reads now call
+`GetStringElementWithFallback` instead of generic `GetItem`.
+
+The generated fixture assembly grew from 22,528 to 23,040 bytes because its 37
+uncertain guarded String method sites now include the safe boxed-receiver arm.
+Per-load allocation was effectively unchanged across these runs.
 
 Array and typed-array facts are consumed by the post-flow specialization pass.
 On a controlled fixture containing one cold Array-candidate call and one call
@@ -218,11 +258,16 @@ Coverage includes:
 - replacement, accessor, deletion, inherited override, and aliased-call
   behavior;
 - uncertain receivers that alternate between strings and ordinary objects;
+- same-realm boxed Strings plus own-assignment, descriptor, custom-prototype,
+  and cross-realm boxed-String fallbacks;
 - cross-realm prototype isolation using one compiled module loaded twice;
 - guarded numeric fallback conversion;
 - zero-allocation guard plus `String.trim` fast-path execution;
+- loop-gated numeric String indexing, including generic cold and invalid-index
+  fallback behavior;
 - the `dromaeo-object-string` fixture, including captured writes and deferred
-  callbacks whose hot calls must keep an `isinst string` plus generic fallback;
+  callbacks whose guarded method calls keep an `isinst string` plus exact
+  generic fallback;
 - targeted `built-ins/String/prototype/**` test262 tests.
 
 The realm-owned invalidation contract is documented in

--- a/docs/compiler/GuardedStringIntrinsicCalls.md
+++ b/docs/compiler/GuardedStringIntrinsicCalls.md
@@ -41,6 +41,22 @@ Stable `substring` calls now pass through this guarded instruction instead of
 using their former unconditional HIR-level direct call. The previous
 unguarded `charCodeAt` numeric fusion is guarded as well.
 
+## Receiver candidates
+
+The symbol-table fixed point separately records reference receiver candidates
+observed at declarations and writes. A candidate is not a CLR storage claim:
+conflicting assignments, captured fields, and deferred callbacks can all make
+the value at a particular read unknown. Candidates therefore never remove a
+runtime check or authorize an unguarded intrinsic call.
+
+When a captured binding has `string` among its candidates, lowering retains the
+guarded String path even if its field is otherwise object-typed or has another
+specialized CLR classification. The generated `isinst string` check selects
+the helper only for a primitive string; every other value, including a boxed
+String object, takes the original generic member-call fallback. Candidate sets
+also retain Array and typed-array observations for future guarded
+specializations, but do not bypass their prototype lookup today.
+
 ## Current specialization surface
 
 The initial allowlist matches the previously supported String early-binding
@@ -76,6 +92,13 @@ The guard removes about 96% of the generic dispatch time in this focused case
 and eliminates its steady-state allocation. The uncertain receiver type test
 adds about 0.2 ns while retaining the complete generic fallback.
 
+The 2026-08-19 local DefaultJob run of `dromaeo-object-string` on .NET
+10.0.11 measured JROC execution at 22.03 ms (N=13) with 44.24 MB allocated
+per module load. Compiling that exact fixture before and after receiver
+candidate tracking produced the same 22,528-byte module assembly. This is
+expected: candidates preserve guarded specialization at object-typed captured
+reads rather than turning them into an unguarded direct call.
+
 ## Validation
 
 Coverage includes:
@@ -87,6 +110,8 @@ Coverage includes:
 - cross-realm prototype isolation using one compiled module loaded twice;
 - guarded numeric fallback conversion;
 - zero-allocation guard plus `String.trim` fast-path execution;
+- the `dromaeo-object-string` fixture, including captured writes and deferred
+  callbacks whose hot calls must keep an `isinst string` plus generic fallback;
 - targeted `built-ins/String/prototype/**` test262 tests.
 
 The realm-owned invalidation contract is documented in

--- a/docs/compiler/GuardedStringIntrinsicCalls.md
+++ b/docs/compiler/GuardedStringIntrinsicCalls.md
@@ -85,6 +85,23 @@ facts, and control leaving a protected region with a `finally` invalidates
 mutable facts rather than assuming the handler has no relevant writes. The
 facts remain analysis-only and do not change generated IL.
 
+### Interprocedural summaries
+
+Statically proven direct-only callables also receive receiver summaries for
+their arguments and return values. Conflicting known call sites retain the
+union of candidate types rather than forcing the callable ABI to one CLR type;
+missing, non-candidate, or unconstrained paths remain explicit in the summary.
+Direct-call results feed those summaries back into the caller's final-LIR flow
+facts.
+
+Captured entry facts are narrower. A closure must be proven direct-only and
+non-escaping, and each call must either observe a lifetime-stable captured
+binding or be immediately preceded in the same statement list by the captured
+binding's assignment. If that ordering proof is unavailable, the closure
+entry remains unknown. Unknown callbacks, exported/aliased callables, optional
+calls, spread calls, async functions, generators, and invocation-context-
+dependent functions do not contribute interprocedural receiver facts.
+
 ## Current specialization surface
 
 The initial allowlist matches the previously supported String early-binding

--- a/docs/compiler/GuardedStringIntrinsicCalls.md
+++ b/docs/compiler/GuardedStringIntrinsicCalls.md
@@ -49,16 +49,19 @@ conflicting assignments, captured fields, and deferred callbacks can all make
 the value at a particular read unknown. Candidates therefore never remove a
 runtime check or authorize an unguarded intrinsic call.
 
-Candidate sets are currently analysis and diagnostics facts only. Existing
-guarded String lowering continues to classify receivers from representation-safe
-storage facts; a candidate never overrides a known non-string classification
-or bypasses storage compatibility checks. In particular, `new String(...)`
-produces a boxed String object and is not recorded as a primitive-string
-candidate. A later `+=` can still establish a primitive-string result because
-JavaScript addition coerces that object to a primitive.
+Candidate sets never override representation-safe storage facts or bypass
+runtime compatibility checks. In particular, `new String(...)` produces a
+boxed String object and is not recorded as a primitive-string candidate. A
+later `+=` can still establish a primitive-string result because JavaScript
+addition coerces that object to a primitive.
 
-Candidate sets also retain Array and typed-array observations for future
-guarded specializations, but do not affect their lowering today.
+Final per-program-point Array and concrete typed-array candidates drive
+guarded instance-method specialization. A candidate-only site retains an
+`isinst` check and generic fallback; only a fact containing one candidate and
+no unknown or non-candidate paths can omit the type test. Object-literal shapes
+and generated user-class metadata remain separate identity domains and
+continue through their existing specialized lowering rather than being
+collapsed into CLR receiver candidates.
 
 ### Per-program-point facts
 
@@ -87,7 +90,8 @@ instruction invalidates every mutable location, and control leaving a protected
 region with a `finally` does likewise rather than assuming the handler has no
 relevant writes. Plain heap mutation does not invalidate a local binding's
 receiver type because changing an object does not replace the binding value.
-The facts remain analysis-only and do not change generated IL.
+The facts remain representation-neutral. Only the guarded receiver
+specialization pass consumes eligible Array and typed-array facts.
 
 ### Interprocedural summaries
 
@@ -110,8 +114,7 @@ contains no separate identifier read.
 
 ## Current specialization surface
 
-The initial allowlist matches the previously supported String early-binding
-surface:
+The String allowlist matches the previously supported early-binding surface:
 
 - arity 0: `charAt`, `charCodeAt`, trim aliases, and case conversion;
 - arity 1: character access, substring/slice operations, searches, and prefix
@@ -120,6 +123,14 @@ surface:
 
 A call is specialized only when a fixed-arity helper preserves each argument's
 existing representation. Otherwise the original generic call remains.
+
+Array specialization currently covers `push`, `unshift`, `pop`, `shift`,
+`slice`, and `splice`. Typed-array specialization covers `at`, `includes`,
+`indexOf`, `lastIndexOf`, `join`, and `reverse`. Their fast paths require a
+pristine realm-owned prototype-family epoch, no own member override, the
+receiver's default intrinsic prototype, and—unless the flow fact proves one
+exact type—a successful CLR type test. Failure of any guard performs the
+original `ObjectRuntime.CallMemberN` operation.
 
 ## Performance
 

--- a/docs/compiler/GuardedStringIntrinsicCalls.md
+++ b/docs/compiler/GuardedStringIntrinsicCalls.md
@@ -93,6 +93,26 @@ receiver type because changing an object does not replace the binding value.
 The facts remain representation-neutral. Only the guarded receiver
 specialization pass consumes eligible Array and typed-array facts.
 
+### Loop hotness gate
+
+Post-flow Array and typed-array guards are emitted only for calls inside a
+natural loop. The final-LIR control-flow graph computes dominators and
+back-edge natural loops, then records the nesting depth of every instruction.
+An otherwise eligible site requires depth one or greater; a cold site keeps
+its original `ObjectRuntime.CallMemberN` instruction and therefore adds no
+guard branches or fallback duplication.
+
+Multiple latches for one loop header are merged before depth is counted, while
+nested loop headers increase the depth independently. Exception handlers are
+separate control-flow roots so an unrelated handler edge cannot make a cold
+block appear loop-hot. The analysis is lazy: methods pay its cost only after
+the receiver specialization pass finds an otherwise eligible Array or
+typed-array call.
+
+This gate does not change existing proven-Array direct calls or the guarded
+String contract. It controls the code-size expansion introduced when the
+post-flow receiver specialization selects a guarded fast path.
+
 ### Interprocedural summaries
 
 Statically proven direct-only callables also receive receiver summaries for
@@ -130,7 +150,9 @@ Array specialization currently covers `push`, `unshift`, `pop`, `shift`,
 pristine realm-owned prototype-family epoch, no own member override, the
 receiver's default intrinsic prototype, and—unless the flow fact proves one
 exact type—a successful CLR type test. Failure of any guard performs the
-original `ObjectRuntime.CallMemberN` operation.
+original `ObjectRuntime.CallMemberN` operation. These post-flow fast paths
+are emitted only at loop-nested call sites; eligible calls outside loops remain
+generic to avoid cold-site IL growth.
 
 ## Performance
 
@@ -157,8 +179,19 @@ adds about 0.2 ns while retaining the complete generic fallback.
 The 2026-08-19 local DefaultJob run of `dromaeo-object-string` on .NET
 10.0.11 measured JROC execution at 22.03 ms (N=13) with 44.24 MB allocated
 per module load. Compiling that exact fixture before and after receiver
-candidate tracking produced the same 22,528-byte module assembly. This confirms
-the current candidate analysis is code-generation-neutral.
+candidate tracking produced the same 22,528-byte module assembly. String
+candidate tracking remains code-generation-neutral until a later
+specialization consumes its final-LIR fact.
+
+Array and typed-array facts are consumed by the post-flow specialization pass.
+On a controlled fixture containing one cold Array-candidate call and one call
+inside a loop, the loop-depth gate reduced guarded sites from two to one and
+total method IL from 498 to 413 bytes. The hot call retained its guard while
+the cold call returned to the original generic instruction. Across five
+existing cold typed-array generator fixtures, the gate removed 16 guards and
+reduced total method IL from 4,704 to 3,699 bytes. The controlled assembly file
+remained 4,608 bytes because both method bodies fit in the same PE file-alignment
+bucket.
 
 ## Validation
 

--- a/docs/compiler/GuardedStringIntrinsicCalls.md
+++ b/docs/compiler/GuardedStringIntrinsicCalls.md
@@ -85,6 +85,13 @@ object coercions, parameter loads/stores, mutable slots, and captured field
 loads/stores, so receiver-relevant dependencies are retained without recording
 unrelated method state.
 
+Normal compilation narrows those roots further to member/index operations that
+the specialization pass can actually consume. A lightweight backward
+reachability check must also find a candidate-producing definition, binding,
+parameter, or callable summary before the compiler builds the CFG and solves
+full flow facts. Verbose and diagnostic-file compilation retains the broader
+dynamic-receiver analysis so diagnostics remain complete.
+
 Each recorded fact distinguishes explicitly observed candidate CLR types from
 non-candidate values and unconstrained values. This preserves uncertainty at
 joins instead of treating a candidate seen on one path as proof for every path.
@@ -239,6 +246,44 @@ change: five hot numeric reads now call
 The generated fixture assembly grew from 22,528 to 23,040 bytes because its 37
 uncertain guarded String method sites now include the safe boxed-receiver arm.
 Per-load allocation was effectively unchanged across these runs.
+
+### Final master-relative validation
+
+The item-9 validation used the repository's branch-comparison workflow, which
+checks out `master` and the PR branch on one GitHub runner, runs the baseline
+first, and uploads both raw BenchmarkDotNet reports. Both candidate checkouts
+were commit `3d07da395` on .NET 10.0.11:
+
+| Workflow | Scenario | Master mean / median | PR mean / median | Mean change | Allocation change |
+| --- | --- | ---: | ---: | ---: | ---: |
+| [32458452258](https://github.com/tomacox74/js2il/actions/runs/32458452258) | `dromaeo-object-string` | 24.282 / 24.380 ms (N=15) | 23.807 / 23.773 ms (N=14) | -1.96% | -0.04% |
+| [32458452751](https://github.com/tomacox74/js2il/actions/runs/32458452751) | `dromaeo-object-regexp` | 148.011 / 148.465 ms (N=39) | 145.743 / 145.870 ms (N=25) | -1.53% | -0.98% |
+
+These are single sequential baseline/candidate runs, so the percentages remain
+noise-sensitive. Generated IL supplies the causal checks:
+
+- `dromaeo-object-string` changes five loop-hot numeric reads from generic
+  `GetItem` to `GetStringElementWithFallback`; its assembly grows 22,528 to
+  23,040 bytes and total method IL grows 9,119 to 9,797 bytes.
+- `dromaeo-object-regexp` adds one loop-hot guarded Array `push`; its assembly
+  remains 47,616 bytes while total method IL grows 16,680 to 16,798 bytes.
+- `dromaeo-object-array` remains byte-identical at 10,752 assembly bytes and
+  2,593 method IL bytes.
+
+The first final-PR compile control exposed a separate regression: three
+interleaved compilations of the 466 KB `ai-astar-data.js` fixture averaged
+4.063 seconds on the PR versus 3.662 seconds on `master`, about 11% slower.
+Receiver candidates had been recomputed inside the unrelated core type
+fixed point, and normal compilation solved broad receiver flow even when no
+eligible specialization had a candidate-producing path.
+
+Item 9 moves candidate inference after core type convergence and gates the
+normal flow solver by specialization eligibility plus backward candidate
+reachability. Two subsequent interleaved five-run batches averaged 3.855
+seconds for the PR and 3.834 seconds for `master` (+0.5%); medians were 3.884
+and 3.816 seconds (+1.8%). The residual difference is within observed
+same-host run-to-run variation. String and RegExp generated IL is
+byte-for-byte unchanged by this compile-time gate.
 
 Array and typed-array facts are consumed by the post-flow specialization pass.
 On a controlled fixture containing one cold Array-candidate call and one call

--- a/docs/compiler/GuardedStringIntrinsicCalls.md
+++ b/docs/compiler/GuardedStringIntrinsicCalls.md
@@ -49,13 +49,16 @@ conflicting assignments, captured fields, and deferred callbacks can all make
 the value at a particular read unknown. Candidates therefore never remove a
 runtime check or authorize an unguarded intrinsic call.
 
-When a captured binding has `string` among its candidates, lowering retains the
-guarded String path even if its field is otherwise object-typed or has another
-specialized CLR classification. The generated `isinst string` check selects
-the helper only for a primitive string; every other value, including a boxed
-String object, takes the original generic member-call fallback. Candidate sets
-also retain Array and typed-array observations for future guarded
-specializations, but do not bypass their prototype lookup today.
+Candidate sets are currently analysis and diagnostics facts only. Existing
+guarded String lowering continues to classify receivers from representation-safe
+storage facts; a candidate never overrides a known non-string classification
+or bypasses storage compatibility checks. In particular, `new String(...)`
+produces a boxed String object and is not recorded as a primitive-string
+candidate. A later `+=` can still establish a primitive-string result because
+JavaScript addition coerces that object to a primitive.
+
+Candidate sets also retain Array and typed-array observations for future
+guarded specializations, but do not affect their lowering today.
 
 ## Current specialization surface
 
@@ -95,9 +98,8 @@ adds about 0.2 ns while retaining the complete generic fallback.
 The 2026-08-19 local DefaultJob run of `dromaeo-object-string` on .NET
 10.0.11 measured JROC execution at 22.03 ms (N=13) with 44.24 MB allocated
 per module load. Compiling that exact fixture before and after receiver
-candidate tracking produced the same 22,528-byte module assembly. This is
-expected: candidates preserve guarded specialization at object-typed captured
-reads rather than turning them into an unguarded direct call.
+candidate tracking produced the same 22,528-byte module assembly. This confirms
+the current candidate analysis is code-generation-neutral.
 
 ## Validation
 

--- a/src/Compiler/IL/LIRInstructionInfo.cs
+++ b/src/Compiler/IL/LIRInstructionInfo.cs
@@ -133,6 +133,7 @@ internal static partial class LIRInstructionInfo
         typeof(LIRCallMember4),
         typeof(LIRCallMember5),
         typeof(LIRCallGuardedStringIntrinsic),
+        typeof(LIRCallGuardedIntrinsicMember),
         typeof(LIRCallNodeModuleContractMember),
         typeof(LIRCallRequire),
         typeof(LIRCallRuntimeServicesStatic),
@@ -283,6 +284,7 @@ internal static partial class LIRInstructionInfo
         typeof(LIRAsyncStoreAwaitedResult),
         typeof(LIRAsyncLoadAwaitedResult),
         typeof(LIRCallGuardedStringIntrinsic),
+        typeof(LIRCallGuardedIntrinsicMember),
         typeof(LIRCallNodeModuleContractMember),
         typeof(LIRCreateLeafScopeInstance),
         typeof(LIRCreateScopeInstance)
@@ -512,6 +514,7 @@ internal static partial class LIRInstructionInfo
                     | CallEffects,
 
             LIRCallGuardedStringIntrinsic
+                or LIRCallGuardedIntrinsicMember
                 => LIRInstructionEffects.EmitsInternalControlFlow
                     | CallEffects,
 

--- a/src/Compiler/IL/LIRStackScheduler.cs
+++ b/src/Compiler/IL/LIRStackScheduler.cs
@@ -1869,6 +1869,7 @@ internal static class LIRStackScheduler
             LIRCallGuardedStringIntrinsic call =>
                 call.ReceiverIsProvenString
                 && call.Receiver.Equals(result),
+            LIRCallGuardedIntrinsicMember => false,
             LIRCallComputedMemberFixed call =>
                 call.Receiver.Equals(result),
             LIRCallFunctionValue call =>

--- a/src/Compiler/IL/LIRToILCompiler.GuardedIntrinsics.cs
+++ b/src/Compiler/IL/LIRToILCompiler.GuardedIntrinsics.cs
@@ -207,7 +207,10 @@ internal sealed partial class LIRToILCompiler
         }
 
         var fallbackLabel = ilEncoder.DefineLabel();
-        var typeFallbackLabel = instruction.ReceiverIsProvenString
+        var stringObjectFallbackLabel = instruction.ReceiverIsProvenString
+            ? default
+            : ilEncoder.DefineLabel();
+        var fastPathLabel = instruction.ReceiverIsProvenString
             ? default
             : ilEncoder.DefineLabel();
         var doneLabel = ilEncoder.DefineLabel();
@@ -243,7 +246,29 @@ internal sealed partial class LIRToILCompiler
             ilEncoder.OpCode(ILOpCode.Isinst);
             ilEncoder.Token(_bclReferences.StringType);
             ilEncoder.OpCode(ILOpCode.Dup);
-            ilEncoder.Branch(ILOpCode.Brfalse, typeFallbackLabel);
+            ilEncoder.Branch(ILOpCode.Brtrue, fastPathLabel);
+            ilEncoder.OpCode(ILOpCode.Pop);
+
+            EmitLoadTempAsObject(
+                instruction.Receiver,
+                ilEncoder,
+                allocation,
+                methodDescriptor);
+            ilEncoder.Ldstr(
+                _metadataBuilder,
+                instruction.MemberName);
+            var tryUnwrap = _memberRefRegistry.GetOrAddMethod(
+                typeof(JavaScriptRuntime.IntrinsicPrototypeEpochs),
+                nameof(JavaScriptRuntime.IntrinsicPrototypeEpochs
+                    .TryUnwrapStringObjectReceiver),
+                [typeof(object), typeof(string)]);
+            ilEncoder.OpCode(ILOpCode.Call);
+            ilEncoder.Token(tryUnwrap);
+            ilEncoder.OpCode(ILOpCode.Dup);
+            ilEncoder.Branch(
+                ILOpCode.Brfalse,
+                stringObjectFallbackLabel);
+            ilEncoder.MarkLabel(fastPathLabel);
         }
 
         for (var i = 0; i < instruction.Arguments.Count; i++)
@@ -270,7 +295,7 @@ internal sealed partial class LIRToILCompiler
 
         if (!instruction.ReceiverIsProvenString)
         {
-            ilEncoder.MarkLabel(typeFallbackLabel);
+            ilEncoder.MarkLabel(stringObjectFallbackLabel);
             ilEncoder.OpCode(ILOpCode.Pop);
         }
 

--- a/src/Compiler/IL/LIRToILCompiler.GuardedIntrinsics.cs
+++ b/src/Compiler/IL/LIRToILCompiler.GuardedIntrinsics.cs
@@ -7,6 +7,186 @@ namespace Jroc.IL;
 
 internal sealed partial class LIRToILCompiler
 {
+    private void EmitGuardedIntrinsicMemberCall(
+        LIRCallGuardedIntrinsicMember instruction,
+        InstructionEncoder ilEncoder,
+        TempLocalAllocation allocation,
+        MethodDescriptor methodDescriptor)
+    {
+        var intrinsicMethod = ResolveTypedInstanceMethodOverload(
+            instruction.ReceiverClrType,
+            instruction.MemberName,
+            instruction.Arguments.Count)
+            ?? throw new InvalidOperationException(
+                $"No guarded intrinsic method found: "
+                + $"{instruction.ReceiverClrType.FullName}."
+                + $"{instruction.MemberName} with "
+                + $"{instruction.Arguments.Count} argument(s).");
+        var fallbackLabel = ilEncoder.DefineLabel();
+        var typeFallbackLabel = instruction.ReceiverIsProvenType
+            ? default
+            : ilEncoder.DefineLabel();
+        var doneLabel = ilEncoder.DefineLabel();
+
+        ilEncoder.LoadConstantI4((int)instruction.PrototypeFamily);
+        var isPristine = _memberRefRegistry.GetOrAddMethod(
+            typeof(JavaScriptRuntime.IntrinsicPrototypeEpochs),
+            nameof(JavaScriptRuntime.IntrinsicPrototypeEpochs.IsPristine),
+            [typeof(JavaScriptRuntime.IntrinsicPrototypeFamily)]);
+        ilEncoder.OpCode(ILOpCode.Call);
+        ilEncoder.Token(isPristine);
+        ilEncoder.Branch(ILOpCode.Brfalse, fallbackLabel);
+
+        if (!instruction.ReceiverIsProvenType)
+        {
+            EmitLoadTempAsObject(
+                instruction.Receiver,
+                ilEncoder,
+                allocation,
+                methodDescriptor);
+            ilEncoder.OpCode(ILOpCode.Isinst);
+            ilEncoder.Token(
+                _typeReferenceRegistry.GetOrAdd(
+                    instruction.ReceiverClrType));
+            ilEncoder.OpCode(ILOpCode.Dup);
+            ilEncoder.Branch(ILOpCode.Brfalse, typeFallbackLabel);
+            ilEncoder.OpCode(ILOpCode.Pop);
+        }
+
+        EmitLoadTempAsObject(
+            instruction.Receiver,
+            ilEncoder,
+            allocation,
+            methodDescriptor);
+        ilEncoder.Ldstr(_metadataBuilder, instruction.MemberName);
+        var hasOwnOverride = _memberRefRegistry.GetOrAddMethod(
+            typeof(JavaScriptRuntime.ObjectRuntime),
+            nameof(JavaScriptRuntime.ObjectRuntime.HasOwnIntrinsicMemberOverride),
+            [typeof(object), typeof(string)]);
+        ilEncoder.OpCode(ILOpCode.Call);
+        ilEncoder.Token(hasOwnOverride);
+        ilEncoder.Branch(ILOpCode.Brtrue, fallbackLabel);
+
+        EmitLoadTempAsObject(
+            instruction.Receiver,
+            ilEncoder,
+            allocation,
+            methodDescriptor);
+        ilEncoder.LoadConstantI4((int)instruction.PrototypeFamily);
+        var hasDefaultPrototype = _memberRefRegistry.GetOrAddMethod(
+            typeof(JavaScriptRuntime.IntrinsicPrototypeEpochs),
+            nameof(JavaScriptRuntime.IntrinsicPrototypeEpochs.HasDefaultPrototype),
+            [typeof(object), typeof(JavaScriptRuntime.IntrinsicPrototypeFamily)]);
+        ilEncoder.OpCode(ILOpCode.Call);
+        ilEncoder.Token(hasDefaultPrototype);
+        ilEncoder.Branch(ILOpCode.Brfalse, fallbackLabel);
+
+        EmitLoadInstanceMethodReceiver(
+            instruction.Receiver,
+            instruction.ReceiverClrType,
+            ilEncoder,
+            allocation,
+            methodDescriptor);
+
+        var parameters = intrinsicMethod.GetParameters();
+        EmitInstanceMethodArguments(
+            instruction.Arguments,
+            parameters,
+            ilEncoder,
+            allocation,
+            methodDescriptor);
+        var methodRef = _memberRefRegistry.GetOrAddMethod(
+            instruction.ReceiverClrType,
+            intrinsicMethod.Name,
+            parameters
+                .Select(static parameter => parameter.ParameterType)
+                .ToArray());
+        ilEncoder.OpCode(ILOpCode.Callvirt);
+        ilEncoder.Token(methodRef);
+
+        if (intrinsicMethod.ReturnType == typeof(void))
+        {
+            ilEncoder.OpCode(ILOpCode.Ldnull);
+        }
+        else if (intrinsicMethod.ReturnType.IsValueType)
+        {
+            ilEncoder.OpCode(ILOpCode.Box);
+            ilEncoder.Token(
+                _typeReferenceRegistry.GetOrAdd(
+                    intrinsicMethod.ReturnType));
+        }
+
+        if (IsMaterialized(instruction.Result, allocation))
+        {
+            EmitStoreTemp(instruction.Result, ilEncoder, allocation);
+        }
+        else
+        {
+            ilEncoder.OpCode(ILOpCode.Pop);
+        }
+        ilEncoder.Branch(ILOpCode.Br, doneLabel);
+
+        if (!instruction.ReceiverIsProvenType)
+        {
+            ilEncoder.MarkLabel(typeFallbackLabel);
+            ilEncoder.OpCode(ILOpCode.Pop);
+        }
+
+        ilEncoder.MarkLabel(fallbackLabel);
+        EmitGuardedIntrinsicMemberFallback(
+            instruction,
+            ilEncoder,
+            allocation,
+            methodDescriptor);
+        if (IsMaterialized(instruction.Result, allocation))
+        {
+            EmitStoreTemp(instruction.Result, ilEncoder, allocation);
+        }
+        else
+        {
+            ilEncoder.OpCode(ILOpCode.Pop);
+        }
+
+        ilEncoder.MarkLabel(doneLabel);
+    }
+
+    private void EmitGuardedIntrinsicMemberFallback(
+        LIRCallGuardedIntrinsicMember instruction,
+        InstructionEncoder ilEncoder,
+        TempLocalAllocation allocation,
+        MethodDescriptor methodDescriptor)
+    {
+        EmitLoadTempAsObject(
+            instruction.Receiver,
+            ilEncoder,
+            allocation,
+            methodDescriptor);
+        ilEncoder.Ldstr(_metadataBuilder, instruction.MemberName);
+        foreach (var argument in instruction.Arguments)
+        {
+            EmitLoadTempAsObject(
+                argument,
+                ilEncoder,
+                allocation,
+                methodDescriptor);
+        }
+
+        var parameterTypes = new Type[instruction.Arguments.Count + 2];
+        parameterTypes[0] = typeof(object);
+        parameterTypes[1] = typeof(string);
+        global::System.Array.Fill(
+            parameterTypes,
+            typeof(object),
+            startIndex: 2,
+            count: instruction.Arguments.Count);
+        var callMember = _memberRefRegistry.GetOrAddMethod(
+            typeof(JavaScriptRuntime.ObjectRuntime),
+            $"CallMember{instruction.Arguments.Count}",
+            parameterTypes);
+        ilEncoder.OpCode(ILOpCode.Call);
+        ilEncoder.Token(callMember);
+    }
+
     private void EmitGuardedStringIntrinsicCall(
         LIRCallGuardedStringIntrinsic instruction,
         InstructionEncoder ilEncoder,

--- a/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Calls.cs
+++ b/src/Compiler/IL/LIRToILCompiler.InstructionEmission.Calls.cs
@@ -1321,6 +1321,16 @@ internal sealed partial class LIRToILCompiler
                     break;
                 }
 
+            case LIRCallGuardedIntrinsicMember guardedIntrinsic:
+                {
+                    EmitGuardedIntrinsicMemberCall(
+                        guardedIntrinsic,
+                        ilEncoder,
+                        allocation,
+                        methodDescriptor);
+                    break;
+                }
+
             case LIRCallComputedMemberFixed callComputedMember:
                 {
                     EmitLoadTempAsObject(

--- a/src/Compiler/IL/LIRToILCompiler.MethodBodyCompilation.cs
+++ b/src/Compiler/IL/LIRToILCompiler.MethodBodyCompilation.cs
@@ -914,6 +914,8 @@ internal sealed partial class LIRToILCompiler
                 }.Max(),
                 LIRCallGuardedStringIntrinsic guardedString =>
                     Math.Max(3, 2 + guardedString.Arguments.Count),
+                LIRCallGuardedIntrinsicMember guardedIntrinsic =>
+                    Math.Max(4, 2 + guardedIntrinsic.Arguments.Count),
 
                 // Known CLR instance method calls: receiver + args (no padding)
                 LIRCallInstanceMethod callInstance => 1 + callInstance.Arguments.Count,

--- a/src/Compiler/IL/TempLocalAllocator.cs
+++ b/src/Compiler/IL/TempLocalAllocator.cs
@@ -507,6 +507,8 @@ internal static partial class LIRInstructionInfo
                 visitor.Visit(value.Receiver); visitor.Visit(value.A0); visitor.Visit(value.A1); visitor.Visit(value.A2); visitor.Visit(value.A3); visitor.Visit(value.A4); break;
             case LIRCallGuardedStringIntrinsic value:
                 visitor.Visit(value.Receiver); VisitList(value.Arguments, ref visitor); break;
+            case LIRCallGuardedIntrinsicMember value:
+                visitor.Visit(value.Receiver); VisitList(value.Arguments, ref visitor); break;
             case LIRCallComputedMemberFixed value:
                 visitor.Visit(value.Receiver); visitor.Visit(value.PropertyKey); VisitList(value.Arguments, ref visitor); break;
             case LIRCallNodeModuleContractMember value:
@@ -1012,6 +1014,9 @@ internal static partial class LIRInstructionInfo
                 return true;
             case LIRCallGuardedStringIntrinsic guardedString:
                 defined = guardedString.Result;
+                return true;
+            case LIRCallGuardedIntrinsicMember guardedIntrinsic:
+                defined = guardedIntrinsic.Result;
                 return true;
             case LIRCallComputedMemberFixed callComputedMember:
                 defined = callComputedMember.Result;

--- a/src/Compiler/IR/LIR/HIRToLIRLower.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLower.cs
@@ -167,6 +167,35 @@ public sealed partial class HIRToLIRLowerer
         _preserveNonClassDoubleReturn = preserveNonClassDoubleReturn;
         _runtimeIntrinsicCatalog = runtimeIntrinsicCatalog ?? new JavaScriptRuntime.RuntimeIntrinsicCatalog();
         InitializeParameters(parameters);
+        InitializeReceiverTypeSummaries();
+    }
+
+    private void InitializeReceiverTypeSummaries()
+    {
+        if (_scope == null)
+        {
+            return;
+        }
+
+        foreach (var (index, summary) in
+                 _scope.ReceiverParameterTypeSummaries)
+        {
+            if (summary.HasCandidates)
+            {
+                _methodBodyIR.ReceiverParameterTypeSummaries[index] =
+                    summary;
+            }
+        }
+
+        foreach (var (binding, summary) in
+                 _scope.ReceiverCapturedEntryTypeSummaries)
+        {
+            if (summary.HasCandidates)
+            {
+                _methodBodyIR.ReceiverCapturedEntryTypeSummaries[binding] =
+                    summary;
+            }
+        }
     }
 
     internal static bool TryLower(HIRMethod hirMethod, Scope? scope, Services.VariableBindings.ScopeMetadataRegistry? scopeMetadataRegistry, Jroc.Services.ScopesAbi.CallableKind callableKind, bool hasScopesParameter, Jroc.Services.ClassRegistry? classRegistry, out MethodBodyIR? lirMethod, bool isAsync = false, bool isGenerator = false, TwoPhase.CallableId? callableId = null, bool isDerivedConstructor = false, TwoPhase.CallableRegistry? callableRegistry = null, TwoPhase.GeneratedFunctionObjectRegistry? generatedFunctionObjectRegistry = null, JavaScriptRuntime.IRuntimeIntrinsicCatalog? runtimeIntrinsicCatalog = null)

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
@@ -604,7 +604,8 @@ public sealed partial class HIRToLIRLowerer
                 DefineDirectCallResultStorage(
                     resultTempVar,
                     stableCallableTarget.CallableId,
-                    symbol.BindingInfo);
+                    symbol.BindingInfo,
+                    stableCallableTarget.CallableScope);
                 return true;
             }
 
@@ -743,7 +744,13 @@ public sealed partial class HIRToLIRLowerer
                 resultTempVar,
                 callableId,
                 callableValue));
-            DefineDirectCallResultStorage(resultTempVar, callableId, symbol.BindingInfo);
+            DefineDirectCallResultStorage(
+                resultTempVar,
+                callableId,
+                symbol.BindingInfo,
+                FindFunctionScope(
+                    symbol.BindingInfo.DeclaringScope,
+                    callableId));
 
             return true;
         }
@@ -1469,7 +1476,11 @@ public sealed partial class HIRToLIRLowerer
         return true;
     }
 
-    private void DefineDirectCallResultStorage(TempVariable resultTempVar, TwoPhase.CallableId? callableId, BindingInfo? symbol)
+    private void DefineDirectCallResultStorage(
+        TempVariable resultTempVar,
+        TwoPhase.CallableId? callableId,
+        BindingInfo? symbol,
+        Scope? callableScope)
     {
         Type? returnClrType = null;
         if (callableId != null && _callableRegistry != null)
@@ -1498,6 +1509,15 @@ public sealed partial class HIRToLIRLowerer
         else
         {
             DefineTempStorage(resultTempVar, new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        }
+
+        if (callableScope?.ReceiverReturnTypeSummary is
+            {
+                HasCandidates: true
+            } summary)
+        {
+            _methodBodyIR.ReceiverTempTypeSummaries[resultTempVar.Index] =
+                summary;
         }
     }
 

--- a/src/Compiler/IR/LIR/LIRControlFlowGraph.cs
+++ b/src/Compiler/IR/LIR/LIRControlFlowGraph.cs
@@ -1,0 +1,216 @@
+using Jroc.IL;
+
+namespace Jroc.IR;
+
+internal sealed class LIRBasicBlock(int start, int end)
+{
+    public int Start { get; } = start;
+    public int End { get; } = end;
+    public HashSet<int> Successors { get; } = [];
+    public HashSet<int> Predecessors { get; } = [];
+    public int? StartLabelId { get; set; }
+}
+
+internal sealed class LIRControlFlowGraph
+{
+    private readonly Dictionary<int, int> _blockByLabel;
+
+    private LIRControlFlowGraph(
+        IReadOnlyList<LIRBasicBlock> blocks,
+        Dictionary<int, int> blockByLabel)
+    {
+        Blocks = blocks;
+        _blockByLabel = blockByLabel;
+    }
+
+    public IReadOnlyList<LIRBasicBlock> Blocks { get; }
+
+    public bool TryGetLabelBlock(int labelId, out int blockIndex)
+        => _blockByLabel.TryGetValue(labelId, out blockIndex);
+
+    public static LIRControlFlowGraph Build(MethodBodyIR methodBody)
+    {
+        var instructions = methodBody.Instructions;
+        if (instructions.Count == 0)
+        {
+            return new LIRControlFlowGraph(
+                [],
+                []);
+        }
+
+        var leaders = new SortedSet<int> { 0 };
+        var labelInstructionIndices = new Dictionary<int, int>();
+
+        for (var index = 0; index < instructions.Count; index++)
+        {
+            if (instructions[index] is LIRLabel label)
+            {
+                leaders.Add(index);
+                labelInstructionIndices[label.LabelId] = index;
+            }
+
+            if (IsBlockEndingInstruction(instructions[index])
+                && index + 1 < instructions.Count)
+            {
+                leaders.Add(index + 1);
+            }
+        }
+
+        var starts = leaders.ToArray();
+        var blocks = new List<LIRBasicBlock>(starts.Length);
+        var blockByInstruction = new int[instructions.Count];
+        for (var blockIndex = 0; blockIndex < starts.Length; blockIndex++)
+        {
+            var start = starts[blockIndex];
+            var end = blockIndex + 1 < starts.Length
+                ? starts[blockIndex + 1]
+                : instructions.Count;
+            var block = new LIRBasicBlock(start, end);
+            if (instructions[start] is LIRLabel startLabel)
+            {
+                block.StartLabelId = startLabel.LabelId;
+            }
+
+            blocks.Add(block);
+            for (var index = start; index < end; index++)
+            {
+                blockByInstruction[index] = blockIndex;
+            }
+        }
+
+        var blockByLabel = labelInstructionIndices.ToDictionary(
+            pair => pair.Key,
+            pair => blockByInstruction[pair.Value]);
+        var resumeBlockByLabel = new Dictionary<int, int>();
+        for (var blockIndex = 0; blockIndex + 1 < blocks.Count; blockIndex++)
+        {
+            switch (instructions[blocks[blockIndex].End - 1])
+            {
+                case LIRAwait awaitInstruction:
+                    resumeBlockByLabel[awaitInstruction.ResumeLabelId] =
+                        blockIndex + 1;
+                    break;
+                case LIRYield yieldInstruction:
+                    resumeBlockByLabel[yieldInstruction.ResumeLabelId] =
+                        blockIndex + 1;
+                    break;
+            }
+        }
+
+        for (var blockIndex = 0; blockIndex < blocks.Count; blockIndex++)
+        {
+            var block = blocks[blockIndex];
+            var last = instructions[block.End - 1];
+
+            void AddLabelSuccessor(int labelId)
+            {
+                if (resumeBlockByLabel.TryGetValue(
+                        labelId,
+                        out var resumeBlock))
+                {
+                    block.Successors.Add(resumeBlock);
+                }
+                else if (blockByLabel.TryGetValue(
+                             labelId,
+                             out var successor))
+                {
+                    block.Successors.Add(successor);
+                }
+            }
+
+            void AddFallthrough()
+            {
+                if (blockIndex + 1 < blocks.Count)
+                {
+                    block.Successors.Add(blockIndex + 1);
+                }
+            }
+
+            switch (last)
+            {
+                case LIRBranch branch:
+                    AddLabelSuccessor(branch.TargetLabel);
+                    break;
+                case LIRLeave leave:
+                    AddLabelSuccessor(leave.TargetLabel);
+                    break;
+                case LIRBranchIfTrue branch:
+                    AddLabelSuccessor(branch.TargetLabel);
+                    AddFallthrough();
+                    break;
+                case LIRBranchIfFalse branch:
+                    AddLabelSuccessor(branch.TargetLabel);
+                    AddFallthrough();
+                    break;
+                case LIRAsyncStateSwitch stateSwitch:
+                    foreach (var label in stateSwitch.StateToLabel.Values)
+                    {
+                        AddLabelSuccessor(label);
+                    }
+                    AddLabelSuccessor(stateSwitch.DefaultLabel);
+                    break;
+                case LIRGeneratorStateSwitch stateSwitch:
+                    foreach (var label in stateSwitch.StateToLabel.Values)
+                    {
+                        AddLabelSuccessor(label);
+                    }
+                    AddLabelSuccessor(stateSwitch.DefaultLabel);
+                    break;
+                case LIRAwait awaitInstruction:
+                    AddFallthrough();
+                    if (awaitInstruction.RejectResumeStateId is int rejectState
+                        && methodBody.AsyncInfo?.ResumeLabels.TryGetValue(
+                            rejectState,
+                            out var rejectLabel) == true)
+                    {
+                        AddLabelSuccessor(rejectLabel);
+                    }
+                    break;
+                case LIRYield:
+                    AddFallthrough();
+                    break;
+                case LIRReturn:
+                case LIRReturnUndefinedImmediate:
+                case LIRTailCallFunctionReturn:
+                case LIRAsyncReturnPromise:
+                case LIRThrow:
+                case LIRThrowNewTypeError:
+                case LIREndFinally:
+                    break;
+                default:
+                    AddFallthrough();
+                    break;
+            }
+        }
+
+        for (var blockIndex = 0; blockIndex < blocks.Count; blockIndex++)
+        {
+            foreach (var successor in blocks[blockIndex].Successors)
+            {
+                blocks[successor].Predecessors.Add(blockIndex);
+            }
+        }
+
+        return new LIRControlFlowGraph(
+            blocks,
+            blockByLabel);
+    }
+
+    private static bool IsBlockEndingInstruction(
+        LIRInstruction instruction)
+        => instruction is LIRBranch
+            or LIRLeave
+            or LIRBranchIfTrue
+            or LIRBranchIfFalse
+            or LIRAsyncStateSwitch
+            or LIRGeneratorStateSwitch
+            or LIRAwait
+            or LIRYield
+            or LIRReturn
+            or LIRReturnUndefinedImmediate
+            or LIRTailCallFunctionReturn
+            or LIRAsyncReturnPromise
+            or LIRThrow
+            or LIRThrowNewTypeError
+            or LIREndFinally;
+}

--- a/src/Compiler/IR/LIR/LIRInstructions.cs
+++ b/src/Compiler/IR/LIR/LIRInstructions.cs
@@ -277,6 +277,20 @@ public record LIRCallGuardedStringIntrinsic(
         LIRGuardedStringFallbackResultConversion.None) : LIRInstruction;
 
 /// <summary>
+/// Calls a runtime intrinsic instance method when its prototype family is
+/// pristine and the receiver has no own override, with ordinary member
+/// dispatch as the fallback.
+/// </summary>
+public record LIRCallGuardedIntrinsicMember(
+    TempVariable Receiver,
+    Type ReceiverClrType,
+    JavaScriptRuntime.IntrinsicPrototypeFamily PrototypeFamily,
+    string MemberName,
+    bool ReceiverIsProvenType,
+    IReadOnlyList<TempVariable> Arguments,
+    TempVariable Result) : LIRInstruction;
+
+/// <summary>
 /// Calls a computed member with inline common-arity arguments.
 /// </summary>
 public record LIRCallComputedMemberFixed(

--- a/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
+++ b/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
@@ -1,5 +1,6 @@
 using Jroc.IL;
 using Jroc.Services;
+using Jroc.SymbolTables;
 using Jroc.Services.TwoPhaseCompilation;
 using System.Linq;
 using System.Reflection.Metadata;
@@ -36,6 +37,9 @@ internal static class LIRIntrinsicNormalization
         // Track temps proven to be constant strings (e.g., property access keys).
         // This allows safe rewrites like `r.promise` -> direct CLR getter when r is known.
         var knownConstStrings = new Dictionary<int, string>();
+
+        // Candidates remain object-typed and can only use guarded specialization.
+        var knownStringCandidateReceivers = new HashSet<int>();
 
         // Seed known intrinsic receiver types from temp storage when it is already specific.
         // This covers cases like Promise.withResolvers() which returns a concrete runtime type.
@@ -94,6 +98,7 @@ internal static class LIRIntrinsicNormalization
                     {
                         knownSpecializedReceiverClrTypes[loadScopeField.Result.Index] = loadScopeField.Binding.ClrType!;
                     }
+                    AddStringReceiverCandidate(loadScopeField.Binding, loadScopeField.Result);
                     break;
 
                 case LIRLoadLeafScopeField loadLeafScopeField:
@@ -102,6 +107,7 @@ internal static class LIRIntrinsicNormalization
                     {
                         knownSpecializedReceiverClrTypes[loadLeafScopeField.Result.Index] = loadLeafScopeField.Binding.ClrType!;
                     }
+                    AddStringReceiverCandidate(loadLeafScopeField.Binding, loadLeafScopeField.Result);
                     break;
 
                 case LIRLoadParentScopeField loadParentScopeField:
@@ -110,6 +116,7 @@ internal static class LIRIntrinsicNormalization
                     {
                         knownSpecializedReceiverClrTypes[loadParentScopeField.Result.Index] = loadParentScopeField.Binding.ClrType!;
                     }
+                    AddStringReceiverCandidate(loadParentScopeField.Binding, loadParentScopeField.Result);
                     break;
 
                 case LIRCallIntrinsicStatic
@@ -123,6 +130,9 @@ internal static class LIRIntrinsicNormalization
                     {
                         knownSpecializedReceiverClrTypes[requireObjectCoercible.Result.Index] = coercedReceiverType;
                     }
+                    CopyStringReceiverCandidate(
+                        requireObjectCoercible.Arguments[0],
+                        requireObjectCoercible.Result);
                     break;
 
                 case LIRCopyTemp copyTemp:
@@ -137,13 +147,15 @@ internal static class LIRIntrinsicNormalization
                     {
                         knownConstStrings[copyTemp.Destination.Index] = srcConstString;
                     }
+                    CopyStringReceiverCandidate(copyTemp.Source, copyTemp.Destination);
                     break;
             }
         }
 
         FuseCharCodeAtWithConvertToNumber(
             methodBody,
-            knownSpecializedReceiverClrTypes);
+            knownSpecializedReceiverClrTypes,
+            knownStringCandidateReceivers);
 
         for (int i = 0; i < methodBody.Instructions.Count; i++)
         {
@@ -162,6 +174,7 @@ internal static class LIRIntrinsicNormalization
                 {
                     knownConstStrings[copyTemp.Destination.Index] = copiedConstString;
                 }
+                CopyStringReceiverCandidate(copyTemp.Source, copyTemp.Destination);
             }
 
             if (instruction is LIRCallIntrinsicStatic
@@ -174,6 +187,18 @@ internal static class LIRIntrinsicNormalization
                 && knownSpecializedReceiverClrTypes.TryGetValue(requireObjectCoercible.Arguments[0].Index, out var coercedReceiverType))
             {
                 knownSpecializedReceiverClrTypes[requireObjectCoercible.Result.Index] = coercedReceiverType;
+            }
+            if (instruction is LIRCallIntrinsicStatic
+                {
+                    IntrinsicName: nameof(JavaScriptRuntime.ObjectRuntime),
+                    MethodName: nameof(JavaScriptRuntime.ObjectRuntime.RequireObjectCoercible)
+                } candidateRequireObjectCoercible
+                && candidateRequireObjectCoercible.Result.Index >= 0
+                && candidateRequireObjectCoercible.Arguments.Count == 1)
+            {
+                CopyStringReceiverCandidate(
+                    candidateRequireObjectCoercible.Arguments[0],
+                    candidateRequireObjectCoercible.Result);
             }
 
             if (instruction is LIRGetLength getLength)
@@ -367,7 +392,8 @@ internal static class LIRIntrinsicNormalization
                         callMember0.MethodName,
                         Array.Empty<TempVariable>(),
                         callMember0.Result,
-                        knownSpecializedReceiverClrTypes))
+                        knownSpecializedReceiverClrTypes,
+                        knownStringCandidateReceivers))
                 {
                     continue;
                 }
@@ -407,7 +433,8 @@ internal static class LIRIntrinsicNormalization
                         callMember1.MethodName,
                         new[] { callMember1.A0 },
                         callMember1.Result,
-                        knownSpecializedReceiverClrTypes))
+                        knownSpecializedReceiverClrTypes,
+                        knownStringCandidateReceivers))
                 {
                     continue;
                 }
@@ -462,7 +489,8 @@ internal static class LIRIntrinsicNormalization
                         callMember2.MethodName,
                         new[] { callMember2.A0, callMember2.A1 },
                         callMember2.Result,
-                        knownSpecializedReceiverClrTypes))
+                        knownSpecializedReceiverClrTypes,
+                        knownStringCandidateReceivers))
                 {
                     continue;
                 }
@@ -490,7 +518,8 @@ internal static class LIRIntrinsicNormalization
                     callMember3.MethodName,
                     new[] { callMember3.A0, callMember3.A1, callMember3.A2 },
                     callMember3.Result,
-                    knownSpecializedReceiverClrTypes);
+                    knownSpecializedReceiverClrTypes,
+                    knownStringCandidateReceivers);
             }
 
             if (instruction is LIRCallMember4 callMember4)
@@ -526,7 +555,8 @@ internal static class LIRIntrinsicNormalization
                         callMember4.A3
                     },
                     callMember4.Result,
-                    knownSpecializedReceiverClrTypes);
+                    knownSpecializedReceiverClrTypes,
+                    knownStringCandidateReceivers);
             }
 
             if (instruction is LIRCallMember5 callMember5)
@@ -564,18 +594,38 @@ internal static class LIRIntrinsicNormalization
                         callMember5.A4
                     },
                     callMember5.Result,
-                    knownSpecializedReceiverClrTypes);
+                    knownSpecializedReceiverClrTypes,
+                    knownStringCandidateReceivers);
             }
         }
 
         FuseGetItemWithConvertToNumber(methodBody);
+
+        void AddStringReceiverCandidate(BindingInfo binding, TempVariable result)
+        {
+            if (result.Index >= 0
+                && binding.ReceiverCandidateClrTypes.Contains(typeof(string)))
+            {
+                knownStringCandidateReceivers.Add(result.Index);
+            }
+        }
+
+        void CopyStringReceiverCandidate(TempVariable source, TempVariable destination)
+        {
+            if (destination.Index >= 0
+                && knownStringCandidateReceivers.Contains(source.Index))
+            {
+                knownStringCandidateReceivers.Add(destination.Index);
+            }
+        }
     }
 
     public static void NormalizeLateNumericMemberCalls(MethodBodyIR methodBody)
     {
         FuseCharCodeAtWithConvertToNumber(
             methodBody,
-            knownSpecializedReceiverClrTypes: null);
+            knownSpecializedReceiverClrTypes: null,
+            knownStringCandidateReceivers: null);
     }
 
     private static bool TryNormalizeGuardedStringMemberCall(
@@ -585,7 +635,8 @@ internal static class LIRIntrinsicNormalization
         string methodName,
         IReadOnlyList<TempVariable> arguments,
         TempVariable result,
-        IReadOnlyDictionary<int, Type> knownSpecializedReceiverClrTypes)
+        IReadOnlyDictionary<int, Type> knownSpecializedReceiverClrTypes,
+        IReadOnlySet<int>? knownStringCandidateReceivers = null)
     {
         if (!TryResolveSafeStringIntrinsicMethod(
                 methodBody,
@@ -600,6 +651,7 @@ internal static class LIRIntrinsicNormalization
                 methodBody,
                 receiver,
                 knownSpecializedReceiverClrTypes,
+                knownStringCandidateReceivers,
                 out var receiverIsProvenString))
         {
             return false;
@@ -630,6 +682,7 @@ internal static class LIRIntrinsicNormalization
         TempVariable receiver,
         IReadOnlyDictionary<int, Type>?
             knownSpecializedReceiverClrTypes,
+        IReadOnlySet<int>? knownStringCandidateReceivers,
         out bool receiverIsProvenString)
     {
         receiverIsProvenString = false;
@@ -639,7 +692,13 @@ internal static class LIRIntrinsicNormalization
         {
             receiverIsProvenString =
                 knownReceiverType == typeof(string);
-            return receiverIsProvenString;
+            return receiverIsProvenString
+                || knownStringCandidateReceivers?.Contains(receiver.Index) == true;
+        }
+
+        if (knownStringCandidateReceivers?.Contains(receiver.Index) == true)
+        {
+            return true;
         }
 
         if (receiver.Index < 0
@@ -1090,7 +1149,8 @@ internal static class LIRIntrinsicNormalization
     private static void FuseCharCodeAtWithConvertToNumber(
         MethodBodyIR methodBody,
         IReadOnlyDictionary<int, Type>?
-            knownSpecializedReceiverClrTypes)
+            knownSpecializedReceiverClrTypes,
+        IReadOnlySet<int>? knownStringCandidateReceivers)
     {
         var singleConvertToNumberConsumerByTempIndex = new Dictionary<int, int>();
         var ineligibleTempIndices = new HashSet<int>();
@@ -1157,6 +1217,7 @@ internal static class LIRIntrinsicNormalization
                     methodBody,
                     callMember.Receiver,
                     knownSpecializedReceiverClrTypes,
+                    knownStringCandidateReceivers,
                     out var receiverIsProvenString))
             {
                 continue;

--- a/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
+++ b/src/Compiler/IR/LIR/LIRIntrinsicNormalization.cs
@@ -1,6 +1,5 @@
 using Jroc.IL;
 using Jroc.Services;
-using Jroc.SymbolTables;
 using Jroc.Services.TwoPhaseCompilation;
 using System.Linq;
 using System.Reflection.Metadata;
@@ -37,9 +36,6 @@ internal static class LIRIntrinsicNormalization
         // Track temps proven to be constant strings (e.g., property access keys).
         // This allows safe rewrites like `r.promise` -> direct CLR getter when r is known.
         var knownConstStrings = new Dictionary<int, string>();
-
-        // Candidates remain object-typed and can only use guarded specialization.
-        var knownStringCandidateReceivers = new HashSet<int>();
 
         // Seed known intrinsic receiver types from temp storage when it is already specific.
         // This covers cases like Promise.withResolvers() which returns a concrete runtime type.
@@ -98,7 +94,6 @@ internal static class LIRIntrinsicNormalization
                     {
                         knownSpecializedReceiverClrTypes[loadScopeField.Result.Index] = loadScopeField.Binding.ClrType!;
                     }
-                    AddStringReceiverCandidate(loadScopeField.Binding, loadScopeField.Result);
                     break;
 
                 case LIRLoadLeafScopeField loadLeafScopeField:
@@ -107,7 +102,6 @@ internal static class LIRIntrinsicNormalization
                     {
                         knownSpecializedReceiverClrTypes[loadLeafScopeField.Result.Index] = loadLeafScopeField.Binding.ClrType!;
                     }
-                    AddStringReceiverCandidate(loadLeafScopeField.Binding, loadLeafScopeField.Result);
                     break;
 
                 case LIRLoadParentScopeField loadParentScopeField:
@@ -116,7 +110,6 @@ internal static class LIRIntrinsicNormalization
                     {
                         knownSpecializedReceiverClrTypes[loadParentScopeField.Result.Index] = loadParentScopeField.Binding.ClrType!;
                     }
-                    AddStringReceiverCandidate(loadParentScopeField.Binding, loadParentScopeField.Result);
                     break;
 
                 case LIRCallIntrinsicStatic
@@ -130,9 +123,6 @@ internal static class LIRIntrinsicNormalization
                     {
                         knownSpecializedReceiverClrTypes[requireObjectCoercible.Result.Index] = coercedReceiverType;
                     }
-                    CopyStringReceiverCandidate(
-                        requireObjectCoercible.Arguments[0],
-                        requireObjectCoercible.Result);
                     break;
 
                 case LIRCopyTemp copyTemp:
@@ -147,15 +137,13 @@ internal static class LIRIntrinsicNormalization
                     {
                         knownConstStrings[copyTemp.Destination.Index] = srcConstString;
                     }
-                    CopyStringReceiverCandidate(copyTemp.Source, copyTemp.Destination);
                     break;
             }
         }
 
         FuseCharCodeAtWithConvertToNumber(
             methodBody,
-            knownSpecializedReceiverClrTypes,
-            knownStringCandidateReceivers);
+            knownSpecializedReceiverClrTypes);
 
         for (int i = 0; i < methodBody.Instructions.Count; i++)
         {
@@ -174,7 +162,6 @@ internal static class LIRIntrinsicNormalization
                 {
                     knownConstStrings[copyTemp.Destination.Index] = copiedConstString;
                 }
-                CopyStringReceiverCandidate(copyTemp.Source, copyTemp.Destination);
             }
 
             if (instruction is LIRCallIntrinsicStatic
@@ -188,19 +175,6 @@ internal static class LIRIntrinsicNormalization
             {
                 knownSpecializedReceiverClrTypes[requireObjectCoercible.Result.Index] = coercedReceiverType;
             }
-            if (instruction is LIRCallIntrinsicStatic
-                {
-                    IntrinsicName: nameof(JavaScriptRuntime.ObjectRuntime),
-                    MethodName: nameof(JavaScriptRuntime.ObjectRuntime.RequireObjectCoercible)
-                } candidateRequireObjectCoercible
-                && candidateRequireObjectCoercible.Result.Index >= 0
-                && candidateRequireObjectCoercible.Arguments.Count == 1)
-            {
-                CopyStringReceiverCandidate(
-                    candidateRequireObjectCoercible.Arguments[0],
-                    candidateRequireObjectCoercible.Result);
-            }
-
             if (instruction is LIRGetLength getLength)
             {
                 if (!knownSpecializedReceiverClrTypes.TryGetValue(getLength.Object.Index, out var receiverType))
@@ -392,8 +366,7 @@ internal static class LIRIntrinsicNormalization
                         callMember0.MethodName,
                         Array.Empty<TempVariable>(),
                         callMember0.Result,
-                        knownSpecializedReceiverClrTypes,
-                        knownStringCandidateReceivers))
+                        knownSpecializedReceiverClrTypes))
                 {
                     continue;
                 }
@@ -433,8 +406,7 @@ internal static class LIRIntrinsicNormalization
                         callMember1.MethodName,
                         new[] { callMember1.A0 },
                         callMember1.Result,
-                        knownSpecializedReceiverClrTypes,
-                        knownStringCandidateReceivers))
+                        knownSpecializedReceiverClrTypes))
                 {
                     continue;
                 }
@@ -489,8 +461,7 @@ internal static class LIRIntrinsicNormalization
                         callMember2.MethodName,
                         new[] { callMember2.A0, callMember2.A1 },
                         callMember2.Result,
-                        knownSpecializedReceiverClrTypes,
-                        knownStringCandidateReceivers))
+                        knownSpecializedReceiverClrTypes))
                 {
                     continue;
                 }
@@ -518,8 +489,7 @@ internal static class LIRIntrinsicNormalization
                     callMember3.MethodName,
                     new[] { callMember3.A0, callMember3.A1, callMember3.A2 },
                     callMember3.Result,
-                    knownSpecializedReceiverClrTypes,
-                    knownStringCandidateReceivers);
+                    knownSpecializedReceiverClrTypes);
             }
 
             if (instruction is LIRCallMember4 callMember4)
@@ -555,8 +525,7 @@ internal static class LIRIntrinsicNormalization
                         callMember4.A3
                     },
                     callMember4.Result,
-                    knownSpecializedReceiverClrTypes,
-                    knownStringCandidateReceivers);
+                    knownSpecializedReceiverClrTypes);
             }
 
             if (instruction is LIRCallMember5 callMember5)
@@ -594,38 +563,19 @@ internal static class LIRIntrinsicNormalization
                         callMember5.A4
                     },
                     callMember5.Result,
-                    knownSpecializedReceiverClrTypes,
-                    knownStringCandidateReceivers);
+                    knownSpecializedReceiverClrTypes);
             }
         }
 
         FuseGetItemWithConvertToNumber(methodBody);
 
-        void AddStringReceiverCandidate(BindingInfo binding, TempVariable result)
-        {
-            if (result.Index >= 0
-                && binding.ReceiverCandidateClrTypes.Contains(typeof(string)))
-            {
-                knownStringCandidateReceivers.Add(result.Index);
-            }
-        }
-
-        void CopyStringReceiverCandidate(TempVariable source, TempVariable destination)
-        {
-            if (destination.Index >= 0
-                && knownStringCandidateReceivers.Contains(source.Index))
-            {
-                knownStringCandidateReceivers.Add(destination.Index);
-            }
-        }
     }
 
     public static void NormalizeLateNumericMemberCalls(MethodBodyIR methodBody)
     {
         FuseCharCodeAtWithConvertToNumber(
             methodBody,
-            knownSpecializedReceiverClrTypes: null,
-            knownStringCandidateReceivers: null);
+            knownSpecializedReceiverClrTypes: null);
     }
 
     private static bool TryNormalizeGuardedStringMemberCall(
@@ -635,8 +585,7 @@ internal static class LIRIntrinsicNormalization
         string methodName,
         IReadOnlyList<TempVariable> arguments,
         TempVariable result,
-        IReadOnlyDictionary<int, Type> knownSpecializedReceiverClrTypes,
-        IReadOnlySet<int>? knownStringCandidateReceivers = null)
+        IReadOnlyDictionary<int, Type> knownSpecializedReceiverClrTypes)
     {
         if (!TryResolveSafeStringIntrinsicMethod(
                 methodBody,
@@ -651,7 +600,6 @@ internal static class LIRIntrinsicNormalization
                 methodBody,
                 receiver,
                 knownSpecializedReceiverClrTypes,
-                knownStringCandidateReceivers,
                 out var receiverIsProvenString))
         {
             return false;
@@ -682,7 +630,6 @@ internal static class LIRIntrinsicNormalization
         TempVariable receiver,
         IReadOnlyDictionary<int, Type>?
             knownSpecializedReceiverClrTypes,
-        IReadOnlySet<int>? knownStringCandidateReceivers,
         out bool receiverIsProvenString)
     {
         receiverIsProvenString = false;
@@ -692,13 +639,7 @@ internal static class LIRIntrinsicNormalization
         {
             receiverIsProvenString =
                 knownReceiverType == typeof(string);
-            return receiverIsProvenString
-                || knownStringCandidateReceivers?.Contains(receiver.Index) == true;
-        }
-
-        if (knownStringCandidateReceivers?.Contains(receiver.Index) == true)
-        {
-            return true;
+            return receiverIsProvenString;
         }
 
         if (receiver.Index < 0
@@ -1149,8 +1090,7 @@ internal static class LIRIntrinsicNormalization
     private static void FuseCharCodeAtWithConvertToNumber(
         MethodBodyIR methodBody,
         IReadOnlyDictionary<int, Type>?
-            knownSpecializedReceiverClrTypes,
-        IReadOnlySet<int>? knownStringCandidateReceivers)
+            knownSpecializedReceiverClrTypes)
     {
         var singleConvertToNumberConsumerByTempIndex = new Dictionary<int, int>();
         var ineligibleTempIndices = new HashSet<int>();
@@ -1217,7 +1157,6 @@ internal static class LIRIntrinsicNormalization
                     methodBody,
                     callMember.Receiver,
                     knownSpecializedReceiverClrTypes,
-                    knownStringCandidateReceivers,
                     out var receiverIsProvenString))
             {
                 continue;

--- a/src/Compiler/IR/LIR/LIRLoopNestingAnalysis.cs
+++ b/src/Compiler/IR/LIR/LIRLoopNestingAnalysis.cs
@@ -1,0 +1,188 @@
+namespace Jroc.IR;
+
+internal sealed class LIRLoopNestingFacts(int[] depthByInstruction)
+{
+    public int GetDepth(int instructionIndex)
+        => instructionIndex >= 0
+            && instructionIndex < depthByInstruction.Length
+                ? depthByInstruction[instructionIndex]
+                : 0;
+}
+
+internal static class LIRLoopNestingAnalysis
+{
+    public static LIRLoopNestingFacts Analyze(MethodBodyIR methodBody)
+    {
+        var depthByInstruction =
+            new int[methodBody.Instructions.Count];
+        if (methodBody.Instructions.Count == 0)
+        {
+            return new LIRLoopNestingFacts(depthByInstruction);
+        }
+
+        var graph = LIRControlFlowGraph.Build(methodBody);
+        var blocks = graph.Blocks;
+        if (!HasPotentialBackEdge(blocks))
+        {
+            return new LIRLoopNestingFacts(depthByInstruction);
+        }
+
+        var roots = FindRoots(methodBody, graph);
+        var dominators = ComputeDominators(blocks, roots);
+        var loopBlocksByHeader =
+            new Dictionary<int, HashSet<int>>();
+
+        for (var source = 0; source < blocks.Count; source++)
+        {
+            foreach (var header in blocks[source].Successors)
+            {
+                if (!dominators[source].Contains(header))
+                {
+                    continue;
+                }
+
+                if (!loopBlocksByHeader.TryGetValue(
+                        header,
+                        out var loopBlocks))
+                {
+                    loopBlocks = [];
+                    loopBlocksByHeader.Add(header, loopBlocks);
+                }
+
+                AddNaturalLoop(
+                    blocks,
+                    source,
+                    header,
+                    loopBlocks);
+            }
+        }
+
+        foreach (var loopBlocks in loopBlocksByHeader.Values)
+        {
+            foreach (var blockIndex in loopBlocks)
+            {
+                var block = blocks[blockIndex];
+                for (var instructionIndex = block.Start;
+                     instructionIndex < block.End;
+                     instructionIndex++)
+                {
+                    depthByInstruction[instructionIndex]++;
+                }
+            }
+        }
+
+        return new LIRLoopNestingFacts(depthByInstruction);
+    }
+
+    private static bool HasPotentialBackEdge(
+        IReadOnlyList<LIRBasicBlock> blocks)
+    {
+        for (var source = 0; source < blocks.Count; source++)
+        {
+            if (blocks[source].Successors.Any(
+                    successor => successor <= source))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static HashSet<int> FindRoots(
+        MethodBodyIR methodBody,
+        LIRControlFlowGraph graph)
+    {
+        var roots = new HashSet<int> { 0 };
+        foreach (var region in methodBody.ExceptionRegions)
+        {
+            if (graph.TryGetLabelBlock(
+                    region.HandlerStartLabelId,
+                    out var handlerBlock))
+            {
+                roots.Add(handlerBlock);
+            }
+        }
+
+        return roots;
+    }
+
+    private static HashSet<int>[] ComputeDominators(
+        IReadOnlyList<LIRBasicBlock> blocks,
+        IReadOnlySet<int> roots)
+    {
+        var allBlocks = Enumerable.Range(0, blocks.Count).ToHashSet();
+        var dominators = new HashSet<int>[blocks.Count];
+        for (var blockIndex = 0;
+             blockIndex < blocks.Count;
+             blockIndex++)
+        {
+            dominators[blockIndex] = roots.Contains(blockIndex)
+                ? [blockIndex]
+                : new HashSet<int>(allBlocks);
+        }
+
+        var changed = true;
+        while (changed)
+        {
+            changed = false;
+            for (var blockIndex = 0;
+                 blockIndex < blocks.Count;
+                 blockIndex++)
+            {
+                if (roots.Contains(blockIndex))
+                {
+                    continue;
+                }
+
+                var predecessors = blocks[blockIndex].Predecessors;
+                var updated = predecessors.Count == 0
+                    ? []
+                    : new HashSet<int>(
+                        dominators[predecessors.First()]);
+                foreach (var predecessor in predecessors.Skip(1))
+                {
+                    updated.IntersectWith(dominators[predecessor]);
+                }
+                updated.Add(blockIndex);
+
+                if (!dominators[blockIndex].SetEquals(updated))
+                {
+                    dominators[blockIndex] = updated;
+                    changed = true;
+                }
+            }
+        }
+
+        return dominators;
+    }
+
+    private static void AddNaturalLoop(
+        IReadOnlyList<LIRBasicBlock> blocks,
+        int source,
+        int header,
+        HashSet<int> loopBlocks)
+    {
+        loopBlocks.Add(header);
+        if (!loopBlocks.Add(source) || source == header)
+        {
+            return;
+        }
+
+        var pending = new Stack<int>();
+        pending.Push(source);
+        while (pending.Count > 0)
+        {
+            var blockIndex = pending.Pop();
+            foreach (var predecessor in
+                     blocks[blockIndex].Predecessors)
+            {
+                if (predecessor != header
+                    && loopBlocks.Add(predecessor))
+                {
+                    pending.Push(predecessor);
+                }
+            }
+        }
+    }
+}

--- a/src/Compiler/IR/LIR/LIRReceiverSpecialization.cs
+++ b/src/Compiler/IR/LIR/LIRReceiverSpecialization.cs
@@ -4,6 +4,8 @@ namespace Jroc.IR;
 
 internal static class LIRReceiverSpecialization
 {
+    private const int MinimumLoopDepth = 1;
+
     public static void Normalize(MethodBodyIR methodBody)
     {
         for (var index = 0; index < methodBody.Instructions.Count; index++)
@@ -23,6 +25,14 @@ internal static class LIRReceiverSpecialization
                     out var receiverType,
                     out var family,
                     out var receiverIsProvenType))
+            {
+                continue;
+            }
+
+            methodBody.LoopNestingFacts ??=
+                LIRLoopNestingAnalysis.Analyze(methodBody);
+            if (methodBody.LoopNestingFacts.GetDepth(index)
+                < MinimumLoopDepth)
             {
                 continue;
             }

--- a/src/Compiler/IR/LIR/LIRReceiverSpecialization.cs
+++ b/src/Compiler/IR/LIR/LIRReceiverSpecialization.cs
@@ -10,8 +10,19 @@ internal static class LIRReceiverSpecialization
         MethodBodyIR methodBody,
         ReceiverTypeFlowDiagnosticTrace? diagnostics = null)
     {
+        Dictionary<int, HashSet<Type>>? staticCandidates = null;
+
         for (var index = 0; index < methodBody.Instructions.Count; index++)
         {
+            if (TryNormalizeStringPropertyAccess(
+                    methodBody,
+                    index,
+                    ref staticCandidates,
+                    diagnostics))
+            {
+                continue;
+            }
+
             if (!TryGetMemberCall(
                     methodBody.Instructions[index],
                     out var receiver,
@@ -68,6 +79,243 @@ internal static class LIRReceiverSpecialization
             SetObjectResultStorage(methodBody, result);
         }
     }
+
+    private static bool TryNormalizeStringPropertyAccess(
+        MethodBodyIR methodBody,
+        int instructionIndex,
+        ref Dictionary<int, HashSet<Type>>? staticCandidates,
+        ReceiverTypeFlowDiagnosticTrace? diagnostics)
+    {
+        TempVariable receiver;
+        TempVariable result;
+        IReadOnlyList<TempVariable> arguments;
+        string memberName;
+        string helperName;
+
+        switch (methodBody.Instructions[instructionIndex])
+        {
+            case LIRGetItem getItem
+                when IsUnboxedDouble(methodBody, getItem.Index):
+                receiver = getItem.Object;
+                result = getItem.Result;
+                arguments = [receiver, getItem.Index];
+                memberName = "[index]";
+                helperName = nameof(
+                    JavaScriptRuntime.ObjectRuntime
+                        .GetStringElementWithFallback);
+                break;
+            default:
+                return false;
+        }
+
+        if (!TryClassifyStringReceiver(
+                methodBody,
+                instructionIndex,
+                receiver,
+                ref staticCandidates,
+                out var receiverIsProvenString))
+        {
+            return false;
+        }
+
+        methodBody.LoopNestingFacts ??=
+            LIRLoopNestingAnalysis.Analyze(methodBody);
+        var loopDepth =
+            methodBody.LoopNestingFacts.GetDepth(instructionIndex);
+        if (loopDepth < MinimumLoopDepth)
+        {
+            diagnostics?.RecordSpecialization(
+                instructionIndex,
+                memberName,
+                receiver,
+                typeof(string),
+                loopDepth,
+                receiverIsProvenString,
+                "retained-generic(cold)");
+            return false;
+        }
+
+        diagnostics?.RecordSpecialization(
+            instructionIndex,
+            memberName,
+            receiver,
+            typeof(string),
+            loopDepth,
+            receiverIsProvenString,
+            "guarded");
+        methodBody.Instructions[instructionIndex] =
+            new LIRCallIntrinsicStatic(
+                nameof(JavaScriptRuntime.ObjectRuntime),
+                helperName,
+                arguments,
+                result);
+        SetObjectResultStorage(methodBody, result);
+        return true;
+    }
+
+    private static bool TryClassifyStringReceiver(
+        MethodBodyIR methodBody,
+        int instructionIndex,
+        TempVariable receiver,
+        ref Dictionary<int, HashSet<Type>>? staticCandidates,
+        out bool receiverIsProvenString)
+    {
+        receiverIsProvenString = false;
+        if (TryGetStorageReceiverType(
+                methodBody,
+                receiver,
+                out var storageType))
+        {
+            if (storageType == typeof(string))
+            {
+                receiverIsProvenString = true;
+                return true;
+            }
+
+            if (storageType != typeof(object))
+            {
+                return false;
+            }
+        }
+
+        var fact = methodBody.ReceiverTypeFlowFacts?
+            .GetTempBefore(instructionIndex, receiver);
+        if (fact?.Contains(typeof(string)) == true)
+        {
+            receiverIsProvenString =
+                !fact.IncludesUnknown
+                && !fact.IncludesNonCandidate
+                && fact.CandidateClrTypes.Count == 1;
+            return true;
+        }
+
+        staticCandidates ??=
+            BuildStaticReceiverCandidates(methodBody);
+        return staticCandidates.TryGetValue(
+                receiver.Index,
+                out var candidates)
+            && candidates.Contains(typeof(string));
+    }
+
+    private static Dictionary<int, HashSet<Type>>
+        BuildStaticReceiverCandidates(MethodBodyIR methodBody)
+    {
+        var candidates = new Dictionary<int, HashSet<Type>>();
+        foreach (var (tempIndex, summary) in
+                 methodBody.ReceiverTempTypeSummaries)
+        {
+            Add(
+                new TempVariable(tempIndex),
+                summary.CandidateClrTypes);
+        }
+
+        bool changed;
+        do
+        {
+            changed = false;
+            foreach (var instruction in methodBody.Instructions)
+            {
+                if (!LIRInstructionInfo.TryGetDefinedTemp(
+                        instruction,
+                        out var result)
+                    || result.Index < 0)
+                {
+                    continue;
+                }
+
+                if (methodBody.ReceiverTempTypeSummaries.TryGetValue(
+                        result.Index,
+                        out var summary))
+                {
+                    changed |= Add(
+                        result,
+                        summary.CandidateClrTypes);
+                }
+
+                switch (instruction)
+                {
+                    case LIRLoadScopeField load:
+                        changed |= Add(
+                            result,
+                            load.Binding.ReceiverCandidateClrTypes);
+                        break;
+                    case LIRLoadLeafScopeField load:
+                        changed |= Add(
+                            result,
+                            load.Binding.ReceiverCandidateClrTypes);
+                        break;
+                    case LIRLoadParentScopeField load:
+                        changed |= Add(
+                            result,
+                            load.Binding.ReceiverCandidateClrTypes);
+                        break;
+                    case LIRCopyTemp copy:
+                        changed |= Copy(copy.Source, result);
+                        break;
+                    case LIRConvertToObject convert:
+                        changed |= Copy(convert.Source, result);
+                        break;
+                    case LIRCallIntrinsicStatic
+                    {
+                        IntrinsicName:
+                            nameof(JavaScriptRuntime.ObjectRuntime),
+                        MethodName:
+                            nameof(JavaScriptRuntime.ObjectRuntime
+                                .RequireObjectCoercible),
+                        Arguments: [var source]
+                    }:
+                        changed |= Copy(source, result);
+                        break;
+                }
+            }
+        }
+        while (changed);
+
+        return candidates;
+
+        bool Add(TempVariable temp, IEnumerable<Type> types)
+        {
+            var added = false;
+            foreach (var type in types)
+            {
+                if (!candidates.TryGetValue(
+                        temp.Index,
+                        out var target))
+                {
+                    target = [];
+                    candidates.Add(temp.Index, target);
+                }
+
+                added |= target.Add(type);
+            }
+
+            return added;
+        }
+
+        bool Copy(TempVariable source, TempVariable target)
+        {
+            if (candidates.TryGetValue(
+                    source.Index,
+                    out var sourceCandidates))
+            {
+                return Add(target, sourceCandidates);
+            }
+
+            return false;
+        }
+    }
+
+    private static bool IsUnboxedDouble(
+        MethodBodyIR methodBody,
+        TempVariable temp)
+        => temp.Index >= 0
+            && temp.Index < methodBody.TempStorages.Count
+            && methodBody.TempStorages[temp.Index] is
+            {
+                Kind: ValueStorageKind.UnboxedValue,
+                ClrType: not null
+            } storage
+            && storage.ClrType == typeof(double);
 
     private static void SetObjectResultStorage(
         MethodBodyIR methodBody,
@@ -316,4 +564,5 @@ internal static class LIRReceiverSpecialization
                 return false;
         }
     }
+
 }

--- a/src/Compiler/IR/LIR/LIRReceiverSpecialization.cs
+++ b/src/Compiler/IR/LIR/LIRReceiverSpecialization.cs
@@ -317,6 +317,38 @@ internal static class LIRReceiverSpecialization
             } storage
             && storage.ClrType == typeof(double);
 
+    internal static bool TryGetPotentialReceiver(
+        MethodBodyIR methodBody,
+        LIRInstruction instruction,
+        out TempVariable receiver)
+    {
+        if (instruction is LIRGetItem getItem
+            && IsUnboxedDouble(methodBody, getItem.Index))
+        {
+            receiver = getItem.Object;
+            return true;
+        }
+
+        if (TryGetMemberCall(
+                instruction,
+                out receiver,
+                out var memberName,
+                out var arguments,
+                out _)
+            && (IsEligibleArrayMember(
+                    memberName,
+                    arguments.Count)
+                || IsEligibleTypedArrayMember(
+                    memberName,
+                    arguments.Count)))
+        {
+            return true;
+        }
+
+        receiver = default;
+        return false;
+    }
+
     private static void SetObjectResultStorage(
         MethodBodyIR methodBody,
         TempVariable result)

--- a/src/Compiler/IR/LIR/LIRReceiverSpecialization.cs
+++ b/src/Compiler/IR/LIR/LIRReceiverSpecialization.cs
@@ -6,7 +6,9 @@ internal static class LIRReceiverSpecialization
 {
     private const int MinimumLoopDepth = 1;
 
-    public static void Normalize(MethodBodyIR methodBody)
+    public static void Normalize(
+        MethodBodyIR methodBody,
+        ReceiverTypeFlowDiagnosticTrace? diagnostics = null)
     {
         for (var index = 0; index < methodBody.Instructions.Count; index++)
         {
@@ -31,12 +33,29 @@ internal static class LIRReceiverSpecialization
 
             methodBody.LoopNestingFacts ??=
                 LIRLoopNestingAnalysis.Analyze(methodBody);
-            if (methodBody.LoopNestingFacts.GetDepth(index)
-                < MinimumLoopDepth)
+            var loopDepth =
+                methodBody.LoopNestingFacts.GetDepth(index);
+            if (loopDepth < MinimumLoopDepth)
             {
+                diagnostics?.RecordSpecialization(
+                    index,
+                    memberName,
+                    receiver,
+                    receiverType,
+                    loopDepth,
+                    receiverIsProvenType,
+                    "retained-generic(cold)");
                 continue;
             }
 
+            diagnostics?.RecordSpecialization(
+                index,
+                memberName,
+                receiver,
+                receiverType,
+                loopDepth,
+                receiverIsProvenType,
+                "guarded");
             methodBody.Instructions[index] =
                 new LIRCallGuardedIntrinsicMember(
                     receiver,

--- a/src/Compiler/IR/LIR/LIRReceiverSpecialization.cs
+++ b/src/Compiler/IR/LIR/LIRReceiverSpecialization.cs
@@ -1,0 +1,290 @@
+using Jroc.IL;
+
+namespace Jroc.IR;
+
+internal static class LIRReceiverSpecialization
+{
+    public static void Normalize(MethodBodyIR methodBody)
+    {
+        for (var index = 0; index < methodBody.Instructions.Count; index++)
+        {
+            if (!TryGetMemberCall(
+                    methodBody.Instructions[index],
+                    out var receiver,
+                    out var memberName,
+                    out var arguments,
+                    out var result)
+                || !TrySelectReceiverType(
+                    methodBody,
+                    index,
+                    receiver,
+                    memberName,
+                    arguments.Count,
+                    out var receiverType,
+                    out var family,
+                    out var receiverIsProvenType))
+            {
+                continue;
+            }
+
+            methodBody.Instructions[index] =
+                new LIRCallGuardedIntrinsicMember(
+                    receiver,
+                    receiverType,
+                    family,
+                    memberName,
+                    receiverIsProvenType,
+                    arguments,
+                    result);
+            SetObjectResultStorage(methodBody, result);
+        }
+    }
+
+    private static void SetObjectResultStorage(
+        MethodBodyIR methodBody,
+        TempVariable result)
+    {
+        if (result.Index < 0
+            || result.Index >= methodBody.TempStorages.Count)
+        {
+            return;
+        }
+
+        var storage = new ValueStorage(
+            ValueStorageKind.Reference,
+            typeof(object));
+        methodBody.TempStorages[result.Index] = storage;
+        if (result.Index >= methodBody.TempVariableSlots.Count)
+        {
+            return;
+        }
+
+        var slot = methodBody.TempVariableSlots[result.Index];
+        if (slot >= 0 && slot < methodBody.VariableStorages.Count)
+        {
+            methodBody.VariableStorages[slot] = storage;
+        }
+    }
+
+    private static bool TrySelectReceiverType(
+        MethodBodyIR methodBody,
+        int instructionIndex,
+        TempVariable receiver,
+        string memberName,
+        int argumentCount,
+        out Type receiverType,
+        out JavaScriptRuntime.IntrinsicPrototypeFamily family,
+        out bool receiverIsProvenType)
+    {
+        receiverType = null!;
+        family = default;
+        receiverIsProvenType = false;
+
+        if (TryGetStorageReceiverType(
+                methodBody,
+                receiver,
+                out var storageType))
+        {
+            if (storageType == typeof(JavaScriptRuntime.Array))
+            {
+                return false;
+            }
+
+            if (TryClassifyEligibleType(
+                    storageType,
+                    memberName,
+                    argumentCount,
+                    out family))
+            {
+                receiverType = storageType;
+                receiverIsProvenType = true;
+                return true;
+            }
+
+            if (storageType != typeof(object))
+            {
+                return false;
+            }
+        }
+
+        var fact = methodBody.ReceiverTypeFlowFacts?
+            .GetTempBefore(instructionIndex, receiver);
+        if (fact == null)
+        {
+            return false;
+        }
+
+        foreach (var candidate in fact.CandidateClrTypes
+                     .OrderBy(GetCandidatePriority)
+                     .ThenBy(
+                         static type => type.FullName,
+                         StringComparer.Ordinal))
+        {
+            if (!TryClassifyEligibleType(
+                    candidate,
+                    memberName,
+                    argumentCount,
+                    out family))
+            {
+                continue;
+            }
+
+            receiverType = candidate;
+            receiverIsProvenType =
+                !fact.IncludesUnknown
+                && !fact.IncludesNonCandidate
+                && fact.CandidateClrTypes.Count == 1;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static int GetCandidatePriority(Type type)
+        => type == typeof(JavaScriptRuntime.Array) ? 0 : 1;
+
+    private static bool TryGetStorageReceiverType(
+        MethodBodyIR methodBody,
+        TempVariable receiver,
+        out Type receiverType)
+    {
+        receiverType = null!;
+        if (receiver.Index < 0
+            || receiver.Index >= methodBody.TempStorages.Count)
+        {
+            return false;
+        }
+
+        var storage = methodBody.TempStorages[receiver.Index];
+        if (storage.Kind != ValueStorageKind.Reference
+            || storage.ClrType == null
+            || storage.ClrType == typeof(object))
+        {
+            return false;
+        }
+
+        receiverType = storage.ClrType;
+        return true;
+    }
+
+    private static bool TryClassifyEligibleType(
+        Type receiverType,
+        string memberName,
+        int argumentCount,
+        out JavaScriptRuntime.IntrinsicPrototypeFamily family)
+    {
+        family = default;
+        if (receiverType == typeof(JavaScriptRuntime.Array))
+        {
+            if (!IsEligibleArrayMember(memberName, argumentCount))
+            {
+                return false;
+            }
+
+            family = JavaScriptRuntime.IntrinsicPrototypeFamily.Array;
+        }
+        else if (typeof(JavaScriptRuntime.TypedArrayBase)
+                 .IsAssignableFrom(receiverType))
+        {
+            if (!IsEligibleTypedArrayMember(memberName, argumentCount))
+            {
+                return false;
+            }
+
+            family =
+                JavaScriptRuntime.IntrinsicPrototypeFamily.TypedArray;
+        }
+        else
+        {
+            return false;
+        }
+
+        return LIRToILCompiler.ResolveTypedInstanceMethodOverload(
+            receiverType,
+            memberName,
+            argumentCount) != null;
+    }
+
+    private static bool IsEligibleArrayMember(
+        string memberName,
+        int argumentCount)
+        => argumentCount is >= 0 and <= 5
+            && IsGuardedArrayMemberName(memberName);
+
+    private static bool IsGuardedArrayMemberName(string memberName)
+        => memberName is
+            "push"
+            or "unshift"
+            or "pop"
+            or "shift"
+            or "slice"
+            or "splice";
+
+    private static bool IsEligibleTypedArrayMember(
+        string memberName,
+        int argumentCount)
+        => memberName switch
+        {
+            "at" => argumentCount is 0 or 1,
+            "includes" or "indexOf" or "lastIndexOf" =>
+                argumentCount is >= 0 and <= 2,
+            "join" => argumentCount is 0 or 1,
+            "reverse" => argumentCount == 0,
+            _ => false
+        };
+
+    private static bool TryGetMemberCall(
+        LIRInstruction instruction,
+        out TempVariable receiver,
+        out string memberName,
+        out IReadOnlyList<TempVariable> arguments,
+        out TempVariable result)
+    {
+        receiver = default;
+        memberName = string.Empty;
+        arguments = [];
+        result = default;
+
+        switch (instruction)
+        {
+            case LIRCallMember0 call:
+                receiver = call.Receiver;
+                memberName = call.MethodName;
+                result = call.Result;
+                return true;
+            case LIRCallMember1 call:
+                receiver = call.Receiver;
+                memberName = call.MethodName;
+                arguments = [call.A0];
+                result = call.Result;
+                return true;
+            case LIRCallMember2 call:
+                receiver = call.Receiver;
+                memberName = call.MethodName;
+                arguments = [call.A0, call.A1];
+                result = call.Result;
+                return true;
+            case LIRCallMember3 call:
+                receiver = call.Receiver;
+                memberName = call.MethodName;
+                arguments = [call.A0, call.A1, call.A2];
+                result = call.Result;
+                return true;
+            case LIRCallMember4 call:
+                receiver = call.Receiver;
+                memberName = call.MethodName;
+                arguments = [call.A0, call.A1, call.A2, call.A3];
+                result = call.Result;
+                return true;
+            case LIRCallMember5 call:
+                receiver = call.Receiver;
+                memberName = call.MethodName;
+                arguments =
+                    [call.A0, call.A1, call.A2, call.A3, call.A4];
+                result = call.Result;
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/src/Compiler/IR/LIR/ReceiverTypeFlowAnalysis.cs
+++ b/src/Compiler/IR/LIR/ReceiverTypeFlowAnalysis.cs
@@ -107,7 +107,8 @@ internal static class ReceiverTypeFlowAnalysis
         }
 
         var slice = BuildAnalysisSlice(methodBody);
-        var blocks = BuildBlocks(methodBody);
+        var controlFlowGraph = LIRControlFlowGraph.Build(methodBody);
+        var blocks = controlFlowGraph.Blocks;
         var hasFinallyRegion = methodBody.ExceptionRegions.Any(
             static region => region.Kind == ExceptionRegionKind.Finally);
         var blockInputs = new FlowState?[blocks.Count];
@@ -117,7 +118,9 @@ internal static class ReceiverTypeFlowAnalysis
         EnqueueWithInput(0, CreateEntryState());
         foreach (var region in methodBody.ExceptionRegions)
         {
-            if (TryGetLabelBlock(blocks, region.HandlerStartLabelId, out var handlerBlock))
+            if (controlFlowGraph.TryGetLabelBlock(
+                    region.HandlerStartLabelId,
+                    out var handlerBlock))
             {
                 EnqueueWithInput(handlerBlock, new FlowState());
             }
@@ -643,195 +646,6 @@ internal static class ReceiverTypeFlowAnalysis
             _ => null!
         };
         return binding != null;
-    }
-
-    private static List<BasicBlock> BuildBlocks(MethodBodyIR methodBody)
-    {
-        var instructions = methodBody.Instructions;
-        var leaders = new SortedSet<int> { 0 };
-        var labelInstructionIndices = new Dictionary<int, int>();
-
-        for (var index = 0; index < instructions.Count; index++)
-        {
-            if (instructions[index] is LIRLabel label)
-            {
-                leaders.Add(index);
-                labelInstructionIndices[label.LabelId] = index;
-            }
-
-            if (IsBlockEndingInstruction(instructions[index])
-                && index + 1 < instructions.Count)
-            {
-                leaders.Add(index + 1);
-            }
-        }
-
-        var starts = leaders.ToArray();
-        var blocks = new List<BasicBlock>(starts.Length);
-        var blockByInstruction = new int[instructions.Count];
-        for (var blockIndex = 0; blockIndex < starts.Length; blockIndex++)
-        {
-            var start = starts[blockIndex];
-            var end = blockIndex + 1 < starts.Length
-                ? starts[blockIndex + 1]
-                : instructions.Count;
-            var block = new BasicBlock(start, end);
-            if (instructions[start] is LIRLabel startLabel)
-            {
-                block.StartLabelId = startLabel.LabelId;
-            }
-            blocks.Add(block);
-            for (var index = start; index < end; index++)
-            {
-                blockByInstruction[index] = blockIndex;
-            }
-        }
-
-        var blockByLabel = labelInstructionIndices.ToDictionary(
-            pair => pair.Key,
-            pair => blockByInstruction[pair.Value]);
-        var resumeBlockByLabel = new Dictionary<int, int>();
-        for (var blockIndex = 0; blockIndex + 1 < blocks.Count; blockIndex++)
-        {
-            switch (instructions[blocks[blockIndex].End - 1])
-            {
-                case LIRAwait awaitInstruction:
-                    resumeBlockByLabel[awaitInstruction.ResumeLabelId] =
-                        blockIndex + 1;
-                    break;
-                case LIRYield yieldInstruction:
-                    resumeBlockByLabel[yieldInstruction.ResumeLabelId] =
-                        blockIndex + 1;
-                    break;
-            }
-        }
-
-        for (var blockIndex = 0; blockIndex < blocks.Count; blockIndex++)
-        {
-            var block = blocks[blockIndex];
-            var last = instructions[block.End - 1];
-
-            void AddLabelSuccessor(int labelId)
-            {
-                if (resumeBlockByLabel.TryGetValue(labelId, out var resumeBlock))
-                {
-                    block.Successors.Add(resumeBlock);
-                }
-                else if (blockByLabel.TryGetValue(labelId, out var successor))
-                {
-                    block.Successors.Add(successor);
-                }
-            }
-
-            void AddFallthrough()
-            {
-                if (blockIndex + 1 < blocks.Count)
-                {
-                    block.Successors.Add(blockIndex + 1);
-                }
-            }
-
-            switch (last)
-            {
-                case LIRBranch branch:
-                    AddLabelSuccessor(branch.TargetLabel);
-                    break;
-                case LIRLeave leave:
-                    AddLabelSuccessor(leave.TargetLabel);
-                    break;
-                case LIRBranchIfTrue branch:
-                    AddLabelSuccessor(branch.TargetLabel);
-                    AddFallthrough();
-                    break;
-                case LIRBranchIfFalse branch:
-                    AddLabelSuccessor(branch.TargetLabel);
-                    AddFallthrough();
-                    break;
-                case LIRAsyncStateSwitch stateSwitch:
-                    foreach (var label in stateSwitch.StateToLabel.Values)
-                    {
-                        AddLabelSuccessor(label);
-                    }
-                    AddLabelSuccessor(stateSwitch.DefaultLabel);
-                    break;
-                case LIRGeneratorStateSwitch stateSwitch:
-                    foreach (var label in stateSwitch.StateToLabel.Values)
-                    {
-                        AddLabelSuccessor(label);
-                    }
-                    AddLabelSuccessor(stateSwitch.DefaultLabel);
-                    break;
-                case LIRAwait awaitInstruction:
-                    AddFallthrough();
-                    if (awaitInstruction.RejectResumeStateId is int rejectState
-                        && methodBody.AsyncInfo?.ResumeLabels.TryGetValue(
-                            rejectState,
-                            out var rejectLabel) == true)
-                    {
-                        AddLabelSuccessor(rejectLabel);
-                    }
-                    break;
-                case LIRYield yieldInstruction:
-                    AddFallthrough();
-                    break;
-                case LIRReturn:
-                case LIRReturnUndefinedImmediate:
-                case LIRTailCallFunctionReturn:
-                case LIRAsyncReturnPromise:
-                case LIRThrow:
-                case LIRThrowNewTypeError:
-                case LIREndFinally:
-                    break;
-                default:
-                    AddFallthrough();
-                    break;
-            }
-        }
-
-        return blocks;
-    }
-
-    private static bool TryGetLabelBlock(
-        IReadOnlyList<BasicBlock> blocks,
-        int labelId,
-        out int blockIndex)
-    {
-        for (var index = 0; index < blocks.Count; index++)
-        {
-            if (blocks[index].StartLabelId == labelId)
-            {
-                blockIndex = index;
-                return true;
-            }
-        }
-
-        blockIndex = -1;
-        return false;
-    }
-
-    private static bool IsBlockEndingInstruction(LIRInstruction instruction)
-        => instruction is LIRBranch
-            or LIRLeave
-            or LIRBranchIfTrue
-            or LIRBranchIfFalse
-            or LIRAsyncStateSwitch
-            or LIRGeneratorStateSwitch
-            or LIRAwait
-            or LIRYield
-            or LIRReturn
-            or LIRReturnUndefinedImmediate
-            or LIRTailCallFunctionReturn
-            or LIRAsyncReturnPromise
-            or LIRThrow
-            or LIRThrowNewTypeError
-            or LIREndFinally;
-
-    private sealed class BasicBlock(int start, int end)
-    {
-        public int Start { get; } = start;
-        public int End { get; } = end;
-        public HashSet<int> Successors { get; } = [];
-        public int? StartLabelId { get; set; }
     }
 
     private sealed class AnalysisSlice

--- a/src/Compiler/IR/LIR/ReceiverTypeFlowAnalysis.cs
+++ b/src/Compiler/IR/LIR/ReceiverTypeFlowAnalysis.cs
@@ -1,0 +1,1042 @@
+using Jroc.IL;
+using Jroc.SymbolTables;
+
+namespace Jroc.IR;
+
+internal sealed record ReceiverTypeFlowValue(
+    bool IncludesUnknown,
+    bool IncludesNonCandidate,
+    IReadOnlySet<Type> CandidateClrTypes)
+{
+    public bool Contains(Type type) => CandidateClrTypes.Contains(type);
+}
+
+internal sealed class ReceiverTypeFlowFacts
+{
+    private readonly Dictionary<(int InstructionIndex, int TempIndex), ReceiverTypeFlowValue>
+        _beforeTemps = [];
+    private readonly Dictionary<(int InstructionIndex, int TempIndex), ReceiverTypeFlowValue>
+        _afterTemps = [];
+    private readonly Dictionary<(int InstructionIndex, BindingInfo Binding), ReceiverTypeFlowValue>
+        _beforeBindings = [];
+    private readonly Dictionary<(int InstructionIndex, BindingInfo Binding), ReceiverTypeFlowValue>
+        _afterBindings = [];
+
+    public ReceiverTypeFlowValue GetTempBefore(int instructionIndex, TempVariable temp)
+        => _beforeTemps.TryGetValue((instructionIndex, temp.Index), out var value)
+            ? value
+            : FlowValue.Unknown.ToPublic();
+
+    public ReceiverTypeFlowValue GetTempAfter(int instructionIndex, TempVariable temp)
+        => _afterTemps.TryGetValue((instructionIndex, temp.Index), out var value)
+            ? value
+            : FlowValue.Unknown.ToPublic();
+
+    public ReceiverTypeFlowValue GetBindingBefore(int instructionIndex, BindingInfo binding)
+        => _beforeBindings.TryGetValue((instructionIndex, binding), out var value)
+            ? value
+            : FlowValue.Unknown.ToPublic();
+
+    public ReceiverTypeFlowValue GetBindingAfter(int instructionIndex, BindingInfo binding)
+        => _afterBindings.TryGetValue((instructionIndex, binding), out var value)
+            ? value
+            : FlowValue.Unknown.ToPublic();
+
+    internal void RecordTempBefore(int instructionIndex, TempVariable temp, FlowValue value)
+    {
+        if (value.HasCandidates)
+        {
+            _beforeTemps[(instructionIndex, temp.Index)] = value.ToPublic();
+        }
+    }
+
+    internal void RecordTempAfter(int instructionIndex, TempVariable temp, FlowValue value)
+    {
+        if (value.HasCandidates)
+        {
+            _afterTemps[(instructionIndex, temp.Index)] = value.ToPublic();
+        }
+    }
+
+    internal void RecordBindingBefore(int instructionIndex, BindingInfo binding, FlowValue value)
+    {
+        if (value.HasCandidates)
+        {
+            _beforeBindings[(instructionIndex, binding)] = value.ToPublic();
+        }
+    }
+
+    internal void RecordBindingAfter(int instructionIndex, BindingInfo binding, FlowValue value)
+    {
+        if (value.HasCandidates)
+        {
+            _afterBindings[(instructionIndex, binding)] = value.ToPublic();
+        }
+    }
+}
+
+internal static class ReceiverTypeFlowAnalysis
+{
+    public static bool RequiresAnalysis(MethodBodyIR methodBody)
+    {
+        foreach (var instruction in methodBody.Instructions)
+        {
+            if (TryGetReceiver(instruction, out var receiver)
+                && receiver.Index >= 0
+                && receiver.Index < methodBody.TempStorages.Count)
+            {
+                var storage = methodBody.TempStorages[receiver.Index];
+                if (storage.Kind == ValueStorageKind.Unknown
+                    || storage.ClrType == null
+                    || storage.ClrType == typeof(object))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public static ReceiverTypeFlowFacts Analyze(MethodBodyIR methodBody)
+    {
+        var facts = new ReceiverTypeFlowFacts();
+        if (methodBody.Instructions.Count == 0)
+        {
+            return facts;
+        }
+
+        var slice = BuildAnalysisSlice(methodBody);
+        var blocks = BuildBlocks(methodBody);
+        var hasFinallyRegion = methodBody.ExceptionRegions.Any(
+            static region => region.Kind == ExceptionRegionKind.Finally);
+        var blockInputs = new FlowState?[blocks.Count];
+        var worklist = new Queue<int>();
+        var queued = new bool[blocks.Count];
+
+        EnqueueWithInput(0, new FlowState());
+        foreach (var region in methodBody.ExceptionRegions)
+        {
+            if (TryGetLabelBlock(blocks, region.HandlerStartLabelId, out var handlerBlock))
+            {
+                EnqueueWithInput(handlerBlock, new FlowState());
+            }
+        }
+
+        while (worklist.Count > 0)
+        {
+            var blockIndex = worklist.Dequeue();
+            queued[blockIndex] = false;
+            var state = blockInputs[blockIndex]!.Clone();
+            var block = blocks[blockIndex];
+
+            for (var instructionIndex = block.Start; instructionIndex < block.End; instructionIndex++)
+            {
+                Transfer(
+                    methodBody,
+                    methodBody.Instructions[instructionIndex],
+                    state,
+                    slice,
+                    hasFinallyRegion);
+            }
+
+            foreach (var successor in block.Successors)
+            {
+                EnqueueWithInput(successor, state);
+            }
+        }
+
+        for (var blockIndex = 0; blockIndex < blocks.Count; blockIndex++)
+        {
+            if (blockInputs[blockIndex] == null)
+            {
+                continue;
+            }
+
+            var state = blockInputs[blockIndex]!.Clone();
+            var block = blocks[blockIndex];
+            for (var instructionIndex = block.Start; instructionIndex < block.End; instructionIndex++)
+            {
+                var instruction = methodBody.Instructions[instructionIndex];
+                var visitor = new TempFactRecorder(
+                    facts,
+                    state,
+                    methodBody,
+                    slice,
+                    instructionIndex);
+                LIRInstructionInfo.VisitUsedTemps(instruction, ref visitor);
+                RecordBindingBefore(instruction, state, facts, instructionIndex);
+
+                Transfer(
+                    methodBody,
+                    instruction,
+                    state,
+                    slice,
+                    hasFinallyRegion);
+
+                if (LIRInstructionInfo.TryGetDefinedTemp(instruction, out var defined)
+                    && defined.Index >= 0)
+                {
+                    facts.RecordTempAfter(
+                        instructionIndex,
+                        defined,
+                        state.GetTemp(methodBody, defined));
+                }
+                RecordBindingAfter(instruction, state, facts, instructionIndex);
+            }
+        }
+
+        return facts;
+
+        void EnqueueWithInput(int blockIndex, FlowState incoming)
+        {
+            if (blockInputs[blockIndex] == null)
+            {
+                blockInputs[blockIndex] = incoming.Clone();
+            }
+            else if (!blockInputs[blockIndex]!.MergeFrom(incoming))
+            {
+                return;
+            }
+
+            if (!queued[blockIndex])
+            {
+                queued[blockIndex] = true;
+                worklist.Enqueue(blockIndex);
+            }
+        }
+    }
+
+    private static void Transfer(
+        MethodBodyIR methodBody,
+        LIRInstruction instruction,
+        FlowState state,
+        AnalysisSlice slice,
+        bool hasFinallyRegion = false)
+    {
+        var effects = LIRInstructionInfo.GetEffectsForScheduling(instruction);
+        if ((effects & (LIRInstructionEffects.Calls
+                | LIRInstructionEffects.Suspension
+                | LIRInstructionEffects.ScopeReplacement)) != 0)
+        {
+            state.InvalidateCapturedBindings();
+        }
+
+        if (hasFinallyRegion && instruction is LIRLeave)
+        {
+            state.InvalidateMutableLocations();
+        }
+
+        switch (instruction)
+        {
+            case LIRStoreScopeField store:
+                if (slice.Bindings.Contains(store.Binding))
+                {
+                    state.SetBinding(
+                        store.Binding,
+                        state.GetTemp(methodBody, store.Value));
+                }
+                break;
+            case LIRStoreLeafScopeField store:
+                if (slice.Bindings.Contains(store.Binding))
+                {
+                    state.SetBinding(
+                        store.Binding,
+                        state.GetTemp(methodBody, store.Value));
+                }
+                break;
+            case LIRStoreParentScopeField store:
+                if (slice.Bindings.Contains(store.Binding))
+                {
+                    state.SetBinding(
+                        store.Binding,
+                        state.GetTemp(methodBody, store.Value));
+                }
+                break;
+            case LIRStoreParameter store:
+                if (slice.Parameters.Contains(store.ParameterIndex))
+                {
+                    state.SetParameter(
+                        store.ParameterIndex,
+                        state.GetTemp(methodBody, store.Value));
+                }
+                break;
+        }
+
+        if (!LIRInstructionInfo.TryGetDefinedTemp(instruction, out var defined)
+            || defined.Index < 0
+            || !slice.IsTempRelevant(methodBody, defined))
+        {
+            return;
+        }
+
+        var value = instruction switch
+        {
+            LIRCopyTemp copy => state.GetTemp(methodBody, copy.Source),
+            LIRLoadScopeField load => ResolveLoadValue(
+                state.GetBinding(load.Binding),
+                ClassifyStorage(methodBody, defined)),
+            LIRLoadLeafScopeField load => ResolveLoadValue(
+                state.GetBinding(load.Binding),
+                ClassifyStorage(methodBody, defined)),
+            LIRLoadParentScopeField load => ResolveLoadValue(
+                state.GetBinding(load.Binding),
+                ClassifyStorage(methodBody, defined)),
+            LIRLoadParameter load => ResolveLoadValue(
+                state.GetParameter(load.ParameterIndex),
+                ClassifyStorage(methodBody, defined)),
+            LIRConvertToObject convert => state.GetTemp(methodBody, convert.Source),
+            LIRCallIntrinsicStatic
+            {
+                IntrinsicName: nameof(JavaScriptRuntime.ObjectRuntime),
+                MethodName: nameof(JavaScriptRuntime.ObjectRuntime.RequireObjectCoercible),
+                Arguments.Count: 1
+            } requireObjectCoercible
+                => state.GetTemp(methodBody, requireObjectCoercible.Arguments[0]),
+            LIRCallIntrinsicStatic
+            {
+                IntrinsicName: nameof(JavaScriptRuntime.Array),
+                MethodName: "Construct"
+            } => FlowValue.ForCandidate(typeof(JavaScriptRuntime.Array)),
+            LIRConstString => FlowValue.ForCandidate(typeof(string)),
+            LIRConvertToString => FlowValue.ForCandidate(typeof(string)),
+            LIRConcatStrings => FlowValue.ForCandidate(typeof(string)),
+            LIRConstNumber or LIRConstBoolean or LIRConstNull or LIRConstUndefined
+                => FlowValue.NonCandidate,
+            _ => ClassifyStorage(methodBody, defined)
+        };
+
+        state.SetTemp(methodBody, defined, value);
+    }
+
+    private static FlowValue ResolveLoadValue(
+        FlowValue flowValue,
+        FlowValue storageValue)
+        => flowValue.Equals(FlowValue.Unknown)
+            ? storageValue
+            : flowValue;
+
+    private static FlowValue ClassifyStorage(
+        MethodBodyIR methodBody,
+        TempVariable temp)
+    {
+        if (temp.Index < 0 || temp.Index >= methodBody.TempStorages.Count)
+        {
+            return FlowValue.Unknown;
+        }
+
+        var storage = methodBody.TempStorages[temp.Index];
+        if (IsReceiverCandidateType(storage.ClrType))
+        {
+            return FlowValue.ForCandidate(storage.ClrType!);
+        }
+
+        if (storage.Kind == ValueStorageKind.Unknown
+            || storage.ClrType == null
+            || storage.ClrType == typeof(object)
+            || !storage.TypeHandle.IsNil)
+        {
+            return FlowValue.Unknown;
+        }
+
+        return FlowValue.NonCandidate;
+    }
+
+    private static bool IsReceiverCandidateType(Type? type)
+        => type == typeof(string)
+           || type is
+           {
+               IsAbstract: false,
+               Namespace: { } namespaceName
+           }
+           && namespaceName.StartsWith("JavaScriptRuntime", StringComparison.Ordinal);
+
+    private static AnalysisSlice BuildAnalysisSlice(MethodBodyIR methodBody)
+    {
+        var slice = new AnalysisSlice();
+        var definitions = new Dictionary<int, List<LIRInstruction>>();
+        var bindingStores =
+            new Dictionary<BindingInfo, List<TempVariable>>();
+        var parameterStores = new Dictionary<int, List<TempVariable>>();
+        var locationWorklist = new Queue<int>();
+        var bindingWorklist = new Queue<BindingInfo>();
+        var parameterWorklist = new Queue<int>();
+
+        foreach (var instruction in methodBody.Instructions)
+        {
+            if (TryGetReceiver(instruction, out var receiver))
+            {
+                AddTemp(receiver);
+            }
+
+            if (LIRInstructionInfo.TryGetDefinedTemp(
+                    instruction,
+                    out var defined)
+                && defined.Index >= 0)
+            {
+                AddToList(
+                    definitions,
+                    GetLocationKey(methodBody, defined),
+                    instruction);
+            }
+
+            switch (instruction)
+            {
+                case LIRStoreScopeField store:
+                    AddToList(bindingStores, store.Binding, store.Value);
+                    break;
+                case LIRStoreLeafScopeField store:
+                    AddToList(bindingStores, store.Binding, store.Value);
+                    break;
+                case LIRStoreParentScopeField store:
+                    AddToList(bindingStores, store.Binding, store.Value);
+                    break;
+                case LIRStoreParameter store:
+                    AddToList(
+                        parameterStores,
+                        store.ParameterIndex,
+                        store.Value);
+                    break;
+            }
+        }
+
+        while (locationWorklist.Count > 0
+               || bindingWorklist.Count > 0
+               || parameterWorklist.Count > 0)
+        {
+            while (locationWorklist.TryDequeue(out var location))
+            {
+                if (!definitions.TryGetValue(location, out var locationDefinitions))
+                {
+                    continue;
+                }
+
+                foreach (var definition in locationDefinitions)
+                {
+                    switch (definition)
+                    {
+                        case LIRCopyTemp copy:
+                            AddTemp(copy.Source);
+                            break;
+                        case LIRConvertToObject convert:
+                            AddTemp(convert.Source);
+                            break;
+                        case LIRCallIntrinsicStatic
+                            {
+                                IntrinsicName:
+                                    nameof(JavaScriptRuntime.ObjectRuntime),
+                                MethodName:
+                                    nameof(JavaScriptRuntime.ObjectRuntime
+                                        .RequireObjectCoercible),
+                                Arguments.Count: 1
+                            } requireObjectCoercible:
+                            AddTemp(requireObjectCoercible.Arguments[0]);
+                            break;
+                        case LIRLoadScopeField load:
+                            AddBinding(load.Binding);
+                            break;
+                        case LIRLoadLeafScopeField load:
+                            AddBinding(load.Binding);
+                            break;
+                        case LIRLoadParentScopeField load:
+                            AddBinding(load.Binding);
+                            break;
+                        case LIRLoadParameter load:
+                            AddParameter(load.ParameterIndex);
+                            break;
+                    }
+                }
+            }
+
+            while (bindingWorklist.TryDequeue(out var binding))
+            {
+                if (bindingStores.TryGetValue(binding, out var storedValues))
+                {
+                    foreach (var storedValue in storedValues)
+                    {
+                        AddTemp(storedValue);
+                    }
+                }
+            }
+
+            while (parameterWorklist.TryDequeue(out var parameter))
+            {
+                if (parameterStores.TryGetValue(parameter, out var storedValues))
+                {
+                    foreach (var storedValue in storedValues)
+                    {
+                        AddTemp(storedValue);
+                    }
+                }
+            }
+        }
+
+        return slice;
+
+        void AddTemp(TempVariable temp)
+        {
+            if (slice.AddTemp(methodBody, temp))
+            {
+                locationWorklist.Enqueue(GetLocationKey(methodBody, temp));
+            }
+        }
+
+        void AddBinding(BindingInfo binding)
+        {
+            if (slice.Bindings.Add(binding))
+            {
+                bindingWorklist.Enqueue(binding);
+            }
+        }
+
+        void AddParameter(int parameter)
+        {
+            if (slice.Parameters.Add(parameter))
+            {
+                parameterWorklist.Enqueue(parameter);
+            }
+        }
+    }
+
+    private static int GetLocationKey(
+        MethodBodyIR methodBody,
+        TempVariable temp)
+    {
+        var slot = AnalysisSlice.GetVariableSlot(methodBody, temp);
+        return slot >= 0 ? -slot - 1 : temp.Index;
+    }
+
+    private static void AddToList<TKey, TValue>(
+        Dictionary<TKey, List<TValue>> lookup,
+        TKey key,
+        TValue value)
+        where TKey : notnull
+    {
+        if (!lookup.TryGetValue(key, out var values))
+        {
+            values = [];
+            lookup.Add(key, values);
+        }
+
+        values.Add(value);
+    }
+
+    private static bool TryGetReceiver(
+        LIRInstruction instruction,
+        out TempVariable receiver)
+    {
+        receiver = instruction switch
+        {
+            LIRCallMember call => call.Receiver,
+            LIRCallMember0 call => call.Receiver,
+            LIRCallMember1 call => call.Receiver,
+            LIRCallMember2 call => call.Receiver,
+            LIRCallMember3 call => call.Receiver,
+            LIRCallMember4 call => call.Receiver,
+            LIRCallMember5 call => call.Receiver,
+            LIRCallGuardedStringIntrinsic call => call.Receiver,
+            LIRGetLength getLength => getLength.Object,
+            LIRGetItem getItem => getItem.Object,
+            _ => default
+        };
+        return instruction is LIRCallMember
+            or LIRCallMember0
+            or LIRCallMember1
+            or LIRCallMember2
+            or LIRCallMember3
+            or LIRCallMember4
+            or LIRCallMember5
+            or LIRCallGuardedStringIntrinsic
+            or LIRGetLength
+            or LIRGetItem;
+    }
+
+    private static void RecordBindingBefore(
+        LIRInstruction instruction,
+        FlowState state,
+        ReceiverTypeFlowFacts facts,
+        int instructionIndex)
+    {
+        if (TryGetBinding(instruction, out var binding))
+        {
+            facts.RecordBindingBefore(
+                instructionIndex,
+                binding,
+                state.GetBinding(binding));
+        }
+    }
+
+    private static void RecordBindingAfter(
+        LIRInstruction instruction,
+        FlowState state,
+        ReceiverTypeFlowFacts facts,
+        int instructionIndex)
+    {
+        if (TryGetBinding(instruction, out var binding))
+        {
+            facts.RecordBindingAfter(
+                instructionIndex,
+                binding,
+                state.GetBinding(binding));
+        }
+    }
+
+    private static bool TryGetBinding(
+        LIRInstruction instruction,
+        out BindingInfo binding)
+    {
+        binding = instruction switch
+        {
+            LIRLoadScopeField load => load.Binding,
+            LIRStoreScopeField store => store.Binding,
+            LIRLoadLeafScopeField load => load.Binding,
+            LIRStoreLeafScopeField store => store.Binding,
+            LIRLoadParentScopeField load => load.Binding,
+            LIRStoreParentScopeField store => store.Binding,
+            _ => null!
+        };
+        return binding != null;
+    }
+
+    private static List<BasicBlock> BuildBlocks(MethodBodyIR methodBody)
+    {
+        var instructions = methodBody.Instructions;
+        var leaders = new SortedSet<int> { 0 };
+        var labelInstructionIndices = new Dictionary<int, int>();
+
+        for (var index = 0; index < instructions.Count; index++)
+        {
+            if (instructions[index] is LIRLabel label)
+            {
+                leaders.Add(index);
+                labelInstructionIndices[label.LabelId] = index;
+            }
+
+            if (IsBlockEndingInstruction(instructions[index])
+                && index + 1 < instructions.Count)
+            {
+                leaders.Add(index + 1);
+            }
+        }
+
+        var starts = leaders.ToArray();
+        var blocks = new List<BasicBlock>(starts.Length);
+        var blockByInstruction = new int[instructions.Count];
+        for (var blockIndex = 0; blockIndex < starts.Length; blockIndex++)
+        {
+            var start = starts[blockIndex];
+            var end = blockIndex + 1 < starts.Length
+                ? starts[blockIndex + 1]
+                : instructions.Count;
+            var block = new BasicBlock(start, end);
+            if (instructions[start] is LIRLabel startLabel)
+            {
+                block.StartLabelId = startLabel.LabelId;
+            }
+            blocks.Add(block);
+            for (var index = start; index < end; index++)
+            {
+                blockByInstruction[index] = blockIndex;
+            }
+        }
+
+        var blockByLabel = labelInstructionIndices.ToDictionary(
+            pair => pair.Key,
+            pair => blockByInstruction[pair.Value]);
+        var resumeBlockByLabel = new Dictionary<int, int>();
+        for (var blockIndex = 0; blockIndex + 1 < blocks.Count; blockIndex++)
+        {
+            switch (instructions[blocks[blockIndex].End - 1])
+            {
+                case LIRAwait awaitInstruction:
+                    resumeBlockByLabel[awaitInstruction.ResumeLabelId] =
+                        blockIndex + 1;
+                    break;
+                case LIRYield yieldInstruction:
+                    resumeBlockByLabel[yieldInstruction.ResumeLabelId] =
+                        blockIndex + 1;
+                    break;
+            }
+        }
+
+        for (var blockIndex = 0; blockIndex < blocks.Count; blockIndex++)
+        {
+            var block = blocks[blockIndex];
+            var last = instructions[block.End - 1];
+
+            void AddLabelSuccessor(int labelId)
+            {
+                if (resumeBlockByLabel.TryGetValue(labelId, out var resumeBlock))
+                {
+                    block.Successors.Add(resumeBlock);
+                }
+                else if (blockByLabel.TryGetValue(labelId, out var successor))
+                {
+                    block.Successors.Add(successor);
+                }
+            }
+
+            void AddFallthrough()
+            {
+                if (blockIndex + 1 < blocks.Count)
+                {
+                    block.Successors.Add(blockIndex + 1);
+                }
+            }
+
+            switch (last)
+            {
+                case LIRBranch branch:
+                    AddLabelSuccessor(branch.TargetLabel);
+                    break;
+                case LIRLeave leave:
+                    AddLabelSuccessor(leave.TargetLabel);
+                    break;
+                case LIRBranchIfTrue branch:
+                    AddLabelSuccessor(branch.TargetLabel);
+                    AddFallthrough();
+                    break;
+                case LIRBranchIfFalse branch:
+                    AddLabelSuccessor(branch.TargetLabel);
+                    AddFallthrough();
+                    break;
+                case LIRAsyncStateSwitch stateSwitch:
+                    foreach (var label in stateSwitch.StateToLabel.Values)
+                    {
+                        AddLabelSuccessor(label);
+                    }
+                    AddLabelSuccessor(stateSwitch.DefaultLabel);
+                    break;
+                case LIRGeneratorStateSwitch stateSwitch:
+                    foreach (var label in stateSwitch.StateToLabel.Values)
+                    {
+                        AddLabelSuccessor(label);
+                    }
+                    AddLabelSuccessor(stateSwitch.DefaultLabel);
+                    break;
+                case LIRAwait awaitInstruction:
+                    AddFallthrough();
+                    if (awaitInstruction.RejectResumeStateId is int rejectState
+                        && methodBody.AsyncInfo?.ResumeLabels.TryGetValue(
+                            rejectState,
+                            out var rejectLabel) == true)
+                    {
+                        AddLabelSuccessor(rejectLabel);
+                    }
+                    break;
+                case LIRYield yieldInstruction:
+                    AddFallthrough();
+                    break;
+                case LIRReturn:
+                case LIRReturnUndefinedImmediate:
+                case LIRTailCallFunctionReturn:
+                case LIRAsyncReturnPromise:
+                case LIRThrow:
+                case LIRThrowNewTypeError:
+                case LIREndFinally:
+                    break;
+                default:
+                    AddFallthrough();
+                    break;
+            }
+        }
+
+        return blocks;
+    }
+
+    private static bool TryGetLabelBlock(
+        IReadOnlyList<BasicBlock> blocks,
+        int labelId,
+        out int blockIndex)
+    {
+        for (var index = 0; index < blocks.Count; index++)
+        {
+            if (blocks[index].StartLabelId == labelId)
+            {
+                blockIndex = index;
+                return true;
+            }
+        }
+
+        blockIndex = -1;
+        return false;
+    }
+
+    private static bool IsBlockEndingInstruction(LIRInstruction instruction)
+        => instruction is LIRBranch
+            or LIRLeave
+            or LIRBranchIfTrue
+            or LIRBranchIfFalse
+            or LIRAsyncStateSwitch
+            or LIRGeneratorStateSwitch
+            or LIRAwait
+            or LIRYield
+            or LIRReturn
+            or LIRReturnUndefinedImmediate
+            or LIRTailCallFunctionReturn
+            or LIRAsyncReturnPromise
+            or LIRThrow
+            or LIRThrowNewTypeError
+            or LIREndFinally;
+
+    private sealed class BasicBlock(int start, int end)
+    {
+        public int Start { get; } = start;
+        public int End { get; } = end;
+        public HashSet<int> Successors { get; } = [];
+        public int? StartLabelId { get; set; }
+    }
+
+    private sealed class AnalysisSlice
+    {
+        public HashSet<int> Temps { get; } = [];
+        public HashSet<int> Slots { get; } = [];
+        public HashSet<int> Parameters { get; } = [];
+        public HashSet<BindingInfo> Bindings { get; } = [];
+
+        public bool AddTemp(MethodBodyIR methodBody, TempVariable temp)
+        {
+            var slot = GetVariableSlot(methodBody, temp);
+            return slot >= 0
+                ? Slots.Add(slot)
+                : Temps.Add(temp.Index);
+        }
+
+        public bool IsTempRelevant(
+            MethodBodyIR methodBody,
+            TempVariable temp)
+        {
+            var slot = GetVariableSlot(methodBody, temp);
+            return slot >= 0
+                ? Slots.Contains(slot)
+                : Temps.Contains(temp.Index);
+        }
+
+        public static int GetVariableSlot(
+            MethodBodyIR methodBody,
+            TempVariable temp)
+            => temp.Index >= 0
+                && temp.Index < methodBody.TempVariableSlots.Count
+                    ? methodBody.TempVariableSlots[temp.Index]
+                    : -1;
+    }
+
+    private sealed class FlowState
+    {
+        private readonly Dictionary<int, FlowValue> _temps = [];
+        private readonly Dictionary<int, FlowValue> _slots = [];
+        private readonly Dictionary<int, FlowValue> _parameters = [];
+        private readonly Dictionary<BindingInfo, FlowValue> _bindings = [];
+
+        public FlowState Clone()
+        {
+            var clone = new FlowState();
+            CopyTo(_temps, clone._temps);
+            CopyTo(_slots, clone._slots);
+            CopyTo(_parameters, clone._parameters);
+            CopyTo(_bindings, clone._bindings);
+            return clone;
+        }
+
+        public FlowValue GetTemp(MethodBodyIR methodBody, TempVariable temp)
+        {
+            var slot = GetVariableSlot(methodBody, temp);
+            return slot >= 0
+                ? Get(_slots, slot)
+                : Get(_temps, temp.Index);
+        }
+
+        public void SetTemp(MethodBodyIR methodBody, TempVariable temp, FlowValue value)
+        {
+            var slot = GetVariableSlot(methodBody, temp);
+            if (slot >= 0)
+            {
+                Set(_slots, slot, value);
+            }
+            else
+            {
+                Set(_temps, temp.Index, value);
+            }
+        }
+
+        public FlowValue GetParameter(int parameterIndex)
+            => Get(_parameters, parameterIndex);
+
+        public void SetParameter(int parameterIndex, FlowValue value)
+            => Set(_parameters, parameterIndex, value);
+
+        public FlowValue GetBinding(BindingInfo binding)
+            => Get(_bindings, binding);
+
+        public void SetBinding(BindingInfo binding, FlowValue value)
+            => Set(_bindings, binding, value);
+
+        public void InvalidateCapturedBindings()
+            => _bindings.Clear();
+
+        public void InvalidateMutableLocations()
+        {
+            _slots.Clear();
+            _parameters.Clear();
+            _bindings.Clear();
+        }
+
+        public bool MergeFrom(FlowState incoming)
+        {
+            var changed = false;
+            changed |= MergeDictionary(_temps, incoming._temps);
+            changed |= MergeDictionary(_slots, incoming._slots);
+            changed |= MergeDictionary(_parameters, incoming._parameters);
+            changed |= MergeDictionary(_bindings, incoming._bindings);
+            return changed;
+        }
+
+        private static int GetVariableSlot(
+            MethodBodyIR methodBody,
+            TempVariable temp)
+            => temp.Index >= 0
+                && temp.Index < methodBody.TempVariableSlots.Count
+                    ? methodBody.TempVariableSlots[temp.Index]
+                    : -1;
+
+        private static FlowValue Get<TKey>(
+            IReadOnlyDictionary<TKey, FlowValue> dictionary,
+            TKey key)
+            where TKey : notnull
+            => dictionary.TryGetValue(key, out var value)
+                ? value
+                : FlowValue.Unknown;
+
+        private static void Set<TKey>(
+            Dictionary<TKey, FlowValue> dictionary,
+            TKey key,
+            FlowValue value)
+            where TKey : notnull
+        {
+            if (value.Equals(FlowValue.Unknown))
+            {
+                dictionary.Remove(key);
+            }
+            else
+            {
+                dictionary[key] = value;
+            }
+        }
+
+        private static bool MergeDictionary<TKey>(
+            Dictionary<TKey, FlowValue> target,
+            IReadOnlyDictionary<TKey, FlowValue> incoming)
+            where TKey : notnull
+        {
+            var changed = false;
+            foreach (var key in target.Keys.Union(incoming.Keys).ToArray())
+            {
+                var merged = Get(target, key).Union(Get(incoming, key));
+                if (merged.Equals(Get(target, key)))
+                {
+                    continue;
+                }
+
+                Set(target, key, merged);
+                changed = true;
+            }
+            return changed;
+        }
+
+        private static void CopyTo<TKey>(
+            IReadOnlyDictionary<TKey, FlowValue> source,
+            Dictionary<TKey, FlowValue> destination)
+            where TKey : notnull
+        {
+            foreach (var pair in source)
+            {
+                destination.Add(pair.Key, pair.Value);
+            }
+        }
+    }
+
+    private readonly record struct TempFactRecorder(
+        ReceiverTypeFlowFacts Facts,
+        FlowState State,
+        MethodBodyIR MethodBody,
+        AnalysisSlice Slice,
+        int InstructionIndex) : ITempUseVisitor
+    {
+        public void Visit(TempVariable temp)
+        {
+            if (Slice.IsTempRelevant(MethodBody, temp))
+            {
+                Facts.RecordTempBefore(
+                    InstructionIndex,
+                    temp,
+                    State.GetTemp(MethodBody, temp));
+            }
+        }
+    }
+}
+
+internal sealed class FlowValue : IEquatable<FlowValue>
+{
+    public static FlowValue Unknown { get; } = new(
+        includesUnknown: true,
+        includesNonCandidate: true,
+        []);
+
+    public static FlowValue NonCandidate { get; } = new(
+        includesUnknown: false,
+        includesNonCandidate: true,
+        []);
+
+    private readonly HashSet<Type> _candidateClrTypes;
+    private ReceiverTypeFlowValue? _publicValue;
+
+    private FlowValue(
+        bool includesUnknown,
+        bool includesNonCandidate,
+        IEnumerable<Type> candidateClrTypes)
+    {
+        IncludesUnknown = includesUnknown;
+        IncludesNonCandidate = includesNonCandidate;
+        _candidateClrTypes = [.. candidateClrTypes];
+    }
+
+    public bool IncludesUnknown { get; }
+    public bool IncludesNonCandidate { get; }
+    public bool HasCandidates => _candidateClrTypes.Count > 0;
+
+    public static FlowValue ForCandidate(Type type)
+        => new(
+            includesUnknown: false,
+            includesNonCandidate: false,
+            [type]);
+
+    public FlowValue Union(FlowValue other)
+        => new(
+            IncludesUnknown || other.IncludesUnknown,
+            IncludesNonCandidate || other.IncludesNonCandidate,
+            _candidateClrTypes.Union(other._candidateClrTypes));
+
+    public ReceiverTypeFlowValue ToPublic()
+        => _publicValue ??= new(
+            IncludesUnknown,
+            IncludesNonCandidate,
+            new HashSet<Type>(_candidateClrTypes));
+
+    public bool Equals(FlowValue? other)
+        => other != null
+            && IncludesUnknown == other.IncludesUnknown
+            && IncludesNonCandidate == other.IncludesNonCandidate
+            && _candidateClrTypes.SetEquals(other._candidateClrTypes);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(IncludesUnknown);
+        hash.Add(IncludesNonCandidate);
+        foreach (var type in _candidateClrTypes.OrderBy(static type => type.FullName, StringComparer.Ordinal))
+        {
+            hash.Add(type);
+        }
+        return hash.ToHashCode();
+    }
+}

--- a/src/Compiler/IR/LIR/ReceiverTypeFlowAnalysis.cs
+++ b/src/Compiler/IR/LIR/ReceiverTypeFlowAnalysis.cs
@@ -114,7 +114,7 @@ internal static class ReceiverTypeFlowAnalysis
         var worklist = new Queue<int>();
         var queued = new bool[blocks.Count];
 
-        EnqueueWithInput(0, new FlowState());
+        EnqueueWithInput(0, CreateEntryState());
         foreach (var region in methodBody.ExceptionRegions)
         {
             if (TryGetLabelBlock(blocks, region.HandlerStartLabelId, out var handlerBlock))
@@ -187,6 +187,34 @@ internal static class ReceiverTypeFlowAnalysis
         }
 
         return facts;
+
+        FlowState CreateEntryState()
+        {
+            var state = new FlowState();
+            foreach (var (parameter, summary) in
+                     methodBody.ReceiverParameterTypeSummaries)
+            {
+                if (slice.Parameters.Contains(parameter))
+                {
+                    state.SetParameter(
+                        parameter,
+                        FlowValue.FromSummary(summary));
+                }
+            }
+
+            foreach (var (binding, summary) in
+                     methodBody.ReceiverCapturedEntryTypeSummaries)
+            {
+                if (slice.Bindings.Contains(binding))
+                {
+                    state.SetBinding(
+                        binding,
+                        FlowValue.FromSummary(summary));
+                }
+            }
+
+            return state;
+        }
 
         void EnqueueWithInput(int blockIndex, FlowState incoming)
         {
@@ -303,7 +331,11 @@ internal static class ReceiverTypeFlowAnalysis
             LIRConcatStrings => FlowValue.ForCandidate(typeof(string)),
             LIRConstNumber or LIRConstBoolean or LIRConstNull or LIRConstUndefined
                 => FlowValue.NonCandidate,
-            _ => ClassifyStorage(methodBody, defined)
+            _ => methodBody.ReceiverTempTypeSummaries.TryGetValue(
+                defined.Index,
+                out var summary)
+                    ? FlowValue.FromSummary(summary)
+                    : ClassifyStorage(methodBody, defined)
         };
 
         state.SetTemp(methodBody, defined, value);
@@ -1009,6 +1041,12 @@ internal sealed class FlowValue : IEquatable<FlowValue>
             includesUnknown: false,
             includesNonCandidate: false,
             [type]);
+
+    public static FlowValue FromSummary(ReceiverTypeSummary summary)
+        => new(
+            summary.IncludesUnknown,
+            summary.IncludesNonCandidate,
+            summary.CandidateClrTypes);
 
     public FlowValue Union(FlowValue other)
         => new(

--- a/src/Compiler/IR/LIR/ReceiverTypeFlowAnalysis.cs
+++ b/src/Compiler/IR/LIR/ReceiverTypeFlowAnalysis.cs
@@ -243,9 +243,14 @@ internal static class ReceiverTypeFlowAnalysis
         bool hasFinallyRegion = false)
     {
         var effects = LIRInstructionInfo.GetEffectsForScheduling(instruction);
-        if ((effects & (LIRInstructionEffects.Calls
-                | LIRInstructionEffects.Suspension
-                | LIRInstructionEffects.ScopeReplacement)) != 0)
+        if ((effects & LIRInstructionEffects.UnsupportedBarrier) != 0)
+        {
+            state.InvalidateMutableLocations();
+        }
+        else if ((effects & (LIRInstructionEffects.Calls
+                     | LIRInstructionEffects.Suspension
+                     | LIRInstructionEffects.ScopeReplacement)) != 0
+                 || MayInvokeDynamicAccessor(instruction))
         {
             state.InvalidateCapturedBindings();
         }
@@ -340,6 +345,14 @@ internal static class ReceiverTypeFlowAnalysis
 
         state.SetTemp(methodBody, defined, value);
     }
+
+    private static bool MayInvokeDynamicAccessor(LIRInstruction instruction)
+        => instruction is LIRGetItem
+            or LIRGetItemAsNumber
+            or LIRGetItemAsNumberString
+            or LIRGetJsArrayElement
+            or LIRGetLength
+            or LIRSetItem;
 
     private static FlowValue ResolveLoadValue(
         FlowValue flowValue,

--- a/src/Compiler/IR/LIR/ReceiverTypeFlowAnalysis.cs
+++ b/src/Compiler/IR/LIR/ReceiverTypeFlowAnalysis.cs
@@ -580,6 +580,7 @@ internal static class ReceiverTypeFlowAnalysis
             LIRCallMember4 call => call.Receiver,
             LIRCallMember5 call => call.Receiver,
             LIRCallGuardedStringIntrinsic call => call.Receiver,
+            LIRCallGuardedIntrinsicMember call => call.Receiver,
             LIRGetLength getLength => getLength.Object,
             LIRGetItem getItem => getItem.Object,
             _ => default
@@ -592,6 +593,7 @@ internal static class ReceiverTypeFlowAnalysis
             or LIRCallMember4
             or LIRCallMember5
             or LIRCallGuardedStringIntrinsic
+            or LIRCallGuardedIntrinsicMember
             or LIRGetLength
             or LIRGetItem;
     }

--- a/src/Compiler/IR/LIR/ReceiverTypeFlowAnalysis.cs
+++ b/src/Compiler/IR/LIR/ReceiverTypeFlowAnalysis.cs
@@ -98,7 +98,9 @@ internal static class ReceiverTypeFlowAnalysis
         return false;
     }
 
-    public static ReceiverTypeFlowFacts Analyze(MethodBodyIR methodBody)
+    public static ReceiverTypeFlowFacts Analyze(
+        MethodBodyIR methodBody,
+        ReceiverTypeFlowDiagnosticTrace? diagnostics = null)
     {
         var facts = new ReceiverTypeFlowFacts();
         if (methodBody.Instructions.Count == 0)
@@ -112,6 +114,9 @@ internal static class ReceiverTypeFlowAnalysis
         var hasFinallyRegion = methodBody.ExceptionRegions.Any(
             static region => region.Kind == ExceptionRegionKind.Finally);
         var blockInputs = new FlowState?[blocks.Count];
+        var blockOutputs = diagnostics != null
+            ? new FlowState?[blocks.Count]
+            : null;
         var worklist = new Queue<int>();
         var queued = new bool[blocks.Count];
 
@@ -143,10 +148,25 @@ internal static class ReceiverTypeFlowAnalysis
                     hasFinallyRegion);
             }
 
+            if (blockOutputs != null)
+            {
+                blockOutputs[blockIndex] = state.Clone();
+            }
             foreach (var successor in block.Successors)
             {
                 EnqueueWithInput(successor, state);
             }
+        }
+
+        if (diagnostics != null)
+        {
+            RecordMergeDiagnostics(
+                methodBody,
+                blocks,
+                blockInputs,
+                blockOutputs!,
+                slice,
+                diagnostics);
         }
 
         for (var blockIndex = 0; blockIndex < blocks.Count; blockIndex++)
@@ -169,13 +189,21 @@ internal static class ReceiverTypeFlowAnalysis
                     instructionIndex);
                 LIRInstructionInfo.VisitUsedTemps(instruction, ref visitor);
                 RecordBindingBefore(instruction, state, facts, instructionIndex);
+                RecordRetainedReceiverFact(
+                    methodBody,
+                    instruction,
+                    state,
+                    instructionIndex,
+                    diagnostics);
 
                 Transfer(
                     methodBody,
                     instruction,
                     state,
                     slice,
-                    hasFinallyRegion);
+                    hasFinallyRegion,
+                    diagnostics,
+                    instructionIndex);
 
                 if (LIRInstructionInfo.TryGetDefinedTemp(instruction, out var defined)
                     && defined.Index >= 0)
@@ -243,11 +271,22 @@ internal static class ReceiverTypeFlowAnalysis
         LIRInstruction instruction,
         FlowState state,
         AnalysisSlice slice,
-        bool hasFinallyRegion = false)
+        bool hasFinallyRegion = false,
+        ReceiverTypeFlowDiagnosticTrace? diagnostics = null,
+        int instructionIndex = -1)
     {
         var effects = LIRInstructionInfo.GetEffectsForScheduling(instruction);
         if ((effects & LIRInstructionEffects.UnsupportedBarrier) != 0)
         {
+            RecordInvalidation(
+                methodBody,
+                state,
+                slice,
+                instruction,
+                instructionIndex,
+                "unsupported-barrier",
+                capturedOnly: false,
+                diagnostics);
             state.InvalidateMutableLocations();
         }
         else if ((effects & (LIRInstructionEffects.Calls
@@ -255,11 +294,34 @@ internal static class ReceiverTypeFlowAnalysis
                      | LIRInstructionEffects.ScopeReplacement)) != 0
                  || MayInvokeDynamicAccessor(instruction))
         {
+            if (diagnostics != null)
+            {
+                RecordInvalidation(
+                    methodBody,
+                    state,
+                    slice,
+                    instruction,
+                    instructionIndex,
+                    FormatCapturedInvalidationReason(
+                        instruction,
+                        effects),
+                    capturedOnly: true,
+                    diagnostics);
+            }
             state.InvalidateCapturedBindings();
         }
 
         if (hasFinallyRegion && instruction is LIRLeave)
         {
+            RecordInvalidation(
+                methodBody,
+                state,
+                slice,
+                instruction,
+                instructionIndex,
+                "finally-leave",
+                capturedOnly: false,
+                diagnostics);
             state.InvalidateMutableLocations();
         }
 
@@ -347,6 +409,233 @@ internal static class ReceiverTypeFlowAnalysis
         };
 
         state.SetTemp(methodBody, defined, value);
+    }
+
+    private static void RecordRetainedReceiverFact(
+        MethodBodyIR methodBody,
+        LIRInstruction instruction,
+        FlowState state,
+        int instructionIndex,
+        ReceiverTypeFlowDiagnosticTrace? diagnostics)
+    {
+        if (diagnostics == null
+            || !TryGetReceiver(instruction, out var receiver))
+        {
+            return;
+        }
+
+        var fact = state.GetTemp(methodBody, receiver);
+        if (fact.HasCandidates)
+        {
+            diagnostics.RecordRetained(
+                instructionIndex,
+                instruction.GetType().Name,
+                receiver,
+                fact.ToDiagnosticText());
+        }
+    }
+
+    private static void RecordInvalidation(
+        MethodBodyIR methodBody,
+        FlowState state,
+        AnalysisSlice slice,
+        LIRInstruction instruction,
+        int instructionIndex,
+        string reason,
+        bool capturedOnly,
+        ReceiverTypeFlowDiagnosticTrace? diagnostics)
+    {
+        if (diagnostics == null)
+        {
+            return;
+        }
+
+        var invalidatedFacts = GetCandidateMutableFacts(
+            methodBody,
+            state,
+            slice,
+            capturedOnly);
+        if (invalidatedFacts.Count == 0)
+        {
+            return;
+        }
+
+        diagnostics.RecordInvalidation(
+            instructionIndex,
+            instruction.GetType().Name,
+            reason,
+            invalidatedFacts);
+    }
+
+    private static string FormatCapturedInvalidationReason(
+        LIRInstruction instruction,
+        LIRInstructionEffects effects)
+    {
+        var reasons = new List<string>(4);
+        if ((effects & LIRInstructionEffects.Calls) != 0)
+        {
+            reasons.Add("call");
+        }
+        if ((effects & LIRInstructionEffects.Suspension) != 0)
+        {
+            reasons.Add("suspension");
+        }
+        if ((effects & LIRInstructionEffects.ScopeReplacement) != 0)
+        {
+            reasons.Add("scope-replacement");
+        }
+        if (MayInvokeDynamicAccessor(instruction))
+        {
+            reasons.Add("dynamic-accessor");
+        }
+
+        return string.Join("+", reasons);
+    }
+
+    private static List<string> GetCandidateMutableFacts(
+        MethodBodyIR methodBody,
+        FlowState state,
+        AnalysisSlice slice,
+        bool capturedOnly)
+    {
+        var facts = new List<string>();
+        if (!capturedOnly)
+        {
+            foreach (var slot in slice.Slots.Order())
+            {
+                Add(
+                    FormatSlot(methodBody, slot),
+                    state.GetSlot(slot));
+            }
+            foreach (var parameter in slice.Parameters.Order())
+            {
+                Add(
+                    $"parameter:{parameter}",
+                    state.GetParameter(parameter));
+            }
+        }
+
+        foreach (var binding in slice.Bindings
+                     .OrderBy(FormatBinding, StringComparer.Ordinal))
+        {
+            Add(
+                FormatBinding(binding),
+                state.GetBinding(binding));
+        }
+
+        return facts;
+
+        void Add(string location, FlowValue value)
+        {
+            if (value.HasCandidates)
+            {
+                facts.Add($"{location}={value.ToDiagnosticText()}");
+            }
+        }
+    }
+
+    private static void RecordMergeDiagnostics(
+        MethodBodyIR methodBody,
+        IReadOnlyList<LIRBasicBlock> blocks,
+        IReadOnlyList<FlowState?> blockInputs,
+        IReadOnlyList<FlowState?> blockOutputs,
+        AnalysisSlice slice,
+        ReceiverTypeFlowDiagnosticTrace diagnostics)
+    {
+        for (var blockIndex = 0;
+             blockIndex < blocks.Count;
+             blockIndex++)
+        {
+            var block = blocks[blockIndex];
+            if (block.Predecessors.Count < 2
+                || blockInputs[blockIndex] == null)
+            {
+                continue;
+            }
+
+            foreach (var temp in slice.Temps.Order())
+            {
+                Record(
+                    $"temp:t{temp}",
+                    state => state.GetTemp(temp));
+            }
+            foreach (var slot in slice.Slots.Order())
+            {
+                Record(
+                    FormatSlot(methodBody, slot),
+                    state => state.GetSlot(slot));
+            }
+            foreach (var parameter in slice.Parameters.Order())
+            {
+                Record(
+                    $"parameter:{parameter}",
+                    state => state.GetParameter(parameter));
+            }
+            foreach (var binding in slice.Bindings
+                         .OrderBy(FormatBinding, StringComparer.Ordinal))
+            {
+                Record(
+                    FormatBinding(binding),
+                    state => state.GetBinding(binding));
+            }
+
+            void Record(
+                string location,
+                Func<FlowState, FlowValue> select)
+            {
+                var inputs = block.Predecessors
+                    .Order()
+                    .Where(predecessor =>
+                        blockOutputs[predecessor] != null)
+                    .Select(predecessor => (
+                        Block: predecessor,
+                        Value: select(blockOutputs[predecessor]!)))
+                    .ToArray();
+                if (inputs.Length < 2
+                    || inputs
+                        .Select(static input => input.Value)
+                        .Distinct()
+                        .Count() < 2)
+                {
+                    return;
+                }
+
+                var result = select(blockInputs[blockIndex]!);
+                if (!result.HasCandidates
+                    && !inputs.Any(
+                        static input => input.Value.HasCandidates))
+                {
+                    return;
+                }
+
+                diagnostics.RecordMerge(
+                    block.Start,
+                    location,
+                    string.Join(
+                        ", ",
+                        inputs.Select(input =>
+                            $"b{input.Block}={input.Value.ToDiagnosticText()}")),
+                    result.ToDiagnosticText());
+            }
+        }
+    }
+
+    private static string FormatSlot(
+        MethodBodyIR methodBody,
+        int slot)
+        => slot >= 0 && slot < methodBody.VariableNames.Count
+            ? $"slot:{slot}({methodBody.VariableNames[slot]})"
+            : $"slot:{slot}";
+
+    private static string FormatBinding(BindingInfo binding)
+    {
+        var scopeName = binding.DeclaringScope?.GetQualifiedName();
+        if (string.IsNullOrEmpty(scopeName))
+        {
+            scopeName = binding.DeclaringScope?.Name ?? "<unknown>";
+        }
+
+        return $"binding:{scopeName}/{binding.Name}";
     }
 
     private static bool MayInvokeDynamicAccessor(LIRInstruction instruction)
@@ -707,6 +996,12 @@ internal static class ReceiverTypeFlowAnalysis
                 : Get(_temps, temp.Index);
         }
 
+        public FlowValue GetTemp(int tempIndex)
+            => Get(_temps, tempIndex);
+
+        public FlowValue GetSlot(int slot)
+            => Get(_slots, slot);
+
         public void SetTemp(MethodBodyIR methodBody, TempVariable temp, FlowValue value)
         {
             var slot = GetVariableSlot(methodBody, temp);
@@ -888,6 +1183,13 @@ internal sealed class FlowValue : IEquatable<FlowValue>
             IncludesUnknown,
             IncludesNonCandidate,
             new HashSet<Type>(_candidateClrTypes));
+
+    public string ToDiagnosticText()
+        => $"candidates=[{string.Join(", ", _candidateClrTypes
+            .OrderBy(static type => type.FullName, StringComparer.Ordinal)
+            .Select(static type => type.FullName))}]; "
+            + $"unknown={IncludesUnknown.ToString().ToLowerInvariant()}; "
+            + $"non-candidate={IncludesNonCandidate.ToString().ToLowerInvariant()}";
 
     public bool Equals(FlowValue? other)
         => other != null

--- a/src/Compiler/IR/LIR/ReceiverTypeFlowAnalysis.cs
+++ b/src/Compiler/IR/LIR/ReceiverTypeFlowAnalysis.cs
@@ -82,25 +82,43 @@ internal static class ReceiverTypeFlowAnalysis
         foreach (var instruction in methodBody.Instructions)
         {
             if (TryGetReceiver(instruction, out var receiver)
-                && receiver.Index >= 0
-                && receiver.Index < methodBody.TempStorages.Count)
+                && IsUncertainReceiver(methodBody, receiver))
             {
-                var storage = methodBody.TempStorages[receiver.Index];
-                if (storage.Kind == ValueStorageKind.Unknown
-                    || storage.ClrType == null
-                    || storage.ClrType == typeof(object))
-                {
-                    return true;
-                }
+                return true;
             }
         }
 
         return false;
     }
 
+    public static bool RequiresSpecializationAnalysis(
+        MethodBodyIR methodBody)
+    {
+        var receiverLocations = new HashSet<int>();
+
+        foreach (var instruction in methodBody.Instructions)
+        {
+            if (LIRReceiverSpecialization.TryGetPotentialReceiver(
+                    methodBody,
+                    instruction,
+                    out var receiver)
+                && IsUncertainReceiver(methodBody, receiver))
+            {
+                receiverLocations.Add(
+                    GetLocationKey(methodBody, receiver));
+            }
+        }
+
+        return receiverLocations.Count > 0
+            && HasCandidatePath(
+                methodBody,
+                receiverLocations);
+    }
+
     public static ReceiverTypeFlowFacts Analyze(
         MethodBodyIR methodBody,
-        ReceiverTypeFlowDiagnosticTrace? diagnostics = null)
+        ReceiverTypeFlowDiagnosticTrace? diagnostics = null,
+        bool specializationOnly = false)
     {
         var facts = new ReceiverTypeFlowFacts();
         if (methodBody.Instructions.Count == 0)
@@ -108,7 +126,14 @@ internal static class ReceiverTypeFlowAnalysis
             return facts;
         }
 
-        var slice = BuildAnalysisSlice(methodBody);
+        var slice = BuildAnalysisSlice(
+            methodBody,
+            specializationOnly);
+        if (!HasCandidateSource(methodBody, slice))
+        {
+            return facts;
+        }
+
         var controlFlowGraph = LIRControlFlowGraph.Build(methodBody);
         var blocks = controlFlowGraph.Blocks;
         var hasFinallyRegion = methodBody.ExceptionRegions.Any(
@@ -688,7 +713,9 @@ internal static class ReceiverTypeFlowAnalysis
            }
            && namespaceName.StartsWith("JavaScriptRuntime", StringComparison.Ordinal);
 
-    private static AnalysisSlice BuildAnalysisSlice(MethodBodyIR methodBody)
+    private static AnalysisSlice BuildAnalysisSlice(
+        MethodBodyIR methodBody,
+        bool specializationOnly)
     {
         var slice = new AnalysisSlice();
         var definitions = new Dictionary<int, List<LIRInstruction>>();
@@ -701,7 +728,12 @@ internal static class ReceiverTypeFlowAnalysis
 
         foreach (var instruction in methodBody.Instructions)
         {
-            if (TryGetReceiver(instruction, out var receiver))
+            if ((specializationOnly
+                    ? LIRReceiverSpecialization.TryGetPotentialReceiver(
+                        methodBody,
+                        instruction,
+                        out var receiver)
+                    : TryGetReceiver(instruction, out receiver)))
             {
                 AddTemp(receiver);
             }
@@ -835,12 +867,240 @@ internal static class ReceiverTypeFlowAnalysis
         }
     }
 
+    private static bool HasCandidateSource(
+        MethodBodyIR methodBody,
+        AnalysisSlice slice)
+    {
+        foreach (var binding in slice.Bindings)
+        {
+            if (binding.ReceiverCandidateClrTypes.Count > 0
+                || methodBody.ReceiverCapturedEntryTypeSummaries
+                    .TryGetValue(binding, out var summary)
+                && summary.CandidateClrTypes.Count > 0)
+            {
+                return true;
+            }
+        }
+
+        foreach (var parameter in slice.Parameters)
+        {
+            if (methodBody.ReceiverParameterTypeSummaries.TryGetValue(
+                    parameter,
+                    out var summary)
+                && summary.CandidateClrTypes.Count > 0)
+            {
+                return true;
+            }
+        }
+
+        foreach (var instruction in methodBody.Instructions)
+        {
+            if (!LIRInstructionInfo.TryGetDefinedTemp(
+                    instruction,
+                    out var defined)
+                || !slice.IsTempRelevant(methodBody, defined))
+            {
+                continue;
+            }
+
+            if (instruction is LIRConstString
+                    or LIRConvertToString
+                    or LIRConcatStrings
+                || instruction is LIRCallIntrinsicStatic
+                {
+                    IntrinsicName:
+                        nameof(JavaScriptRuntime.Array),
+                    MethodName: "Construct"
+                })
+            {
+                return true;
+            }
+        }
+
+        for (var index = 0;
+             index < methodBody.TempStorages.Count;
+             index++)
+        {
+            var temp = new TempVariable(index);
+            if (!slice.IsTempRelevant(methodBody, temp))
+            {
+                continue;
+            }
+
+            if (IsReceiverCandidateType(
+                    methodBody.TempStorages[index].ClrType)
+                || methodBody.ReceiverTempTypeSummaries.TryGetValue(
+                    index,
+                    out var summary)
+                && summary.CandidateClrTypes.Count > 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasCandidatePath(
+        MethodBodyIR methodBody,
+        HashSet<int> locations)
+    {
+        var bindings = new HashSet<BindingInfo>();
+        var parameters = new HashSet<int>();
+        bool changed;
+
+        do
+        {
+            changed = false;
+            foreach (var instruction in methodBody.Instructions)
+            {
+                if (LIRInstructionInfo.TryGetDefinedTemp(
+                        instruction,
+                        out var defined)
+                    && locations.Contains(
+                        GetLocationKey(methodBody, defined)))
+                {
+                    if (IsCandidateDefinition(
+                            methodBody,
+                            instruction,
+                            defined))
+                    {
+                        return true;
+                    }
+
+                    switch (instruction)
+                    {
+                        case LIRCopyTemp copy:
+                            changed |= Add(copy.Source);
+                            break;
+                        case LIRConvertToObject convert:
+                            changed |= Add(convert.Source);
+                            break;
+                        case LIRCallIntrinsicStatic
+                        {
+                            IntrinsicName:
+                                nameof(JavaScriptRuntime.ObjectRuntime),
+                            MethodName:
+                                nameof(JavaScriptRuntime.ObjectRuntime
+                                    .RequireObjectCoercible),
+                            Arguments.Count: 1
+                        } requireObjectCoercible:
+                            changed |= Add(
+                                requireObjectCoercible.Arguments[0]);
+                            break;
+                        case LIRLoadScopeField load:
+                            changed |= bindings.Add(load.Binding);
+                            break;
+                        case LIRLoadLeafScopeField load:
+                            changed |= bindings.Add(load.Binding);
+                            break;
+                        case LIRLoadParentScopeField load:
+                            changed |= bindings.Add(load.Binding);
+                            break;
+                        case LIRLoadParameter load:
+                            changed |= parameters.Add(
+                                load.ParameterIndex);
+                            break;
+                    }
+                }
+
+                switch (instruction)
+                {
+                    case LIRStoreScopeField store
+                        when bindings.Contains(store.Binding):
+                        changed |= Add(store.Value);
+                        break;
+                    case LIRStoreLeafScopeField store
+                        when bindings.Contains(store.Binding):
+                        changed |= Add(store.Value);
+                        break;
+                    case LIRStoreParentScopeField store
+                        when bindings.Contains(store.Binding):
+                        changed |= Add(store.Value);
+                        break;
+                    case LIRStoreParameter store
+                        when parameters.Contains(
+                            store.ParameterIndex):
+                        changed |= Add(store.Value);
+                        break;
+                }
+            }
+
+            foreach (var binding in bindings)
+            {
+                if (binding.ReceiverCandidateClrTypes.Count > 0
+                    || methodBody
+                        .ReceiverCapturedEntryTypeSummaries
+                        .TryGetValue(binding, out var summary)
+                    && summary.CandidateClrTypes.Count > 0)
+                {
+                    return true;
+                }
+            }
+
+            foreach (var parameter in parameters)
+            {
+                if (methodBody.ReceiverParameterTypeSummaries
+                    .TryGetValue(parameter, out var summary)
+                    && summary.CandidateClrTypes.Count > 0)
+                {
+                    return true;
+                }
+            }
+        }
+        while (changed);
+
+        return false;
+
+        bool Add(TempVariable temp)
+            => locations.Add(
+                GetLocationKey(methodBody, temp));
+    }
+
+    private static bool IsCandidateDefinition(
+        MethodBodyIR methodBody,
+        LIRInstruction instruction,
+        TempVariable defined)
+        => instruction is LIRConstString
+                or LIRConvertToString
+                or LIRConcatStrings
+            || instruction is LIRCallIntrinsicStatic
+            {
+                IntrinsicName:
+                    nameof(JavaScriptRuntime.Array),
+                MethodName: "Construct"
+            }
+            || defined.Index >= 0
+            && defined.Index < methodBody.TempStorages.Count
+            && IsReceiverCandidateType(
+                methodBody.TempStorages[defined.Index].ClrType)
+            || methodBody.ReceiverTempTypeSummaries.TryGetValue(
+                defined.Index,
+                out var summary)
+            && summary.CandidateClrTypes.Count > 0;
+
     private static int GetLocationKey(
         MethodBodyIR methodBody,
         TempVariable temp)
     {
         var slot = AnalysisSlice.GetVariableSlot(methodBody, temp);
         return slot >= 0 ? -slot - 1 : temp.Index;
+    }
+
+    private static bool IsUncertainReceiver(
+        MethodBodyIR methodBody,
+        TempVariable receiver)
+    {
+        if (receiver.Index < 0
+            || receiver.Index >= methodBody.TempStorages.Count)
+        {
+            return false;
+        }
+
+        var storage = methodBody.TempStorages[receiver.Index];
+        return storage.Kind == ValueStorageKind.Unknown
+            || storage.ClrType == null
+            || storage.ClrType == typeof(object);
     }
 
     private static void AddToList<TKey, TValue>(

--- a/src/Compiler/IR/LIR/ReceiverTypeFlowDiagnostics.cs
+++ b/src/Compiler/IR/LIR/ReceiverTypeFlowDiagnostics.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.Logging;
+
+namespace Jroc.IR;
+
+internal enum ReceiverTypeFlowDiagnosticKind
+{
+    Merge,
+    Invalidation,
+    Retained,
+    Specialization
+}
+
+internal sealed record ReceiverTypeFlowDiagnosticEvent(
+    int InstructionIndex,
+    ReceiverTypeFlowDiagnosticKind Kind,
+    string Message);
+
+internal sealed class ReceiverTypeFlowDiagnosticTrace
+{
+    private readonly List<ReceiverTypeFlowDiagnosticEvent> _events = [];
+
+    public IReadOnlyList<ReceiverTypeFlowDiagnosticEvent> Events
+        => _events
+            .OrderBy(static item => item.InstructionIndex)
+            .ThenBy(static item => item.Kind)
+            .ThenBy(static item => item.Message, StringComparer.Ordinal)
+            .ToArray();
+
+    public void RecordMerge(
+        int instructionIndex,
+        string location,
+        string inputs,
+        string result)
+        => Record(
+            instructionIndex,
+            ReceiverTypeFlowDiagnosticKind.Merge,
+            $"merge @{instructionIndex} {location}: {inputs} => {result}");
+
+    public void RecordInvalidation(
+        int instructionIndex,
+        string instructionName,
+        string reason,
+        IReadOnlyList<string> invalidatedFacts)
+        => Record(
+            instructionIndex,
+            ReceiverTypeFlowDiagnosticKind.Invalidation,
+            $"invalidate @{instructionIndex} {instructionName} reason={reason}: "
+            + string.Join("; ", invalidatedFacts));
+
+    public void RecordRetained(
+        int instructionIndex,
+        string instructionName,
+        TempVariable receiver,
+        string fact)
+        => Record(
+            instructionIndex,
+            ReceiverTypeFlowDiagnosticKind.Retained,
+            $"retain @{instructionIndex} {instructionName} receiver=t{receiver.Index}: {fact}");
+
+    public void RecordSpecialization(
+        int instructionIndex,
+        string memberName,
+        TempVariable receiver,
+        Type receiverType,
+        int loopDepth,
+        bool receiverIsProvenType,
+        string action)
+        => Record(
+            instructionIndex,
+            ReceiverTypeFlowDiagnosticKind.Specialization,
+            $"specialize @{instructionIndex} member={memberName} receiver=t{receiver.Index} "
+            + $"candidate={receiverType.FullName} loop-depth={loopDepth} "
+            + $"type-proven={receiverIsProvenType.ToString().ToLowerInvariant()} action={action}");
+
+    public void LogTo(
+        Microsoft.Extensions.Logging.ILogger logger,
+        string scopeName)
+    {
+        foreach (var item in Events)
+        {
+            logger.LogInformation(
+                "[ReceiverFlow] scope={ScopeName} {Message}",
+                scopeName,
+                item.Message);
+        }
+    }
+
+    private void Record(
+        int instructionIndex,
+        ReceiverTypeFlowDiagnosticKind kind,
+        string message)
+    {
+        _events.Add(
+            new ReceiverTypeFlowDiagnosticEvent(
+                instructionIndex,
+                kind,
+                message));
+    }
+}

--- a/src/Compiler/IR/MethodBodyIR.cs
+++ b/src/Compiler/IR/MethodBodyIR.cs
@@ -1,4 +1,5 @@
 using Jroc.Services.TwoPhaseCompilation;
+using Jroc.SymbolTables;
 
 namespace Jroc.IR;
 
@@ -115,4 +116,13 @@ public sealed class MethodBodyIR
     /// Populated after all normalization and variable-slot coalescing passes.
     /// </summary>
     internal ReceiverTypeFlowFacts? ReceiverTypeFlowFacts { get; set; }
+
+    internal Dictionary<int, ReceiverTypeSummary>
+        ReceiverParameterTypeSummaries { get; } = new();
+
+    internal Dictionary<BindingInfo, ReceiverTypeSummary>
+        ReceiverCapturedEntryTypeSummaries { get; } = new();
+
+    internal Dictionary<int, ReceiverTypeSummary>
+        ReceiverTempTypeSummaries { get; } = new();
 }

--- a/src/Compiler/IR/MethodBodyIR.cs
+++ b/src/Compiler/IR/MethodBodyIR.cs
@@ -109,4 +109,10 @@ public sealed class MethodBodyIR
     /// This enables optimizations like inlining LIRConvertToObject for const variables.
     /// </summary>
     public HashSet<int> SingleAssignmentSlots { get; } = new();
+
+    /// <summary>
+    /// Flow-sensitive receiver facts for the final LIR instruction sequence.
+    /// Populated after all normalization and variable-slot coalescing passes.
+    /// </summary>
+    internal ReceiverTypeFlowFacts? ReceiverTypeFlowFacts { get; set; }
 }

--- a/src/Compiler/IR/MethodBodyIR.cs
+++ b/src/Compiler/IR/MethodBodyIR.cs
@@ -117,6 +117,12 @@ public sealed class MethodBodyIR
     /// </summary>
     internal ReceiverTypeFlowFacts? ReceiverTypeFlowFacts { get; set; }
 
+    /// <summary>
+    /// Natural-loop nesting depth for the final LIR instruction sequence.
+    /// Computed lazily when a guarded receiver specialization is eligible.
+    /// </summary>
+    internal LIRLoopNestingFacts? LoopNestingFacts { get; set; }
+
     internal Dictionary<int, ReceiverTypeSummary>
         ReceiverParameterTypeSummaries { get; } = new();
 

--- a/src/Compiler/JsMethodCompiler.cs
+++ b/src/Compiler/JsMethodCompiler.cs
@@ -1130,6 +1130,15 @@ internal sealed class JsMethodCompiler
         // sequence produced by the normalization and CSE passes above.
         LIRVariableSlotCoalescing.Optimize(lirMethod!);
 
+        // Compute per-program-point receiver facts over the final control-flow
+        // graph. These facts are analysis-only until a guarded specialization
+        // explicitly consumes them.
+        if (ReceiverTypeFlowAnalysis.RequiresAnalysis(lirMethod!))
+        {
+            lirMethod!.ReceiverTypeFlowFacts =
+                ReceiverTypeFlowAnalysis.Analyze(lirMethod);
+        }
+
         methodBody = lirMethod!;
         return true;
     }

--- a/src/Compiler/JsMethodCompiler.cs
+++ b/src/Compiler/JsMethodCompiler.cs
@@ -11,6 +11,7 @@ using Jroc.Utilities.Ecma335;
 using Jroc.Services;
 using Jroc.Services.TwoPhaseCompilation;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using ScopesCallableKind = Jroc.Services.ScopesAbi.CallableKind;
 using Jroc.Utilities;
 
@@ -136,6 +137,8 @@ internal sealed class JsMethodCompiler
     private readonly Services.NestedTypeRelationshipRegistry _nestedTypeRelationshipRegistry;
     private readonly Services.ModuleTypeMetadataRegistry _moduleTypeRegistry;
     private readonly JavaScriptRuntime.IRuntimeIntrinsicCatalog _runtimeIntrinsicCatalog;
+    private readonly ILogger<JsMethodCompiler> _diagnosticLogger;
+    private readonly bool _diagnosticsEnabled;
 
     public JsMethodCompiler(
         MetadataBuilder metadataBuilder,
@@ -148,6 +151,8 @@ internal sealed class JsMethodCompiler
         Services.NestedTypeRelationshipRegistry nestedTypeRelationshipRegistry,
         Services.ModuleTypeMetadataRegistry moduleTypeRegistry,
         JavaScriptRuntime.IRuntimeIntrinsicCatalog runtimeIntrinsicCatalog,
+        CompilerOptions options,
+        ILogger<JsMethodCompiler> diagnosticLogger,
         IServiceProvider serviceProvider)
     {
         _metadataBuilder = metadataBuilder;
@@ -160,6 +165,8 @@ internal sealed class JsMethodCompiler
         _nestedTypeRelationshipRegistry = nestedTypeRelationshipRegistry;
         _moduleTypeRegistry = moduleTypeRegistry;
         _runtimeIntrinsicCatalog = runtimeIntrinsicCatalog;
+        _diagnosticsEnabled = options.DiagnosticsEnabled;
+        _diagnosticLogger = diagnosticLogger;
         _serviceProvider = serviceProvider;
     }
 
@@ -1133,13 +1140,29 @@ internal sealed class JsMethodCompiler
         // Compute per-program-point receiver facts over the final control-flow
         // graph. These facts are analysis-only until a guarded specialization
         // explicitly consumes them.
+        var receiverDiagnostics = _diagnosticsEnabled
+            ? new ReceiverTypeFlowDiagnosticTrace()
+            : null;
         if (ReceiverTypeFlowAnalysis.RequiresAnalysis(lirMethod!))
         {
             lirMethod!.ReceiverTypeFlowFacts =
-                ReceiverTypeFlowAnalysis.Analyze(lirMethod);
+                ReceiverTypeFlowAnalysis.Analyze(
+                    lirMethod,
+                    receiverDiagnostics);
         }
 
-        LIRReceiverSpecialization.Normalize(lirMethod!);
+        LIRReceiverSpecialization.Normalize(
+            lirMethod!,
+            receiverDiagnostics);
+        if (receiverDiagnostics != null)
+        {
+            var scopeName = scope.GetQualifiedName();
+            receiverDiagnostics.LogTo(
+                _diagnosticLogger,
+                string.IsNullOrEmpty(scopeName)
+                    ? scope.Name
+                    : scopeName);
+        }
 
         methodBody = lirMethod!;
         return true;

--- a/src/Compiler/JsMethodCompiler.cs
+++ b/src/Compiler/JsMethodCompiler.cs
@@ -1139,6 +1139,8 @@ internal sealed class JsMethodCompiler
                 ReceiverTypeFlowAnalysis.Analyze(lirMethod);
         }
 
+        LIRReceiverSpecialization.Normalize(lirMethod!);
+
         methodBody = lirMethod!;
         return true;
     }

--- a/src/Compiler/JsMethodCompiler.cs
+++ b/src/Compiler/JsMethodCompiler.cs
@@ -1143,12 +1143,17 @@ internal sealed class JsMethodCompiler
         var receiverDiagnostics = _diagnosticsEnabled
             ? new ReceiverTypeFlowDiagnosticTrace()
             : null;
-        if (ReceiverTypeFlowAnalysis.RequiresAnalysis(lirMethod!))
+        var requiresReceiverAnalysis = receiverDiagnostics != null
+            ? ReceiverTypeFlowAnalysis.RequiresAnalysis(lirMethod!)
+            : ReceiverTypeFlowAnalysis
+                .RequiresSpecializationAnalysis(lirMethod!);
+        if (requiresReceiverAnalysis)
         {
             lirMethod!.ReceiverTypeFlowFacts =
                 ReceiverTypeFlowAnalysis.Analyze(
                     lirMethod,
-                    receiverDiagnostics);
+                    receiverDiagnostics,
+                    specializationOnly: receiverDiagnostics == null);
         }
 
         LIRReceiverSpecialization.Normalize(

--- a/src/Compiler/SymbolTable/BindingInfo.cs
+++ b/src/Compiler/SymbolTable/BindingInfo.cs
@@ -82,9 +82,10 @@ public class BindingInfo
     }
 
     /// <summary>
-    /// Reference receiver types observed at any write to this binding. Unlike
-    /// <see cref="ClrType"/>, these are candidates rather than a representation
-    /// guarantee, so consumers must retain a runtime guard and generic fallback.
+    /// Reference receiver types conservatively observed as possible assignment
+    /// results for this binding. Unlike <see cref="ClrType"/>, these are
+    /// analysis candidates rather than a representation guarantee, so future
+    /// consumers must retain a runtime guard and generic fallback.
     /// </summary>
     public HashSet<Type> ReceiverCandidateClrTypes { get; } = [];
 

--- a/src/Compiler/SymbolTable/BindingInfo.cs
+++ b/src/Compiler/SymbolTable/BindingInfo.cs
@@ -82,6 +82,13 @@ public class BindingInfo
     }
 
     /// <summary>
+    /// Reference receiver types observed at any write to this binding. Unlike
+    /// <see cref="ClrType"/>, these are candidates rather than a representation
+    /// guarantee, so consumers must retain a runtime guard and generic fallback.
+    /// </summary>
+    public HashSet<Type> ReceiverCandidateClrTypes { get; } = [];
+
+    /// <summary>
     /// True when this binding is the target of any write operation (assignment/update/initializer).
     /// This is used for conservative optimizations that require proving a binding is never reassigned.
     /// </summary>

--- a/src/Compiler/SymbolTable/ReceiverTypeSummary.cs
+++ b/src/Compiler/SymbolTable/ReceiverTypeSummary.cs
@@ -1,0 +1,73 @@
+namespace Jroc.SymbolTables;
+
+internal sealed class ReceiverTypeSummary : IEquatable<ReceiverTypeSummary>
+{
+    public static ReceiverTypeSummary Empty { get; } = new(
+        includesUnknown: false,
+        includesNonCandidate: false,
+        []);
+
+    public static ReceiverTypeSummary Unknown { get; } = new(
+        includesUnknown: true,
+        includesNonCandidate: true,
+        []);
+
+    public static ReceiverTypeSummary NonCandidate { get; } = new(
+        includesUnknown: false,
+        includesNonCandidate: true,
+        []);
+
+    public ReceiverTypeSummary(
+        bool includesUnknown,
+        bool includesNonCandidate,
+        IEnumerable<Type> candidateClrTypes)
+    {
+        IncludesUnknown = includesUnknown;
+        IncludesNonCandidate = includesNonCandidate;
+        CandidateClrTypes = new HashSet<Type>(candidateClrTypes);
+    }
+
+    public bool IncludesUnknown { get; }
+    public bool IncludesNonCandidate { get; }
+    public IReadOnlySet<Type> CandidateClrTypes { get; }
+    public bool HasCandidates => CandidateClrTypes.Count > 0;
+    public bool IsEmpty => !IncludesUnknown
+        && !IncludesNonCandidate
+        && CandidateClrTypes.Count == 0;
+
+    public static ReceiverTypeSummary ForCandidate(Type type)
+        => new(
+            includesUnknown: false,
+            includesNonCandidate: false,
+            [type]);
+
+    public ReceiverTypeSummary Union(ReceiverTypeSummary other)
+        => new(
+            IncludesUnknown || other.IncludesUnknown,
+            IncludesNonCandidate || other.IncludesNonCandidate,
+            CandidateClrTypes.Union(other.CandidateClrTypes));
+
+    public bool Equals(ReceiverTypeSummary? other)
+        => other != null
+            && IncludesUnknown == other.IncludesUnknown
+            && IncludesNonCandidate == other.IncludesNonCandidate
+            && CandidateClrTypes.SetEquals(other.CandidateClrTypes);
+
+    public override bool Equals(object? obj)
+        => obj is ReceiverTypeSummary other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(IncludesUnknown);
+        hash.Add(IncludesNonCandidate);
+        foreach (var type in CandidateClrTypes.OrderBy(
+                     static type => type.FullName,
+                     StringComparer.Ordinal))
+        {
+            hash.Add(type);
+        }
+
+        return hash.ToHashCode();
+    }
+}

--- a/src/Compiler/SymbolTable/Scope.cs
+++ b/src/Compiler/SymbolTable/Scope.cs
@@ -118,6 +118,28 @@ public class Scope
     /// </summary>
     public Dictionary<int, Type> StableParameterClrTypes { get; } = new();
 
+    /// <summary>
+    /// Receiver facts observed at every statically proven call site for a
+    /// parameter. Unlike <see cref="StableParameterClrTypes"/>, candidate
+    /// unions do not change the callable ABI.
+    /// </summary>
+    internal Dictionary<int, ReceiverTypeSummary>
+        ReceiverParameterTypeSummaries { get; } = new();
+
+    /// <summary>
+    /// Receiver facts produced by this callable's conservatively analyzed
+    /// return expressions.
+    /// </summary>
+    internal ReceiverTypeSummary ReceiverReturnTypeSummary { get; set; } =
+        ReceiverTypeSummary.Empty;
+
+    /// <summary>
+    /// Captured receiver facts proven at entry to a non-escaping direct-only
+    /// closure.
+    /// </summary>
+    internal Dictionary<BindingInfo, ReceiverTypeSummary>
+        ReceiverCapturedEntryTypeSummaries { get; } = new();
+
     // Names of parameters (for function scopes) so we can avoid generating backing fields for them.
     public HashSet<string> Parameters { get; } = new();
     /// <summary>

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.CallableMaterialization.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.CallableMaterialization.cs
@@ -35,6 +35,7 @@ public partial class SymbolTableBuilder
     {
         var scopeByAstNode = new Dictionary<Node, Scope>(ReferenceEqualityComparer.Instance);
         var states = new Dictionary<BindingInfo, CallableAnalysisState>();
+        var parentMap = BuildParentMap(globalScope.AstNode);
         CollectScopes(globalScope);
 
         foreach (var scope in EnumerateCallableAnalysisScopes(globalScope))
@@ -74,6 +75,11 @@ public partial class SymbolTableBuilder
 
                 var state = new CallableAnalysisState(binding, initializer);
                 states.Add(binding, state);
+
+                if (IsWithinExportDeclaration(initializer, parentMap))
+                {
+                    state.Reasons |= CallableMaterializationReason.Export;
+                }
 
                 if (binding.Kind != BindingKind.Const)
                 {
@@ -380,6 +386,33 @@ public partial class SymbolTableBuilder
                     return;
             }
         }
+    }
+
+    private static bool IsWithinExportDeclaration(
+        Node node,
+        IReadOnlyDictionary<Node, Node> parentMap)
+    {
+        var current = node;
+        while (parentMap.TryGetValue(current, out var parent))
+        {
+            if (parent is ExportNamedDeclaration
+                or ExportDefaultDeclaration
+                or ExportAllDeclaration)
+            {
+                return true;
+            }
+
+            if (parent is FunctionDeclaration
+                or FunctionExpression
+                or ArrowFunctionExpression)
+            {
+                return false;
+            }
+
+            current = parent;
+        }
+
+        return false;
     }
 
     private static IEnumerable<Scope> EnumerateCallableAnalysisScopes(Scope scope)

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.InferTypes.cs
@@ -82,9 +82,14 @@ public partial class SymbolTableBuilder
         var parentMap = BuildParentMap(root.AstNode);
         foreach (var candidate in candidatesByScope.Values)
         {
-            if (candidate.Scope.AstNode is FunctionExpression
-                && parentMap.TryGetValue(candidate.Scope.AstNode, out var parent)
-                && parent is not Acornima.Ast.MethodDefinition)
+            if (IsWithinExportDeclaration(
+                    candidate.Scope.AstNode,
+                    parentMap)
+                || (candidate.Scope.AstNode is FunctionExpression
+                    && parentMap.TryGetValue(
+                        candidate.Scope.AstNode,
+                        out var parent)
+                    && parent is not Acornima.Ast.MethodDefinition))
             {
                 candidate.IsCallableUnsafe = true;
             }

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.InferenceFixedPoint.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.InferenceFixedPoint.cs
@@ -99,11 +99,34 @@ public partial class SymbolTableBuilder
             AppendType(state, scope.StableReturnClrType);
             AppendType(state, scope.StableReturnArrayElementClrType);
             state.Append(scope.StableReturnIsThis ? '1' : '0').Append(';');
+            state.Append('R');
+            AppendReceiverSummary(
+                state,
+                scope.ReceiverReturnTypeSummary);
 
             foreach (var (index, type) in scope.StableParameterClrTypes.OrderBy(pair => pair.Key))
             {
                 state.Append('P').Append(index).Append(':');
                 AppendType(state, type);
+            }
+
+            foreach (var (index, summary) in
+                     scope.ReceiverParameterTypeSummaries.OrderBy(
+                         pair => pair.Key))
+            {
+                state.Append('Q').Append(index).Append(':');
+                AppendReceiverSummary(state, summary);
+            }
+
+            foreach (var (binding, summary) in
+                     scope.ReceiverCapturedEntryTypeSummaries.OrderBy(
+                         pair => pair.Key.Name,
+                         StringComparer.Ordinal))
+            {
+                state.Append('C');
+                AppendText(state, binding.DeclaringScope.Name);
+                AppendText(state, binding.Name);
+                AppendReceiverSummary(state, summary);
             }
 
             foreach (var (name, type) in scope.StableInstanceFieldClrTypes.OrderBy(pair => pair.Key, StringComparer.Ordinal))
@@ -152,6 +175,21 @@ public partial class SymbolTableBuilder
 
     private static void AppendType(StringBuilder state, Type? type)
         => AppendText(state, type?.AssemblyQualifiedName);
+
+    private static void AppendReceiverSummary(
+        StringBuilder state,
+        ReceiverTypeSummary summary)
+    {
+        state.Append(summary.IncludesUnknown ? '1' : '0');
+        state.Append(summary.IncludesNonCandidate ? '1' : '0');
+        foreach (var candidate in summary.CandidateClrTypes.OrderBy(
+                     static type => type.FullName,
+                     StringComparer.Ordinal))
+        {
+            AppendType(state, candidate);
+        }
+        state.Append(';');
+    }
 
     private static void AppendText(StringBuilder state, string? value)
     {

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.InferenceFixedPoint.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.InferenceFixedPoint.cs
@@ -23,19 +23,20 @@ public partial class SymbolTableBuilder
             // Definite-initialization runs immediately after variable inference so transient
             // guesses from hoisted var initializers cannot become field or return facts.
             InferVariableClrTypes(root);
-            InferReceiverTypeCandidates(root);
             InferDefinitelyInitializedNumericVarLocals(root);
             InferClassInstanceFieldClrTypes(root);
             InferCallableReturnClrTypes(root);
             AnalyzeObjectLiteralShapes(root);
 
-            LogInferredTypes(root, passNumber);
-
             var after = CaptureInferenceState(root);
             if (string.Equals(before, after, StringComparison.Ordinal))
             {
+                InferReceiverTypeCandidates(root);
+                LogInferredTypes(root, passNumber);
                 return;
             }
+
+            LogInferredTypes(root, passNumber);
 
             if (!visitedStates.Add(after))
             {
@@ -99,34 +100,11 @@ public partial class SymbolTableBuilder
             AppendType(state, scope.StableReturnClrType);
             AppendType(state, scope.StableReturnArrayElementClrType);
             state.Append(scope.StableReturnIsThis ? '1' : '0').Append(';');
-            state.Append('R');
-            AppendReceiverSummary(
-                state,
-                scope.ReceiverReturnTypeSummary);
 
             foreach (var (index, type) in scope.StableParameterClrTypes.OrderBy(pair => pair.Key))
             {
                 state.Append('P').Append(index).Append(':');
                 AppendType(state, type);
-            }
-
-            foreach (var (index, summary) in
-                     scope.ReceiverParameterTypeSummaries.OrderBy(
-                         pair => pair.Key))
-            {
-                state.Append('Q').Append(index).Append(':');
-                AppendReceiverSummary(state, summary);
-            }
-
-            foreach (var (binding, summary) in
-                     scope.ReceiverCapturedEntryTypeSummaries.OrderBy(
-                         pair => pair.Key.Name,
-                         StringComparer.Ordinal))
-            {
-                state.Append('C');
-                AppendText(state, binding.DeclaringScope.Name);
-                AppendText(state, binding.Name);
-                AppendReceiverSummary(state, summary);
             }
 
             foreach (var (name, type) in scope.StableInstanceFieldClrTypes.OrderBy(pair => pair.Key, StringComparer.Ordinal))
@@ -151,10 +129,6 @@ public partial class SymbolTableBuilder
                 AppendType(state, binding.StableElementClrType);
                 state.Append(binding.IsStableType ? '1' : '0');
                 state.Append(binding.CanUseUnboxedLocal ? '1' : '0');
-                foreach (var candidate in binding.ReceiverCandidateClrTypes.OrderBy(static type => type.FullName, StringComparer.Ordinal))
-                {
-                    AppendType(state, candidate);
-                }
                 state.Append(';');
 
                 if (binding.ObjectLiteralShape is not { } shape)
@@ -175,21 +149,6 @@ public partial class SymbolTableBuilder
 
     private static void AppendType(StringBuilder state, Type? type)
         => AppendText(state, type?.AssemblyQualifiedName);
-
-    private static void AppendReceiverSummary(
-        StringBuilder state,
-        ReceiverTypeSummary summary)
-    {
-        state.Append(summary.IncludesUnknown ? '1' : '0');
-        state.Append(summary.IncludesNonCandidate ? '1' : '0');
-        foreach (var candidate in summary.CandidateClrTypes.OrderBy(
-                     static type => type.FullName,
-                     StringComparer.Ordinal))
-        {
-            AppendType(state, candidate);
-        }
-        state.Append(';');
-    }
 
     private static void AppendText(StringBuilder state, string? value)
     {

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.InferenceFixedPoint.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.InferenceFixedPoint.cs
@@ -23,6 +23,7 @@ public partial class SymbolTableBuilder
             // Definite-initialization runs immediately after variable inference so transient
             // guesses from hoisted var initializers cannot become field or return facts.
             InferVariableClrTypes(root);
+            InferReceiverTypeCandidates(root);
             InferDefinitelyInitializedNumericVarLocals(root);
             InferClassInstanceFieldClrTypes(root);
             InferCallableReturnClrTypes(root);
@@ -72,16 +73,19 @@ public partial class SymbolTableBuilder
     private static string FormatInferredType(BindingInfo binding)
     {
         var clrType = binding.ClrType?.FullName ?? "<unknown>";
+        var receiverCandidates = binding.ReceiverCandidateClrTypes.Count == 0
+            ? string.Empty
+            : $" [receiver candidates: {string.Join(", ", binding.ReceiverCandidateClrTypes.Select(static type => type.FullName))}]";
         if (binding.ObjectLiteralShape is not { IsEligible: true } shape)
         {
-            return clrType;
+            return clrType + receiverCandidates;
         }
 
         var members = string.Join(
             ", ",
             shape.Members.Select(member =>
                 $"{member.Name}: {(member.IsFunction ? "function" : member.ClrType?.FullName ?? "System.Object")}"));
-        return $"{clrType} [object literal: {{ {members} }}]";
+        return $"{clrType} [object literal: {{ {members} }}]{receiverCandidates}";
     }
 
     private static string CaptureInferenceState(Scope root)
@@ -124,6 +128,11 @@ public partial class SymbolTableBuilder
                 AppendType(state, binding.StableElementClrType);
                 state.Append(binding.IsStableType ? '1' : '0');
                 state.Append(binding.CanUseUnboxedLocal ? '1' : '0');
+                foreach (var candidate in binding.ReceiverCandidateClrTypes.OrderBy(static type => type.FullName, StringComparer.Ordinal))
+                {
+                    AppendType(state, candidate);
+                }
+                state.Append(';');
 
                 if (binding.ObjectLiteralShape is not { } shape)
                 {

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.ReceiverTypeCandidates.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.ReceiverTypeCandidates.cs
@@ -8,9 +8,35 @@ public partial class SymbolTableBuilder
     private void InferReceiverTypeCandidates(Scope root)
     {
         var stringObjectCandidateBindings = new HashSet<BindingInfo>();
+        Dictionary<Node, Node>? parentMap = null;
+        var capturedBindingsByScope =
+            new Dictionary<Scope, IReadOnlyList<BindingInfo>>();
+        var receiverCallTargets =
+            new Dictionary<CallExpression, Scope?>(
+                ReferenceEqualityComparer.Instance);
+        var receiverTargetScopes = new HashSet<Scope>();
 
         foreach (var scope in EnumerateScopes(root))
         {
+            scope.ReceiverParameterTypeSummaries.Clear();
+            scope.ReceiverCapturedEntryTypeSummaries.Clear();
+            scope.ReceiverReturnTypeSummary = ReceiverTypeSummary.Empty;
+
+            foreach (var (index, type) in scope.StableParameterClrTypes)
+            {
+                if (IsReceiverCandidateType(type))
+                {
+                    scope.ReceiverParameterTypeSummaries[index] =
+                        ReceiverTypeSummary.ForCandidate(type);
+                }
+            }
+
+            if (IsReceiverCandidateType(scope.StableReturnClrType))
+            {
+                scope.ReceiverReturnTypeSummary =
+                    ReceiverTypeSummary.ForCandidate(scope.StableReturnClrType!);
+            }
+
             foreach (var binding in scope.Bindings.Values)
             {
                 binding.ReceiverCandidateClrTypes.Clear();
@@ -25,6 +51,12 @@ public partial class SymbolTableBuilder
             foreach (var scope in EnumerateScopes(root))
             {
                 VisitScope(scope);
+            }
+
+            foreach (var scope in EnumerateScopes(root))
+            {
+                changed |= ApplyParameterCandidates(scope);
+                changed |= UpdateReturnSummary(scope);
             }
         }
         while (changed);
@@ -79,6 +111,15 @@ public partial class SymbolTableBuilder
                         }
                         break;
                     }
+
+                    case CallExpression call
+                        when TryGetReceiverCallTarget(
+                            call,
+                            scope,
+                            out var targetScope):
+                        RecordParameterInputs(call, scope, targetScope);
+                        RecordCapturedInputs(call, scope, targetScope);
+                        break;
                 }
 
                 foreach (var child in node.ChildNodes)
@@ -162,6 +203,19 @@ public partial class SymbolTableBuilder
                     when string.Equals(constructor.Name, "Array", StringComparison.Ordinal)
                          && !IsIdentifierShadowed(scope, "Array"):
                     yield return typeof(JavaScriptRuntime.Array);
+                    yield break;
+
+                case CallExpression call
+                    when TryGetReceiverCallTarget(
+                        call,
+                        scope,
+                        out var targetScope):
+                    foreach (var candidate in targetScope
+                                 .ReceiverReturnTypeSummary
+                                 .CandidateClrTypes)
+                    {
+                        yield return candidate;
+                    }
                     yield break;
 
                 case NewExpression
@@ -260,6 +314,526 @@ public partial class SymbolTableBuilder
             }
 
             return false;
+        }
+
+        void RecordParameterInputs(
+            CallExpression call,
+            Scope callScope,
+            Scope targetScope)
+        {
+            if (!TryGetSimpleParameterNames(
+                    targetScope.AstNode,
+                    out var parameterNames))
+            {
+                return;
+            }
+
+            for (var index = 0; index < parameterNames.Count; index++)
+            {
+                var summary = index < call.Arguments.Count
+                    && call.Arguments[index] is Expression argument
+                        ? GetReceiverSummary(argument, callScope)
+                        : ReceiverTypeSummary.NonCandidate;
+                changed |= UnionSummary(
+                    targetScope.ReceiverParameterTypeSummaries,
+                    index,
+                    summary);
+            }
+        }
+
+        void RecordCapturedInputs(
+            CallExpression call,
+            Scope callScope,
+            Scope targetScope)
+        {
+            if (!capturedBindingsByScope.TryGetValue(
+                    targetScope,
+                    out var capturedBindings))
+            {
+                capturedBindings = FindCapturedBindings(targetScope);
+                capturedBindingsByScope.Add(targetScope, capturedBindings);
+            }
+
+            foreach (var binding in capturedBindings)
+            {
+                ReceiverTypeSummary summary;
+                if (binding.IsStableType
+                    && IsReceiverCandidateType(binding.ClrType))
+                {
+                    summary = ReceiverTypeSummary.ForCandidate(
+                        binding.ClrType!);
+                }
+                else if (!TryGetImmediatelyPrecedingAssignment(
+                             call,
+                             binding,
+                             callScope,
+                             out var assignedExpression,
+                             out var assignmentScope))
+                {
+                    summary = ReceiverTypeSummary.Unknown;
+                }
+                else
+                {
+                    summary = GetReceiverSummary(
+                        assignedExpression,
+                        assignmentScope);
+                }
+
+                changed |= UnionSummary(
+                    targetScope.ReceiverCapturedEntryTypeSummaries,
+                    binding,
+                    summary);
+            }
+        }
+
+        IReadOnlyList<BindingInfo> FindCapturedBindings(Scope targetScope)
+        {
+            var possibleBindings = new List<BindingInfo>();
+            var current = targetScope.Parent;
+            while (current != null)
+            {
+                possibleBindings.AddRange(
+                    current.Bindings.Values.Where(
+                        static binding => binding.IsCaptured));
+                current = current.Parent;
+            }
+
+            if (possibleBindings.Count == 0)
+            {
+                return [];
+            }
+
+            var referencedNames = new HashSet<string>(StringComparer.Ordinal);
+            var pending = new Stack<Node>();
+            pending.Push(targetScope.AstNode);
+            while (pending.Count > 0)
+            {
+                var node = pending.Pop();
+                if (!ReferenceEquals(node, targetScope.AstNode)
+                    && node is FunctionDeclaration
+                        or FunctionExpression
+                        or ArrowFunctionExpression)
+                {
+                    continue;
+                }
+
+                if (node is Identifier identifier
+                    && GetParentMap().TryGetValue(
+                        identifier,
+                        out var parent)
+                    && !IsIdentifierDeclarationName(identifier, parent))
+                {
+                    referencedNames.Add(identifier.Name);
+                }
+
+                foreach (var child in node.ChildNodes)
+                {
+                    pending.Push(child);
+                }
+            }
+
+            return possibleBindings
+                .Where(binding => referencedNames.Contains(binding.Name))
+                .ToArray();
+        }
+
+        bool TryGetImmediatelyPrecedingAssignment(
+            CallExpression call,
+            BindingInfo binding,
+            Scope callScope,
+            out Expression expression,
+            out Scope assignmentScope)
+        {
+            expression = null!;
+            assignmentScope = null!;
+            Node statement = call;
+            var parents = GetParentMap();
+            while (parents.TryGetValue(statement, out var parent)
+                   && parent is not Acornima.Ast.Program
+                       and not BlockStatement
+                       and not SwitchCase)
+            {
+                statement = parent;
+            }
+
+            if (!parents.TryGetValue(statement, out var statementList))
+            {
+                return false;
+            }
+
+            IReadOnlyList<Node> statements = statementList switch
+            {
+                Acornima.Ast.Program program =>
+                    program.Body.Cast<Node>().ToArray(),
+                BlockStatement block =>
+                    block.Body.Cast<Node>().ToArray(),
+                SwitchCase switchCase =>
+                    switchCase.Consequent.Cast<Node>().ToArray(),
+                _ => []
+            };
+            var statementIndex = statements
+                .Select((candidate, index) => (candidate, index))
+                .FirstOrDefault(pair => ReferenceEquals(
+                    pair.candidate,
+                    statement))
+                .index;
+            if (statementIndex <= 0)
+            {
+                return false;
+            }
+
+            var preceding = statements[statementIndex - 1];
+            assignmentScope = callScope;
+
+            if (preceding is ExpressionStatement
+                {
+                    Expression: AssignmentExpression
+                    {
+                        Operator: Operator.Assignment,
+                        Left: Identifier assignedIdentifier,
+                        Right: var assignedValue
+                    }
+                }
+                && ReferenceEquals(
+                    TryResolveBinding(
+                        assignmentScope,
+                        assignedIdentifier.Name),
+                    binding))
+            {
+                expression = assignedValue;
+                return true;
+            }
+
+            if (preceding is VariableDeclaration declaration)
+            {
+                foreach (var declarator in declaration.Declarations)
+                {
+                    if (declarator is
+                        {
+                            Id: Identifier declaredIdentifier,
+                            Init: { } initializer
+                        }
+                        && ReferenceEquals(
+                            TryResolveBinding(
+                                assignmentScope,
+                                declaredIdentifier.Name),
+                            binding))
+                    {
+                        expression = initializer;
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        bool ApplyParameterCandidates(Scope scope)
+        {
+            if (!TryGetSimpleParameterNames(
+                    scope.AstNode,
+                    out var parameterNames))
+            {
+                return false;
+            }
+
+            var added = false;
+            foreach (var (index, summary) in
+                     scope.ReceiverParameterTypeSummaries)
+            {
+                if (index < 0
+                    || index >= parameterNames.Count
+                    || !scope.Bindings.TryGetValue(
+                        parameterNames[index],
+                        out var binding))
+                {
+                    continue;
+                }
+
+                foreach (var candidate in summary.CandidateClrTypes)
+                {
+                    added |= binding.ReceiverCandidateClrTypes.Add(candidate);
+                }
+            }
+
+            return added;
+        }
+
+        bool UpdateReturnSummary(Scope scope)
+        {
+            if (scope.Kind != ScopeKind.Function
+                || scope.IsAsync
+                || scope.IsGenerator
+                || !receiverTargetScopes.Contains(scope))
+            {
+                return false;
+            }
+
+            var inferred = GetCallableReturnSummary(scope);
+            var merged = scope.ReceiverReturnTypeSummary.Union(inferred);
+            if (merged.Equals(scope.ReceiverReturnTypeSummary))
+            {
+                return false;
+            }
+
+            scope.ReceiverReturnTypeSummary = merged;
+            return true;
+        }
+
+        ReceiverTypeSummary GetCallableReturnSummary(Scope scope)
+        {
+            if (scope.AstNode is ArrowFunctionExpression
+                {
+                    Body: Expression expressionBody
+                })
+            {
+                return GetReceiverSummary(expressionBody, scope);
+            }
+
+            BlockStatement? body = scope.AstNode switch
+            {
+                FunctionDeclaration function => function.Body,
+                FunctionExpression function => function.Body,
+                MethodDefinition { Value.Body: BlockStatement methodBody } =>
+                    methodBody,
+                ArrowFunctionExpression { Body: BlockStatement arrowBody } =>
+                    arrowBody,
+                _ => null
+            };
+            if (body == null)
+            {
+                return ReceiverTypeSummary.Unknown;
+            }
+
+            var returns = new List<ReturnStatement>();
+            var pending = new Stack<Node>();
+            pending.Push(body);
+            while (pending.Count > 0)
+            {
+                var node = pending.Pop();
+                if (!ReferenceEquals(node, body)
+                    && node is FunctionDeclaration
+                        or FunctionExpression
+                        or ArrowFunctionExpression)
+                {
+                    continue;
+                }
+
+                if (node is ReturnStatement returnStatement)
+                {
+                    returns.Add(returnStatement);
+                    continue;
+                }
+
+                foreach (var child in node.ChildNodes)
+                {
+                    pending.Push(child);
+                }
+            }
+
+            if (returns.Count == 1
+                && body.Body.Count > 0
+                && ReferenceEquals(body.Body.Last(), returns[0]))
+            {
+                return returns[0].Argument is Expression returnedExpression
+                    ? GetReceiverSummary(returnedExpression, scope)
+                    : ReceiverTypeSummary.NonCandidate;
+            }
+
+            var summary = ReceiverTypeSummary.Unknown;
+            foreach (var returnStatement in returns)
+            {
+                summary = summary.Union(
+                    returnStatement.Argument is Expression returnedExpression
+                        ? GetReceiverSummary(returnedExpression, scope)
+                        : ReceiverTypeSummary.NonCandidate);
+            }
+
+            return summary;
+        }
+
+        ReceiverTypeSummary GetReceiverSummary(
+            Expression expression,
+            Scope scope)
+        {
+            if (expression is Identifier identifier
+                && TryResolveBinding(scope, identifier.Name) is
+                    { } binding)
+            {
+                if (!binding.HasWrite
+                    && TryGetSimpleParameterNames(
+                        binding.DeclaringScope.AstNode,
+                        out var parameterNames))
+                {
+                    var parameterIndex = parameterNames
+                        .Select((name, index) => (name, index))
+                        .FirstOrDefault(pair => string.Equals(
+                            pair.name,
+                            binding.Name,
+                            StringComparison.Ordinal))
+                        .index;
+                    if (parameterIndex >= 0
+                        && parameterIndex < parameterNames.Count
+                        && string.Equals(
+                            parameterNames[parameterIndex],
+                            binding.Name,
+                            StringComparison.Ordinal)
+                        && binding.DeclaringScope
+                            .ReceiverParameterTypeSummaries
+                            .TryGetValue(
+                                parameterIndex,
+                                out var parameterSummary))
+                    {
+                        return parameterSummary;
+                    }
+                }
+
+                if (binding.IsStableType
+                    && IsReceiverCandidateType(binding.ClrType))
+                {
+                    return ReceiverTypeSummary.ForCandidate(
+                        binding.ClrType!);
+                }
+
+                if (binding.ReceiverCandidateClrTypes.Count > 0)
+                {
+                    return new ReceiverTypeSummary(
+                        includesUnknown: true,
+                        includesNonCandidate: true,
+                        binding.ReceiverCandidateClrTypes);
+                }
+
+                return ReceiverTypeSummary.Unknown;
+            }
+
+            if (expression is NonLogicalBinaryExpression
+                {
+                    Operator: Operator.Addition
+                } addition
+                && ContainsStringCandidate(addition, scope))
+            {
+                return new ReceiverTypeSummary(
+                    includesUnknown: true,
+                    includesNonCandidate: true,
+                    [typeof(string)]);
+            }
+
+            var candidates = GetReceiverCandidates(expression, scope)
+                .Distinct()
+                .ToArray();
+            if (candidates.Length > 0)
+            {
+                return ReceiverTypeSummary.ForCandidate(candidates[0])
+                    .Union(new ReceiverTypeSummary(
+                        includesUnknown: false,
+                        includesNonCandidate: false,
+                        candidates.Skip(1)));
+            }
+
+            return expression is NumericLiteral
+                or BooleanLiteral
+                or NullLiteral
+                ? ReceiverTypeSummary.NonCandidate
+                : ReceiverTypeSummary.Unknown;
+        }
+
+        bool TryGetReceiverCallTarget(
+            CallExpression call,
+            Scope callScope,
+            out Scope targetScope)
+        {
+            targetScope = null!;
+            if (receiverCallTargets.TryGetValue(
+                    call,
+                    out var cachedTarget))
+            {
+                targetScope = cachedTarget!;
+                if (cachedTarget != null)
+                {
+                    receiverTargetScopes.Add(cachedTarget);
+                }
+                return cachedTarget != null;
+            }
+
+            if (call.Optional
+                || call.Arguments.Any(
+                    argument => argument is SpreadElement))
+            {
+                receiverCallTargets.Add(call, null);
+                return false;
+            }
+
+            if (call.Callee is FunctionExpression
+                or ArrowFunctionExpression)
+            {
+                var directScope = FindScopeByAstNode(
+                    root,
+                    call.Callee);
+                if (directScope == null
+                    || StableDirectCallableEligibility
+                        .GetCallableIneligibilityReason(
+                            call.Callee,
+                            directScope)
+                        != CallableMaterializationReason.None)
+                {
+                    receiverCallTargets.Add(call, null);
+                    return false;
+                }
+
+                targetScope = directScope;
+                receiverCallTargets.Add(call, targetScope);
+                receiverTargetScopes.Add(targetScope);
+                return true;
+            }
+
+            if (call.Callee is not Identifier calleeIdentifier
+                || TryResolveBinding(
+                    callScope,
+                    calleeIdentifier.Name) is not { } callableBinding
+                || callableBinding.CallableMaterialization?.Kind
+                    != CallableMaterializationKind.DirectOnly
+                || !StableDirectCallableEligibility.TryGetEligibleCall(
+                    callableBinding,
+                    call,
+                    callScope,
+                    out _,
+                    out var eligibleScope,
+                    out _)
+                || eligibleScope == null)
+            {
+                receiverCallTargets.Add(call, null);
+                return false;
+            }
+
+            targetScope = eligibleScope;
+            receiverCallTargets.Add(call, targetScope);
+            receiverTargetScopes.Add(targetScope);
+            return true;
+        }
+
+        Dictionary<Node, Node> GetParentMap()
+            => parentMap ??= BuildParentMap(root.AstNode);
+
+        static bool UnionSummary<TKey>(
+            Dictionary<TKey, ReceiverTypeSummary> summaries,
+            TKey key,
+            ReceiverTypeSummary incoming)
+            where TKey : notnull
+        {
+            if (!summaries.TryGetValue(key, out var existing))
+            {
+                summaries.Add(key, incoming);
+                return true;
+            }
+
+            var merged = existing.Union(incoming);
+            if (merged.Equals(existing))
+            {
+                return false;
+            }
+
+            summaries[key] = merged;
+            return true;
         }
     }
 

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.ReceiverTypeCandidates.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.ReceiverTypeCandidates.cs
@@ -1,0 +1,189 @@
+using Acornima;
+using Acornima.Ast;
+
+namespace Jroc.SymbolTables;
+
+public partial class SymbolTableBuilder
+{
+    private void InferReceiverTypeCandidates(Scope root)
+    {
+        foreach (var scope in EnumerateScopes(root))
+        {
+            foreach (var binding in scope.Bindings.Values)
+            {
+                binding.ReceiverCandidateClrTypes.Clear();
+                AddStableReceiverCandidate(binding);
+            }
+        }
+
+        bool changed;
+        do
+        {
+            changed = false;
+            foreach (var scope in EnumerateScopes(root))
+            {
+                VisitScope(scope);
+            }
+        }
+        while (changed);
+
+        void VisitScope(Scope scope)
+        {
+            Visit(scope.AstNode, scope, isScopeRoot: true);
+        }
+
+        void Visit(Node node, Scope scope, bool isScopeRoot)
+        {
+            if (!isScopeRoot
+                && scope.Children.Any(child => ReferenceEquals(child.AstNode, node)))
+            {
+                return;
+            }
+
+            switch (node)
+            {
+                case VariableDeclarator
+                {
+                    Id: Identifier identifier,
+                    Init: { } initializer
+                }:
+                    AddCandidates(
+                        TryResolveBinding(scope, identifier.Name),
+                        initializer,
+                        scope);
+                    break;
+
+                case AssignmentExpression
+                {
+                    Left: Identifier identifier
+                } assignment:
+                {
+                    var binding = TryResolveBinding(scope, identifier.Name);
+                    AddCandidates(binding, assignment.Right, scope);
+
+                    if (assignment.Operator == Operator.AdditionAssignment
+                        && binding?.ReceiverCandidateClrTypes.Contains(typeof(string)) == true)
+                    {
+                        changed |= binding.ReceiverCandidateClrTypes.Add(typeof(string));
+                    }
+                    break;
+                }
+            }
+
+            foreach (var child in node.ChildNodes)
+            {
+                Visit(child, scope, isScopeRoot: false);
+            }
+        }
+
+        void AddCandidates(BindingInfo? binding, Expression expression, Scope scope)
+        {
+            if (binding == null)
+            {
+                return;
+            }
+
+            foreach (var type in GetReceiverCandidates(expression, scope))
+            {
+                changed |= binding.ReceiverCandidateClrTypes.Add(type);
+            }
+        }
+
+        IEnumerable<Type> GetReceiverCandidates(Expression expression, Scope scope)
+        {
+            if (expression is Identifier identifier
+                && TryResolveBinding(scope, identifier.Name) is { } sourceBinding)
+            {
+                foreach (var candidate in sourceBinding.ReceiverCandidateClrTypes)
+                {
+                    yield return candidate;
+                }
+
+                yield break;
+            }
+
+            if (expression is NewExpression
+                {
+                    Callee: Identifier { Name: "String" }
+                }
+                && !IsIdentifierShadowed(scope, "String"))
+            {
+                yield return typeof(string);
+                yield break;
+            }
+
+            if (expression is CallExpression
+                {
+                    Callee: Identifier { Name: "String" }
+                }
+                && !IsIdentifierShadowed(scope, "String"))
+            {
+                yield return typeof(string);
+                yield break;
+            }
+
+            if (expression is CallExpression
+                {
+                    Callee: MemberExpression
+                    {
+                        Computed: false,
+                        Object: Identifier { Name: "String" },
+                        Property: Identifier { Name: "fromCharCode" }
+                    }
+                }
+                && !IsIdentifierShadowed(scope, "String"))
+            {
+                yield return typeof(string);
+                yield break;
+            }
+
+            if (expression is NonLogicalBinaryExpression
+                {
+                    Operator: Operator.Addition
+                } addition)
+            {
+                foreach (var candidate in GetReceiverCandidates(addition.Left, scope))
+                {
+                    if (candidate == typeof(string))
+                    {
+                        yield return candidate;
+                        yield break;
+                    }
+                }
+
+                foreach (var candidate in GetReceiverCandidates(addition.Right, scope))
+                {
+                    if (candidate == typeof(string))
+                    {
+                        yield return candidate;
+                        yield break;
+                    }
+                }
+            }
+
+            var inferredType = InferExpressionClrType(expression, scope);
+            if (IsReceiverCandidateType(inferredType))
+            {
+                yield return inferredType!;
+            }
+        }
+    }
+
+    private static void AddStableReceiverCandidate(BindingInfo binding)
+    {
+        if (IsReceiverCandidateType(binding.ClrType))
+        {
+            binding.ReceiverCandidateClrTypes.Add(binding.ClrType!);
+        }
+    }
+
+    private static bool IsReceiverCandidateType(Type? type)
+        => type == typeof(string)
+           || type is
+           {
+               IsAbstract: false,
+               IsSealed: false,
+               Namespace: { } namespaceName
+           }
+           && namespaceName.StartsWith("JavaScriptRuntime", StringComparison.Ordinal);
+}

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.ReceiverTypeCandidates.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.ReceiverTypeCandidates.cs
@@ -7,6 +7,8 @@ public partial class SymbolTableBuilder
 {
     private void InferReceiverTypeCandidates(Scope root)
     {
+        var stringObjectCandidateBindings = new HashSet<BindingInfo>();
+
         foreach (var scope in EnumerateScopes(root))
         {
             foreach (var binding in scope.Bindings.Values)
@@ -48,7 +50,7 @@ public partial class SymbolTableBuilder
                         Id: Identifier identifier,
                         Init: { } initializer
                     }:
-                        AddCandidates(
+                        AddAssignmentCandidates(
                             TryResolveBinding(scope, identifier.Name),
                             initializer,
                             scope);
@@ -60,10 +62,18 @@ public partial class SymbolTableBuilder
                     } assignment:
                     {
                         var binding = TryResolveBinding(scope, identifier.Name);
-                        AddCandidates(binding, assignment.Right, scope);
-
-                        if (assignment.Operator == Operator.AdditionAssignment
-                            && binding?.ReceiverCandidateClrTypes.Contains(typeof(string)) == true)
+                        if (assignment.Operator == Operator.Assignment)
+                        {
+                            AddAssignmentCandidates(
+                                binding,
+                                assignment.Right,
+                                scope);
+                        }
+                        else if (assignment.Operator == Operator.AdditionAssignment
+                            && binding != null
+                            && (binding.ReceiverCandidateClrTypes.Contains(typeof(string))
+                                || stringObjectCandidateBindings.Contains(binding)
+                                || ContainsStringCandidate(assignment.Right, scope)))
                         {
                             changed |= binding.ReceiverCandidateClrTypes.Add(typeof(string));
                         }
@@ -75,6 +85,19 @@ public partial class SymbolTableBuilder
                 {
                     pending.Push((child, false));
                 }
+            }
+        }
+
+        void AddAssignmentCandidates(
+            BindingInfo? binding,
+            Expression expression,
+            Scope scope)
+        {
+            AddCandidates(binding, expression, scope);
+            if (binding != null
+                && IsStringObjectCandidate(expression, scope))
+            {
+                changed |= stringObjectCandidateBindings.Add(binding);
             }
         }
 
@@ -114,11 +137,6 @@ public partial class SymbolTableBuilder
                     yield return typeof(JavaScriptRuntime.Array);
                     yield break;
 
-                case NewExpression
-                    {
-                        Callee: Identifier { Name: "String" }
-                    }
-                    when !IsIdentifierShadowed(scope, "String"):
                 case CallExpression
                     {
                         Callee: Identifier { Name: "String" }
@@ -181,6 +199,18 @@ public partial class SymbolTableBuilder
             }
         }
 
+        bool IsStringObjectCandidate(Expression expression, Scope scope)
+            => expression switch
+            {
+                NewExpression
+                {
+                    Callee: Identifier { Name: "String" }
+                } => !IsIdentifierShadowed(scope, "String"),
+                Identifier identifier => TryResolveBinding(scope, identifier.Name) is { } sourceBinding
+                    && stringObjectCandidateBindings.Contains(sourceBinding),
+                _ => false
+            };
+
         bool ContainsStringCandidate(Expression expression, Scope scope)
         {
             var pending = new Stack<Expression>();
@@ -214,8 +244,9 @@ public partial class SymbolTableBuilder
                         return true;
 
                     case Identifier identifier
-                        when TryResolveBinding(scope, identifier.Name)
-                            ?.ReceiverCandidateClrTypes.Contains(typeof(string)) == true:
+                        when TryResolveBinding(scope, identifier.Name) is { } binding
+                            && (binding.ReceiverCandidateClrTypes.Contains(typeof(string))
+                                || stringObjectCandidateBindings.Contains(binding)):
                         return true;
 
                     case NonLogicalBinaryExpression

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.ReceiverTypeCandidates.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.ReceiverTypeCandidates.cs
@@ -29,50 +29,52 @@ public partial class SymbolTableBuilder
 
         void VisitScope(Scope scope)
         {
-            Visit(scope.AstNode, scope, isScopeRoot: true);
-        }
+            var pending = new Stack<(Node Node, bool IsScopeRoot)>();
+            pending.Push((scope.AstNode, true));
 
-        void Visit(Node node, Scope scope, bool isScopeRoot)
-        {
-            if (!isScopeRoot
-                && scope.Children.Any(child => ReferenceEquals(child.AstNode, node)))
+            while (pending.Count > 0)
             {
-                return;
-            }
-
-            switch (node)
-            {
-                case VariableDeclarator
+                var (node, isScopeRoot) = pending.Pop();
+                if (!isScopeRoot
+                    && scope.Children.Any(child => ReferenceEquals(child.AstNode, node)))
                 {
-                    Id: Identifier identifier,
-                    Init: { } initializer
-                }:
-                    AddCandidates(
-                        TryResolveBinding(scope, identifier.Name),
-                        initializer,
-                        scope);
-                    break;
-
-                case AssignmentExpression
-                {
-                    Left: Identifier identifier
-                } assignment:
-                {
-                    var binding = TryResolveBinding(scope, identifier.Name);
-                    AddCandidates(binding, assignment.Right, scope);
-
-                    if (assignment.Operator == Operator.AdditionAssignment
-                        && binding?.ReceiverCandidateClrTypes.Contains(typeof(string)) == true)
-                    {
-                        changed |= binding.ReceiverCandidateClrTypes.Add(typeof(string));
-                    }
-                    break;
+                    continue;
                 }
-            }
 
-            foreach (var child in node.ChildNodes)
-            {
-                Visit(child, scope, isScopeRoot: false);
+                switch (node)
+                {
+                    case VariableDeclarator
+                    {
+                        Id: Identifier identifier,
+                        Init: { } initializer
+                    }:
+                        AddCandidates(
+                            TryResolveBinding(scope, identifier.Name),
+                            initializer,
+                            scope);
+                        break;
+
+                    case AssignmentExpression
+                    {
+                        Left: Identifier identifier
+                    } assignment:
+                    {
+                        var binding = TryResolveBinding(scope, identifier.Name);
+                        AddCandidates(binding, assignment.Right, scope);
+
+                        if (assignment.Operator == Operator.AdditionAssignment
+                            && binding?.ReceiverCandidateClrTypes.Contains(typeof(string)) == true)
+                        {
+                            changed |= binding.ReceiverCandidateClrTypes.Add(typeof(string));
+                        }
+                        break;
+                    }
+                }
+
+                foreach (var child in node.ChildNodes)
+                {
+                    pending.Push((child, false));
+                }
             }
         }
 
@@ -102,70 +104,131 @@ public partial class SymbolTableBuilder
                 yield break;
             }
 
-            if (expression is NewExpression
-                {
-                    Callee: Identifier { Name: "String" }
-                }
-                && !IsIdentifierShadowed(scope, "String"))
+            switch (expression)
             {
-                yield return typeof(string);
-                yield break;
-            }
+                case StringLiteral:
+                    yield return typeof(string);
+                    yield break;
 
-            if (expression is CallExpression
-                {
-                    Callee: Identifier { Name: "String" }
-                }
-                && !IsIdentifierShadowed(scope, "String"))
-            {
-                yield return typeof(string);
-                yield break;
-            }
+                case ArrayExpression:
+                    yield return typeof(JavaScriptRuntime.Array);
+                    yield break;
 
-            if (expression is CallExpression
-                {
-                    Callee: MemberExpression
+                case NewExpression
                     {
-                        Computed: false,
-                        Object: Identifier { Name: "String" },
-                        Property: Identifier { Name: "fromCharCode" }
+                        Callee: Identifier { Name: "String" }
                     }
-                }
-                && !IsIdentifierShadowed(scope, "String"))
-            {
-                yield return typeof(string);
-                yield break;
-            }
-
-            if (expression is NonLogicalBinaryExpression
-                {
-                    Operator: Operator.Addition
-                } addition)
-            {
-                foreach (var candidate in GetReceiverCandidates(addition.Left, scope))
-                {
-                    if (candidate == typeof(string))
+                    when !IsIdentifierShadowed(scope, "String"):
+                case CallExpression
                     {
-                        yield return candidate;
-                        yield break;
+                        Callee: Identifier { Name: "String" }
                     }
-                }
-
-                foreach (var candidate in GetReceiverCandidates(addition.Right, scope))
-                {
-                    if (candidate == typeof(string))
+                    when !IsIdentifierShadowed(scope, "String"):
+                case CallExpression
                     {
-                        yield return candidate;
-                        yield break;
+                        Callee: MemberExpression
+                        {
+                            Computed: false,
+                            Object: Identifier { Name: "String" },
+                            Property: Identifier { Name: "fromCharCode" }
+                        }
                     }
+                    when !IsIdentifierShadowed(scope, "String"):
+                    yield return typeof(string);
+                    yield break;
+
+                case NewExpression
+                    {
+                        Callee: Identifier constructor
+                    }
+                    when string.Equals(constructor.Name, "Array", StringComparison.Ordinal)
+                         && !IsIdentifierShadowed(scope, "Array"):
+                    yield return typeof(JavaScriptRuntime.Array);
+                    yield break;
+
+                case NewExpression
+                    {
+                        Callee: Identifier constructor
+                    }
+                    when _runtimeIntrinsicCatalog.TryGetIntrinsicObject(constructor.Name, out var intrinsic)
+                         && intrinsic != null:
+                    if (IsReceiverCandidateType(intrinsic.Type))
+                    {
+                        yield return intrinsic.Type;
+                    }
+                    yield break;
+
+                case CallExpression
+                    {
+                        Callee: MemberExpression
+                        {
+                            Computed: false,
+                            Object: Identifier { Name: "Array" },
+                            Property: Identifier { Name: "of" or "from" }
+                        }
+                    }
+                    when !IsIdentifierShadowed(scope, "Array"):
+                    yield return typeof(JavaScriptRuntime.Array);
+                    yield break;
+
+                case NonLogicalBinaryExpression
+                    {
+                        Operator: Operator.Addition
+                    } addition
+                    when ContainsStringCandidate(addition, scope):
+                    yield return typeof(string);
+                    yield break;
+            }
+        }
+
+        bool ContainsStringCandidate(Expression expression, Scope scope)
+        {
+            var pending = new Stack<Expression>();
+            pending.Push(expression);
+
+            while (pending.Count > 0)
+            {
+                switch (pending.Pop())
+                {
+                    case StringLiteral:
+                    case NewExpression
+                        {
+                            Callee: Identifier { Name: "String" }
+                        }
+                        when !IsIdentifierShadowed(scope, "String"):
+                    case CallExpression
+                        {
+                            Callee: Identifier { Name: "String" }
+                        }
+                        when !IsIdentifierShadowed(scope, "String"):
+                    case CallExpression
+                        {
+                            Callee: MemberExpression
+                            {
+                                Computed: false,
+                                Object: Identifier { Name: "String" },
+                                Property: Identifier { Name: "fromCharCode" }
+                            }
+                        }
+                        when !IsIdentifierShadowed(scope, "String"):
+                        return true;
+
+                    case Identifier identifier
+                        when TryResolveBinding(scope, identifier.Name)
+                            ?.ReceiverCandidateClrTypes.Contains(typeof(string)) == true:
+                        return true;
+
+                    case NonLogicalBinaryExpression
+                        {
+                            Operator: Operator.Addition
+                        } addition:
+                        pending.Push(addition.Left);
+                        pending.Push(addition.Right);
+                        break;
                 }
             }
 
-            var inferredType = InferExpressionClrType(expression, scope);
-            if (IsReceiverCandidateType(inferredType))
-            {
-                yield return inferredType!;
-            }
+            return false;
         }
     }
 

--- a/src/Compiler/Utilities/AstWalker.cs
+++ b/src/Compiler/Utilities/AstWalker.cs
@@ -258,6 +258,28 @@ public class AstWalker
             case ImportExpression importExpr:
                 Visit(importExpr.Source, visitor);
                 break;
+
+            case ExportNamedDeclaration exportNamed:
+                Visit(exportNamed.Declaration, visitor);
+                if (exportNamed.Source == null)
+                {
+                    VisitNodes(exportNamed.Specifiers, visitor);
+                }
+                Visit(exportNamed.Source, visitor);
+                break;
+
+            case ExportDefaultDeclaration exportDefault:
+                Visit(exportDefault.Declaration, visitor);
+                break;
+
+            case ExportAllDeclaration exportAll:
+                Visit(exportAll.Exported, visitor);
+                Visit(exportAll.Source, visitor);
+                break;
+
+            case ExportSpecifier exportSpecifier:
+                Visit(exportSpecifier.Local, visitor);
+                break;
         }
     }
 
@@ -512,6 +534,49 @@ public class AstWalker
 
             case ImportExpression importExpr:
                 VisitWithContext(importExpr.Source, enterNode, exitNode);
+                break;
+
+            case ExportNamedDeclaration exportNamed:
+                VisitWithContext(
+                    exportNamed.Declaration,
+                    enterNode,
+                    exitNode);
+                if (exportNamed.Source == null)
+                {
+                    VisitNodesWithContext(
+                        exportNamed.Specifiers,
+                        enterNode,
+                        exitNode);
+                }
+                VisitWithContext(
+                    exportNamed.Source,
+                    enterNode,
+                    exitNode);
+                break;
+
+            case ExportDefaultDeclaration exportDefault:
+                VisitWithContext(
+                    exportDefault.Declaration,
+                    enterNode,
+                    exitNode);
+                break;
+
+            case ExportAllDeclaration exportAll:
+                VisitWithContext(
+                    exportAll.Exported,
+                    enterNode,
+                    exitNode);
+                VisitWithContext(
+                    exportAll.Source,
+                    enterNode,
+                    exitNode);
+                break;
+
+            case ExportSpecifier exportSpecifier:
+                VisitWithContext(
+                    exportSpecifier.Local,
+                    enterNode,
+                    exitNode);
                 break;
         }
 

--- a/src/JavaScriptRuntime/IntrinsicPrototypeEpochs.cs
+++ b/src/JavaScriptRuntime/IntrinsicPrototypeEpochs.cs
@@ -55,4 +55,28 @@ public static class IntrinsicPrototypeEpochs
                 PrototypeChain.GetPrototypeOrNull(receiver),
                 expectedPrototype);
     }
+
+    public static string? TryUnwrapStringObjectReceiver(
+        object receiver,
+        string memberName)
+    {
+        if (receiver is not JsObject
+            || !ReferenceEquals(
+                PrototypeChain.GetPrototypeOrNull(receiver),
+                String.Prototype)
+            || ObjectRuntime.HasOwnIntrinsicMemberOverride(
+                receiver,
+                memberName)
+            || !PropertyDescriptorStore.TryGetOwn(
+                receiver,
+                String.StringDataPropertyName,
+                out var descriptor)
+            || descriptor.Kind != JsPropertyDescriptorKind.Data
+            || descriptor.Value is not string value)
+        {
+            return null;
+        }
+
+        return value;
+    }
 }

--- a/src/JavaScriptRuntime/IntrinsicPrototypeEpochs.cs
+++ b/src/JavaScriptRuntime/IntrinsicPrototypeEpochs.cs
@@ -8,7 +8,9 @@ namespace JavaScriptRuntime;
 /// </summary>
 public enum IntrinsicPrototypeFamily
 {
-    String = 0
+    String = 0,
+    Array = 1,
+    TypedArray = 2
 }
 
 /// <summary>
@@ -32,4 +34,25 @@ public static class IntrinsicPrototypeEpochs
         IntrinsicPrototypeFamily family,
         long expectedEpoch)
         => Read(family) == expectedEpoch;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool HasDefaultPrototype(
+        object receiver,
+        IntrinsicPrototypeFamily family)
+    {
+        var expectedPrototype = family switch
+        {
+            IntrinsicPrototypeFamily.Array
+                when receiver is Array => Array.Prototype,
+            IntrinsicPrototypeFamily.TypedArray
+                when receiver is TypedArrayBase typedArray =>
+                    GlobalThis.GetTypedArrayInstancePrototype(typedArray),
+            _ => null
+        };
+
+        return expectedPrototype != null
+            && ReferenceEquals(
+                PrototypeChain.GetPrototypeOrNull(receiver),
+                expectedPrototype);
+    }
 }

--- a/src/JavaScriptRuntime/ObjectRuntime.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.cs
@@ -40,6 +40,17 @@ namespace JavaScriptRuntime
                 || PropertyDescriptorStore.GetOwnLookup(target, key, out _) != PropertyDescriptorLookup.None;
         }
 
+        public static bool HasOwnIntrinsicMemberOverride(
+            object target,
+            string key)
+        {
+            ArgumentNullException.ThrowIfNull(target);
+            ArgumentNullException.ThrowIfNull(key);
+
+            return target is JsObject jsObject
+                && jsObject.HasOwnPropertyValue(key);
+        }
+
         internal static bool TrySetOwnValue(object target, string key, object? value)
         {
             if (target is JsObject jsObject)

--- a/src/JavaScriptRuntime/ObjectRuntime.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.cs
@@ -894,6 +894,23 @@ namespace JavaScriptRuntime
             }
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(
+            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static object GetStringElementWithFallback(
+            object receiver,
+            double index)
+        {
+            if (receiver is string value
+                && TryGetCanonicalInt32Index(index, out var intIndex)
+                && (uint)intIndex < (uint)value.Length)
+            {
+                return JavaScriptRuntime.String.CharToStringFast(
+                    value[intIndex]);
+            }
+
+            return GetItem(receiver, index);
+        }
+
         /// <summary>
         /// Fast-path overload for string key reads.
         /// Avoids boxing at the call site when the compiler has proven the key is a string.

--- a/src/JavaScriptRuntime/RuntimeIntrinsics.cs
+++ b/src/JavaScriptRuntime/RuntimeIntrinsics.cs
@@ -139,7 +139,7 @@ internal enum RuntimeIntrinsicSlot
 internal sealed class RuntimeIntrinsics
 {
     private const int MaxWaitChainLength = 64;
-    private const int PrototypeFamilyCount = 1;
+    private const int PrototypeFamilyCount = 3;
 
     private static readonly TimeSpan WaitSlice = TimeSpan.FromMilliseconds(20);
 
@@ -209,21 +209,57 @@ internal sealed class RuntimeIntrinsics
 
     private void NotifyOwnedPrototypeMutation(object target)
     {
+        var objectPrototype = Volatile.Read(
+            ref _published[
+                (int)RuntimeIntrinsicSlot.ObjectPrototype]);
         if (ReferenceEquals(
                 target,
                 Volatile.Read(
                     ref _published[
                         (int)RuntimeIntrinsicSlot.StringPrototype]))
-            || ReferenceEquals(
-                target,
-                Volatile.Read(
-                    ref _published[
-                        (int)RuntimeIntrinsicSlot.ObjectPrototype])))
+            || ReferenceEquals(target, objectPrototype))
         {
             Interlocked.Increment(
                 ref _prototypeMutationEpochs[
                     (int)IntrinsicPrototypeFamily.String]);
         }
+
+        if (ReferenceEquals(
+                target,
+                Volatile.Read(
+                    ref _published[
+                        (int)RuntimeIntrinsicSlot.ArrayPrototype]))
+            || ReferenceEquals(target, objectPrototype))
+        {
+            Interlocked.Increment(
+                ref _prototypeMutationEpochs[
+                    (int)IntrinsicPrototypeFamily.Array]);
+        }
+
+        if (ReferenceEquals(target, objectPrototype)
+            || IsTypedArrayPrototype(target))
+        {
+            Interlocked.Increment(
+                ref _prototypeMutationEpochs[
+                    (int)IntrinsicPrototypeFamily.TypedArray]);
+        }
+    }
+
+    private bool IsTypedArrayPrototype(object target)
+    {
+        for (var slot = RuntimeIntrinsicSlot.TypedArrayPrototype;
+             slot <= RuntimeIntrinsicSlot.Uint8ClampedArrayPrototype;
+             slot++)
+        {
+            if (ReferenceEquals(
+                    target,
+                    Volatile.Read(ref _published[(int)slot])))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -1768,7 +1768,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 204 (0xcc)
+			// Code size: 223 (0xdf)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Error,
@@ -1795,77 +1795,84 @@
 			IL_001b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_0020: stloc.2
 			IL_0021: ldloc.2
-			IL_0022: brtrue IL_0080
+			IL_0022: brtrue IL_0093
 
 			IL_0027: ldarg.1
 			IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 			IL_002d: stloc.s 4
 			IL_002f: ldc.i4.0
 			IL_0030: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0035: brfalse IL_0054
+			IL_0035: brfalse IL_0067
 
 			IL_003a: ldloc.s 4
 			IL_003c: isinst [System.Runtime]System.String
 			IL_0041: dup
-			IL_0042: brfalse IL_0053
+			IL_0042: brtrue IL_005a
 
-			IL_0047: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_004c: stloc.s 4
-			IL_004e: br IL_0062
+			IL_0047: pop
+			IL_0048: ldloc.s 4
+			IL_004a: ldstr "trim"
+			IL_004f: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0054: dup
+			IL_0055: brfalse IL_0066
 
-			IL_0053: pop
+			IL_005a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_005f: stloc.s 4
+			IL_0061: br IL_0075
 
-			IL_0054: ldloc.s 4
-			IL_0056: ldstr "trim"
-			IL_005b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0060: stloc.s 4
+			IL_0066: pop
 
-			IL_0062: ldloc.s 4
-			IL_0064: ldstr ""
-			IL_0069: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_006e: stloc.2
-			IL_006f: ldloc.2
-			IL_0070: box [System.Runtime]System.Boolean
-			IL_0075: stloc.s 5
-			IL_0077: ldloc.s 5
-			IL_0079: stloc.s 7
-			IL_007b: br IL_0083
+			IL_0067: ldloc.s 4
+			IL_0069: ldstr "trim"
+			IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0073: stloc.s 4
 
-			IL_0080: ldloc.3
-			IL_0081: stloc.s 7
+			IL_0075: ldloc.s 4
+			IL_0077: ldstr ""
+			IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0081: stloc.2
+			IL_0082: ldloc.2
+			IL_0083: box [System.Runtime]System.Boolean
+			IL_0088: stloc.s 5
+			IL_008a: ldloc.s 5
+			IL_008c: stloc.s 7
+			IL_008e: br IL_0096
 
-			IL_0083: ldloc.s 7
-			IL_0085: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_008a: stloc.2
-			IL_008b: ldloc.2
-			IL_008c: brfalse IL_00ca
+			IL_0093: ldloc.3
+			IL_0094: stloc.s 7
 
-			IL_0091: ldarg.2
-			IL_0092: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0097: stloc.1
-			IL_0098: ldstr "Invalid pin file: expected non-empty string for '"
-			IL_009d: ldloc.1
-			IL_009e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00a3: ldstr "'."
-			IL_00a8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00ad: stloc.1
-			IL_00ae: ldloc.1
-			IL_00af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00b4: stloc.0
-			IL_00b5: ldloc.0
-			IL_00b6: isinst [System.Runtime]System.Exception
-			IL_00bb: dup
-			IL_00bc: brtrue IL_00c9
+			IL_0096: ldloc.s 7
+			IL_0098: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_009d: stloc.2
+			IL_009e: ldloc.2
+			IL_009f: brfalse IL_00dd
 
-			IL_00c1: pop
-			IL_00c2: ldloc.0
-			IL_00c3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_00c8: throw
+			IL_00a4: ldarg.2
+			IL_00a5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00aa: stloc.1
+			IL_00ab: ldstr "Invalid pin file: expected non-empty string for '"
+			IL_00b0: ldloc.1
+			IL_00b1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00b6: ldstr "'."
+			IL_00bb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00c0: stloc.1
+			IL_00c1: ldloc.1
+			IL_00c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_00c7: stloc.0
+			IL_00c8: ldloc.0
+			IL_00c9: isinst [System.Runtime]System.Exception
+			IL_00ce: dup
+			IL_00cf: brtrue IL_00dc
 
-			IL_00c9: throw
+			IL_00d4: pop
+			IL_00d5: ldloc.0
+			IL_00d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_00db: throw
 
-			IL_00ca: ldnull
-			IL_00cb: ret
+			IL_00dc: throw
+
+			IL_00dd: ldnull
+			IL_00de: ret
 		} // end of method ensureString::__js_call__
 
 	} // end of class ensureString
@@ -2091,7 +2098,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 497 (0x1f1)
+			// Code size: 516 (0x204)
 			.maxstack 10
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Error,
@@ -2194,7 +2201,7 @@
 					IL_00c6: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
 					IL_00cb: stloc.s 6
 					IL_00cd: ldloc.s 6
-					IL_00cf: brtrue IL_01d5
+					IL_00cf: brtrue IL_01e8
 
 					IL_00d4: ldloc.s 8
 					IL_00d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
@@ -2217,103 +2224,110 @@
 					IL_0105: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 					IL_010a: stloc.s 6
 					IL_010c: ldloc.s 6
-					IL_010e: brtrue IL_016f
+					IL_010e: brtrue IL_0182
 
 					IL_0113: ldloc.s 4
 					IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 					IL_011a: stloc.s 8
 					IL_011c: ldc.i4.0
 					IL_011d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-					IL_0122: brfalse IL_0141
+					IL_0122: brfalse IL_0154
 
 					IL_0127: ldloc.s 8
 					IL_0129: isinst [System.Runtime]System.String
 					IL_012e: dup
-					IL_012f: brfalse IL_0140
+					IL_012f: brtrue IL_0147
 
-					IL_0134: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-					IL_0139: stloc.s 8
-					IL_013b: br IL_014f
+					IL_0134: pop
+					IL_0135: ldloc.s 8
+					IL_0137: ldstr "trim"
+					IL_013c: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+					IL_0141: dup
+					IL_0142: brfalse IL_0153
 
-					IL_0140: pop
+					IL_0147: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+					IL_014c: stloc.s 8
+					IL_014e: br IL_0162
 
-					IL_0141: ldloc.s 8
-					IL_0143: ldstr "trim"
-					IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-					IL_014d: stloc.s 8
+					IL_0153: pop
 
-					IL_014f: ldloc.s 8
-					IL_0151: ldstr ""
-					IL_0156: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-					IL_015b: stloc.s 6
-					IL_015d: ldloc.s 6
-					IL_015f: box [System.Runtime]System.Boolean
-					IL_0164: stloc.s 9
-					IL_0166: ldloc.s 9
-					IL_0168: stloc.s 13
-					IL_016a: br IL_0173
+					IL_0154: ldloc.s 8
+					IL_0156: ldstr "trim"
+					IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_0160: stloc.s 8
 
-					IL_016f: ldloc.s 7
-					IL_0171: stloc.s 13
+					IL_0162: ldloc.s 8
+					IL_0164: ldstr ""
+					IL_0169: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+					IL_016e: stloc.s 6
+					IL_0170: ldloc.s 6
+					IL_0172: box [System.Runtime]System.Boolean
+					IL_0177: stloc.s 9
+					IL_0179: ldloc.s 9
+					IL_017b: stloc.s 13
+					IL_017d: br IL_0186
 
-					IL_0173: ldloc.s 13
-					IL_0175: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_017a: stloc.s 6
-					IL_017c: ldloc.s 6
-					IL_017e: brfalse IL_01c3
+					IL_0182: ldloc.s 7
+					IL_0184: stloc.s 13
 
-					IL_0183: ldarg.2
-					IL_0184: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-					IL_0189: stloc.s 12
-					IL_018b: ldstr "Invalid pin file: '"
-					IL_0190: ldloc.s 12
-					IL_0192: call string [System.Runtime]System.String::Concat(string, string)
-					IL_0197: ldstr "' entries must be non-empty strings."
-					IL_019c: call string [System.Runtime]System.String::Concat(string, string)
-					IL_01a1: stloc.s 12
+					IL_0186: ldloc.s 13
+					IL_0188: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_018d: stloc.s 6
+					IL_018f: ldloc.s 6
+					IL_0191: brfalse IL_01d6
+
+					IL_0196: ldarg.2
+					IL_0197: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_019c: stloc.s 12
+					IL_019e: ldstr "Invalid pin file: '"
 					IL_01a3: ldloc.s 12
-					IL_01a5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_01aa: stloc.s 5
-					IL_01ac: ldloc.s 5
-					IL_01ae: isinst [System.Runtime]System.Exception
-					IL_01b3: dup
-					IL_01b4: brtrue IL_01c2
+					IL_01a5: call string [System.Runtime]System.String::Concat(string, string)
+					IL_01aa: ldstr "' entries must be non-empty strings."
+					IL_01af: call string [System.Runtime]System.String::Concat(string, string)
+					IL_01b4: stloc.s 12
+					IL_01b6: ldloc.s 12
+					IL_01b8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_01bd: stloc.s 5
+					IL_01bf: ldloc.s 5
+					IL_01c1: isinst [System.Runtime]System.Exception
+					IL_01c6: dup
+					IL_01c7: brtrue IL_01d5
 
-					IL_01b9: pop
-					IL_01ba: ldloc.s 5
-					IL_01bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-					IL_01c1: throw
+					IL_01cc: pop
+					IL_01cd: ldloc.s 5
+					IL_01cf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+					IL_01d4: throw
 
-					IL_01c2: throw
+					IL_01d5: throw
 
-					IL_01c3: br IL_00ba
+					IL_01d6: br IL_00ba
 				// end loop
-				IL_01c8: ldloc.1
-				IL_01c9: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_01ce: ldc.i4.1
-				IL_01cf: stloc.3
-				IL_01d0: leave IL_01ef
+				IL_01db: ldloc.1
+				IL_01dc: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_01e1: ldc.i4.1
+				IL_01e2: stloc.3
+				IL_01e3: leave IL_0202
 
-				IL_01d5: ldc.i4.1
-				IL_01d6: stloc.2
-				IL_01d7: leave IL_01ef
+				IL_01e8: ldc.i4.1
+				IL_01e9: stloc.2
+				IL_01ea: leave IL_0202
 			} // end .try
 			finally
 			{
-				IL_01dc: ldloc.2
-				IL_01dd: brtrue IL_01ee
+				IL_01ef: ldloc.2
+				IL_01f0: brtrue IL_0201
 
-				IL_01e2: ldloc.3
-				IL_01e3: brtrue IL_01ee
+				IL_01f5: ldloc.3
+				IL_01f6: brtrue IL_0201
 
-				IL_01e8: ldloc.1
-				IL_01e9: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_01fb: ldloc.1
+				IL_01fc: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_01ee: endfinally
+				IL_0201: endfinally
 			} // end handler
 
-			IL_01ef: ldnull
-			IL_01f0: ret
+			IL_0202: ldnull
+			IL_0203: ret
 		} // end of method ensureStringArray::__js_call__
 
 	} // end of class ensureStringArray
@@ -2524,7 +2538,7 @@
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 258 (0x102)
+			// Code size: 277 (0x115)
 			.maxstack 10
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.IJavaScriptIterator,
@@ -2572,7 +2586,7 @@
 					IL_003b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultDone(object)
 					IL_0040: stloc.s 7
 					IL_0042: ldloc.s 7
-					IL_0044: brtrue IL_00e6
+					IL_0044: brtrue IL_00f9
 
 					IL_0049: ldloc.s 5
 					IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorResultValue(object)
@@ -2586,76 +2600,83 @@
 					IL_005d: stloc.s 5
 					IL_005f: ldc.i4.0
 					IL_0060: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-					IL_0065: brfalse IL_008e
+					IL_0065: brfalse IL_00a1
 
 					IL_006a: ldloc.s 5
 					IL_006c: isinst [System.Runtime]System.String
 					IL_0071: dup
-					IL_0072: brfalse IL_008d
+					IL_0072: brtrue IL_008a
 
-					IL_0077: ldstr "frontmatter:"
-					IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-					IL_0081: box [System.Runtime]System.Boolean
-					IL_0086: stloc.s 5
-					IL_0088: br IL_00a1
+					IL_0077: pop
+					IL_0078: ldloc.s 5
+					IL_007a: ldstr "startsWith"
+					IL_007f: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+					IL_0084: dup
+					IL_0085: brfalse IL_00a0
 
-					IL_008d: pop
+					IL_008a: ldstr "frontmatter:"
+					IL_008f: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+					IL_0094: box [System.Runtime]System.Boolean
+					IL_0099: stloc.s 5
+					IL_009b: br IL_00b4
 
-					IL_008e: ldloc.s 5
-					IL_0090: ldstr "startsWith"
-					IL_0095: ldstr "frontmatter:"
-					IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_009f: stloc.s 5
+					IL_00a0: pop
 
 					IL_00a1: ldloc.s 5
-					IL_00a3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-					IL_00a8: stloc.s 7
-					IL_00aa: ldloc.s 7
-					IL_00ac: brfalse IL_00d4
+					IL_00a3: ldstr "startsWith"
+					IL_00a8: ldstr "frontmatter:"
+					IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_00b2: stloc.s 5
 
-					IL_00b1: ldstr "Invalid pin file: 'excludedFromMvp' now accepts only path-based exclusions; frontmatter rules belong in metadata-driven unsupported classification."
-					IL_00b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-					IL_00bb: stloc.s 4
-					IL_00bd: ldloc.s 4
-					IL_00bf: isinst [System.Runtime]System.Exception
-					IL_00c4: dup
-					IL_00c5: brtrue IL_00d3
+					IL_00b4: ldloc.s 5
+					IL_00b6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+					IL_00bb: stloc.s 7
+					IL_00bd: ldloc.s 7
+					IL_00bf: brfalse IL_00e7
 
-					IL_00ca: pop
-					IL_00cb: ldloc.s 4
-					IL_00cd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-					IL_00d2: throw
+					IL_00c4: ldstr "Invalid pin file: 'excludedFromMvp' now accepts only path-based exclusions; frontmatter rules belong in metadata-driven unsupported classification."
+					IL_00c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+					IL_00ce: stloc.s 4
+					IL_00d0: ldloc.s 4
+					IL_00d2: isinst [System.Runtime]System.Exception
+					IL_00d7: dup
+					IL_00d8: brtrue IL_00e6
 
-					IL_00d3: throw
+					IL_00dd: pop
+					IL_00de: ldloc.s 4
+					IL_00e0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+					IL_00e5: throw
 
-					IL_00d4: br IL_002f
+					IL_00e6: throw
+
+					IL_00e7: br IL_002f
 				// end loop
-				IL_00d9: ldloc.0
-				IL_00da: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
-				IL_00df: ldc.i4.1
-				IL_00e0: stloc.2
-				IL_00e1: leave IL_0100
+				IL_00ec: ldloc.0
+				IL_00ed: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorClose(object)
+				IL_00f2: ldc.i4.1
+				IL_00f3: stloc.2
+				IL_00f4: leave IL_0113
 
-				IL_00e6: ldc.i4.1
-				IL_00e7: stloc.1
-				IL_00e8: leave IL_0100
+				IL_00f9: ldc.i4.1
+				IL_00fa: stloc.1
+				IL_00fb: leave IL_0113
 			} // end .try
 			finally
 			{
-				IL_00ed: ldloc.1
-				IL_00ee: brtrue IL_00ff
+				IL_0100: ldloc.1
+				IL_0101: brtrue IL_0112
 
-				IL_00f3: ldloc.2
-				IL_00f4: brtrue IL_00ff
+				IL_0106: ldloc.2
+				IL_0107: brtrue IL_0112
 
-				IL_00f9: ldloc.0
-				IL_00fa: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
+				IL_010c: ldloc.0
+				IL_010d: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::IteratorCloseForThrowCompletion(object)
 
-				IL_00ff: endfinally
+				IL_0112: endfinally
 			} // end handler
 
-			IL_0100: ldnull
-			IL_0101: ret
+			IL_0113: ldnull
+			IL_0114: ret
 		} // end of method validateExcludedFromMvp::__js_call__
 
 	} // end of class validateExcludedFromMvp
@@ -8915,7 +8936,7 @@
 				74 61 54 6f 6b 65 6e 1b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 492 (0x1ec)
+			// Code size: 511 (0x1ff)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -8953,190 +8974,197 @@
 			IL_0031: stloc.s 7
 			IL_0033: ldc.i4.0
 			IL_0034: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0039: brfalse IL_0066
+			IL_0039: brfalse IL_0079
 
 			IL_003e: ldloc.s 7
 			IL_0040: isinst [System.Runtime]System.String
 			IL_0045: dup
-			IL_0046: brfalse IL_0065
+			IL_0046: brtrue IL_005e
 
-			IL_004b: ldc.r8 2
-			IL_0054: box [System.Runtime]System.Double
-			IL_0059: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
-			IL_005e: stloc.s 7
-			IL_0060: br IL_0082
+			IL_004b: pop
+			IL_004c: ldloc.s 7
+			IL_004e: ldstr "slice"
+			IL_0053: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0058: dup
+			IL_0059: brfalse IL_0078
 
-			IL_0065: pop
+			IL_005e: ldc.r8 2
+			IL_0067: box [System.Runtime]System.Double
+			IL_006c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
+			IL_0071: stloc.s 7
+			IL_0073: br IL_0095
 
-			IL_0066: ldloc.s 7
-			IL_0068: ldstr "slice"
-			IL_006d: ldc.r8 2
-			IL_0076: box [System.Runtime]System.Double
-			IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0080: stloc.s 7
+			IL_0078: pop
 
-			IL_0082: ldloc.s 5
-			IL_0084: ldloc.s 6
-			IL_0086: ldloc.s 7
-			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_008d: stloc.0
-			IL_008e: ldloc.0
-			IL_008f: ldstr "help"
-			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0099: stloc.s 7
-			IL_009b: ldloc.s 7
-			IL_009d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00a2: stloc.s 8
-			IL_00a4: ldloc.s 8
-			IL_00a6: brfalse IL_00c7
+			IL_0079: ldloc.s 7
+			IL_007b: ldstr "slice"
+			IL_0080: ldc.r8 2
+			IL_0089: box [System.Runtime]System.Double
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0093: stloc.s 7
 
-			IL_00ab: ldarg.0
-			IL_00ac: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printHelp
-			IL_00b1: stloc.s 7
-			IL_00b3: ldloc.s 7
-			IL_00b5: ldc.i4.1
-			IL_00b6: newarr [System.Runtime]System.Object
-			IL_00bb: dup
-			IL_00bc: ldc.i4.0
-			IL_00bd: ldarg.0
-			IL_00be: stelem.ref
-			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_00c4: pop
-			IL_00c5: ldnull
-			IL_00c6: ret
+			IL_0095: ldloc.s 5
+			IL_0097: ldloc.s 6
+			IL_0099: ldloc.s 7
+			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00a0: stloc.0
+			IL_00a1: ldloc.0
+			IL_00a2: ldstr "help"
+			IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00ac: stloc.s 7
+			IL_00ae: ldloc.s 7
+			IL_00b0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00b5: stloc.s 8
+			IL_00b7: ldloc.s 8
+			IL_00b9: brfalse IL_00da
 
-			IL_00c7: ldarg.0
-			IL_00c8: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolvePathFromCwd
-			IL_00cd: stloc.s 7
-			IL_00cf: ldc.i4.1
-			IL_00d0: newarr [System.Runtime]System.Object
-			IL_00d5: dup
-			IL_00d6: ldc.i4.0
-			IL_00d7: ldarg.0
-			IL_00d8: stelem.ref
-			IL_00d9: stloc.s 6
-			IL_00db: ldloc.0
-			IL_00dc: ldstr "pin"
-			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00e6: stloc.s 5
-			IL_00e8: ldloc.s 5
-			IL_00ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00ef: stloc.s 8
-			IL_00f1: ldloc.s 8
-			IL_00f3: brtrue IL_0118
+			IL_00be: ldarg.0
+			IL_00bf: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printHelp
+			IL_00c4: stloc.s 7
+			IL_00c6: ldloc.s 7
+			IL_00c8: ldc.i4.1
+			IL_00c9: newarr [System.Runtime]System.Object
+			IL_00ce: dup
+			IL_00cf: ldc.i4.0
+			IL_00d0: ldarg.0
+			IL_00d1: stelem.ref
+			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_00d7: pop
+			IL_00d8: ldnull
+			IL_00d9: ret
 
-			IL_00f8: ldarg.0
-			IL_00f9: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::defaultPinPath
-			IL_00fe: ldc.i4.1
-			IL_00ff: newarr [System.Runtime]System.Object
-			IL_0104: dup
-			IL_0105: ldc.i4.0
-			IL_0106: ldarg.0
-			IL_0107: stelem.ref
-			IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_010d: stloc.s 9
-			IL_010f: ldloc.s 9
-			IL_0111: stloc.s 11
-			IL_0113: br IL_011c
+			IL_00da: ldarg.0
+			IL_00db: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolvePathFromCwd
+			IL_00e0: stloc.s 7
+			IL_00e2: ldc.i4.1
+			IL_00e3: newarr [System.Runtime]System.Object
+			IL_00e8: dup
+			IL_00e9: ldc.i4.0
+			IL_00ea: ldarg.0
+			IL_00eb: stelem.ref
+			IL_00ec: stloc.s 6
+			IL_00ee: ldloc.0
+			IL_00ef: ldstr "pin"
+			IL_00f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f9: stloc.s 5
+			IL_00fb: ldloc.s 5
+			IL_00fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0102: stloc.s 8
+			IL_0104: ldloc.s 8
+			IL_0106: brtrue IL_012b
 
-			IL_0118: ldloc.s 5
-			IL_011a: stloc.s 11
+			IL_010b: ldarg.0
+			IL_010c: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::defaultPinPath
+			IL_0111: ldc.i4.1
+			IL_0112: newarr [System.Runtime]System.Object
+			IL_0117: dup
+			IL_0118: ldc.i4.0
+			IL_0119: ldarg.0
+			IL_011a: stelem.ref
+			IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0120: stloc.s 9
+			IL_0122: ldloc.s 9
+			IL_0124: stloc.s 11
+			IL_0126: br IL_012f
 
-			IL_011c: ldloc.s 7
-			IL_011e: ldloc.s 6
-			IL_0120: ldloc.s 11
-			IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0127: stloc.1
-			IL_0128: ldarg.0
-			IL_0129: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::loadPin
-			IL_012e: ldc.i4.1
-			IL_012f: newarr [System.Runtime]System.Object
-			IL_0134: dup
-			IL_0135: ldc.i4.0
-			IL_0136: ldarg.0
-			IL_0137: stelem.ref
-			IL_0138: ldloc.1
-			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_013e: stloc.2
-			IL_013f: ldarg.0
-			IL_0140: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
-			IL_0145: ldc.i4.1
-			IL_0146: newarr [System.Runtime]System.Object
-			IL_014b: dup
-			IL_014c: ldc.i4.0
-			IL_014d: ldarg.0
-			IL_014e: stelem.ref
-			IL_014f: ldloc.0
-			IL_0150: ldloc.2
-			IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0156: stloc.3
-			IL_0157: ldloc.0
-			IL_0158: ldstr "describe"
-			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0162: stloc.s 7
-			IL_0164: ldloc.s 7
-			IL_0166: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_016b: stloc.s 8
-			IL_016d: ldloc.s 8
-			IL_016f: brfalse IL_01a0
+			IL_012b: ldloc.s 5
+			IL_012d: stloc.s 11
 
-			IL_0174: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0179: stloc.s 12
-			IL_017b: ldarg.0
-			IL_017c: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::describePlan
-			IL_0181: ldc.i4.1
-			IL_0182: newarr [System.Runtime]System.Object
-			IL_0187: dup
-			IL_0188: ldc.i4.0
-			IL_0189: ldarg.0
-			IL_018a: stelem.ref
-			IL_018b: ldloc.2
-			IL_018c: ldloc.3
-			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0192: stloc.s 7
-			IL_0194: ldloc.s 12
-			IL_0196: ldloc.s 7
-			IL_0198: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_019d: pop
-			IL_019e: ldnull
-			IL_019f: ret
+			IL_012f: ldloc.s 7
+			IL_0131: ldloc.s 6
+			IL_0133: ldloc.s 11
+			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_013a: stloc.1
+			IL_013b: ldarg.0
+			IL_013c: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::loadPin
+			IL_0141: ldc.i4.1
+			IL_0142: newarr [System.Runtime]System.Object
+			IL_0147: dup
+			IL_0148: ldc.i4.0
+			IL_0149: ldarg.0
+			IL_014a: stelem.ref
+			IL_014b: ldloc.1
+			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0151: stloc.2
+			IL_0152: ldarg.0
+			IL_0153: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveOverrideRoot
+			IL_0158: ldc.i4.1
+			IL_0159: newarr [System.Runtime]System.Object
+			IL_015e: dup
+			IL_015f: ldc.i4.0
+			IL_0160: ldarg.0
+			IL_0161: stelem.ref
+			IL_0162: ldloc.0
+			IL_0163: ldloc.2
+			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0169: stloc.3
+			IL_016a: ldloc.0
+			IL_016b: ldstr "describe"
+			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0175: stloc.s 7
+			IL_0177: ldloc.s 7
+			IL_0179: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_017e: stloc.s 8
+			IL_0180: ldloc.s 8
+			IL_0182: brfalse IL_01b3
 
-			IL_01a0: ldarg.0
-			IL_01a1: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveBootstrapRoot
-			IL_01a6: ldc.i4.1
-			IL_01a7: newarr [System.Runtime]System.Object
-			IL_01ac: dup
-			IL_01ad: ldc.i4.0
-			IL_01ae: ldarg.0
-			IL_01af: stelem.ref
-			IL_01b0: ldloc.1
-			IL_01b1: ldloc.2
-			IL_01b2: ldloc.0
-			IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_01b8: stloc.s 4
-			IL_01ba: ldarg.0
-			IL_01bb: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printResolvedRoot
-			IL_01c0: stloc.s 7
-			IL_01c2: ldc.i4.1
-			IL_01c3: newarr [System.Runtime]System.Object
-			IL_01c8: dup
-			IL_01c9: ldc.i4.0
-			IL_01ca: ldarg.0
-			IL_01cb: stelem.ref
-			IL_01cc: stloc.s 6
-			IL_01ce: ldloc.0
-			IL_01cf: ldstr "printRoot"
-			IL_01d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01d9: stloc.s 5
-			IL_01db: ldloc.s 7
-			IL_01dd: ldloc.s 6
-			IL_01df: ldloc.s 4
-			IL_01e1: ldloc.2
-			IL_01e2: ldloc.s 5
-			IL_01e4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_01e9: pop
-			IL_01ea: ldnull
-			IL_01eb: ret
+			IL_0187: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_018c: stloc.s 12
+			IL_018e: ldarg.0
+			IL_018f: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::describePlan
+			IL_0194: ldc.i4.1
+			IL_0195: newarr [System.Runtime]System.Object
+			IL_019a: dup
+			IL_019b: ldc.i4.0
+			IL_019c: ldarg.0
+			IL_019d: stelem.ref
+			IL_019e: ldloc.2
+			IL_019f: ldloc.3
+			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01a5: stloc.s 7
+			IL_01a7: ldloc.s 12
+			IL_01a9: ldloc.s 7
+			IL_01ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01b0: pop
+			IL_01b1: ldnull
+			IL_01b2: ret
+
+			IL_01b3: ldarg.0
+			IL_01b4: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::resolveBootstrapRoot
+			IL_01b9: ldc.i4.1
+			IL_01ba: newarr [System.Runtime]System.Object
+			IL_01bf: dup
+			IL_01c0: ldc.i4.0
+			IL_01c1: ldarg.0
+			IL_01c2: stelem.ref
+			IL_01c3: ldloc.1
+			IL_01c4: ldloc.2
+			IL_01c5: ldloc.0
+			IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_01cb: stloc.s 4
+			IL_01cd: ldarg.0
+			IL_01ce: ldfld object Modules.Compile_Scripts_Test262Bootstrap/Scope::printResolvedRoot
+			IL_01d3: stloc.s 7
+			IL_01d5: ldc.i4.1
+			IL_01d6: newarr [System.Runtime]System.Object
+			IL_01db: dup
+			IL_01dc: ldc.i4.0
+			IL_01dd: ldarg.0
+			IL_01de: stelem.ref
+			IL_01df: stloc.s 6
+			IL_01e1: ldloc.0
+			IL_01e2: ldstr "printRoot"
+			IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ec: stloc.s 5
+			IL_01ee: ldloc.s 7
+			IL_01f0: ldloc.s 6
+			IL_01f2: ldloc.s 4
+			IL_01f4: ldloc.2
+			IL_01f5: ldloc.s 5
+			IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_01fc: pop
+			IL_01fd: ldnull
+			IL_01fe: ret
 		} // end of method main::__js_call__
 
 	} // end of class main

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -3763,7 +3763,7 @@
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 406 (0x196)
+			// Code size: 424 (0x1a8)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3791,7 +3791,7 @@
 			IL_001b: clt
 			IL_001d: ldc.i4.0
 			IL_001e: ceq
-			IL_0020: brfalse IL_0194
+			IL_0020: brfalse IL_01a6
 
 			IL_0025: ldarg.2
 			IL_0026: ldc.r8 0.0
@@ -3878,7 +3878,7 @@
 			IL_0107: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_010c: stloc.s 4
 			IL_010e: ldloc.s 4
-			IL_0110: brfalse IL_0194
+			IL_0110: brfalse IL_01a6
 
 			IL_0115: ldarg.2
 			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
@@ -3897,35 +3897,42 @@
 			IL_0141: stloc.s 12
 			IL_0143: ldc.i4.0
 			IL_0144: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0149: brfalse IL_0176
+			IL_0149: brfalse IL_0188
 
 			IL_014e: ldloc.2
 			IL_014f: isinst [System.Runtime]System.String
 			IL_0154: dup
-			IL_0155: brfalse IL_0175
+			IL_0155: brtrue IL_016c
 
-			IL_015a: ldc.r8 1
-			IL_0163: box [System.Runtime]System.Double
-			IL_0168: ldloc.s 12
-			IL_016a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_016f: stloc.2
-			IL_0170: br IL_0192
+			IL_015a: pop
+			IL_015b: ldloc.2
+			IL_015c: ldstr "substring"
+			IL_0161: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0166: dup
+			IL_0167: brfalse IL_0187
 
-			IL_0175: pop
+			IL_016c: ldc.r8 1
+			IL_0175: box [System.Runtime]System.Double
+			IL_017a: ldloc.s 12
+			IL_017c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_0181: stloc.2
+			IL_0182: br IL_01a4
 
-			IL_0176: ldloc.2
-			IL_0177: ldstr "substring"
-			IL_017c: ldc.r8 1
-			IL_0185: box [System.Runtime]System.Double
-			IL_018a: ldloc.s 12
-			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0191: stloc.2
+			IL_0187: pop
 
-			IL_0192: ldloc.2
-			IL_0193: ret
+			IL_0188: ldloc.2
+			IL_0189: ldstr "substring"
+			IL_018e: ldc.r8 1
+			IL_0197: box [System.Runtime]System.Double
+			IL_019c: ldloc.s 12
+			IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01a3: stloc.2
 
-			IL_0194: ldarg.2
-			IL_0195: ret
+			IL_01a4: ldloc.2
+			IL_01a5: ret
+
+			IL_01a6: ldarg.2
+			IL_01a7: ret
 		} // end of method unquote::__js_call__
 
 	} // end of class unquote
@@ -4157,7 +4164,7 @@
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 430 (0x1ae)
+			// Code size: 487 (0x1e7)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -4191,148 +4198,169 @@
 			IL_002f: stloc.s 8
 			IL_0031: ldc.i4.0
 			IL_0032: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0037: brfalse IL_0066
+			IL_0037: brfalse IL_0079
 
 			IL_003c: ldloc.s 5
 			IL_003e: isinst [System.Runtime]System.String
 			IL_0043: dup
-			IL_0044: brfalse IL_0065
+			IL_0044: brtrue IL_005c
 
-			IL_0049: ldc.r8 1
-			IL_0052: box [System.Runtime]System.Double
-			IL_0057: ldloc.s 8
-			IL_0059: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_005e: stloc.s 5
-			IL_0060: br IL_0084
+			IL_0049: pop
+			IL_004a: ldloc.s 5
+			IL_004c: ldstr "substring"
+			IL_0051: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0056: dup
+			IL_0057: brfalse IL_0078
 
-			IL_0065: pop
+			IL_005c: ldc.r8 1
+			IL_0065: box [System.Runtime]System.Double
+			IL_006a: ldloc.s 8
+			IL_006c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_0071: stloc.s 5
+			IL_0073: br IL_0097
 
-			IL_0066: ldloc.s 5
-			IL_0068: ldstr "substring"
-			IL_006d: ldc.r8 1
-			IL_0076: box [System.Runtime]System.Double
-			IL_007b: ldloc.s 8
-			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0082: stloc.s 5
+			IL_0078: pop
 
-			IL_0084: ldloc.s 5
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_008b: stloc.s 5
-			IL_008d: ldc.i4.0
-			IL_008e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0093: brfalse IL_00b1
+			IL_0079: ldloc.s 5
+			IL_007b: ldstr "substring"
+			IL_0080: ldc.r8 1
+			IL_0089: box [System.Runtime]System.Double
+			IL_008e: ldloc.s 8
+			IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0095: stloc.s 5
 
-			IL_0098: ldloc.s 5
-			IL_009a: isinst [System.Runtime]System.String
-			IL_009f: dup
-			IL_00a0: brfalse IL_00b0
+			IL_0097: ldloc.s 5
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_009e: stloc.s 5
+			IL_00a0: ldc.i4.0
+			IL_00a1: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00a6: brfalse IL_00d7
 
-			IL_00a5: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_00aa: stloc.0
-			IL_00ab: br IL_00be
+			IL_00ab: ldloc.s 5
+			IL_00ad: isinst [System.Runtime]System.String
+			IL_00b2: dup
+			IL_00b3: brtrue IL_00cb
 
-			IL_00b0: pop
+			IL_00b8: pop
+			IL_00b9: ldloc.s 5
+			IL_00bb: ldstr "trim"
+			IL_00c0: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_00c5: dup
+			IL_00c6: brfalse IL_00d6
 
-			IL_00b1: ldloc.s 5
-			IL_00b3: ldstr "trim"
-			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_00bd: stloc.0
+			IL_00cb: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_00d0: stloc.0
+			IL_00d1: br IL_00e4
 
-			IL_00be: ldloc.0
-			IL_00bf: ldstr ""
-			IL_00c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00c9: stloc.s 9
-			IL_00cb: ldloc.s 9
-			IL_00cd: brfalse IL_00dd
+			IL_00d6: pop
 
-			IL_00d2: ldc.i4.0
-			IL_00d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00d8: stloc.s 10
-			IL_00da: ldloc.s 10
-			IL_00dc: ret
+			IL_00d7: ldloc.s 5
+			IL_00d9: ldstr "trim"
+			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_00e3: stloc.0
 
-			IL_00dd: ldloc.0
-			IL_00de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00e3: ldstr "split"
-			IL_00e8: ldstr ","
-			IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00f2: stloc.1
-			IL_00f3: ldc.i4.0
-			IL_00f4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_00f9: stloc.2
-			IL_00fa: ldc.r8 0.0
-			IL_0103: stloc.3
-			// loop start (head: IL_0104)
-				IL_0104: ldloc.3
-				IL_0105: stloc.s 7
-				IL_0107: ldloc.1
-				IL_0108: ldstr "length"
-				IL_010d: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0112: stloc.s 11
-				IL_0114: ldloc.s 7
-				IL_0116: ldloc.s 11
-				IL_0118: clt
-				IL_011a: brfalse IL_01ac
+			IL_00e4: ldloc.0
+			IL_00e5: ldstr ""
+			IL_00ea: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00ef: stloc.s 9
+			IL_00f1: ldloc.s 9
+			IL_00f3: brfalse IL_0103
 
-				IL_011f: ldloc.1
-				IL_0120: ldloc.3
-				IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0126: stloc.s 5
-				IL_0128: ldloc.s 5
-				IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_012f: stloc.s 5
-				IL_0131: ldc.i4.0
-				IL_0132: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0137: brfalse IL_0156
+			IL_00f8: ldc.i4.0
+			IL_00f9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_00fe: stloc.s 10
+			IL_0100: ldloc.s 10
+			IL_0102: ret
 
-				IL_013c: ldloc.s 5
-				IL_013e: isinst [System.Runtime]System.String
-				IL_0143: dup
-				IL_0144: brfalse IL_0155
+			IL_0103: ldloc.0
+			IL_0104: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0109: ldstr "split"
+			IL_010e: ldstr ","
+			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0118: stloc.1
+			IL_0119: ldc.i4.0
+			IL_011a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_011f: stloc.2
+			IL_0120: ldc.r8 0.0
+			IL_0129: stloc.3
+			// loop start (head: IL_012a)
+				IL_012a: ldloc.3
+				IL_012b: stloc.s 7
+				IL_012d: ldloc.1
+				IL_012e: ldstr "length"
+				IL_0133: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_0138: stloc.s 11
+				IL_013a: ldloc.s 7
+				IL_013c: ldloc.s 11
+				IL_013e: clt
+				IL_0140: brfalse IL_01e5
 
-				IL_0149: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-				IL_014e: stloc.s 4
-				IL_0150: br IL_0164
+				IL_0145: ldloc.1
+				IL_0146: ldloc.3
+				IL_0147: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_014c: stloc.s 5
+				IL_014e: ldloc.s 5
+				IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0155: stloc.s 5
+				IL_0157: ldc.i4.0
+				IL_0158: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_015d: brfalse IL_018f
 
-				IL_0155: pop
+				IL_0162: ldloc.s 5
+				IL_0164: isinst [System.Runtime]System.String
+				IL_0169: dup
+				IL_016a: brtrue IL_0182
 
-				IL_0156: ldloc.s 5
-				IL_0158: ldstr "trim"
-				IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_0162: stloc.s 4
+				IL_016f: pop
+				IL_0170: ldloc.s 5
+				IL_0172: ldstr "trim"
+				IL_0177: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_017c: dup
+				IL_017d: brfalse IL_018e
 
-				IL_0164: ldloc.s 4
-				IL_0166: ldstr ""
-				IL_016b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-				IL_0170: stloc.s 9
-				IL_0172: ldloc.s 9
-				IL_0174: brfalse IL_019b
+				IL_0182: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_0187: stloc.s 4
+				IL_0189: br IL_019d
 
-				IL_0179: ldarg.0
-				IL_017a: ldfld object Modules.test262_metadataParser/Scope::unquote
-				IL_017f: ldc.i4.1
-				IL_0180: newarr [System.Runtime]System.Object
-				IL_0185: dup
-				IL_0186: ldc.i4.0
-				IL_0187: ldarg.0
-				IL_0188: stelem.ref
-				IL_0189: ldloc.s 4
-				IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0190: stloc.s 5
-				IL_0192: ldloc.2
-				IL_0193: ldloc.s 5
-				IL_0195: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_019a: pop
+				IL_018e: pop
 
-				IL_019b: ldloc.3
-				IL_019c: ldc.r8 1
-				IL_01a5: add
-				IL_01a6: stloc.3
-				IL_01a7: br IL_0104
+				IL_018f: ldloc.s 5
+				IL_0191: ldstr "trim"
+				IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_019b: stloc.s 4
+
+				IL_019d: ldloc.s 4
+				IL_019f: ldstr ""
+				IL_01a4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+				IL_01a9: stloc.s 9
+				IL_01ab: ldloc.s 9
+				IL_01ad: brfalse IL_01d4
+
+				IL_01b2: ldarg.0
+				IL_01b3: ldfld object Modules.test262_metadataParser/Scope::unquote
+				IL_01b8: ldc.i4.1
+				IL_01b9: newarr [System.Runtime]System.Object
+				IL_01be: dup
+				IL_01bf: ldc.i4.0
+				IL_01c0: ldarg.0
+				IL_01c1: stelem.ref
+				IL_01c2: ldloc.s 4
+				IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_01c9: stloc.s 5
+				IL_01cb: ldloc.2
+				IL_01cc: ldloc.s 5
+				IL_01ce: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_01d3: pop
+
+				IL_01d4: ldloc.3
+				IL_01d5: ldc.r8 1
+				IL_01de: add
+				IL_01df: stloc.3
+				IL_01e0: br IL_012a
 			// end loop
 
-			IL_01ac: ldloc.2
-			IL_01ad: ret
+			IL_01e5: ldloc.2
+			IL_01e6: ret
 		} // end of method parseInlineList::__js_call__
 
 	} // end of class parseInlineList
@@ -4503,7 +4531,7 @@
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 294 (0x126)
+			// Code size: 348 (0x15c)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -4520,131 +4548,152 @@
 			IL_0006: stloc.1
 			IL_0007: ldc.i4.0
 			IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_000d: brfalse IL_002a
+			IL_000d: brfalse IL_003c
 
 			IL_0012: ldloc.1
 			IL_0013: isinst [System.Runtime]System.String
 			IL_0018: dup
-			IL_0019: brfalse IL_0029
+			IL_0019: brtrue IL_0030
 
-			IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0023: stloc.0
-			IL_0024: br IL_0036
+			IL_001e: pop
+			IL_001f: ldloc.1
+			IL_0020: ldstr "trim"
+			IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_002a: dup
+			IL_002b: brfalse IL_003b
 
-			IL_0029: pop
-
-			IL_002a: ldloc.1
-			IL_002b: ldstr "trim"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0030: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
 			IL_0035: stloc.0
+			IL_0036: br IL_0048
 
-			IL_0036: ldloc.0
-			IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_003c: stloc.1
-			IL_003d: ldc.i4.0
-			IL_003e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0043: brfalse IL_006a
+			IL_003b: pop
 
-			IL_0048: ldloc.1
-			IL_0049: isinst [System.Runtime]System.String
-			IL_004e: dup
-			IL_004f: brfalse IL_0069
+			IL_003c: ldloc.1
+			IL_003d: ldstr "trim"
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0047: stloc.0
 
-			IL_0054: ldstr "["
-			IL_0059: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-			IL_005e: box [System.Runtime]System.Boolean
-			IL_0063: stloc.1
-			IL_0064: br IL_007b
+			IL_0048: ldloc.0
+			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_004e: stloc.1
+			IL_004f: ldc.i4.0
+			IL_0050: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0055: brfalse IL_008e
 
-			IL_0069: pop
+			IL_005a: ldloc.1
+			IL_005b: isinst [System.Runtime]System.String
+			IL_0060: dup
+			IL_0061: brtrue IL_0078
 
-			IL_006a: ldloc.1
-			IL_006b: ldstr "startsWith"
-			IL_0070: ldstr "["
-			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_007a: stloc.1
+			IL_0066: pop
+			IL_0067: ldloc.1
+			IL_0068: ldstr "startsWith"
+			IL_006d: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0072: dup
+			IL_0073: brfalse IL_008d
 
-			IL_007b: ldloc.1
-			IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0081: stloc.2
-			IL_0082: ldloc.2
-			IL_0083: brfalse IL_00d5
+			IL_0078: ldstr "["
+			IL_007d: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+			IL_0082: box [System.Runtime]System.Boolean
+			IL_0087: stloc.1
+			IL_0088: br IL_009f
 
-			IL_0088: ldloc.0
-			IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_008e: stloc.3
-			IL_008f: ldc.i4.0
-			IL_0090: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0095: brfalse IL_00bc
+			IL_008d: pop
 
-			IL_009a: ldloc.3
-			IL_009b: isinst [System.Runtime]System.String
-			IL_00a0: dup
-			IL_00a1: brfalse IL_00bb
+			IL_008e: ldloc.1
+			IL_008f: ldstr "startsWith"
+			IL_0094: ldstr "["
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_009e: stloc.1
 
-			IL_00a6: ldstr "]"
-			IL_00ab: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
-			IL_00b0: box [System.Runtime]System.Boolean
-			IL_00b5: stloc.3
-			IL_00b6: br IL_00cd
+			IL_009f: ldloc.1
+			IL_00a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_00a5: stloc.2
+			IL_00a6: ldloc.2
+			IL_00a7: brfalse IL_010b
 
-			IL_00bb: pop
+			IL_00ac: ldloc.0
+			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b2: stloc.3
+			IL_00b3: ldc.i4.0
+			IL_00b4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00b9: brfalse IL_00f2
 
-			IL_00bc: ldloc.3
-			IL_00bd: ldstr "endsWith"
-			IL_00c2: ldstr "]"
-			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00cc: stloc.3
+			IL_00be: ldloc.3
+			IL_00bf: isinst [System.Runtime]System.String
+			IL_00c4: dup
+			IL_00c5: brtrue IL_00dc
 
-			IL_00cd: ldloc.3
-			IL_00ce: stloc.s 5
-			IL_00d0: br IL_00d8
+			IL_00ca: pop
+			IL_00cb: ldloc.3
+			IL_00cc: ldstr "endsWith"
+			IL_00d1: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_00d6: dup
+			IL_00d7: brfalse IL_00f1
 
-			IL_00d5: ldloc.1
-			IL_00d6: stloc.s 5
+			IL_00dc: ldstr "]"
+			IL_00e1: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
+			IL_00e6: box [System.Runtime]System.Boolean
+			IL_00eb: stloc.3
+			IL_00ec: br IL_0103
 
-			IL_00d8: ldloc.s 5
-			IL_00da: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_00df: stloc.2
-			IL_00e0: ldloc.2
-			IL_00e1: brfalse IL_0105
+			IL_00f1: pop
 
-			IL_00e6: ldc.i4.1
-			IL_00e7: newarr [System.Runtime]System.Object
-			IL_00ec: dup
-			IL_00ed: ldc.i4.0
-			IL_00ee: ldarg.0
-			IL_00ef: stelem.ref
-			IL_00f0: stloc.s 6
-			IL_00f2: ldloc.s 6
-			IL_00f4: ldc.i4.0
-			IL_00f5: ldelem.ref
-			IL_00f6: castclass Modules.test262_metadataParser/Scope
-			IL_00fb: ldnull
-			IL_00fc: ldloc.0
-			IL_00fd: tail.
-			IL_00ff: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/parseInlineList::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-			IL_0104: ret
+			IL_00f2: ldloc.3
+			IL_00f3: ldstr "endsWith"
+			IL_00f8: ldstr "]"
+			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0102: stloc.3
 
-			IL_0105: ldc.i4.1
-			IL_0106: newarr [System.Runtime]System.Object
-			IL_010b: dup
-			IL_010c: ldc.i4.0
-			IL_010d: ldarg.0
-			IL_010e: stelem.ref
-			IL_010f: stloc.s 6
-			IL_0111: ldloc.s 6
-			IL_0113: ldc.i4.0
-			IL_0114: ldelem.ref
-			IL_0115: castclass Modules.test262_metadataParser/Scope
-			IL_011a: ldnull
-			IL_011b: ldloc.0
-			IL_011c: tail.
-			IL_011e: call object Modules.test262_metadataParser/unquote::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-			IL_0123: ret
+			IL_0103: ldloc.3
+			IL_0104: stloc.s 5
+			IL_0106: br IL_010e
 
-			IL_0124: ldnull
-			IL_0125: ret
+			IL_010b: ldloc.1
+			IL_010c: stloc.s 5
+
+			IL_010e: ldloc.s 5
+			IL_0110: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0115: stloc.2
+			IL_0116: ldloc.2
+			IL_0117: brfalse IL_013b
+
+			IL_011c: ldc.i4.1
+			IL_011d: newarr [System.Runtime]System.Object
+			IL_0122: dup
+			IL_0123: ldc.i4.0
+			IL_0124: ldarg.0
+			IL_0125: stelem.ref
+			IL_0126: stloc.s 6
+			IL_0128: ldloc.s 6
+			IL_012a: ldc.i4.0
+			IL_012b: ldelem.ref
+			IL_012c: castclass Modules.test262_metadataParser/Scope
+			IL_0131: ldnull
+			IL_0132: ldloc.0
+			IL_0133: tail.
+			IL_0135: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/parseInlineList::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+			IL_013a: ret
+
+			IL_013b: ldc.i4.1
+			IL_013c: newarr [System.Runtime]System.Object
+			IL_0141: dup
+			IL_0142: ldc.i4.0
+			IL_0143: ldarg.0
+			IL_0144: stelem.ref
+			IL_0145: stloc.s 6
+			IL_0147: ldloc.s 6
+			IL_0149: ldc.i4.0
+			IL_014a: ldelem.ref
+			IL_014b: castclass Modules.test262_metadataParser/Scope
+			IL_0150: ldnull
+			IL_0151: ldloc.0
+			IL_0152: tail.
+			IL_0154: call object Modules.test262_metadataParser/unquote::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+			IL_0159: ret
+
+			IL_015a: ldnull
+			IL_015b: ret
 		} // end of method parseInlineValue::__js_call__
 
 	} // end of class parseInlineValue
@@ -5290,7 +5339,7 @@
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 521 (0x209)
+			// Code size: 559 (0x22f)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -5329,7 +5378,7 @@
 				IL_003c: ldloc.s 6
 				IL_003e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0043: clt
-				IL_0045: brfalse IL_01b7
+				IL_0045: brfalse IL_01dd
 
 				IL_004a: ldarg.3
 				IL_004b: ldstr "index"
@@ -5344,170 +5393,184 @@
 				IL_0066: stloc.s 6
 				IL_0068: ldc.i4.0
 				IL_0069: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_006e: brfalse IL_008d
+				IL_006e: brfalse IL_00a0
 
 				IL_0073: ldloc.s 6
 				IL_0075: isinst [System.Runtime]System.String
 				IL_007a: dup
-				IL_007b: brfalse IL_008c
+				IL_007b: brtrue IL_0093
 
-				IL_0080: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-				IL_0085: stloc.s 6
-				IL_0087: br IL_009b
+				IL_0080: pop
+				IL_0081: ldloc.s 6
+				IL_0083: ldstr "trim"
+				IL_0088: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_008d: dup
+				IL_008e: brfalse IL_009f
 
-				IL_008c: pop
+				IL_0093: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_0098: stloc.s 6
+				IL_009a: br IL_00ae
 
-				IL_008d: ldloc.s 6
-				IL_008f: ldstr "trim"
-				IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_0099: stloc.s 6
+				IL_009f: pop
 
-				IL_009b: ldloc.s 6
-				IL_009d: ldstr ""
-				IL_00a2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_00a7: stloc.s 7
-				IL_00a9: ldloc.s 7
-				IL_00ab: brfalse IL_00eb
+				IL_00a0: ldloc.s 6
+				IL_00a2: ldstr "trim"
+				IL_00a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_00ac: stloc.s 6
 
-				IL_00b0: ldloc.0
-				IL_00b1: ldstr ""
-				IL_00b6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_00bb: pop
-				IL_00bc: ldarg.3
-				IL_00bd: ldstr "index"
-				IL_00c2: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_00c7: stloc.s 4
-				IL_00c9: ldloc.s 4
-				IL_00cb: ldc.r8 1
-				IL_00d4: add
-				IL_00d5: stloc.s 4
-				IL_00d7: ldarg.3
-				IL_00d8: ldstr "index"
-				IL_00dd: ldloc.s 4
-				IL_00df: ldc.i4.1
-				IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_00e5: pop
-				IL_00e6: br IL_001b
+				IL_00ae: ldloc.s 6
+				IL_00b0: ldstr ""
+				IL_00b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00ba: stloc.s 7
+				IL_00bc: ldloc.s 7
+				IL_00be: brfalse IL_00fe
 
-				IL_00eb: ldarg.0
-				IL_00ec: ldfld object Modules.test262_metadataParser/Scope::countIndent
-				IL_00f1: ldc.i4.1
-				IL_00f2: newarr [System.Runtime]System.Object
-				IL_00f7: dup
-				IL_00f8: ldc.i4.0
-				IL_00f9: ldarg.0
-				IL_00fa: stelem.ref
-				IL_00fb: ldloc.2
-				IL_00fc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0101: stloc.s 6
-				IL_0103: ldloc.s 6
-				IL_0105: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_010a: stloc.3
-				IL_010b: ldloc.3
-				IL_010c: ldarg.s parentIndent
-				IL_010e: cgt
-				IL_0110: ldc.i4.0
-				IL_0111: ceq
-				IL_0113: brfalse IL_011d
+				IL_00c3: ldloc.0
+				IL_00c4: ldstr ""
+				IL_00c9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_00ce: pop
+				IL_00cf: ldarg.3
+				IL_00d0: ldstr "index"
+				IL_00d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_00da: stloc.s 4
+				IL_00dc: ldloc.s 4
+				IL_00de: ldc.r8 1
+				IL_00e7: add
+				IL_00e8: stloc.s 4
+				IL_00ea: ldarg.3
+				IL_00eb: ldstr "index"
+				IL_00f0: ldloc.s 4
+				IL_00f2: ldc.i4.1
+				IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_00f8: pop
+				IL_00f9: br IL_001b
 
-				IL_0118: br IL_01b7
+				IL_00fe: ldarg.0
+				IL_00ff: ldfld object Modules.test262_metadataParser/Scope::countIndent
+				IL_0104: ldc.i4.1
+				IL_0105: newarr [System.Runtime]System.Object
+				IL_010a: dup
+				IL_010b: ldc.i4.0
+				IL_010c: ldarg.0
+				IL_010d: stelem.ref
+				IL_010e: ldloc.2
+				IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0114: stloc.s 6
+				IL_0116: ldloc.s 6
+				IL_0118: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_011d: stloc.3
+				IL_011e: ldloc.3
+				IL_011f: ldarg.s parentIndent
+				IL_0121: cgt
+				IL_0123: ldc.i4.0
+				IL_0124: ceq
+				IL_0126: brfalse IL_0130
 
-				IL_011d: ldloc.1
-				IL_011e: stloc.s 8
-				IL_0120: ldloc.s 8
-				IL_0122: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0127: ldc.r8 0.0
-				IL_0130: clt
-				IL_0132: brfalse IL_0142
+				IL_012b: br IL_01dd
 
-				IL_0137: ldloc.3
-				IL_0138: box [System.Runtime]System.Double
-				IL_013d: stloc.s 8
-				IL_013f: ldloc.s 8
-				IL_0141: stloc.1
+				IL_0130: ldloc.1
+				IL_0131: stloc.s 8
+				IL_0133: ldloc.s 8
+				IL_0135: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_013a: ldc.r8 0.0
+				IL_0143: clt
+				IL_0145: brfalse IL_0155
 
-				IL_0142: ldloc.2
-				IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0148: stloc.s 6
-				IL_014a: ldc.i4.0
-				IL_014b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0150: brfalse IL_0170
+				IL_014a: ldloc.3
+				IL_014b: box [System.Runtime]System.Double
+				IL_0150: stloc.s 8
+				IL_0152: ldloc.s 8
+				IL_0154: stloc.1
 
-				IL_0155: ldloc.s 6
-				IL_0157: isinst [System.Runtime]System.String
-				IL_015c: dup
-				IL_015d: brfalse IL_016f
+				IL_0155: ldloc.2
+				IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_015b: stloc.s 6
+				IL_015d: ldc.i4.0
+				IL_015e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0163: brfalse IL_0196
 
-				IL_0162: ldloc.1
-				IL_0163: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-				IL_0168: stloc.s 6
-				IL_016a: br IL_017f
+				IL_0168: ldloc.s 6
+				IL_016a: isinst [System.Runtime]System.String
+				IL_016f: dup
+				IL_0170: brtrue IL_0188
 
-				IL_016f: pop
+				IL_0175: pop
+				IL_0176: ldloc.s 6
+				IL_0178: ldstr "substring"
+				IL_017d: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0182: dup
+				IL_0183: brfalse IL_0195
 
-				IL_0170: ldloc.s 6
-				IL_0172: ldstr "substring"
-				IL_0177: ldloc.1
-				IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_017d: stloc.s 6
+				IL_0188: ldloc.1
+				IL_0189: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+				IL_018e: stloc.s 6
+				IL_0190: br IL_01a5
 
-				IL_017f: ldloc.0
-				IL_0180: ldloc.s 6
-				IL_0182: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_0187: pop
-				IL_0188: ldarg.3
-				IL_0189: ldstr "index"
-				IL_018e: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_0193: stloc.s 4
-				IL_0195: ldloc.s 4
-				IL_0197: ldc.r8 1
-				IL_01a0: add
-				IL_01a1: stloc.s 4
-				IL_01a3: ldarg.3
-				IL_01a4: ldstr "index"
-				IL_01a9: ldloc.s 4
-				IL_01ab: ldc.i4.1
-				IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_01b1: pop
-				IL_01b2: br IL_001b
+				IL_0195: pop
+
+				IL_0196: ldloc.s 6
+				IL_0198: ldstr "substring"
+				IL_019d: ldloc.1
+				IL_019e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01a3: stloc.s 6
+
+				IL_01a5: ldloc.0
+				IL_01a6: ldloc.s 6
+				IL_01a8: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_01ad: pop
+				IL_01ae: ldarg.3
+				IL_01af: ldstr "index"
+				IL_01b4: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_01b9: stloc.s 4
+				IL_01bb: ldloc.s 4
+				IL_01bd: ldc.r8 1
+				IL_01c6: add
+				IL_01c7: stloc.s 4
+				IL_01c9: ldarg.3
+				IL_01ca: ldstr "index"
+				IL_01cf: ldloc.s 4
+				IL_01d1: ldc.i4.1
+				IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_01d7: pop
+				IL_01d8: br IL_001b
 			// end loop
 
-			IL_01b7: ldarg.s style
-			IL_01b9: ldstr ">"
-			IL_01be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01c3: stloc.s 7
-			IL_01c5: ldloc.s 7
-			IL_01c7: brfalse IL_01f0
+			IL_01dd: ldarg.s style
+			IL_01df: ldstr ">"
+			IL_01e4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01e9: stloc.s 7
+			IL_01eb: ldloc.s 7
+			IL_01ed: brfalse IL_0216
 
-			IL_01cc: ldc.i4.1
-			IL_01cd: newarr [System.Runtime]System.Object
-			IL_01d2: dup
-			IL_01d3: ldc.i4.0
-			IL_01d4: ldarg.0
-			IL_01d5: stelem.ref
-			IL_01d6: stloc.s 9
-			IL_01d8: ldloc.s 9
-			IL_01da: ldc.i4.0
-			IL_01db: ldelem.ref
-			IL_01dc: castclass Modules.test262_metadataParser/Scope
-			IL_01e1: ldnull
-			IL_01e2: ldloc.0
-			IL_01e3: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_01e8: tail.
-			IL_01ea: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-			IL_01ef: ret
+			IL_01f2: ldc.i4.1
+			IL_01f3: newarr [System.Runtime]System.Object
+			IL_01f8: dup
+			IL_01f9: ldc.i4.0
+			IL_01fa: ldarg.0
+			IL_01fb: stelem.ref
+			IL_01fc: stloc.s 9
+			IL_01fe: ldloc.s 9
+			IL_0200: ldc.i4.0
+			IL_0201: ldelem.ref
+			IL_0202: castclass Modules.test262_metadataParser/Scope
+			IL_0207: ldnull
+			IL_0208: ldloc.0
+			IL_0209: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_020e: tail.
+			IL_0210: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+			IL_0215: ret
 
-			IL_01f0: ldloc.0
-			IL_01f1: ldc.i4.1
-			IL_01f2: newarr [System.Runtime]System.Object
-			IL_01f7: dup
-			IL_01f8: ldc.i4.0
-			IL_01f9: ldstr "\n"
-			IL_01fe: stelem.ref
-			IL_01ff: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
-			IL_0204: stloc.s 10
-			IL_0206: ldloc.s 10
-			IL_0208: ret
+			IL_0216: ldloc.0
+			IL_0217: ldc.i4.1
+			IL_0218: newarr [System.Runtime]System.Object
+			IL_021d: dup
+			IL_021e: ldc.i4.0
+			IL_021f: ldstr "\n"
+			IL_0224: stelem.ref
+			IL_0225: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_022a: stloc.s 10
+			IL_022c: ldloc.s 10
+			IL_022e: ret
 		} // end of method parseBlockScalar::__js_call__
 
 	} // end of class parseBlockScalar
@@ -5732,7 +5795,7 @@
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 405 (0x195)
+			// Code size: 423 (0x1a7)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -5773,7 +5836,7 @@
 				IL_0035: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 				IL_003a: stloc.s 4
 				IL_003c: ldloc.s 4
-				IL_003e: brfalse IL_00a0
+				IL_003e: brfalse IL_00b2
 
 				IL_0043: ldarg.2
 				IL_0044: ldloc.0
@@ -5784,147 +5847,154 @@
 				IL_0051: stloc.3
 				IL_0052: ldc.i4.0
 				IL_0053: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0058: brfalse IL_0075
+				IL_0058: brfalse IL_0087
 
 				IL_005d: ldloc.3
 				IL_005e: isinst [System.Runtime]System.String
 				IL_0063: dup
-				IL_0064: brfalse IL_0074
+				IL_0064: brtrue IL_007b
 
-				IL_0069: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-				IL_006e: stloc.3
-				IL_006f: br IL_0081
+				IL_0069: pop
+				IL_006a: ldloc.3
+				IL_006b: ldstr "trim"
+				IL_0070: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0075: dup
+				IL_0076: brfalse IL_0086
 
-				IL_0074: pop
-
-				IL_0075: ldloc.3
-				IL_0076: ldstr "trim"
-				IL_007b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_007b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
 				IL_0080: stloc.3
+				IL_0081: br IL_0093
 
-				IL_0081: ldloc.3
-				IL_0082: ldstr ""
-				IL_0087: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_008c: stloc.s 4
-				IL_008e: ldloc.s 4
-				IL_0090: box [System.Runtime]System.Boolean
-				IL_0095: stloc.s 6
-				IL_0097: ldloc.s 6
-				IL_0099: stloc.s 8
-				IL_009b: br IL_00a4
+				IL_0086: pop
 
-				IL_00a0: ldloc.s 5
-				IL_00a2: stloc.s 8
+				IL_0087: ldloc.3
+				IL_0088: ldstr "trim"
+				IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0092: stloc.3
 
-				IL_00a4: ldloc.s 8
-				IL_00a6: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_00ab: stloc.s 4
-				IL_00ad: ldloc.s 4
-				IL_00af: brfalse IL_00d7
+				IL_0093: ldloc.3
+				IL_0094: ldstr ""
+				IL_0099: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_009e: stloc.s 4
+				IL_00a0: ldloc.s 4
+				IL_00a2: box [System.Runtime]System.Boolean
+				IL_00a7: stloc.s 6
+				IL_00a9: ldloc.s 6
+				IL_00ab: stloc.s 8
+				IL_00ad: br IL_00b6
 
-				IL_00b4: ldloc.0
-				IL_00b5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00ba: ldc.r8 1
-				IL_00c3: add
-				IL_00c4: stloc.s 9
-				IL_00c6: ldloc.s 9
-				IL_00c8: box [System.Runtime]System.Double
-				IL_00cd: stloc.s 10
-				IL_00cf: ldloc.s 10
-				IL_00d1: stloc.0
-				IL_00d2: br IL_000c
+				IL_00b2: ldloc.s 5
+				IL_00b4: stloc.s 8
+
+				IL_00b6: ldloc.s 8
+				IL_00b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_00bd: stloc.s 4
+				IL_00bf: ldloc.s 4
+				IL_00c1: brfalse IL_00e9
+
+				IL_00c6: ldloc.0
+				IL_00c7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00cc: ldc.r8 1
+				IL_00d5: add
+				IL_00d6: stloc.s 9
+				IL_00d8: ldloc.s 9
+				IL_00da: box [System.Runtime]System.Double
+				IL_00df: stloc.s 10
+				IL_00e1: ldloc.s 10
+				IL_00e3: stloc.0
+				IL_00e4: br IL_000c
 			// end loop
 
-			IL_00d7: ldloc.0
-			IL_00d8: stloc.s 10
-			IL_00da: ldarg.2
-			IL_00db: ldstr "length"
-			IL_00e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_00e5: stloc.3
-			IL_00e6: ldloc.s 10
-			IL_00e8: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00ed: ldloc.3
-			IL_00ee: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00f3: clt
-			IL_00f5: ldc.i4.0
-			IL_00f6: ceq
-			IL_00f8: brfalse IL_0111
+			IL_00e9: ldloc.0
+			IL_00ea: stloc.s 10
+			IL_00ec: ldarg.2
+			IL_00ed: ldstr "length"
+			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00f7: stloc.3
+			IL_00f8: ldloc.s 10
+			IL_00fa: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00ff: ldloc.3
+			IL_0100: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0105: clt
+			IL_0107: ldc.i4.0
+			IL_0108: ceq
+			IL_010a: brfalse IL_0123
 
-			IL_00fd: ldarg.3
-			IL_00fe: ldstr "index"
-			IL_0103: ldloc.0
-			IL_0104: ldc.i4.1
-			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_010a: pop
-			IL_010b: ldstr ""
-			IL_0110: ret
+			IL_010f: ldarg.3
+			IL_0110: ldstr "index"
+			IL_0115: ldloc.0
+			IL_0116: ldc.i4.1
+			IL_0117: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_011c: pop
+			IL_011d: ldstr ""
+			IL_0122: ret
 
-			IL_0111: ldarg.0
-			IL_0112: ldfld object Modules.test262_metadataParser/Scope::countIndent
-			IL_0117: ldc.i4.1
-			IL_0118: newarr [System.Runtime]System.Object
-			IL_011d: dup
-			IL_011e: ldc.i4.0
-			IL_011f: ldarg.0
-			IL_0120: stelem.ref
-			IL_0121: stloc.s 11
-			IL_0123: ldarg.2
-			IL_0124: ldloc.0
-			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
-			IL_012a: stloc.3
-			IL_012b: ldloc.s 11
-			IL_012d: ldloc.3
-			IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0133: stloc.3
-			IL_0134: ldloc.3
-			IL_0135: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_013a: stloc.1
-			IL_013b: ldloc.1
-			IL_013c: ldarg.s parentIndent
-			IL_013e: cgt
-			IL_0140: ldc.i4.0
-			IL_0141: ceq
-			IL_0143: brfalse IL_015c
+			IL_0123: ldarg.0
+			IL_0124: ldfld object Modules.test262_metadataParser/Scope::countIndent
+			IL_0129: ldc.i4.1
+			IL_012a: newarr [System.Runtime]System.Object
+			IL_012f: dup
+			IL_0130: ldc.i4.0
+			IL_0131: ldarg.0
+			IL_0132: stelem.ref
+			IL_0133: stloc.s 11
+			IL_0135: ldarg.2
+			IL_0136: ldloc.0
+			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_013c: stloc.3
+			IL_013d: ldloc.s 11
+			IL_013f: ldloc.3
+			IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0145: stloc.3
+			IL_0146: ldloc.3
+			IL_0147: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_014c: stloc.1
+			IL_014d: ldloc.1
+			IL_014e: ldarg.s parentIndent
+			IL_0150: cgt
+			IL_0152: ldc.i4.0
+			IL_0153: ceq
+			IL_0155: brfalse IL_016e
 
-			IL_0148: ldarg.3
-			IL_0149: ldstr "index"
-			IL_014e: ldloc.0
-			IL_014f: ldc.i4.1
-			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0155: pop
-			IL_0156: ldstr ""
-			IL_015b: ret
+			IL_015a: ldarg.3
+			IL_015b: ldstr "index"
+			IL_0160: ldloc.0
+			IL_0161: ldc.i4.1
+			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0167: pop
+			IL_0168: ldstr ""
+			IL_016d: ret
 
-			IL_015c: ldarg.3
-			IL_015d: ldstr "index"
-			IL_0162: ldloc.0
-			IL_0163: ldc.i4.1
-			IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_0169: pop
-			IL_016a: ldloc.1
-			IL_016b: box [System.Runtime]System.Double
-			IL_0170: stloc.s 10
-			IL_0172: ldc.i4.1
-			IL_0173: newarr [System.Runtime]System.Object
-			IL_0178: dup
-			IL_0179: ldc.i4.0
-			IL_017a: ldarg.0
-			IL_017b: stelem.ref
-			IL_017c: stloc.s 11
-			IL_017e: ldloc.s 11
-			IL_0180: ldc.i4.0
-			IL_0181: ldelem.ref
-			IL_0182: castclass Modules.test262_metadataParser/Scope
-			IL_0187: ldnull
-			IL_0188: ldarg.2
-			IL_0189: ldarg.3
-			IL_018a: ldloc.1
-			IL_018b: tail.
-			IL_018d: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
-			IL_0192: ret
+			IL_016e: ldarg.3
+			IL_016f: ldstr "index"
+			IL_0174: ldloc.0
+			IL_0175: ldc.i4.1
+			IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_017b: pop
+			IL_017c: ldloc.1
+			IL_017d: box [System.Runtime]System.Double
+			IL_0182: stloc.s 10
+			IL_0184: ldc.i4.1
+			IL_0185: newarr [System.Runtime]System.Object
+			IL_018a: dup
+			IL_018b: ldc.i4.0
+			IL_018c: ldarg.0
+			IL_018d: stelem.ref
+			IL_018e: stloc.s 11
+			IL_0190: ldloc.s 11
+			IL_0192: ldc.i4.0
+			IL_0193: ldelem.ref
+			IL_0194: castclass Modules.test262_metadataParser/Scope
+			IL_0199: ldnull
+			IL_019a: ldarg.2
+			IL_019b: ldarg.3
+			IL_019c: ldloc.1
+			IL_019d: tail.
+			IL_019f: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
+			IL_01a4: ret
 
-			IL_0193: ldnull
-			IL_0194: ret
+			IL_01a5: ldnull
+			IL_01a6: ret
 		} // end of method parseIndentedValue::__js_call__
 
 	} // end of class parseIndentedValue
@@ -6246,7 +6316,7 @@
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 980 (0x3d4)
+			// Code size: 1037 (0x40d)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -6289,7 +6359,7 @@
 				IL_0027: ldloc.s 11
 				IL_0029: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_002e: clt
-				IL_0030: brfalse IL_03d2
+				IL_0030: brfalse IL_040b
 
 				IL_0035: ldarg.3
 				IL_0036: ldstr "index"
@@ -6304,340 +6374,361 @@
 				IL_0051: stloc.s 11
 				IL_0053: ldc.i4.0
 				IL_0054: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0059: brfalse IL_0078
+				IL_0059: brfalse IL_008b
 
 				IL_005e: ldloc.s 11
 				IL_0060: isinst [System.Runtime]System.String
 				IL_0065: dup
-				IL_0066: brfalse IL_0077
+				IL_0066: brtrue IL_007e
 
-				IL_006b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-				IL_0070: stloc.s 11
-				IL_0072: br IL_0086
+				IL_006b: pop
+				IL_006c: ldloc.s 11
+				IL_006e: ldstr "trim"
+				IL_0073: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0078: dup
+				IL_0079: brfalse IL_008a
 
-				IL_0077: pop
+				IL_007e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_0083: stloc.s 11
+				IL_0085: br IL_0099
 
-				IL_0078: ldloc.s 11
-				IL_007a: ldstr "trim"
-				IL_007f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_0084: stloc.s 11
+				IL_008a: pop
 
-				IL_0086: ldloc.s 11
-				IL_0088: ldstr ""
-				IL_008d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_0092: stloc.s 12
-				IL_0094: ldloc.s 12
-				IL_0096: brfalse IL_00ca
+				IL_008b: ldloc.s 11
+				IL_008d: ldstr "trim"
+				IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0097: stloc.s 11
 
-				IL_009b: ldarg.3
-				IL_009c: ldstr "index"
-				IL_00a1: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_00a6: stloc.s 13
-				IL_00a8: ldloc.s 13
-				IL_00aa: ldc.r8 1
-				IL_00b3: add
-				IL_00b4: stloc.s 13
-				IL_00b6: ldarg.3
-				IL_00b7: ldstr "index"
-				IL_00bc: ldloc.s 13
-				IL_00be: ldc.i4.1
-				IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_00c4: pop
-				IL_00c5: br IL_0006
+				IL_0099: ldloc.s 11
+				IL_009b: ldstr ""
+				IL_00a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_00a5: stloc.s 12
+				IL_00a7: ldloc.s 12
+				IL_00a9: brfalse IL_00dd
 
-				IL_00ca: ldarg.0
-				IL_00cb: ldfld object Modules.test262_metadataParser/Scope::countIndent
-				IL_00d0: ldc.i4.1
-				IL_00d1: newarr [System.Runtime]System.Object
-				IL_00d6: dup
-				IL_00d7: ldc.i4.0
-				IL_00d8: ldarg.0
-				IL_00d9: stelem.ref
-				IL_00da: ldloc.1
-				IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_00e0: stloc.s 11
-				IL_00e2: ldloc.s 11
-				IL_00e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00e9: stloc.2
-				IL_00ea: ldloc.2
-				IL_00eb: ldarg.s baseIndent
-				IL_00ed: clt
-				IL_00ef: brfalse IL_00f9
+				IL_00ae: ldarg.3
+				IL_00af: ldstr "index"
+				IL_00b4: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_00b9: stloc.s 13
+				IL_00bb: ldloc.s 13
+				IL_00bd: ldc.r8 1
+				IL_00c6: add
+				IL_00c7: stloc.s 13
+				IL_00c9: ldarg.3
+				IL_00ca: ldstr "index"
+				IL_00cf: ldloc.s 13
+				IL_00d1: ldc.i4.1
+				IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_00d7: pop
+				IL_00d8: br IL_0006
 
-				IL_00f4: br IL_03d2
+				IL_00dd: ldarg.0
+				IL_00de: ldfld object Modules.test262_metadataParser/Scope::countIndent
+				IL_00e3: ldc.i4.1
+				IL_00e4: newarr [System.Runtime]System.Object
+				IL_00e9: dup
+				IL_00ea: ldc.i4.0
+				IL_00eb: ldarg.0
+				IL_00ec: stelem.ref
+				IL_00ed: ldloc.1
+				IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_00f3: stloc.s 11
+				IL_00f5: ldloc.s 11
+				IL_00f7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00fc: stloc.2
+				IL_00fd: ldloc.2
+				IL_00fe: ldarg.s baseIndent
+				IL_0100: clt
+				IL_0102: brfalse IL_010c
 
-				IL_00f9: ldloc.2
-				IL_00fa: ldarg.s baseIndent
-				IL_00fc: cgt
-				IL_00fe: brfalse IL_0160
+				IL_0107: br IL_040b
 
-				IL_0103: ldarg.3
-				IL_0104: ldstr "index"
-				IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_010e: stloc.s 11
-				IL_0110: ldloc.s 11
-				IL_0112: ldc.r8 1
-				IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_0120: stloc.s 14
-				IL_0122: ldloc.s 14
-				IL_0124: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0129: stloc.s 15
-				IL_012b: ldstr "Unexpected indentation at frontmatter line "
-				IL_0130: ldloc.s 15
-				IL_0132: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0137: ldstr "."
-				IL_013c: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0141: stloc.s 15
+				IL_010c: ldloc.2
+				IL_010d: ldarg.s baseIndent
+				IL_010f: cgt
+				IL_0111: brfalse IL_0173
+
+				IL_0116: ldarg.3
+				IL_0117: ldstr "index"
+				IL_011c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0121: stloc.s 11
+				IL_0123: ldloc.s 11
+				IL_0125: ldc.r8 1
+				IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_0133: stloc.s 14
+				IL_0135: ldloc.s 14
+				IL_0137: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_013c: stloc.s 15
+				IL_013e: ldstr "Unexpected indentation at frontmatter line "
 				IL_0143: ldloc.s 15
-				IL_0145: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_014a: stloc.3
-				IL_014b: ldloc.3
-				IL_014c: isinst [System.Runtime]System.Exception
-				IL_0151: dup
-				IL_0152: brtrue IL_015f
+				IL_0145: call string [System.Runtime]System.String::Concat(string, string)
+				IL_014a: ldstr "."
+				IL_014f: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0154: stloc.s 15
+				IL_0156: ldloc.s 15
+				IL_0158: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_015d: stloc.3
+				IL_015e: ldloc.3
+				IL_015f: isinst [System.Runtime]System.Exception
+				IL_0164: dup
+				IL_0165: brtrue IL_0172
 
-				IL_0157: pop
-				IL_0158: ldloc.3
-				IL_0159: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_015e: throw
+				IL_016a: pop
+				IL_016b: ldloc.3
+				IL_016c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_0171: throw
 
-				IL_015f: throw
+				IL_0172: throw
 
-				IL_0160: ldloc.1
-				IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0166: stloc.s 11
-				IL_0168: ldloc.2
-				IL_0169: box [System.Runtime]System.Double
-				IL_016e: stloc.s 16
-				IL_0170: ldc.i4.0
-				IL_0171: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0176: brfalse IL_0197
+				IL_0173: ldloc.1
+				IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0179: stloc.s 11
+				IL_017b: ldloc.2
+				IL_017c: box [System.Runtime]System.Double
+				IL_0181: stloc.s 16
+				IL_0183: ldc.i4.0
+				IL_0184: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0189: brfalse IL_01bd
 
-				IL_017b: ldloc.s 11
-				IL_017d: isinst [System.Runtime]System.String
-				IL_0182: dup
-				IL_0183: brfalse IL_0196
+				IL_018e: ldloc.s 11
+				IL_0190: isinst [System.Runtime]System.String
+				IL_0195: dup
+				IL_0196: brtrue IL_01ae
 
-				IL_0188: ldloc.s 16
-				IL_018a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-				IL_018f: stloc.s 4
-				IL_0191: br IL_01a7
+				IL_019b: pop
+				IL_019c: ldloc.s 11
+				IL_019e: ldstr "substring"
+				IL_01a3: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_01a8: dup
+				IL_01a9: brfalse IL_01bc
 
-				IL_0196: pop
+				IL_01ae: ldloc.s 16
+				IL_01b0: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+				IL_01b5: stloc.s 4
+				IL_01b7: br IL_01cd
 
-				IL_0197: ldloc.s 11
-				IL_0199: ldstr "substring"
-				IL_019e: ldloc.s 16
-				IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_01a5: stloc.s 4
+				IL_01bc: pop
 
-				IL_01a7: ldstr "^([A-Za-z0-9_-]+):(.*)$"
-				IL_01ac: ldstr ""
-				IL_01b1: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-				IL_01b6: stloc.s 17
-				IL_01b8: ldloc.s 17
-				IL_01ba: ldstr "exec"
-				IL_01bf: ldloc.s 4
-				IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_01c6: stloc.s 5
-				IL_01c8: ldloc.s 5
-				IL_01ca: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_01cf: ldc.i4.0
-				IL_01d0: ceq
-				IL_01d2: stloc.s 12
-				IL_01d4: ldloc.s 12
-				IL_01d6: brfalse IL_024b
+				IL_01bd: ldloc.s 11
+				IL_01bf: ldstr "substring"
+				IL_01c4: ldloc.s 16
+				IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01cb: stloc.s 4
 
-				IL_01db: ldarg.3
-				IL_01dc: ldstr "index"
-				IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_01e6: stloc.s 11
-				IL_01e8: ldloc.s 11
-				IL_01ea: ldc.r8 1
-				IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-				IL_01f8: stloc.s 14
-				IL_01fa: ldloc.s 14
-				IL_01fc: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0201: stloc.s 15
-				IL_0203: ldstr "Invalid frontmatter line "
-				IL_0208: ldloc.s 15
-				IL_020a: call string [System.Runtime]System.String::Concat(string, string)
-				IL_020f: ldstr ": "
-				IL_0214: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0219: ldloc.s 4
-				IL_021b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0220: stloc.s 15
-				IL_0222: ldloc.s 15
-				IL_0224: call string [System.Runtime]System.String::Concat(string, string)
-				IL_0229: stloc.s 15
-				IL_022b: ldloc.s 15
-				IL_022d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-				IL_0232: stloc.s 6
-				IL_0234: ldloc.s 6
-				IL_0236: isinst [System.Runtime]System.Exception
-				IL_023b: dup
-				IL_023c: brtrue IL_024a
+				IL_01cd: ldstr "^([A-Za-z0-9_-]+):(.*)$"
+				IL_01d2: ldstr ""
+				IL_01d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+				IL_01dc: stloc.s 17
+				IL_01de: ldloc.s 17
+				IL_01e0: ldstr "exec"
+				IL_01e5: ldloc.s 4
+				IL_01e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01ec: stloc.s 5
+				IL_01ee: ldloc.s 5
+				IL_01f0: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_01f5: ldc.i4.0
+				IL_01f6: ceq
+				IL_01f8: stloc.s 12
+				IL_01fa: ldloc.s 12
+				IL_01fc: brfalse IL_0271
 
-				IL_0241: pop
-				IL_0242: ldloc.s 6
-				IL_0244: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-				IL_0249: throw
+				IL_0201: ldarg.3
+				IL_0202: ldstr "index"
+				IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_020c: stloc.s 11
+				IL_020e: ldloc.s 11
+				IL_0210: ldc.r8 1
+				IL_0219: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+				IL_021e: stloc.s 14
+				IL_0220: ldloc.s 14
+				IL_0222: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0227: stloc.s 15
+				IL_0229: ldstr "Invalid frontmatter line "
+				IL_022e: ldloc.s 15
+				IL_0230: call string [System.Runtime]System.String::Concat(string, string)
+				IL_0235: ldstr ": "
+				IL_023a: call string [System.Runtime]System.String::Concat(string, string)
+				IL_023f: ldloc.s 4
+				IL_0241: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0246: stloc.s 15
+				IL_0248: ldloc.s 15
+				IL_024a: call string [System.Runtime]System.String::Concat(string, string)
+				IL_024f: stloc.s 15
+				IL_0251: ldloc.s 15
+				IL_0253: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+				IL_0258: stloc.s 6
+				IL_025a: ldloc.s 6
+				IL_025c: isinst [System.Runtime]System.Exception
+				IL_0261: dup
+				IL_0262: brtrue IL_0270
 
-				IL_024a: throw
+				IL_0267: pop
+				IL_0268: ldloc.s 6
+				IL_026a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+				IL_026f: throw
 
-				IL_024b: ldloc.s 5
-				IL_024d: ldc.r8 1
-				IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_025b: stloc.s 7
-				IL_025d: ldloc.s 5
-				IL_025f: ldc.r8 2
-				IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_026d: stloc.s 11
-				IL_026f: ldloc.s 11
-				IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0276: stloc.s 11
-				IL_0278: ldc.i4.0
-				IL_0279: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_027e: brfalse IL_029d
+				IL_0270: throw
 
-				IL_0283: ldloc.s 11
-				IL_0285: isinst [System.Runtime]System.String
-				IL_028a: dup
-				IL_028b: brfalse IL_029c
+				IL_0271: ldloc.s 5
+				IL_0273: ldc.r8 1
+				IL_027c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0281: stloc.s 7
+				IL_0283: ldloc.s 5
+				IL_0285: ldc.r8 2
+				IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0293: stloc.s 11
+				IL_0295: ldloc.s 11
+				IL_0297: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_029c: stloc.s 11
+				IL_029e: ldc.i4.0
+				IL_029f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_02a4: brfalse IL_02d6
 
-				IL_0290: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-				IL_0295: stloc.s 8
-				IL_0297: br IL_02ab
+				IL_02a9: ldloc.s 11
+				IL_02ab: isinst [System.Runtime]System.String
+				IL_02b0: dup
+				IL_02b1: brtrue IL_02c9
 
-				IL_029c: pop
+				IL_02b6: pop
+				IL_02b7: ldloc.s 11
+				IL_02b9: ldstr "trim"
+				IL_02be: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_02c3: dup
+				IL_02c4: brfalse IL_02d5
 
-				IL_029d: ldloc.s 11
-				IL_029f: ldstr "trim"
-				IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_02a9: stloc.s 8
+				IL_02c9: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_02ce: stloc.s 8
+				IL_02d0: br IL_02e4
 
-				IL_02ab: ldarg.3
-				IL_02ac: ldstr "index"
-				IL_02b1: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
-				IL_02b6: stloc.s 13
-				IL_02b8: ldloc.s 13
-				IL_02ba: ldc.r8 1
-				IL_02c3: add
-				IL_02c4: stloc.s 13
-				IL_02c6: ldarg.3
-				IL_02c7: ldstr "index"
-				IL_02cc: ldloc.s 13
-				IL_02ce: ldc.i4.1
-				IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-				IL_02d4: pop
-				IL_02d5: ldnull
-				IL_02d6: stloc.s 9
-				IL_02d8: ldloc.s 8
-				IL_02da: ldstr "|"
-				IL_02df: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_02e4: stloc.s 12
-				IL_02e6: ldloc.s 12
-				IL_02e8: box [System.Runtime]System.Boolean
-				IL_02ed: stloc.s 18
-				IL_02ef: ldloc.s 18
-				IL_02f1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02f6: stloc.s 12
-				IL_02f8: ldloc.s 12
-				IL_02fa: brtrue IL_031f
+				IL_02d5: pop
 
-				IL_02ff: ldloc.s 8
-				IL_0301: ldstr ">"
-				IL_0306: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_030b: stloc.s 12
-				IL_030d: ldloc.s 12
-				IL_030f: box [System.Runtime]System.Boolean
-				IL_0314: stloc.s 19
-				IL_0316: ldloc.s 19
-				IL_0318: stloc.s 20
-				IL_031a: br IL_0323
+				IL_02d6: ldloc.s 11
+				IL_02d8: ldstr "trim"
+				IL_02dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_02e2: stloc.s 8
 
-				IL_031f: ldloc.s 18
-				IL_0321: stloc.s 20
+				IL_02e4: ldarg.3
+				IL_02e5: ldstr "index"
+				IL_02ea: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItemAsNumber(object, object)
+				IL_02ef: stloc.s 13
+				IL_02f1: ldloc.s 13
+				IL_02f3: ldc.r8 1
+				IL_02fc: add
+				IL_02fd: stloc.s 13
+				IL_02ff: ldarg.3
+				IL_0300: ldstr "index"
+				IL_0305: ldloc.s 13
+				IL_0307: ldc.i4.1
+				IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+				IL_030d: pop
+				IL_030e: ldnull
+				IL_030f: stloc.s 9
+				IL_0311: ldloc.s 8
+				IL_0313: ldstr "|"
+				IL_0318: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_031d: stloc.s 12
+				IL_031f: ldloc.s 12
+				IL_0321: box [System.Runtime]System.Boolean
+				IL_0326: stloc.s 18
+				IL_0328: ldloc.s 18
+				IL_032a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_032f: stloc.s 12
+				IL_0331: ldloc.s 12
+				IL_0333: brtrue IL_0358
 
-				IL_0323: ldloc.s 20
-				IL_0325: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_032a: stloc.s 12
-				IL_032c: ldloc.s 12
-				IL_032e: brfalse IL_0362
+				IL_0338: ldloc.s 8
+				IL_033a: ldstr ">"
+				IL_033f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_0344: stloc.s 12
+				IL_0346: ldloc.s 12
+				IL_0348: box [System.Runtime]System.Boolean
+				IL_034d: stloc.s 19
+				IL_034f: ldloc.s 19
+				IL_0351: stloc.s 20
+				IL_0353: br IL_035c
 
-				IL_0333: ldarg.0
-				IL_0334: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
-				IL_0339: ldc.i4.1
-				IL_033a: newarr [System.Runtime]System.Object
-				IL_033f: dup
-				IL_0340: ldc.i4.0
-				IL_0341: ldarg.0
-				IL_0342: stelem.ref
-				IL_0343: stloc.s 21
-				IL_0345: ldloc.s 21
-				IL_0347: ldarg.2
-				IL_0348: ldarg.3
-				IL_0349: ldarg.s baseIndent
-				IL_034b: box [System.Runtime]System.Double
-				IL_0350: ldloc.s 8
-				IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
-				IL_0357: stloc.s 11
-				IL_0359: ldloc.s 11
-				IL_035b: stloc.s 9
-				IL_035d: br IL_03c1
+				IL_0358: ldloc.s 18
+				IL_035a: stloc.s 20
 
-				IL_0362: ldloc.s 8
-				IL_0364: ldstr ""
-				IL_0369: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_036e: stloc.s 12
-				IL_0370: ldloc.s 12
-				IL_0372: brfalse IL_03a4
+				IL_035c: ldloc.s 20
+				IL_035e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0363: stloc.s 12
+				IL_0365: ldloc.s 12
+				IL_0367: brfalse IL_039b
 
-				IL_0377: ldarg.0
-				IL_0378: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
-				IL_037d: ldc.i4.1
-				IL_037e: newarr [System.Runtime]System.Object
-				IL_0383: dup
-				IL_0384: ldc.i4.0
-				IL_0385: ldarg.0
-				IL_0386: stelem.ref
-				IL_0387: stloc.s 21
-				IL_0389: ldloc.s 21
-				IL_038b: ldarg.2
-				IL_038c: ldarg.3
-				IL_038d: ldarg.s baseIndent
-				IL_038f: box [System.Runtime]System.Double
-				IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-				IL_0399: stloc.s 11
-				IL_039b: ldloc.s 11
-				IL_039d: stloc.s 9
-				IL_039f: br IL_03c1
+				IL_036c: ldarg.0
+				IL_036d: ldfld object Modules.test262_metadataParser/Scope::parseBlockScalar
+				IL_0372: ldc.i4.1
+				IL_0373: newarr [System.Runtime]System.Object
+				IL_0378: dup
+				IL_0379: ldc.i4.0
+				IL_037a: ldarg.0
+				IL_037b: stelem.ref
+				IL_037c: stloc.s 21
+				IL_037e: ldloc.s 21
+				IL_0380: ldarg.2
+				IL_0381: ldarg.3
+				IL_0382: ldarg.s baseIndent
+				IL_0384: box [System.Runtime]System.Double
+				IL_0389: ldloc.s 8
+				IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs4(object, object[], object, object, object, object)
+				IL_0390: stloc.s 11
+				IL_0392: ldloc.s 11
+				IL_0394: stloc.s 9
+				IL_0396: br IL_03fa
 
-				IL_03a4: ldarg.0
-				IL_03a5: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
-				IL_03aa: ldc.i4.1
-				IL_03ab: newarr [System.Runtime]System.Object
-				IL_03b0: dup
-				IL_03b1: ldc.i4.0
-				IL_03b2: ldarg.0
-				IL_03b3: stelem.ref
-				IL_03b4: ldloc.s 8
-				IL_03b6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_03bb: stloc.s 11
-				IL_03bd: ldloc.s 11
-				IL_03bf: stloc.s 9
+				IL_039b: ldloc.s 8
+				IL_039d: ldstr ""
+				IL_03a2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_03a7: stloc.s 12
+				IL_03a9: ldloc.s 12
+				IL_03ab: brfalse IL_03dd
 
-				IL_03c1: ldloc.0
-				IL_03c2: ldloc.s 7
-				IL_03c4: ldloc.s 9
-				IL_03c6: ldc.i4.1
-				IL_03c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
-				IL_03cc: pop
-				IL_03cd: br IL_0006
+				IL_03b0: ldarg.0
+				IL_03b1: ldfld object Modules.test262_metadataParser/Scope::parseIndentedValue
+				IL_03b6: ldc.i4.1
+				IL_03b7: newarr [System.Runtime]System.Object
+				IL_03bc: dup
+				IL_03bd: ldc.i4.0
+				IL_03be: ldarg.0
+				IL_03bf: stelem.ref
+				IL_03c0: stloc.s 21
+				IL_03c2: ldloc.s 21
+				IL_03c4: ldarg.2
+				IL_03c5: ldarg.3
+				IL_03c6: ldarg.s baseIndent
+				IL_03c8: box [System.Runtime]System.Double
+				IL_03cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+				IL_03d2: stloc.s 11
+				IL_03d4: ldloc.s 11
+				IL_03d6: stloc.s 9
+				IL_03d8: br IL_03fa
+
+				IL_03dd: ldarg.0
+				IL_03de: ldfld object Modules.test262_metadataParser/Scope::parseInlineValue
+				IL_03e3: ldc.i4.1
+				IL_03e4: newarr [System.Runtime]System.Object
+				IL_03e9: dup
+				IL_03ea: ldc.i4.0
+				IL_03eb: ldarg.0
+				IL_03ec: stelem.ref
+				IL_03ed: ldloc.s 8
+				IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_03f4: stloc.s 11
+				IL_03f6: ldloc.s 11
+				IL_03f8: stloc.s 9
+
+				IL_03fa: ldloc.0
+				IL_03fb: ldloc.s 7
+				IL_03fd: ldloc.s 9
+				IL_03ff: ldc.i4.1
+				IL_0400: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, object, object, bool)
+				IL_0405: pop
+				IL_0406: br IL_0006
 			// end loop
 
-			IL_03d2: ldloc.0
-			IL_03d3: ret
+			IL_040b: ldloc.0
+			IL_040c: ret
 		} // end of method parseYamlSubsetLines::__js_call__
 
 	} // end of class parseYamlSubsetLines
@@ -7050,7 +7141,7 @@
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 543 (0x21f)
+			// Code size: 638 (0x27e)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -7082,185 +7173,220 @@
 			IL_0021: stloc.s 6
 			IL_0023: ldc.i4.0
 			IL_0024: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0029: brfalse IL_0051
+			IL_0029: brfalse IL_0064
 
 			IL_002e: ldloc.s 6
 			IL_0030: isinst [System.Runtime]System.String
 			IL_0035: dup
-			IL_0036: brfalse IL_0050
+			IL_0036: brtrue IL_004e
 
-			IL_003b: ldstr "/*---"
-			IL_0040: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_0045: box [System.Runtime]System.Double
-			IL_004a: stloc.1
-			IL_004b: br IL_0063
+			IL_003b: pop
+			IL_003c: ldloc.s 6
+			IL_003e: ldstr "indexOf"
+			IL_0043: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0048: dup
+			IL_0049: brfalse IL_0063
 
-			IL_0050: pop
+			IL_004e: ldstr "/*---"
+			IL_0053: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0058: box [System.Runtime]System.Double
+			IL_005d: stloc.1
+			IL_005e: br IL_0076
 
-			IL_0051: ldloc.s 6
-			IL_0053: ldstr "indexOf"
-			IL_0058: ldstr "/*---"
-			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0062: stloc.1
+			IL_0063: pop
 
-			IL_0063: ldloc.1
-			IL_0064: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0069: ldc.r8 0.0
-			IL_0072: clt
-			IL_0074: brfalse IL_0080
+			IL_0064: ldloc.s 6
+			IL_0066: ldstr "indexOf"
+			IL_006b: ldstr "/*---"
+			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0075: stloc.1
 
-			IL_0079: ldc.i4.0
-			IL_007a: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_007f: ret
+			IL_0076: ldloc.1
+			IL_0077: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_007c: ldc.r8 0.0
+			IL_0085: clt
+			IL_0087: brfalse IL_0093
 
-			IL_0080: ldloc.0
-			IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0086: stloc.s 6
-			IL_0088: ldloc.1
-			IL_0089: ldc.r8 5
-			IL_0092: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0097: stloc.s 7
-			IL_0099: ldc.i4.0
-			IL_009a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_009f: brfalse IL_00c9
+			IL_008c: ldc.i4.0
+			IL_008d: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0092: ret
 
-			IL_00a4: ldloc.s 6
-			IL_00a6: isinst [System.Runtime]System.String
-			IL_00ab: dup
-			IL_00ac: brfalse IL_00c8
+			IL_0093: ldloc.0
+			IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0099: stloc.s 6
+			IL_009b: ldloc.1
+			IL_009c: ldc.r8 5
+			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_00aa: stloc.s 7
+			IL_00ac: ldc.i4.0
+			IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00b2: brfalse IL_00ef
 
-			IL_00b1: ldstr "---*/"
-			IL_00b6: ldloc.s 7
-			IL_00b8: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string, object)
-			IL_00bd: box [System.Runtime]System.Double
-			IL_00c2: stloc.2
-			IL_00c3: br IL_00dd
+			IL_00b7: ldloc.s 6
+			IL_00b9: isinst [System.Runtime]System.String
+			IL_00be: dup
+			IL_00bf: brtrue IL_00d7
 
-			IL_00c8: pop
+			IL_00c4: pop
+			IL_00c5: ldloc.s 6
+			IL_00c7: ldstr "indexOf"
+			IL_00cc: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_00d1: dup
+			IL_00d2: brfalse IL_00ee
 
-			IL_00c9: ldloc.s 6
-			IL_00cb: ldstr "indexOf"
-			IL_00d0: ldstr "---*/"
-			IL_00d5: ldloc.s 7
-			IL_00d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00dc: stloc.2
+			IL_00d7: ldstr "---*/"
+			IL_00dc: ldloc.s 7
+			IL_00de: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string, object)
+			IL_00e3: box [System.Runtime]System.Double
+			IL_00e8: stloc.2
+			IL_00e9: br IL_0103
 
-			IL_00dd: ldloc.2
-			IL_00de: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00e3: ldc.r8 0.0
-			IL_00ec: clt
-			IL_00ee: brfalse IL_0113
+			IL_00ee: pop
 
-			IL_00f3: ldstr "Unterminated test262 frontmatter block."
-			IL_00f8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_00fd: stloc.3
-			IL_00fe: ldloc.3
-			IL_00ff: isinst [System.Runtime]System.Exception
-			IL_0104: dup
-			IL_0105: brtrue IL_0112
+			IL_00ef: ldloc.s 6
+			IL_00f1: ldstr "indexOf"
+			IL_00f6: ldstr "---*/"
+			IL_00fb: ldloc.s 7
+			IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0102: stloc.2
 
-			IL_010a: pop
-			IL_010b: ldloc.3
-			IL_010c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0111: throw
+			IL_0103: ldloc.2
+			IL_0104: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0109: ldc.r8 0.0
+			IL_0112: clt
+			IL_0114: brfalse IL_0139
 
-			IL_0112: throw
+			IL_0119: ldstr "Unterminated test262 frontmatter block."
+			IL_011e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0123: stloc.3
+			IL_0124: ldloc.3
+			IL_0125: isinst [System.Runtime]System.Exception
+			IL_012a: dup
+			IL_012b: brtrue IL_0138
 
-			IL_0113: ldloc.0
-			IL_0114: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0119: stloc.s 6
-			IL_011b: ldloc.1
-			IL_011c: ldc.r8 5
-			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_012a: stloc.s 7
-			IL_012c: ldc.i4.0
-			IL_012d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0132: brfalse IL_0154
+			IL_0130: pop
+			IL_0131: ldloc.3
+			IL_0132: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0137: throw
 
-			IL_0137: ldloc.s 6
-			IL_0139: isinst [System.Runtime]System.String
-			IL_013e: dup
-			IL_013f: brfalse IL_0153
+			IL_0138: throw
 
-			IL_0144: ldloc.s 7
-			IL_0146: ldloc.2
-			IL_0147: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_014c: stloc.s 4
-			IL_014e: br IL_0165
+			IL_0139: ldloc.0
+			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_013f: stloc.s 6
+			IL_0141: ldloc.1
+			IL_0142: ldc.r8 5
+			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0150: stloc.s 7
+			IL_0152: ldc.i4.0
+			IL_0153: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0158: brfalse IL_018d
 
-			IL_0153: pop
+			IL_015d: ldloc.s 6
+			IL_015f: isinst [System.Runtime]System.String
+			IL_0164: dup
+			IL_0165: brtrue IL_017d
 
-			IL_0154: ldloc.s 6
-			IL_0156: ldstr "substring"
-			IL_015b: ldloc.s 7
-			IL_015d: ldloc.2
-			IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0163: stloc.s 4
+			IL_016a: pop
+			IL_016b: ldloc.s 6
+			IL_016d: ldstr "substring"
+			IL_0172: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0177: dup
+			IL_0178: brfalse IL_018c
 
-			IL_0165: ldloc.s 4
-			IL_0167: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_016c: stloc.s 6
-			IL_016e: ldc.i4.0
-			IL_016f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0174: brfalse IL_019d
+			IL_017d: ldloc.s 7
+			IL_017f: ldloc.2
+			IL_0180: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_0185: stloc.s 4
+			IL_0187: br IL_019e
 
-			IL_0179: ldloc.s 6
-			IL_017b: isinst [System.Runtime]System.String
-			IL_0180: dup
-			IL_0181: brfalse IL_019c
+			IL_018c: pop
 
-			IL_0186: ldstr "\n"
-			IL_018b: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-			IL_0190: box [System.Runtime]System.Boolean
-			IL_0195: stloc.s 6
-			IL_0197: br IL_01b0
+			IL_018d: ldloc.s 6
+			IL_018f: ldstr "substring"
+			IL_0194: ldloc.s 7
+			IL_0196: ldloc.2
+			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_019c: stloc.s 4
 
-			IL_019c: pop
+			IL_019e: ldloc.s 4
+			IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01a5: stloc.s 6
+			IL_01a7: ldc.i4.0
+			IL_01a8: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01ad: brfalse IL_01e9
 
-			IL_019d: ldloc.s 6
-			IL_019f: ldstr "startsWith"
-			IL_01a4: ldstr "\n"
-			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01ae: stloc.s 6
+			IL_01b2: ldloc.s 6
+			IL_01b4: isinst [System.Runtime]System.String
+			IL_01b9: dup
+			IL_01ba: brtrue IL_01d2
 
-			IL_01b0: ldloc.s 6
-			IL_01b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_01b7: stloc.s 8
-			IL_01b9: ldloc.s 8
-			IL_01bb: brfalse IL_021c
+			IL_01bf: pop
+			IL_01c0: ldloc.s 6
+			IL_01c2: ldstr "startsWith"
+			IL_01c7: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_01cc: dup
+			IL_01cd: brfalse IL_01e8
 
-			IL_01c0: ldloc.s 4
-			IL_01c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01c7: stloc.s 6
-			IL_01c9: ldc.i4.0
-			IL_01ca: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_01cf: brfalse IL_01fc
+			IL_01d2: ldstr "\n"
+			IL_01d7: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+			IL_01dc: box [System.Runtime]System.Boolean
+			IL_01e1: stloc.s 6
+			IL_01e3: br IL_01fc
 
-			IL_01d4: ldloc.s 6
-			IL_01d6: isinst [System.Runtime]System.String
-			IL_01db: dup
-			IL_01dc: brfalse IL_01fb
+			IL_01e8: pop
 
-			IL_01e1: ldc.r8 1
-			IL_01ea: box [System.Runtime]System.Double
-			IL_01ef: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-			IL_01f4: stloc.s 6
-			IL_01f6: br IL_0218
-
-			IL_01fb: pop
+			IL_01e9: ldloc.s 6
+			IL_01eb: ldstr "startsWith"
+			IL_01f0: ldstr "\n"
+			IL_01f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01fa: stloc.s 6
 
 			IL_01fc: ldloc.s 6
-			IL_01fe: ldstr "substring"
-			IL_0203: ldc.r8 1
-			IL_020c: box [System.Runtime]System.Double
-			IL_0211: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0216: stloc.s 6
+			IL_01fe: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0203: stloc.s 8
+			IL_0205: ldloc.s 8
+			IL_0207: brfalse IL_027b
 
-			IL_0218: ldloc.s 6
-			IL_021a: stloc.s 4
+			IL_020c: ldloc.s 4
+			IL_020e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0213: stloc.s 6
+			IL_0215: ldc.i4.0
+			IL_0216: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_021b: brfalse IL_025b
 
-			IL_021c: ldloc.s 4
-			IL_021e: ret
+			IL_0220: ldloc.s 6
+			IL_0222: isinst [System.Runtime]System.String
+			IL_0227: dup
+			IL_0228: brtrue IL_0240
+
+			IL_022d: pop
+			IL_022e: ldloc.s 6
+			IL_0230: ldstr "substring"
+			IL_0235: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_023a: dup
+			IL_023b: brfalse IL_025a
+
+			IL_0240: ldc.r8 1
+			IL_0249: box [System.Runtime]System.Double
+			IL_024e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_0253: stloc.s 6
+			IL_0255: br IL_0277
+
+			IL_025a: pop
+
+			IL_025b: ldloc.s 6
+			IL_025d: ldstr "substring"
+			IL_0262: ldc.r8 1
+			IL_026b: box [System.Runtime]System.Double
+			IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0275: stloc.s 6
+
+			IL_0277: ldloc.s 6
+			IL_0279: stloc.s 4
+
+			IL_027b: ldloc.s 4
+			IL_027d: ret
 		} // end of method extractTest262Frontmatter::__js_call__
 
 	} // end of class extractTest262Frontmatter
@@ -7588,7 +7714,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 192 (0xc0)
+			// Code size: 228 (0xe4)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -7613,69 +7739,83 @@
 			IL_001c: stloc.2
 			IL_001d: ldc.i4.0
 			IL_001e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0023: brfalse IL_004a
+			IL_0023: brfalse IL_005c
 
 			IL_0028: ldloc.2
 			IL_0029: isinst [System.Runtime]System.String
 			IL_002e: dup
-			IL_002f: brfalse IL_0049
+			IL_002f: brtrue IL_0046
 
-			IL_0034: ldstr "/"
-			IL_0039: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
-			IL_003e: box [System.Runtime]System.Double
-			IL_0043: stloc.0
-			IL_0044: br IL_005b
+			IL_0034: pop
+			IL_0035: ldloc.2
+			IL_0036: ldstr "lastIndexOf"
+			IL_003b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0040: dup
+			IL_0041: brfalse IL_005b
 
-			IL_0049: pop
+			IL_0046: ldstr "/"
+			IL_004b: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+			IL_0050: box [System.Runtime]System.Double
+			IL_0055: stloc.0
+			IL_0056: br IL_006d
 
-			IL_004a: ldloc.2
-			IL_004b: ldstr "lastIndexOf"
-			IL_0050: ldstr "/"
-			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_005a: stloc.0
+			IL_005b: pop
 
-			IL_005b: ldloc.0
-			IL_005c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0061: ldc.r8 0.0
-			IL_006a: clt
-			IL_006c: ldc.i4.0
-			IL_006d: ceq
-			IL_006f: brfalse IL_00be
+			IL_005c: ldloc.2
+			IL_005d: ldstr "lastIndexOf"
+			IL_0062: ldstr "/"
+			IL_0067: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_006c: stloc.0
 
-			IL_0074: ldarg.1
-			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_007a: stloc.2
-			IL_007b: ldloc.0
-			IL_007c: ldc.r8 1
-			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_008a: stloc.3
-			IL_008b: ldc.i4.0
-			IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0091: brfalse IL_00af
+			IL_006d: ldloc.0
+			IL_006e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0073: ldc.r8 0.0
+			IL_007c: clt
+			IL_007e: ldc.i4.0
+			IL_007f: ceq
+			IL_0081: brfalse IL_00e2
 
-			IL_0096: ldloc.2
-			IL_0097: isinst [System.Runtime]System.String
-			IL_009c: dup
-			IL_009d: brfalse IL_00ae
+			IL_0086: ldarg.1
+			IL_0087: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_008c: stloc.2
+			IL_008d: ldloc.0
+			IL_008e: ldc.r8 1
+			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_009c: stloc.3
+			IL_009d: ldc.i4.0
+			IL_009e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00a3: brfalse IL_00d3
 
-			IL_00a2: ldloc.3
-			IL_00a3: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-			IL_00a8: stloc.2
-			IL_00a9: br IL_00bc
+			IL_00a8: ldloc.2
+			IL_00a9: isinst [System.Runtime]System.String
+			IL_00ae: dup
+			IL_00af: brtrue IL_00c6
 
-			IL_00ae: pop
+			IL_00b4: pop
+			IL_00b5: ldloc.2
+			IL_00b6: ldstr "substring"
+			IL_00bb: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_00c0: dup
+			IL_00c1: brfalse IL_00d2
 
-			IL_00af: ldloc.2
-			IL_00b0: ldstr "substring"
-			IL_00b5: ldloc.3
-			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00bb: stloc.2
+			IL_00c6: ldloc.3
+			IL_00c7: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+			IL_00cc: stloc.2
+			IL_00cd: br IL_00e0
 
-			IL_00bc: ldloc.2
-			IL_00bd: ret
+			IL_00d2: pop
 
-			IL_00be: ldarg.1
-			IL_00bf: ret
+			IL_00d3: ldloc.2
+			IL_00d4: ldstr "substring"
+			IL_00d9: ldloc.3
+			IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00df: stloc.2
+
+			IL_00e0: ldloc.2
+			IL_00e1: ret
+
+			IL_00e2: ldarg.1
+			IL_00e3: ret
 		} // end of method getFileName::__js_call__
 
 	} // end of class getFileName
@@ -9924,7 +10064,7 @@
 				74 61 54 6f 6b 65 6e 2a 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1634 (0x662)
+			// Code size: 1653 (0x675)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -10043,545 +10183,552 @@
 			IL_00a8: stloc.s 22
 			IL_00aa: ldc.i4.0
 			IL_00ab: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_00b0: brfalse IL_00d9
+			IL_00b0: brfalse IL_00ec
 
 			IL_00b5: ldloc.s 22
 			IL_00b7: isinst [System.Runtime]System.String
 			IL_00bc: dup
-			IL_00bd: brfalse IL_00d8
+			IL_00bd: brtrue IL_00d5
 
-			IL_00c2: ldstr "_FIXTURE"
-			IL_00c7: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_00cc: box [System.Runtime]System.Double
-			IL_00d1: stloc.s 22
-			IL_00d3: br IL_00ec
+			IL_00c2: pop
+			IL_00c3: ldloc.s 22
+			IL_00c5: ldstr "indexOf"
+			IL_00ca: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_00cf: dup
+			IL_00d0: brfalse IL_00eb
 
-			IL_00d8: pop
+			IL_00d5: ldstr "_FIXTURE"
+			IL_00da: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_00df: box [System.Runtime]System.Double
+			IL_00e4: stloc.s 22
+			IL_00e6: br IL_00ff
 
-			IL_00d9: ldloc.s 22
-			IL_00db: ldstr "indexOf"
-			IL_00e0: ldstr "_FIXTURE"
-			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00ea: stloc.s 22
+			IL_00eb: pop
 
 			IL_00ec: ldloc.s 22
-			IL_00ee: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00f3: ldc.r8 0.0
-			IL_00fc: clt
-			IL_00fe: ldc.i4.0
-			IL_00ff: ceq
-			IL_0101: stloc.s 5
-			IL_0103: ldc.i4.0
-			IL_0104: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0109: stloc.s 6
-			IL_010b: ldc.i4.4
-			IL_010c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0111: dup
-			IL_0112: ldstr "onlyStrict"
-			IL_0117: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_011c: dup
-			IL_011d: ldstr "noStrict"
-			IL_0122: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0127: dup
-			IL_0128: ldstr "module"
-			IL_012d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0132: dup
-			IL_0133: ldstr "raw"
-			IL_0138: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_013d: stloc.s 7
-			IL_013f: ldc.r8 0.0
-			IL_0148: stloc.s 8
-			// loop start (head: IL_014a)
-				IL_014a: ldloc.s 8
-				IL_014c: stloc.s 23
-				IL_014e: ldloc.s 7
-				IL_0150: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-				IL_0155: stloc.s 24
-				IL_0157: ldloc.s 23
-				IL_0159: ldloc.s 24
-				IL_015b: clt
-				IL_015d: brfalse IL_01bd
+			IL_00ee: ldstr "indexOf"
+			IL_00f3: ldstr "_FIXTURE"
+			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00fd: stloc.s 22
 
-				IL_0162: ldloc.s 7
-				IL_0164: ldloc.s 8
-				IL_0166: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_016b: castclass [System.Runtime]System.String
-				IL_0170: stloc.s 9
-				IL_0172: ldarg.0
-				IL_0173: ldfld object Modules.test262_metadataParser/Scope::contains
-				IL_0178: ldc.i4.1
-				IL_0179: newarr [System.Runtime]System.Object
-				IL_017e: dup
-				IL_017f: ldc.i4.0
-				IL_0180: ldarg.0
-				IL_0181: stelem.ref
-				IL_0182: stloc.s 21
-				IL_0184: ldloc.s 21
-				IL_0186: ldarg.2
-				IL_0187: ldloc.s 9
-				IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_018e: stloc.s 22
-				IL_0190: ldloc.s 22
-				IL_0192: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0197: stloc.s 25
-				IL_0199: ldloc.s 25
-				IL_019b: brfalse IL_01aa
+			IL_00ff: ldloc.s 22
+			IL_0101: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0106: ldc.r8 0.0
+			IL_010f: clt
+			IL_0111: ldc.i4.0
+			IL_0112: ceq
+			IL_0114: stloc.s 5
+			IL_0116: ldc.i4.0
+			IL_0117: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_011c: stloc.s 6
+			IL_011e: ldc.i4.4
+			IL_011f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0124: dup
+			IL_0125: ldstr "onlyStrict"
+			IL_012a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_012f: dup
+			IL_0130: ldstr "noStrict"
+			IL_0135: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_013a: dup
+			IL_013b: ldstr "module"
+			IL_0140: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0145: dup
+			IL_0146: ldstr "raw"
+			IL_014b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0150: stloc.s 7
+			IL_0152: ldc.r8 0.0
+			IL_015b: stloc.s 8
+			// loop start (head: IL_015d)
+				IL_015d: ldloc.s 8
+				IL_015f: stloc.s 23
+				IL_0161: ldloc.s 7
+				IL_0163: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+				IL_0168: stloc.s 24
+				IL_016a: ldloc.s 23
+				IL_016c: ldloc.s 24
+				IL_016e: clt
+				IL_0170: brfalse IL_01d0
 
-				IL_01a0: ldloc.s 6
-				IL_01a2: ldloc.s 9
-				IL_01a4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_01a9: pop
+				IL_0175: ldloc.s 7
+				IL_0177: ldloc.s 8
+				IL_0179: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_017e: castclass [System.Runtime]System.String
+				IL_0183: stloc.s 9
+				IL_0185: ldarg.0
+				IL_0186: ldfld object Modules.test262_metadataParser/Scope::contains
+				IL_018b: ldc.i4.1
+				IL_018c: newarr [System.Runtime]System.Object
+				IL_0191: dup
+				IL_0192: ldc.i4.0
+				IL_0193: ldarg.0
+				IL_0194: stelem.ref
+				IL_0195: stloc.s 21
+				IL_0197: ldloc.s 21
+				IL_0199: ldarg.2
+				IL_019a: ldloc.s 9
+				IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_01a1: stloc.s 22
+				IL_01a3: ldloc.s 22
+				IL_01a5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_01aa: stloc.s 25
+				IL_01ac: ldloc.s 25
+				IL_01ae: brfalse IL_01bd
 
-				IL_01aa: ldloc.s 8
-				IL_01ac: ldc.r8 1
-				IL_01b5: add
-				IL_01b6: stloc.s 8
-				IL_01b8: br IL_014a
+				IL_01b3: ldloc.s 6
+				IL_01b5: ldloc.s 9
+				IL_01b7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_01bc: pop
+
+				IL_01bd: ldloc.s 8
+				IL_01bf: ldc.r8 1
+				IL_01c8: add
+				IL_01c9: stloc.s 8
+				IL_01cb: br IL_015d
 			// end loop
 
-			IL_01bd: ldstr "strict-and-non-strict"
-			IL_01c2: stloc.s 10
-			IL_01c4: ldloc.s 6
-			IL_01c6: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_01cb: ldc.r8 1
-			IL_01d4: ceq
-			IL_01d6: brfalse IL_0296
+			IL_01d0: ldstr "strict-and-non-strict"
+			IL_01d5: stloc.s 10
+			IL_01d7: ldloc.s 6
+			IL_01d9: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_01de: ldc.r8 1
+			IL_01e7: ceq
+			IL_01e9: brfalse IL_02a9
 
-			IL_01db: ldloc.s 6
-			IL_01dd: ldc.r8 0.0
-			IL_01e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-			IL_01eb: stloc.s 11
-			IL_01ed: ldloc.s 11
-			IL_01ef: ldstr "onlyStrict"
-			IL_01f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01f9: stloc.s 25
-			IL_01fb: ldloc.s 25
-			IL_01fd: brfalse IL_020e
+			IL_01ee: ldloc.s 6
+			IL_01f0: ldc.r8 0.0
+			IL_01f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+			IL_01fe: stloc.s 11
+			IL_0200: ldloc.s 11
+			IL_0202: ldstr "onlyStrict"
+			IL_0207: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_020c: stloc.s 25
+			IL_020e: ldloc.s 25
+			IL_0210: brfalse IL_0221
 
-			IL_0202: ldstr "strict-only"
-			IL_0207: stloc.s 10
-			IL_0209: br IL_0291
+			IL_0215: ldstr "strict-only"
+			IL_021a: stloc.s 10
+			IL_021c: br IL_02a4
 
-			IL_020e: ldloc.s 11
-			IL_0210: ldstr "noStrict"
-			IL_0215: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_021a: stloc.s 25
-			IL_021c: ldloc.s 25
-			IL_021e: box [System.Runtime]System.Boolean
-			IL_0223: stloc.s 26
-			IL_0225: ldloc.s 26
-			IL_0227: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_022c: stloc.s 25
-			IL_022e: ldloc.s 25
-			IL_0230: brtrue IL_0255
+			IL_0221: ldloc.s 11
+			IL_0223: ldstr "noStrict"
+			IL_0228: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_022d: stloc.s 25
+			IL_022f: ldloc.s 25
+			IL_0231: box [System.Runtime]System.Boolean
+			IL_0236: stloc.s 26
+			IL_0238: ldloc.s 26
+			IL_023a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_023f: stloc.s 25
+			IL_0241: ldloc.s 25
+			IL_0243: brtrue IL_0268
 
-			IL_0235: ldloc.s 11
-			IL_0237: ldstr "raw"
-			IL_023c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0241: stloc.s 25
-			IL_0243: ldloc.s 25
-			IL_0245: box [System.Runtime]System.Boolean
-			IL_024a: stloc.s 27
-			IL_024c: ldloc.s 27
-			IL_024e: stloc.s 29
-			IL_0250: br IL_0259
+			IL_0248: ldloc.s 11
+			IL_024a: ldstr "raw"
+			IL_024f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0254: stloc.s 25
+			IL_0256: ldloc.s 25
+			IL_0258: box [System.Runtime]System.Boolean
+			IL_025d: stloc.s 27
+			IL_025f: ldloc.s 27
+			IL_0261: stloc.s 29
+			IL_0263: br IL_026c
 
-			IL_0255: ldloc.s 26
-			IL_0257: stloc.s 29
+			IL_0268: ldloc.s 26
+			IL_026a: stloc.s 29
 
-			IL_0259: ldloc.s 29
-			IL_025b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0260: stloc.s 25
-			IL_0262: ldloc.s 25
-			IL_0264: brfalse IL_0275
+			IL_026c: ldloc.s 29
+			IL_026e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0273: stloc.s 25
+			IL_0275: ldloc.s 25
+			IL_0277: brfalse IL_0288
 
-			IL_0269: ldstr "non-strict-only"
-			IL_026e: stloc.s 10
-			IL_0270: br IL_0291
+			IL_027c: ldstr "non-strict-only"
+			IL_0281: stloc.s 10
+			IL_0283: br IL_02a4
 
-			IL_0275: ldloc.s 11
-			IL_0277: ldstr "module"
-			IL_027c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0281: stloc.s 25
-			IL_0283: ldloc.s 25
-			IL_0285: brfalse IL_0291
-
+			IL_0288: ldloc.s 11
 			IL_028a: ldstr "module"
-			IL_028f: stloc.s 10
+			IL_028f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0294: stloc.s 25
+			IL_0296: ldloc.s 25
+			IL_0298: brfalse IL_02a4
 
-			IL_0291: br IL_02b4
+			IL_029d: ldstr "module"
+			IL_02a2: stloc.s 10
 
-			IL_0296: ldloc.s 6
-			IL_0298: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-			IL_029d: ldc.r8 1
-			IL_02a6: cgt
-			IL_02a8: brfalse IL_02b4
+			IL_02a4: br IL_02c7
 
-			IL_02ad: ldstr "conflicting-flags"
-			IL_02b2: stloc.s 10
+			IL_02a9: ldloc.s 6
+			IL_02ab: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+			IL_02b0: ldc.r8 1
+			IL_02b9: cgt
+			IL_02bb: brfalse IL_02c7
 
-			IL_02b4: ldloc.1
-			IL_02b5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_02ba: stloc.s 25
-			IL_02bc: ldloc.s 25
-			IL_02be: brfalse IL_02d4
+			IL_02c0: ldstr "conflicting-flags"
+			IL_02c5: stloc.s 10
 
-			IL_02c3: ldc.i4.0
-			IL_02c4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_02c9: stloc.s 30
-			IL_02cb: ldloc.s 30
-			IL_02cd: stloc.s 12
-			IL_02cf: br IL_02e5
+			IL_02c7: ldloc.1
+			IL_02c8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02cd: stloc.s 25
+			IL_02cf: ldloc.s 25
+			IL_02d1: brfalse IL_02e7
 
-			IL_02d4: ldarg.0
-			IL_02d5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
-			IL_02da: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
-			IL_02df: stloc.s 30
-			IL_02e1: ldloc.s 30
-			IL_02e3: stloc.s 12
+			IL_02d6: ldc.i4.0
+			IL_02d7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02dc: stloc.s 30
+			IL_02de: ldloc.s 30
+			IL_02e0: stloc.s 12
+			IL_02e2: br IL_02f8
 
-			IL_02e5: ldloc.s 12
-			IL_02e7: stloc.s 13
-			IL_02e9: ldloc.s 13
-			IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02f0: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_02f5: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
-			IL_02fa: stloc.s 30
-			IL_02fc: ldloc.s 30
-			IL_02fe: stloc.s 14
-			IL_0300: ldloc.2
-			IL_0301: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0306: stloc.s 25
-			IL_0308: ldloc.s 25
-			IL_030a: brfalse IL_032c
+			IL_02e7: ldarg.0
+			IL_02e8: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/Scope::DEFAULT_HARNESS_INCLUDES
+			IL_02ed: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
+			IL_02f2: stloc.s 30
+			IL_02f4: ldloc.s 30
+			IL_02f6: stloc.s 12
 
-			IL_030f: ldloc.1
-			IL_0310: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0315: ldc.i4.0
-			IL_0316: ceq
-			IL_0318: stloc.s 25
-			IL_031a: ldloc.s 25
-			IL_031c: box [System.Runtime]System.Boolean
-			IL_0321: stloc.s 26
-			IL_0323: ldloc.s 26
-			IL_0325: stloc.s 31
-			IL_0327: br IL_032f
+			IL_02f8: ldloc.s 12
+			IL_02fa: stloc.s 13
+			IL_02fc: ldloc.s 13
+			IL_02fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0303: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0308: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Array [JavaScriptRuntime]JavaScriptRuntime.Array::slice()
+			IL_030d: stloc.s 30
+			IL_030f: ldloc.s 30
+			IL_0311: stloc.s 14
+			IL_0313: ldloc.2
+			IL_0314: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0319: stloc.s 25
+			IL_031b: ldloc.s 25
+			IL_031d: brfalse IL_033f
 
-			IL_032c: ldloc.2
-			IL_032d: stloc.s 31
+			IL_0322: ldloc.1
+			IL_0323: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0328: ldc.i4.0
+			IL_0329: ceq
+			IL_032b: stloc.s 25
+			IL_032d: ldloc.s 25
+			IL_032f: box [System.Runtime]System.Boolean
+			IL_0334: stloc.s 26
+			IL_0336: ldloc.s 26
+			IL_0338: stloc.s 31
+			IL_033a: br IL_0342
 
-			IL_032f: ldloc.s 31
-			IL_0331: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0336: stloc.s 25
-			IL_0338: ldloc.s 25
-			IL_033a: brfalse IL_0384
+			IL_033f: ldloc.2
+			IL_0340: stloc.s 31
 
-			IL_033f: ldarg.0
-			IL_0340: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0345: ldc.i4.1
-			IL_0346: newarr [System.Runtime]System.Object
-			IL_034b: dup
-			IL_034c: ldc.i4.0
-			IL_034d: ldarg.0
-			IL_034e: stelem.ref
-			IL_034f: stloc.s 21
-			IL_0351: ldarg.0
-			IL_0352: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_0357: stloc.s 32
-			IL_0359: ldloc.s 21
-			IL_035b: ldloc.s 14
-			IL_035d: ldloc.s 32
-			IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0364: stloc.s 22
-			IL_0366: ldloc.s 22
-			IL_0368: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_036d: ldc.i4.0
-			IL_036e: ceq
-			IL_0370: stloc.s 25
-			IL_0372: ldloc.s 25
-			IL_0374: box [System.Runtime]System.Boolean
-			IL_0379: stloc.s 26
-			IL_037b: ldloc.s 26
-			IL_037d: stloc.s 31
-			IL_037f: br IL_0384
+			IL_0342: ldloc.s 31
+			IL_0344: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0349: stloc.s 25
+			IL_034b: ldloc.s 25
+			IL_034d: brfalse IL_0397
 
-			IL_0384: ldloc.s 31
-			IL_0386: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_038b: stloc.s 25
-			IL_038d: ldloc.s 25
-			IL_038f: brfalse IL_03b4
+			IL_0352: ldarg.0
+			IL_0353: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_0358: ldc.i4.1
+			IL_0359: newarr [System.Runtime]System.Object
+			IL_035e: dup
+			IL_035f: ldc.i4.0
+			IL_0360: ldarg.0
+			IL_0361: stelem.ref
+			IL_0362: stloc.s 21
+			IL_0364: ldarg.0
+			IL_0365: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_036a: stloc.s 32
+			IL_036c: ldloc.s 21
+			IL_036e: ldloc.s 14
+			IL_0370: ldloc.s 32
+			IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0377: stloc.s 22
+			IL_0379: ldloc.s 22
+			IL_037b: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0380: ldc.i4.0
+			IL_0381: ceq
+			IL_0383: stloc.s 25
+			IL_0385: ldloc.s 25
+			IL_0387: box [System.Runtime]System.Boolean
+			IL_038c: stloc.s 26
+			IL_038e: ldloc.s 26
+			IL_0390: stloc.s 31
+			IL_0392: br IL_0397
 
-			IL_0394: ldloc.s 14
-			IL_0396: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_039b: stloc.s 22
-			IL_039d: ldarg.0
-			IL_039e: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_03a3: stloc.s 32
-			IL_03a5: ldloc.s 22
-			IL_03a7: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_03ac: ldloc.s 32
-			IL_03ae: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-			IL_03b3: pop
+			IL_0397: ldloc.s 31
+			IL_0399: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_039e: stloc.s 25
+			IL_03a0: ldloc.s 25
+			IL_03a2: brfalse IL_03c7
 
-			IL_03b4: ldc.r8 0.0
-			IL_03bd: stloc.s 15
-			// loop start (head: IL_03bf)
-				IL_03bf: ldloc.s 15
-				IL_03c1: stloc.s 24
-				IL_03c3: ldarg.3
-				IL_03c4: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
-				IL_03c9: stloc.s 23
-				IL_03cb: ldloc.s 24
-				IL_03cd: ldloc.s 23
-				IL_03cf: clt
-				IL_03d1: brfalse IL_0443
+			IL_03a7: ldloc.s 14
+			IL_03a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_03ae: stloc.s 22
+			IL_03b0: ldarg.0
+			IL_03b1: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_03b6: stloc.s 32
+			IL_03b8: ldloc.s 22
+			IL_03ba: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_03bf: ldloc.s 32
+			IL_03c1: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_03c6: pop
 
-				IL_03d6: ldarg.0
-				IL_03d7: ldfld object Modules.test262_metadataParser/Scope::contains
-				IL_03dc: ldc.i4.1
-				IL_03dd: newarr [System.Runtime]System.Object
-				IL_03e2: dup
-				IL_03e3: ldc.i4.0
-				IL_03e4: ldarg.0
-				IL_03e5: stelem.ref
-				IL_03e6: stloc.s 21
-				IL_03e8: ldarg.3
-				IL_03e9: ldloc.s 15
-				IL_03eb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_03f0: stloc.s 22
-				IL_03f2: ldloc.s 21
-				IL_03f4: ldloc.s 14
-				IL_03f6: ldloc.s 22
-				IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-				IL_03fd: stloc.s 22
-				IL_03ff: ldloc.s 22
-				IL_0401: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0406: ldc.i4.0
-				IL_0407: ceq
-				IL_0409: stloc.s 25
-				IL_040b: ldloc.s 25
-				IL_040d: brfalse IL_0430
+			IL_03c7: ldc.r8 0.0
+			IL_03d0: stloc.s 15
+			// loop start (head: IL_03d2)
+				IL_03d2: ldloc.s 15
+				IL_03d4: stloc.s 24
+				IL_03d6: ldarg.3
+				IL_03d7: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::get_length()
+				IL_03dc: stloc.s 23
+				IL_03de: ldloc.s 24
+				IL_03e0: ldloc.s 23
+				IL_03e2: clt
+				IL_03e4: brfalse IL_0456
 
-				IL_0412: ldloc.s 14
-				IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0419: ldarg.3
-				IL_041a: ldloc.s 15
-				IL_041c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
-				IL_0421: stloc.s 22
-				IL_0423: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-				IL_0428: ldloc.s 22
-				IL_042a: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-				IL_042f: pop
+				IL_03e9: ldarg.0
+				IL_03ea: ldfld object Modules.test262_metadataParser/Scope::contains
+				IL_03ef: ldc.i4.1
+				IL_03f0: newarr [System.Runtime]System.Object
+				IL_03f5: dup
+				IL_03f6: ldc.i4.0
+				IL_03f7: ldarg.0
+				IL_03f8: stelem.ref
+				IL_03f9: stloc.s 21
+				IL_03fb: ldarg.3
+				IL_03fc: ldloc.s 15
+				IL_03fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0403: stloc.s 22
+				IL_0405: ldloc.s 21
+				IL_0407: ldloc.s 14
+				IL_0409: ldloc.s 22
+				IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_0410: stloc.s 22
+				IL_0412: ldloc.s 22
+				IL_0414: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0419: ldc.i4.0
+				IL_041a: ceq
+				IL_041c: stloc.s 25
+				IL_041e: ldloc.s 25
+				IL_0420: brfalse IL_0443
 
-				IL_0430: ldloc.s 15
-				IL_0432: ldc.r8 1
-				IL_043b: add
-				IL_043c: stloc.s 15
-				IL_043e: br IL_03bf
+				IL_0425: ldloc.s 14
+				IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_042c: ldarg.3
+				IL_042d: ldloc.s 15
+				IL_042f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Array::get_Item(float64)
+				IL_0434: stloc.s 22
+				IL_0436: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_043b: ldloc.s 22
+				IL_043d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_0442: pop
+
+				IL_0443: ldloc.s 15
+				IL_0445: ldc.r8 1
+				IL_044e: add
+				IL_044f: stloc.s 15
+				IL_0451: br IL_03d2
 			// end loop
 
-			IL_0443: ldarg.0
-			IL_0444: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0449: ldc.i4.1
-			IL_044a: newarr [System.Runtime]System.Object
-			IL_044f: dup
-			IL_0450: ldc.i4.0
-			IL_0451: ldarg.0
-			IL_0452: stelem.ref
-			IL_0453: stloc.s 21
-			IL_0455: ldloc.s 21
-			IL_0457: ldarg.3
-			IL_0458: ldstr "agent.js"
-			IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0462: stloc.s 16
+			IL_0456: ldarg.0
+			IL_0457: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_045c: ldc.i4.1
+			IL_045d: newarr [System.Runtime]System.Object
+			IL_0462: dup
+			IL_0463: ldc.i4.0
 			IL_0464: ldarg.0
-			IL_0465: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_046a: ldc.i4.1
-			IL_046b: newarr [System.Runtime]System.Object
-			IL_0470: dup
-			IL_0471: ldc.i4.0
-			IL_0472: ldarg.0
-			IL_0473: stelem.ref
-			IL_0474: stloc.s 21
-			IL_0476: ldloc.s 21
-			IL_0478: ldarg.2
-			IL_0479: ldstr "CanBlockIsFalse"
-			IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0483: stloc.s 22
-			IL_0485: ldloc.s 22
-			IL_0487: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_048c: stloc.s 25
-			IL_048e: ldloc.s 25
-			IL_0490: brfalse IL_04a1
+			IL_0465: stelem.ref
+			IL_0466: stloc.s 21
+			IL_0468: ldloc.s 21
+			IL_046a: ldarg.3
+			IL_046b: ldstr "agent.js"
+			IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0475: stloc.s 16
+			IL_0477: ldarg.0
+			IL_0478: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_047d: ldc.i4.1
+			IL_047e: newarr [System.Runtime]System.Object
+			IL_0483: dup
+			IL_0484: ldc.i4.0
+			IL_0485: ldarg.0
+			IL_0486: stelem.ref
+			IL_0487: stloc.s 21
+			IL_0489: ldloc.s 21
+			IL_048b: ldarg.2
+			IL_048c: ldstr "CanBlockIsFalse"
+			IL_0491: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0496: stloc.s 22
+			IL_0498: ldloc.s 22
+			IL_049a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_049f: stloc.s 25
+			IL_04a1: ldloc.s 25
+			IL_04a3: brfalse IL_04b4
 
-			IL_0495: ldstr "false"
-			IL_049a: stloc.s 17
-			IL_049c: br IL_04e9
+			IL_04a8: ldstr "false"
+			IL_04ad: stloc.s 17
+			IL_04af: br IL_04fc
 
-			IL_04a1: ldarg.0
-			IL_04a2: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_04a7: ldc.i4.1
-			IL_04a8: newarr [System.Runtime]System.Object
-			IL_04ad: dup
-			IL_04ae: ldc.i4.0
-			IL_04af: ldarg.0
-			IL_04b0: stelem.ref
-			IL_04b1: stloc.s 21
-			IL_04b3: ldloc.s 21
-			IL_04b5: ldarg.2
-			IL_04b6: ldstr "CanBlockIsTrue"
-			IL_04bb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04c0: stloc.s 22
-			IL_04c2: ldloc.s 22
-			IL_04c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04c9: stloc.s 25
-			IL_04cb: ldloc.s 25
-			IL_04cd: brfalse IL_04de
+			IL_04b4: ldarg.0
+			IL_04b5: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_04ba: ldc.i4.1
+			IL_04bb: newarr [System.Runtime]System.Object
+			IL_04c0: dup
+			IL_04c1: ldc.i4.0
+			IL_04c2: ldarg.0
+			IL_04c3: stelem.ref
+			IL_04c4: stloc.s 21
+			IL_04c6: ldloc.s 21
+			IL_04c8: ldarg.2
+			IL_04c9: ldstr "CanBlockIsTrue"
+			IL_04ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04d3: stloc.s 22
+			IL_04d5: ldloc.s 22
+			IL_04d7: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_04dc: stloc.s 25
+			IL_04de: ldloc.s 25
+			IL_04e0: brfalse IL_04f1
 
-			IL_04d2: ldstr "true"
-			IL_04d7: stloc.s 18
-			IL_04d9: br IL_04e5
+			IL_04e5: ldstr "true"
+			IL_04ea: stloc.s 18
+			IL_04ec: br IL_04f8
 
-			IL_04de: ldstr "unspecified"
-			IL_04e3: stloc.s 18
+			IL_04f1: ldstr "unspecified"
+			IL_04f6: stloc.s 18
 
-			IL_04e5: ldloc.s 18
-			IL_04e7: stloc.s 17
+			IL_04f8: ldloc.s 18
+			IL_04fa: stloc.s 17
 
-			IL_04e9: ldloc.s 17
-			IL_04eb: stloc.s 19
-			IL_04ed: ldloc.0
-			IL_04ee: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_04f3: stloc.s 25
-			IL_04f5: ldloc.s 25
-			IL_04f7: brfalse IL_0508
+			IL_04fc: ldloc.s 17
+			IL_04fe: stloc.s 19
+			IL_0500: ldloc.0
+			IL_0501: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0506: stloc.s 25
+			IL_0508: ldloc.s 25
+			IL_050a: brfalse IL_051b
 
-			IL_04fc: ldstr "module"
-			IL_0501: stloc.s 20
-			IL_0503: br IL_050f
+			IL_050f: ldstr "module"
+			IL_0514: stloc.s 20
+			IL_0516: br IL_0522
 
-			IL_0508: ldstr "script"
-			IL_050d: stloc.s 20
+			IL_051b: ldstr "script"
+			IL_0520: stloc.s 20
 
-			IL_050f: ldloc.s 13
-			IL_0511: ldstr "length"
-			IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_051b: stloc.s 22
-			IL_051d: ldloc.s 22
-			IL_051f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0524: ldc.r8 0.0
-			IL_052d: cgt
-			IL_052f: stloc.s 25
-			IL_0531: ldloc.2
-			IL_0532: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0537: stloc.s 34
-			IL_0539: ldloc.s 34
-			IL_053b: brtrue IL_056f
+			IL_0522: ldloc.s 13
+			IL_0524: ldstr "length"
+			IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_052e: stloc.s 22
+			IL_0530: ldloc.s 22
+			IL_0532: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0537: ldc.r8 0.0
+			IL_0540: cgt
+			IL_0542: stloc.s 25
+			IL_0544: ldloc.2
+			IL_0545: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_054a: stloc.s 34
+			IL_054c: ldloc.s 34
+			IL_054e: brtrue IL_0582
 
-			IL_0540: ldarg.0
-			IL_0541: ldfld object Modules.test262_metadataParser/Scope::contains
-			IL_0546: ldc.i4.1
-			IL_0547: newarr [System.Runtime]System.Object
-			IL_054c: dup
-			IL_054d: ldc.i4.0
-			IL_054e: ldarg.0
-			IL_054f: stelem.ref
-			IL_0550: stloc.s 21
-			IL_0552: ldarg.0
-			IL_0553: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
-			IL_0558: stloc.s 32
-			IL_055a: ldloc.s 21
-			IL_055c: ldarg.3
-			IL_055d: ldloc.s 32
-			IL_055f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0564: stloc.s 22
-			IL_0566: ldloc.s 22
-			IL_0568: stloc.s 35
-			IL_056a: br IL_0572
+			IL_0553: ldarg.0
+			IL_0554: ldfld object Modules.test262_metadataParser/Scope::contains
+			IL_0559: ldc.i4.1
+			IL_055a: newarr [System.Runtime]System.Object
+			IL_055f: dup
+			IL_0560: ldc.i4.0
+			IL_0561: ldarg.0
+			IL_0562: stelem.ref
+			IL_0563: stloc.s 21
+			IL_0565: ldarg.0
+			IL_0566: ldfld string Modules.test262_metadataParser/Scope::ASYNC_HARNESS_INCLUDE
+			IL_056b: stloc.s 32
+			IL_056d: ldloc.s 21
+			IL_056f: ldarg.3
+			IL_0570: ldloc.s 32
+			IL_0572: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0577: stloc.s 22
+			IL_0579: ldloc.s 22
+			IL_057b: stloc.s 35
+			IL_057d: br IL_0585
 
-			IL_056f: ldloc.2
-			IL_0570: stloc.s 35
+			IL_0582: ldloc.2
+			IL_0583: stloc.s 35
 
-			IL_0572: ldloc.s 16
-			IL_0574: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0579: stloc.s 34
-			IL_057b: ldloc.s 34
-			IL_057d: brtrue IL_05a2
+			IL_0585: ldloc.s 16
+			IL_0587: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_058c: stloc.s 34
+			IL_058e: ldloc.s 34
+			IL_0590: brtrue IL_05b5
 
-			IL_0582: ldloc.s 19
-			IL_0584: ldstr "unspecified"
-			IL_0589: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_058e: stloc.s 34
-			IL_0590: ldloc.s 34
-			IL_0592: box [System.Runtime]System.Boolean
-			IL_0597: stloc.s 26
-			IL_0599: ldloc.s 26
-			IL_059b: stloc.s 37
-			IL_059d: br IL_05a6
+			IL_0595: ldloc.s 19
+			IL_0597: ldstr "unspecified"
+			IL_059c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_05a1: stloc.s 34
+			IL_05a3: ldloc.s 34
+			IL_05a5: box [System.Runtime]System.Boolean
+			IL_05aa: stloc.s 26
+			IL_05ac: ldloc.s 26
+			IL_05ae: stloc.s 37
+			IL_05b0: br IL_05b9
 
-			IL_05a2: ldloc.s 16
-			IL_05a4: stloc.s 37
+			IL_05b5: ldloc.s 16
+			IL_05b7: stloc.s 37
 
-			IL_05a6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_05ab: dup
-			IL_05ac: ldstr "sourceType"
-			IL_05b1: ldloc.s 20
-			IL_05b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05b8: dup
-			IL_05b9: ldstr "strictMode"
-			IL_05be: ldloc.s 10
-			IL_05c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05c5: dup
-			IL_05c6: ldstr "defaultHarnessIncludes"
-			IL_05cb: ldloc.s 13
-			IL_05cd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05d2: dup
-			IL_05d3: ldstr "harnessIncludes"
-			IL_05d8: ldloc.s 14
-			IL_05da: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05df: dup
-			IL_05e0: ldstr "requiresDefaultHarness"
-			IL_05e5: ldloc.s 25
-			IL_05e7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_05ec: dup
-			IL_05ed: ldstr "requiresAsyncHarness"
-			IL_05f2: ldloc.s 35
-			IL_05f4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_05f9: dup
-			IL_05fa: ldstr "requiresAgent"
-			IL_05ff: ldloc.s 37
-			IL_0601: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0606: dup
-			IL_0607: ldstr "canBlock"
-			IL_060c: ldloc.s 19
-			IL_060e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0613: dup
-			IL_0614: ldstr "isModule"
-			IL_0619: ldloc.0
-			IL_061a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_061f: dup
-			IL_0620: ldstr "isRaw"
-			IL_0625: ldloc.1
-			IL_0626: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_062b: dup
-			IL_062c: ldstr "isAsync"
-			IL_0631: ldloc.2
-			IL_0632: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0637: dup
-			IL_0638: ldstr "isGenerated"
-			IL_063d: ldloc.3
-			IL_063e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0643: dup
-			IL_0644: ldstr "isNonDeterministic"
-			IL_0649: ldloc.s 4
-			IL_064b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0650: dup
-			IL_0651: ldstr "isFixture"
-			IL_0656: ldloc.s 5
-			IL_0658: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_065d: stloc.s 38
-			IL_065f: ldloc.s 38
-			IL_0661: ret
+			IL_05b9: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05be: dup
+			IL_05bf: ldstr "sourceType"
+			IL_05c4: ldloc.s 20
+			IL_05c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05cb: dup
+			IL_05cc: ldstr "strictMode"
+			IL_05d1: ldloc.s 10
+			IL_05d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05d8: dup
+			IL_05d9: ldstr "defaultHarnessIncludes"
+			IL_05de: ldloc.s 13
+			IL_05e0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05e5: dup
+			IL_05e6: ldstr "harnessIncludes"
+			IL_05eb: ldloc.s 14
+			IL_05ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_05f2: dup
+			IL_05f3: ldstr "requiresDefaultHarness"
+			IL_05f8: ldloc.s 25
+			IL_05fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_05ff: dup
+			IL_0600: ldstr "requiresAsyncHarness"
+			IL_0605: ldloc.s 35
+			IL_0607: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_060c: dup
+			IL_060d: ldstr "requiresAgent"
+			IL_0612: ldloc.s 37
+			IL_0614: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0619: dup
+			IL_061a: ldstr "canBlock"
+			IL_061f: ldloc.s 19
+			IL_0621: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0626: dup
+			IL_0627: ldstr "isModule"
+			IL_062c: ldloc.0
+			IL_062d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0632: dup
+			IL_0633: ldstr "isRaw"
+			IL_0638: ldloc.1
+			IL_0639: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_063e: dup
+			IL_063f: ldstr "isAsync"
+			IL_0644: ldloc.2
+			IL_0645: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_064a: dup
+			IL_064b: ldstr "isGenerated"
+			IL_0650: ldloc.3
+			IL_0651: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0656: dup
+			IL_0657: ldstr "isNonDeterministic"
+			IL_065c: ldloc.s 4
+			IL_065e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0663: dup
+			IL_0664: ldstr "isFixture"
+			IL_0669: ldloc.s 5
+			IL_066b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0670: stloc.s 38
+			IL_0672: ldloc.s 38
+			IL_0674: ret
 		} // end of method buildExecutionMetadata::__js_call__
 
 	} // end of class buildExecutionMetadata

--- a/tests/Jroc.Tests/Array/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Array/ExecutionTests.cs
@@ -41,6 +41,9 @@ namespace Jroc.Tests.Array
         public Task Array_Push_Basic() { var testName = nameof(Array_Push_Basic); return ExecutionTest(testName); }
 
         [Fact]
+        public Task Array_ReceiverCandidate_GuardedOverrides() { var testName = nameof(Array_ReceiverCandidate_GuardedOverrides); return ExecutionTest(testName); }
+
+        [Fact]
         public Task Array_Slice_Basic() { var testName = nameof(Array_Slice_Basic); return ExecutionTest(testName); }
 
         [Fact]

--- a/tests/Jroc.Tests/Array/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Array/GeneratorTests.cs
@@ -46,6 +46,9 @@ namespace Jroc.Tests.Array
         public Task Array_Push_Basic() { var testName = nameof(Array_Push_Basic); return GenerateTest(testName); }
 
         [Fact]
+        public Task Array_ReceiverCandidate_GuardedOverrides() { var testName = nameof(Array_ReceiverCandidate_GuardedOverrides); return GenerateTest(testName); }
+
+        [Fact]
         public Task Array_Slice_Basic() { var testName = nameof(Array_Slice_Basic); return GenerateTest(testName); }
 
         [Fact]

--- a/tests/Jroc.Tests/Array/JavaScript/Array_ReceiverCandidate_GuardedOverrides.js
+++ b/tests/Jroc.Tests/Array/JavaScript/Array_ReceiverCandidate_GuardedOverrides.js
@@ -1,0 +1,39 @@
+"use strict";
+
+let useArray = true;
+let receiver = useArray ? [] : {
+    push(value) {
+        return "object:" + value;
+    }
+};
+console.log(receiver.push(1));
+
+receiver.push = function (value) {
+    return "own:" + value;
+};
+console.log(receiver.push(2));
+
+delete receiver.push;
+Object.defineProperty(receiver, "push", {
+    configurable: true,
+    get() {
+        return function (value) {
+            return "getter:" + value;
+        };
+    }
+});
+console.log(receiver.push(3));
+
+delete receiver.push;
+Object.setPrototypeOf(receiver, {
+    push(value) {
+        return "custom:" + value;
+    }
+});
+console.log(receiver.push(4));
+
+Object.setPrototypeOf(receiver, Array.prototype);
+Array.prototype.push = function (value) {
+    return "prototype:" + value;
+};
+console.log(receiver.push(5));

--- a/tests/Jroc.Tests/Array/JavaScript/Array_ReceiverCandidate_GuardedOverrides.js
+++ b/tests/Jroc.Tests/Array/JavaScript/Array_ReceiverCandidate_GuardedOverrides.js
@@ -6,34 +6,38 @@ let receiver = useArray ? [] : {
         return "object:" + value;
     }
 };
-console.log(receiver.push(1));
+console.log(receiver.push(0));
 
-receiver.push = function (value) {
-    return "own:" + value;
-};
-console.log(receiver.push(2));
+for (let iteration = 0; iteration < 1; iteration++) {
+    console.log(receiver.push(1));
 
-delete receiver.push;
-Object.defineProperty(receiver, "push", {
-    configurable: true,
-    get() {
-        return function (value) {
-            return "getter:" + value;
-        };
-    }
-});
-console.log(receiver.push(3));
+    receiver.push = function (value) {
+        return "own:" + value;
+    };
+    console.log(receiver.push(2));
 
-delete receiver.push;
-Object.setPrototypeOf(receiver, {
-    push(value) {
-        return "custom:" + value;
-    }
-});
-console.log(receiver.push(4));
+    delete receiver.push;
+    Object.defineProperty(receiver, "push", {
+        configurable: true,
+        get() {
+            return function (value) {
+                return "getter:" + value;
+            };
+        }
+    });
+    console.log(receiver.push(3));
 
-Object.setPrototypeOf(receiver, Array.prototype);
-Array.prototype.push = function (value) {
-    return "prototype:" + value;
-};
-console.log(receiver.push(5));
+    delete receiver.push;
+    Object.setPrototypeOf(receiver, {
+        push(value) {
+            return "custom:" + value;
+        }
+    });
+    console.log(receiver.push(4));
+
+    Object.setPrototypeOf(receiver, Array.prototype);
+    Array.prototype.push = function (value) {
+        return "prototype:" + value;
+    };
+    console.log(receiver.push(5));
+}

--- a/tests/Jroc.Tests/Array/Snapshots/ExecutionTests.Array_ReceiverCandidate_GuardedOverrides.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/ExecutionTests.Array_ReceiverCandidate_GuardedOverrides.verified.txt
@@ -1,0 +1,5 @@
+1
+own:2
+getter:3
+custom:4
+prototype:5

--- a/tests/Jroc.Tests/Array/Snapshots/ExecutionTests.Array_ReceiverCandidate_GuardedOverrides.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/ExecutionTests.Array_ReceiverCandidate_GuardedOverrides.verified.txt
@@ -1,4 +1,5 @@
 1
+2
 own:2
 getter:3
 custom:4

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_ExplicitReceiverAbi.verified.txt
@@ -137,7 +137,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 56 (0x38)
+			// Code size: 74 (0x4a)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -148,26 +148,33 @@
 			IL_0006: stloc.0
 			IL_0007: ldc.i4.0
 			IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_000d: brfalse IL_002a
+			IL_000d: brfalse IL_003c
 
 			IL_0012: ldloc.0
 			IL_0013: isinst [System.Runtime]System.String
 			IL_0018: dup
-			IL_0019: brfalse IL_0029
+			IL_0019: brtrue IL_0030
 
-			IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
-			IL_0023: stloc.0
-			IL_0024: br IL_0036
+			IL_001e: pop
+			IL_001f: ldloc.0
+			IL_0020: ldstr "toUpperCase"
+			IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_002a: dup
+			IL_002b: brfalse IL_003b
 
-			IL_0029: pop
-
-			IL_002a: ldloc.0
-			IL_002b: ldstr "toUpperCase"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0030: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
 			IL_0035: stloc.0
+			IL_0036: br IL_0048
 
-			IL_0036: ldloc.0
-			IL_0037: ret
+			IL_003b: pop
+
+			IL_003c: ldloc.0
+			IL_003d: ldstr "toUpperCase"
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0047: stloc.0
+
+			IL_0048: ldloc.0
+			IL_0049: ret
 		} // end of method FunctionExpression_L7C48::__js_call__
 
 	} // end of class FunctionExpression_L7C48

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_ReceiverCandidate_GuardedOverrides.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_ReceiverCandidate_GuardedOverrides.verified.txt
@@ -116,7 +116,7 @@
 
 	} // end of class FunctionExpression_receiver
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L11C16
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L14C20
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -191,7 +191,7 @@
 				IL_0001: ldarg.2
 				IL_0002: ldc.i4.0
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L11C16::__js_call__(object, object)
+				IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C20::__js_call__(object, object)
 				IL_000d: ret
 			} // end of method FunctionObject::CallCore
 
@@ -210,7 +210,7 @@
 				IL_0001: ldarg.2
 				IL_0002: ldc.i4.0
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L11C16::__js_call__(object, object)
+				IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C20::__js_call__(object, object)
 				IL_000d: ret
 			} // end of method FunctionObject::ConstructBodyCore
 
@@ -258,15 +258,15 @@
 			IL_000b: stloc.0
 			IL_000c: ldloc.0
 			IL_000d: ret
-		} // end of method FunctionExpression_L11C16::__js_call__
+		} // end of method FunctionExpression_L14C20::__js_call__
 
-	} // end of class FunctionExpression_L11C16
+	} // end of class FunctionExpression_L14C20
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L19C7
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L22C11
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L20C15
+		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L23C19
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
@@ -341,7 +341,7 @@
 					IL_0001: ldarg.2
 					IL_0002: ldc.i4.0
 					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-					IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionExpression_L20C15::__js_call__(object, object)
+					IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/FunctionExpression_L23C19::__js_call__(object, object)
 					IL_000d: ret
 				} // end of method FunctionObject::CallCore
 
@@ -360,7 +360,7 @@
 					IL_0001: ldarg.2
 					IL_0002: ldc.i4.0
 					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-					IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionExpression_L20C15::__js_call__(object, object)
+					IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/FunctionExpression_L23C19::__js_call__(object, object)
 					IL_000d: ret
 				} // end of method FunctionObject::ConstructBodyCore
 
@@ -408,9 +408,9 @@
 				IL_000b: stloc.0
 				IL_000c: ldloc.0
 				IL_000d: ret
-			} // end of method FunctionExpression_L20C15::__js_call__
+			} // end of method FunctionExpression_L23C19::__js_call__
 
-		} // end of class FunctionExpression_L20C15
+		} // end of class FunctionExpression_L23C19
 
 		.class nested public auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
@@ -480,7 +480,7 @@
 				.maxstack 8
 
 				IL_0000: ldnull
-				IL_0001: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7::__js_call__(object)
+				IL_0001: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::CallCore
 
@@ -500,30 +500,30 @@
 			// Code size: 34 (0x22)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/Scope,
+				[0] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/Scope,
 				[1] object[],
-				[2] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionExpression_L20C15/FunctionObject
+				[2] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/FunctionExpression_L23C19/FunctionObject
 			)
 
-			IL_0000: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/Scope::.ctor()
+			IL_0000: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_000b: stloc.1
-			IL_000c: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionExpression_L20C15/FunctionObject::.ctor()
+			IL_000c: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/FunctionExpression_L23C19/FunctionObject::.ctor()
 			IL_0011: ldc.i4.1
 			IL_0012: conv.r8
 			IL_0013: ldstr ""
 			IL_0018: ldc.i4.0
 			IL_0019: ldc.i4.1
-			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionExpression_L20C15/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/FunctionExpression_L23C19/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_001f: stloc.2
 			IL_0020: ldloc.2
 			IL_0021: ret
-		} // end of method FunctionExpression_L19C7::__js_call__
+		} // end of method FunctionExpression_L22C11::__js_call__
 
-	} // end of class FunctionExpression_L19C7
+	} // end of class FunctionExpression_L22C11
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L29C8
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L32C12
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -598,7 +598,7 @@
 				IL_0001: ldarg.2
 				IL_0002: ldc.i4.0
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L29C8::__js_call__(object, object)
+				IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L32C12::__js_call__(object, object)
 				IL_000d: ret
 			} // end of method FunctionObject::CallCore
 
@@ -628,11 +628,11 @@
 			IL_000b: stloc.0
 			IL_000c: ldloc.0
 			IL_000d: ret
-		} // end of method FunctionExpression_L29C8::__js_call__
+		} // end of method FunctionExpression_L32C12::__js_call__
 
-	} // end of class FunctionExpression_L29C8
+	} // end of class FunctionExpression_L32C12
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L36C23
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L39C27
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -707,7 +707,7 @@
 				IL_0001: ldarg.2
 				IL_0002: ldc.i4.0
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L36C23::__js_call__(object, object)
+				IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L39C27::__js_call__(object, object)
 				IL_000d: ret
 			} // end of method FunctionObject::CallCore
 
@@ -726,7 +726,7 @@
 				IL_0001: ldarg.2
 				IL_0002: ldc.i4.0
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L36C23::__js_call__(object, object)
+				IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L39C27::__js_call__(object, object)
 				IL_000d: ret
 			} // end of method FunctionObject::ConstructBodyCore
 
@@ -774,9 +774,9 @@
 			IL_000b: stloc.0
 			IL_000c: ldloc.0
 			IL_000d: ret
-		} // end of method FunctionExpression_L36C23::__js_call__
+		} // end of method FunctionExpression_L39C27::__js_call__
 
-	} // end of class FunctionExpression_L36C23
+	} // end of class FunctionExpression_L39C27
 
 	.class nested public auto ansi beforefieldinit Scope
 		extends [System.Runtime]System.Object
@@ -797,6 +797,46 @@
 
 	} // end of class Scope
 
+	.class nested public auto ansi beforefieldinit Scope_For_L11C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Block_L11C52
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L11C52::.ctor
+
+		} // end of class Block_L11C52
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope_For_L11C5::.ctor
+
+	} // end of class Scope_For_L11C5
+
 
 	// Methods
 	.method public hidebysig static 
@@ -809,24 +849,26 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1170 (0x492)
+		// Code size: 1271 (0x4f7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_ReceiverCandidate_GuardedOverrides/Scope,
 			[1] bool,
 			[2] object,
 			[3] object,
-			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[6] object[],
-			[7] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_receiver/FunctionObject,
-			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[9] object,
-			[10] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L11C16/FunctionObject,
-			[11] bool,
-			[12] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionObject,
-			[13] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L29C8/FunctionObject,
-			[14] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L36C23/FunctionObject
+			[4] float64,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[7] object[],
+			[8] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_receiver/FunctionObject,
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[10] object,
+			[11] float64,
+			[12] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C20/FunctionObject,
+			[13] bool,
+			[14] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/FunctionObject,
+			[15] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L32C12/FunctionObject,
+			[16] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L39C27/FunctionObject
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -840,20 +882,20 @@
 
 		IL_0014: ldc.i4.0
 		IL_0015: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_001a: stloc.s 4
-		IL_001c: ldloc.s 4
+		IL_001a: stloc.s 5
+		IL_001c: ldloc.s 5
 		IL_001e: stloc.2
 		IL_001f: br IL_0063
 
 		IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0029: stloc.s 5
+		IL_0029: stloc.s 6
 		IL_002b: ldc.i4.1
 		IL_002c: newarr [System.Runtime]System.Object
 		IL_0031: dup
 		IL_0032: ldc.i4.0
 		IL_0033: ldloc.0
 		IL_0034: stelem.ref
-		IL_0035: stloc.s 6
+		IL_0035: stloc.s 7
 		IL_0037: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_receiver/FunctionObject::.ctor()
 		IL_003c: ldc.i4.1
 		IL_003d: conv.r8
@@ -862,377 +904,407 @@
 		IL_0044: ldc.i4.1
 		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_receiver/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_receiver/FunctionObject>(!!0)
-		IL_004f: stloc.s 7
-		IL_0051: ldloc.s 5
+		IL_004f: stloc.s 8
+		IL_0051: ldloc.s 6
 		IL_0053: ldstr "push"
-		IL_0058: ldloc.s 7
+		IL_0058: ldloc.s 8
 		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
 		IL_005f: pop
-		IL_0060: ldloc.s 5
+		IL_0060: ldloc.s 6
 		IL_0062: stloc.2
 
 		IL_0063: ldloc.2
 		IL_0064: stloc.3
 		IL_0065: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_006a: stloc.s 8
+		IL_006a: stloc.s 9
 		IL_006c: ldloc.3
 		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0072: stloc.s 9
-		IL_0074: ldc.i4.1
-		IL_0075: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_007a: brfalse IL_00d2
+		IL_0072: ldstr "push"
+		IL_0077: ldc.r8 0.0
+		IL_0080: box [System.Runtime]System.Double
+		IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_008a: stloc.s 10
+		IL_008c: ldloc.s 9
+		IL_008e: ldloc.s 10
+		IL_0090: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0095: pop
+		IL_0096: ldc.r8 0.0
+		IL_009f: stloc.s 4
+		// loop start (head: IL_00a1)
+			IL_00a1: ldloc.s 4
+			IL_00a3: stloc.s 11
+			IL_00a5: ldloc.s 11
+			IL_00a7: ldc.r8 1
+			IL_00b0: clt
+			IL_00b2: brfalse IL_04f6
 
-		IL_007f: ldloc.s 9
-		IL_0081: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0086: dup
-		IL_0087: brfalse IL_00d1
+			IL_00b7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00bc: stloc.s 9
+			IL_00be: ldloc.3
+			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00c4: stloc.s 10
+			IL_00c6: ldc.i4.1
+			IL_00c7: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00cc: brfalse IL_0124
 
-		IL_008c: pop
-		IL_008d: ldloc.s 9
-		IL_008f: ldstr "push"
-		IL_0094: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_0099: brtrue IL_00d2
+			IL_00d1: ldloc.s 10
+			IL_00d3: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_00d8: dup
+			IL_00d9: brfalse IL_0123
 
-		IL_009e: ldloc.s 9
-		IL_00a0: ldc.i4.1
-		IL_00a1: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_00a6: brfalse IL_00d2
+			IL_00de: pop
+			IL_00df: ldloc.s 10
+			IL_00e1: ldstr "push"
+			IL_00e6: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_00eb: brtrue IL_0124
 
-		IL_00ab: ldloc.s 9
-		IL_00ad: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_00b2: ldc.r8 1
-		IL_00bb: box [System.Runtime]System.Double
-		IL_00c0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-		IL_00c5: box [System.Runtime]System.Double
-		IL_00ca: stloc.s 9
-		IL_00cc: br IL_00ee
+			IL_00f0: ldloc.s 10
+			IL_00f2: ldc.i4.1
+			IL_00f3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00f8: brfalse IL_0124
 
-		IL_00d1: pop
+			IL_00fd: ldloc.s 10
+			IL_00ff: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0104: ldc.r8 1
+			IL_010d: box [System.Runtime]System.Double
+			IL_0112: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_0117: box [System.Runtime]System.Double
+			IL_011c: stloc.s 10
+			IL_011e: br IL_0140
 
-		IL_00d2: ldloc.s 9
-		IL_00d4: ldstr "push"
-		IL_00d9: ldc.r8 1
-		IL_00e2: box [System.Runtime]System.Double
-		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ec: stloc.s 9
+			IL_0123: pop
 
-		IL_00ee: ldloc.s 8
-		IL_00f0: ldloc.s 9
-		IL_00f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00f7: pop
-		IL_00f8: ldc.i4.1
-		IL_00f9: newarr [System.Runtime]System.Object
-		IL_00fe: dup
-		IL_00ff: ldc.i4.0
-		IL_0100: ldloc.0
-		IL_0101: stelem.ref
-		IL_0102: stloc.s 6
-		IL_0104: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L11C16/FunctionObject::.ctor()
-		IL_0109: ldc.i4.1
-		IL_010a: conv.r8
-		IL_010b: ldstr ""
-		IL_0110: ldc.i4.0
-		IL_0111: ldc.i4.1
-		IL_0112: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L11C16/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0117: stloc.s 10
-		IL_0119: ldloc.3
-		IL_011a: ldstr "push"
-		IL_011f: ldloc.s 10
-		IL_0121: ldc.i4.1
-		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0127: pop
-		IL_0128: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_012d: stloc.s 8
-		IL_012f: ldloc.3
-		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0135: stloc.s 9
-		IL_0137: ldc.i4.1
-		IL_0138: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_013d: brfalse IL_0195
+			IL_0124: ldloc.s 10
+			IL_0126: ldstr "push"
+			IL_012b: ldc.r8 1
+			IL_0134: box [System.Runtime]System.Double
+			IL_0139: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_013e: stloc.s 10
 
-		IL_0142: ldloc.s 9
-		IL_0144: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0149: dup
-		IL_014a: brfalse IL_0194
+			IL_0140: ldloc.s 9
+			IL_0142: ldloc.s 10
+			IL_0144: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0149: pop
+			IL_014a: ldc.i4.1
+			IL_014b: newarr [System.Runtime]System.Object
+			IL_0150: dup
+			IL_0151: ldc.i4.0
+			IL_0152: ldloc.0
+			IL_0153: stelem.ref
+			IL_0154: stloc.s 7
+			IL_0156: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C20/FunctionObject::.ctor()
+			IL_015b: ldc.i4.1
+			IL_015c: conv.r8
+			IL_015d: ldstr ""
+			IL_0162: ldc.i4.0
+			IL_0163: ldc.i4.1
+			IL_0164: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C20/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0169: stloc.s 12
+			IL_016b: ldloc.3
+			IL_016c: ldstr "push"
+			IL_0171: ldloc.s 12
+			IL_0173: ldc.i4.1
+			IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0179: pop
+			IL_017a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_017f: stloc.s 9
+			IL_0181: ldloc.3
+			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0187: stloc.s 10
+			IL_0189: ldc.i4.1
+			IL_018a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_018f: brfalse IL_01e7
 
-		IL_014f: pop
-		IL_0150: ldloc.s 9
-		IL_0152: ldstr "push"
-		IL_0157: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_015c: brtrue IL_0195
+			IL_0194: ldloc.s 10
+			IL_0196: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_019b: dup
+			IL_019c: brfalse IL_01e6
 
-		IL_0161: ldloc.s 9
-		IL_0163: ldc.i4.1
-		IL_0164: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0169: brfalse IL_0195
+			IL_01a1: pop
+			IL_01a2: ldloc.s 10
+			IL_01a4: ldstr "push"
+			IL_01a9: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_01ae: brtrue IL_01e7
 
-		IL_016e: ldloc.s 9
-		IL_0170: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0175: ldc.r8 2
-		IL_017e: box [System.Runtime]System.Double
-		IL_0183: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-		IL_0188: box [System.Runtime]System.Double
-		IL_018d: stloc.s 9
-		IL_018f: br IL_01b1
+			IL_01b3: ldloc.s 10
+			IL_01b5: ldc.i4.1
+			IL_01b6: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01bb: brfalse IL_01e7
 
-		IL_0194: pop
+			IL_01c0: ldloc.s 10
+			IL_01c2: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01c7: ldc.r8 2
+			IL_01d0: box [System.Runtime]System.Double
+			IL_01d5: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_01da: box [System.Runtime]System.Double
+			IL_01df: stloc.s 10
+			IL_01e1: br IL_0203
 
-		IL_0195: ldloc.s 9
-		IL_0197: ldstr "push"
-		IL_019c: ldc.r8 2
-		IL_01a5: box [System.Runtime]System.Double
-		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01af: stloc.s 9
+			IL_01e6: pop
 
-		IL_01b1: ldloc.s 8
-		IL_01b3: ldloc.s 9
-		IL_01b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ba: pop
-		IL_01bb: ldloc.3
-		IL_01bc: ldstr "push"
-		IL_01c1: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_01c6: stloc.s 11
-		IL_01c8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01cd: stloc.s 5
-		IL_01cf: ldloc.s 5
-		IL_01d1: ldstr "configurable"
-		IL_01d6: ldc.i4.1
-		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
-		IL_01dc: pop
-		IL_01dd: ldc.i4.1
-		IL_01de: newarr [System.Runtime]System.Object
-		IL_01e3: dup
-		IL_01e4: ldc.i4.0
-		IL_01e5: ldloc.0
-		IL_01e6: stelem.ref
-		IL_01e7: stloc.s 6
-		IL_01e9: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionObject::.ctor()
-		IL_01ee: ldc.i4.0
-		IL_01ef: conv.r8
-		IL_01f0: ldstr ""
-		IL_01f5: ldc.i4.0
-		IL_01f6: ldc.i4.1
-		IL_01f7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionObject>(!!0)
-		IL_0201: stloc.s 12
-		IL_0203: ldloc.s 5
-		IL_0205: ldstr "get"
-		IL_020a: ldloc.s 12
-		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0211: pop
-		IL_0212: ldloc.3
-		IL_0213: ldstr "push"
-		IL_0218: ldloc.s 5
-		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_021f: pop
-		IL_0220: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0225: stloc.s 8
-		IL_0227: ldloc.3
-		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_022d: stloc.s 9
-		IL_022f: ldc.i4.1
-		IL_0230: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0235: brfalse IL_028d
+			IL_01e7: ldloc.s 10
+			IL_01e9: ldstr "push"
+			IL_01ee: ldc.r8 2
+			IL_01f7: box [System.Runtime]System.Double
+			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0201: stloc.s 10
 
-		IL_023a: ldloc.s 9
-		IL_023c: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0241: dup
-		IL_0242: brfalse IL_028c
+			IL_0203: ldloc.s 9
+			IL_0205: ldloc.s 10
+			IL_0207: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_020c: pop
+			IL_020d: ldloc.3
+			IL_020e: ldstr "push"
+			IL_0213: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+			IL_0218: stloc.s 13
+			IL_021a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_021f: stloc.s 6
+			IL_0221: ldloc.s 6
+			IL_0223: ldstr "configurable"
+			IL_0228: ldc.i4.1
+			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
+			IL_022e: pop
+			IL_022f: ldc.i4.1
+			IL_0230: newarr [System.Runtime]System.Object
+			IL_0235: dup
+			IL_0236: ldc.i4.0
+			IL_0237: ldloc.0
+			IL_0238: stelem.ref
+			IL_0239: stloc.s 7
+			IL_023b: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/FunctionObject::.ctor()
+			IL_0240: ldc.i4.0
+			IL_0241: conv.r8
+			IL_0242: ldstr ""
+			IL_0247: ldc.i4.0
+			IL_0248: ldc.i4.1
+			IL_0249: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_024e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L22C11/FunctionObject>(!!0)
+			IL_0253: stloc.s 14
+			IL_0255: ldloc.s 6
+			IL_0257: ldstr "get"
+			IL_025c: ldloc.s 14
+			IL_025e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0263: pop
+			IL_0264: ldloc.3
+			IL_0265: ldstr "push"
+			IL_026a: ldloc.s 6
+			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+			IL_0271: pop
+			IL_0272: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0277: stloc.s 9
+			IL_0279: ldloc.3
+			IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_027f: stloc.s 10
+			IL_0281: ldc.i4.1
+			IL_0282: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0287: brfalse IL_02df
 
-		IL_0247: pop
-		IL_0248: ldloc.s 9
-		IL_024a: ldstr "push"
-		IL_024f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_0254: brtrue IL_028d
+			IL_028c: ldloc.s 10
+			IL_028e: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0293: dup
+			IL_0294: brfalse IL_02de
 
-		IL_0259: ldloc.s 9
-		IL_025b: ldc.i4.1
-		IL_025c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0261: brfalse IL_028d
+			IL_0299: pop
+			IL_029a: ldloc.s 10
+			IL_029c: ldstr "push"
+			IL_02a1: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_02a6: brtrue IL_02df
 
-		IL_0266: ldloc.s 9
-		IL_0268: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_026d: ldc.r8 3
-		IL_0276: box [System.Runtime]System.Double
-		IL_027b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-		IL_0280: box [System.Runtime]System.Double
-		IL_0285: stloc.s 9
-		IL_0287: br IL_02a9
+			IL_02ab: ldloc.s 10
+			IL_02ad: ldc.i4.1
+			IL_02ae: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_02b3: brfalse IL_02df
 
-		IL_028c: pop
+			IL_02b8: ldloc.s 10
+			IL_02ba: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_02bf: ldc.r8 3
+			IL_02c8: box [System.Runtime]System.Double
+			IL_02cd: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_02d2: box [System.Runtime]System.Double
+			IL_02d7: stloc.s 10
+			IL_02d9: br IL_02fb
 
-		IL_028d: ldloc.s 9
-		IL_028f: ldstr "push"
-		IL_0294: ldc.r8 3
-		IL_029d: box [System.Runtime]System.Double
-		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02a7: stloc.s 9
+			IL_02de: pop
 
-		IL_02a9: ldloc.s 8
-		IL_02ab: ldloc.s 9
-		IL_02ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02b2: pop
-		IL_02b3: ldloc.3
-		IL_02b4: ldstr "push"
-		IL_02b9: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_02be: stloc.s 11
-		IL_02c0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02c5: stloc.s 5
-		IL_02c7: ldc.i4.1
-		IL_02c8: newarr [System.Runtime]System.Object
-		IL_02cd: dup
-		IL_02ce: ldc.i4.0
-		IL_02cf: ldloc.0
-		IL_02d0: stelem.ref
-		IL_02d1: stloc.s 6
-		IL_02d3: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L29C8/FunctionObject::.ctor()
-		IL_02d8: ldc.i4.1
-		IL_02d9: conv.r8
-		IL_02da: ldstr ""
-		IL_02df: ldc.i4.0
-		IL_02e0: ldc.i4.1
-		IL_02e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L29C8/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L29C8/FunctionObject>(!!0)
-		IL_02eb: stloc.s 13
-		IL_02ed: ldloc.s 5
-		IL_02ef: ldstr "push"
-		IL_02f4: ldloc.s 13
-		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_02fb: pop
-		IL_02fc: ldloc.3
-		IL_02fd: ldloc.s 5
-		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_0304: pop
-		IL_0305: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_030a: stloc.s 8
-		IL_030c: ldloc.3
-		IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0312: stloc.s 9
-		IL_0314: ldc.i4.1
-		IL_0315: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_031a: brfalse IL_0372
+			IL_02df: ldloc.s 10
+			IL_02e1: ldstr "push"
+			IL_02e6: ldc.r8 3
+			IL_02ef: box [System.Runtime]System.Double
+			IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02f9: stloc.s 10
 
-		IL_031f: ldloc.s 9
-		IL_0321: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0326: dup
-		IL_0327: brfalse IL_0371
+			IL_02fb: ldloc.s 9
+			IL_02fd: ldloc.s 10
+			IL_02ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0304: pop
+			IL_0305: ldloc.3
+			IL_0306: ldstr "push"
+			IL_030b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+			IL_0310: stloc.s 13
+			IL_0312: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0317: stloc.s 6
+			IL_0319: ldc.i4.1
+			IL_031a: newarr [System.Runtime]System.Object
+			IL_031f: dup
+			IL_0320: ldc.i4.0
+			IL_0321: ldloc.0
+			IL_0322: stelem.ref
+			IL_0323: stloc.s 7
+			IL_0325: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L32C12/FunctionObject::.ctor()
+			IL_032a: ldc.i4.1
+			IL_032b: conv.r8
+			IL_032c: ldstr ""
+			IL_0331: ldc.i4.0
+			IL_0332: ldc.i4.1
+			IL_0333: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L32C12/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0338: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L32C12/FunctionObject>(!!0)
+			IL_033d: stloc.s 15
+			IL_033f: ldloc.s 6
+			IL_0341: ldstr "push"
+			IL_0346: ldloc.s 15
+			IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_034d: pop
+			IL_034e: ldloc.3
+			IL_034f: ldloc.s 6
+			IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+			IL_0356: pop
+			IL_0357: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_035c: stloc.s 9
+			IL_035e: ldloc.3
+			IL_035f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0364: stloc.s 10
+			IL_0366: ldc.i4.1
+			IL_0367: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_036c: brfalse IL_03c4
 
-		IL_032c: pop
-		IL_032d: ldloc.s 9
-		IL_032f: ldstr "push"
-		IL_0334: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_0339: brtrue IL_0372
+			IL_0371: ldloc.s 10
+			IL_0373: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0378: dup
+			IL_0379: brfalse IL_03c3
 
-		IL_033e: ldloc.s 9
-		IL_0340: ldc.i4.1
-		IL_0341: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0346: brfalse IL_0372
+			IL_037e: pop
+			IL_037f: ldloc.s 10
+			IL_0381: ldstr "push"
+			IL_0386: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_038b: brtrue IL_03c4
 
-		IL_034b: ldloc.s 9
-		IL_034d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0352: ldc.r8 4
-		IL_035b: box [System.Runtime]System.Double
-		IL_0360: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-		IL_0365: box [System.Runtime]System.Double
-		IL_036a: stloc.s 9
-		IL_036c: br IL_038e
+			IL_0390: ldloc.s 10
+			IL_0392: ldc.i4.1
+			IL_0393: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0398: brfalse IL_03c4
 
-		IL_0371: pop
+			IL_039d: ldloc.s 10
+			IL_039f: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_03a4: ldc.r8 4
+			IL_03ad: box [System.Runtime]System.Double
+			IL_03b2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_03b7: box [System.Runtime]System.Double
+			IL_03bc: stloc.s 10
+			IL_03be: br IL_03e0
 
-		IL_0372: ldloc.s 9
-		IL_0374: ldstr "push"
-		IL_0379: ldc.r8 4
-		IL_0382: box [System.Runtime]System.Double
-		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_038c: stloc.s 9
+			IL_03c3: pop
 
-		IL_038e: ldloc.s 8
-		IL_0390: ldloc.s 9
-		IL_0392: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0397: pop
-		IL_0398: ldstr "Array"
-		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03a2: ldstr "prototype"
-		IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03ac: stloc.s 9
-		IL_03ae: ldloc.3
-		IL_03af: ldloc.s 9
-		IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_03b6: pop
-		IL_03b7: ldstr "Array"
-		IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03c1: ldstr "prototype"
-		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03cb: stloc.s 9
-		IL_03cd: ldc.i4.1
-		IL_03ce: newarr [System.Runtime]System.Object
-		IL_03d3: dup
-		IL_03d4: ldc.i4.0
-		IL_03d5: ldloc.0
-		IL_03d6: stelem.ref
-		IL_03d7: stloc.s 6
-		IL_03d9: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L36C23/FunctionObject::.ctor()
-		IL_03de: ldc.i4.1
-		IL_03df: conv.r8
-		IL_03e0: ldstr ""
-		IL_03e5: ldc.i4.0
-		IL_03e6: ldc.i4.1
-		IL_03e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L36C23/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03ec: stloc.s 14
-		IL_03ee: ldloc.s 9
-		IL_03f0: ldstr "push"
-		IL_03f5: ldloc.s 14
-		IL_03f7: ldc.i4.1
-		IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_03fd: pop
-		IL_03fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0403: stloc.s 8
-		IL_0405: ldloc.3
-		IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_040b: stloc.s 9
-		IL_040d: ldc.i4.1
-		IL_040e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0413: brfalse IL_046b
+			IL_03c4: ldloc.s 10
+			IL_03c6: ldstr "push"
+			IL_03cb: ldc.r8 4
+			IL_03d4: box [System.Runtime]System.Double
+			IL_03d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03de: stloc.s 10
 
-		IL_0418: ldloc.s 9
-		IL_041a: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_041f: dup
-		IL_0420: brfalse IL_046a
+			IL_03e0: ldloc.s 9
+			IL_03e2: ldloc.s 10
+			IL_03e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03e9: pop
+			IL_03ea: ldstr "Array"
+			IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03f4: ldstr "prototype"
+			IL_03f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03fe: stloc.s 10
+			IL_0400: ldloc.3
+			IL_0401: ldloc.s 10
+			IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+			IL_0408: pop
+			IL_0409: ldstr "Array"
+			IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0413: ldstr "prototype"
+			IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_041d: stloc.s 10
+			IL_041f: ldc.i4.1
+			IL_0420: newarr [System.Runtime]System.Object
+			IL_0425: dup
+			IL_0426: ldc.i4.0
+			IL_0427: ldloc.0
+			IL_0428: stelem.ref
+			IL_0429: stloc.s 7
+			IL_042b: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L39C27/FunctionObject::.ctor()
+			IL_0430: ldc.i4.1
+			IL_0431: conv.r8
+			IL_0432: ldstr ""
+			IL_0437: ldc.i4.0
+			IL_0438: ldc.i4.1
+			IL_0439: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L39C27/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_043e: stloc.s 16
+			IL_0440: ldloc.s 10
+			IL_0442: ldstr "push"
+			IL_0447: ldloc.s 16
+			IL_0449: ldc.i4.1
+			IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_044f: pop
+			IL_0450: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0455: stloc.s 9
+			IL_0457: ldloc.3
+			IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_045d: stloc.s 10
+			IL_045f: ldc.i4.1
+			IL_0460: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0465: brfalse IL_04bd
 
-		IL_0425: pop
-		IL_0426: ldloc.s 9
-		IL_0428: ldstr "push"
-		IL_042d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_0432: brtrue IL_046b
+			IL_046a: ldloc.s 10
+			IL_046c: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_0471: dup
+			IL_0472: brfalse IL_04bc
 
-		IL_0437: ldloc.s 9
-		IL_0439: ldc.i4.1
-		IL_043a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_043f: brfalse IL_046b
+			IL_0477: pop
+			IL_0478: ldloc.s 10
+			IL_047a: ldstr "push"
+			IL_047f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_0484: brtrue IL_04bd
 
-		IL_0444: ldloc.s 9
-		IL_0446: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_044b: ldc.r8 5
-		IL_0454: box [System.Runtime]System.Double
-		IL_0459: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
-		IL_045e: box [System.Runtime]System.Double
-		IL_0463: stloc.s 9
-		IL_0465: br IL_0487
+			IL_0489: ldloc.s 10
+			IL_048b: ldc.i4.1
+			IL_048c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0491: brfalse IL_04bd
 
-		IL_046a: pop
+			IL_0496: ldloc.s 10
+			IL_0498: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_049d: ldc.r8 5
+			IL_04a6: box [System.Runtime]System.Double
+			IL_04ab: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_04b0: box [System.Runtime]System.Double
+			IL_04b5: stloc.s 10
+			IL_04b7: br IL_04d9
 
-		IL_046b: ldloc.s 9
-		IL_046d: ldstr "push"
-		IL_0472: ldc.r8 5
-		IL_047b: box [System.Runtime]System.Double
-		IL_0480: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0485: stloc.s 9
+			IL_04bc: pop
 
-		IL_0487: ldloc.s 8
-		IL_0489: ldloc.s 9
-		IL_048b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0490: pop
-		IL_0491: ret
+			IL_04bd: ldloc.s 10
+			IL_04bf: ldstr "push"
+			IL_04c4: ldc.r8 5
+			IL_04cd: box [System.Runtime]System.Double
+			IL_04d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_04d7: stloc.s 10
+
+			IL_04d9: ldloc.s 9
+			IL_04db: ldloc.s 10
+			IL_04dd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04e2: pop
+			IL_04e3: ldloc.s 4
+			IL_04e5: ldc.r8 1
+			IL_04ee: add
+			IL_04ef: stloc.s 4
+			IL_04f1: br IL_00a1
+		// end loop
+
+		IL_04f6: ret
 	} // end of method Array_ReceiverCandidate_GuardedOverrides::__js_module_init__
 
 } // end of class Modules.Array_ReceiverCandidate_GuardedOverrides

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_ReceiverCandidate_GuardedOverrides.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_ReceiverCandidate_GuardedOverrides.verified.txt
@@ -1,0 +1,1261 @@
+﻿// IL code: Array_ReceiverCandidate_GuardedOverrides
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Array_ReceiverCandidate_GuardedOverrides
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_receiver
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_receiver::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject::CallCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 14 (0xe)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldstr "object:"
+			IL_0005: ldarg.1
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_000b: stloc.0
+			IL_000c: ldloc.0
+			IL_000d: ret
+		} // end of method FunctionExpression_receiver::__js_call__
+
+	} // end of class FunctionExpression_receiver
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L11C16
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L11C16::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L11C16::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 14 (0xe)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldstr "own:"
+			IL_0005: ldarg.1
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_000b: stloc.0
+			IL_000c: ldloc.0
+			IL_000d: ret
+		} // end of method FunctionExpression_L11C16::__js_call__
+
+	} // end of class FunctionExpression_L11C16
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L19C7
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L20C15
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Scope
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Scope::.ctor
+
+			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldnull
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionExpression_L20C15::__js_call__(object, object)
+					IL_000d: ret
+				} // end of method FunctionObject::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionExpression_L20C15::__js_call__(object, object)
+					IL_000d: ret
+				} // end of method FunctionObject::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject::ConstructCore
+
+			} // end of class FunctionObject
+
+
+			// Methods
+			.method public hidebysig static 
+				object __js_call__ (
+					object newTarget,
+					object 'value'
+				) cil managed 
+			{
+				.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+					01 00 00 00 00 00 00 00
+				)
+				// Header size: 12
+				// Code size: 14 (0xe)
+				.maxstack 8
+				.locals init (
+					[0] object
+				)
+
+				IL_0000: ldstr "getter:"
+				IL_0005: ldarg.1
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_000b: stloc.0
+				IL_000c: ldloc.0
+				IL_000d: ret
+			} // end of method FunctionExpression_L20C15::__js_call__
+
+		} // end of class FunctionExpression_L20C15
+
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::CallCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 34 (0x22)
+			.maxstack 8
+			.locals init (
+				[0] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/Scope,
+				[1] object[],
+				[2] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionExpression_L20C15/FunctionObject
+			)
+
+			IL_0000: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/Scope::.ctor()
+			IL_0005: stloc.0
+			IL_0006: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_000b: stloc.1
+			IL_000c: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionExpression_L20C15/FunctionObject::.ctor()
+			IL_0011: ldc.i4.1
+			IL_0012: conv.r8
+			IL_0013: ldstr ""
+			IL_0018: ldc.i4.0
+			IL_0019: ldc.i4.1
+			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionExpression_L20C15/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_001f: stloc.2
+			IL_0020: ldloc.2
+			IL_0021: ret
+		} // end of method FunctionExpression_L19C7::__js_call__
+
+	} // end of class FunctionExpression_L19C7
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L29C8
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L29C8::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject::CallCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 14 (0xe)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldstr "custom:"
+			IL_0005: ldarg.1
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_000b: stloc.0
+			IL_000c: ldloc.0
+			IL_000d: ret
+		} // end of method FunctionExpression_L29C8::__js_call__
+
+	} // end of class FunctionExpression_L29C8
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L36C23
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L36C23::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L36C23::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object 'value'
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 14 (0xe)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldstr "prototype:"
+			IL_0005: ldarg.1
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_000b: stloc.0
+			IL_000c: ldloc.0
+			IL_000d: ret
+		} // end of method FunctionExpression_L36C23::__js_call__
+
+	} // end of class FunctionExpression_L36C23
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Header size: 12
+		// Code size: 1170 (0x492)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Array_ReceiverCandidate_GuardedOverrides/Scope,
+			[1] bool,
+			[2] object,
+			[3] object,
+			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[6] object[],
+			[7] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_receiver/FunctionObject,
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[9] object,
+			[10] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L11C16/FunctionObject,
+			[11] bool,
+			[12] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionObject,
+			[13] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L29C8/FunctionObject,
+			[14] class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L36C23/FunctionObject
+		)
+
+		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
+		IL_0005: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/Scope::.ctor()
+		IL_000a: stloc.0
+		IL_000b: nop
+		IL_000c: ldc.i4.1
+		IL_000d: stloc.1
+		IL_000e: ldloc.1
+		IL_000f: brfalse IL_0024
+
+		IL_0014: ldc.i4.0
+		IL_0015: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_001a: stloc.s 4
+		IL_001c: ldloc.s 4
+		IL_001e: stloc.2
+		IL_001f: br IL_0063
+
+		IL_0024: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0029: stloc.s 5
+		IL_002b: ldc.i4.1
+		IL_002c: newarr [System.Runtime]System.Object
+		IL_0031: dup
+		IL_0032: ldc.i4.0
+		IL_0033: ldloc.0
+		IL_0034: stelem.ref
+		IL_0035: stloc.s 6
+		IL_0037: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_receiver/FunctionObject::.ctor()
+		IL_003c: ldc.i4.1
+		IL_003d: conv.r8
+		IL_003e: ldstr ""
+		IL_0043: ldc.i4.0
+		IL_0044: ldc.i4.1
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_receiver/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_receiver/FunctionObject>(!!0)
+		IL_004f: stloc.s 7
+		IL_0051: ldloc.s 5
+		IL_0053: ldstr "push"
+		IL_0058: ldloc.s 7
+		IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_005f: pop
+		IL_0060: ldloc.s 5
+		IL_0062: stloc.2
+
+		IL_0063: ldloc.2
+		IL_0064: stloc.3
+		IL_0065: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_006a: stloc.s 8
+		IL_006c: ldloc.3
+		IL_006d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0072: stloc.s 9
+		IL_0074: ldc.i4.1
+		IL_0075: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_007a: brfalse IL_00d2
+
+		IL_007f: ldloc.s 9
+		IL_0081: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_0086: dup
+		IL_0087: brfalse IL_00d1
+
+		IL_008c: pop
+		IL_008d: ldloc.s 9
+		IL_008f: ldstr "push"
+		IL_0094: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_0099: brtrue IL_00d2
+
+		IL_009e: ldloc.s 9
+		IL_00a0: ldc.i4.1
+		IL_00a1: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_00a6: brfalse IL_00d2
+
+		IL_00ab: ldloc.s 9
+		IL_00ad: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_00b2: ldc.r8 1
+		IL_00bb: box [System.Runtime]System.Double
+		IL_00c0: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+		IL_00c5: box [System.Runtime]System.Double
+		IL_00ca: stloc.s 9
+		IL_00cc: br IL_00ee
+
+		IL_00d1: pop
+
+		IL_00d2: ldloc.s 9
+		IL_00d4: ldstr "push"
+		IL_00d9: ldc.r8 1
+		IL_00e2: box [System.Runtime]System.Double
+		IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ec: stloc.s 9
+
+		IL_00ee: ldloc.s 8
+		IL_00f0: ldloc.s 9
+		IL_00f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00f7: pop
+		IL_00f8: ldc.i4.1
+		IL_00f9: newarr [System.Runtime]System.Object
+		IL_00fe: dup
+		IL_00ff: ldc.i4.0
+		IL_0100: ldloc.0
+		IL_0101: stelem.ref
+		IL_0102: stloc.s 6
+		IL_0104: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L11C16/FunctionObject::.ctor()
+		IL_0109: ldc.i4.1
+		IL_010a: conv.r8
+		IL_010b: ldstr ""
+		IL_0110: ldc.i4.0
+		IL_0111: ldc.i4.1
+		IL_0112: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L11C16/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0117: stloc.s 10
+		IL_0119: ldloc.3
+		IL_011a: ldstr "push"
+		IL_011f: ldloc.s 10
+		IL_0121: ldc.i4.1
+		IL_0122: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0127: pop
+		IL_0128: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_012d: stloc.s 8
+		IL_012f: ldloc.3
+		IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0135: stloc.s 9
+		IL_0137: ldc.i4.1
+		IL_0138: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_013d: brfalse IL_0195
+
+		IL_0142: ldloc.s 9
+		IL_0144: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_0149: dup
+		IL_014a: brfalse IL_0194
+
+		IL_014f: pop
+		IL_0150: ldloc.s 9
+		IL_0152: ldstr "push"
+		IL_0157: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_015c: brtrue IL_0195
+
+		IL_0161: ldloc.s 9
+		IL_0163: ldc.i4.1
+		IL_0164: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0169: brfalse IL_0195
+
+		IL_016e: ldloc.s 9
+		IL_0170: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_0175: ldc.r8 2
+		IL_017e: box [System.Runtime]System.Double
+		IL_0183: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+		IL_0188: box [System.Runtime]System.Double
+		IL_018d: stloc.s 9
+		IL_018f: br IL_01b1
+
+		IL_0194: pop
+
+		IL_0195: ldloc.s 9
+		IL_0197: ldstr "push"
+		IL_019c: ldc.r8 2
+		IL_01a5: box [System.Runtime]System.Double
+		IL_01aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01af: stloc.s 9
+
+		IL_01b1: ldloc.s 8
+		IL_01b3: ldloc.s 9
+		IL_01b5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01ba: pop
+		IL_01bb: ldloc.3
+		IL_01bc: ldstr "push"
+		IL_01c1: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_01c6: stloc.s 11
+		IL_01c8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01cd: stloc.s 5
+		IL_01cf: ldloc.s 5
+		IL_01d1: ldstr "configurable"
+		IL_01d6: ldc.i4.1
+		IL_01d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
+		IL_01dc: pop
+		IL_01dd: ldc.i4.1
+		IL_01de: newarr [System.Runtime]System.Object
+		IL_01e3: dup
+		IL_01e4: ldc.i4.0
+		IL_01e5: ldloc.0
+		IL_01e6: stelem.ref
+		IL_01e7: stloc.s 6
+		IL_01e9: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionObject::.ctor()
+		IL_01ee: ldc.i4.0
+		IL_01ef: conv.r8
+		IL_01f0: ldstr ""
+		IL_01f5: ldc.i4.0
+		IL_01f6: ldc.i4.1
+		IL_01f7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L19C7/FunctionObject>(!!0)
+		IL_0201: stloc.s 12
+		IL_0203: ldloc.s 5
+		IL_0205: ldstr "get"
+		IL_020a: ldloc.s 12
+		IL_020c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0211: pop
+		IL_0212: ldloc.3
+		IL_0213: ldstr "push"
+		IL_0218: ldloc.s 5
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_021f: pop
+		IL_0220: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0225: stloc.s 8
+		IL_0227: ldloc.3
+		IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_022d: stloc.s 9
+		IL_022f: ldc.i4.1
+		IL_0230: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0235: brfalse IL_028d
+
+		IL_023a: ldloc.s 9
+		IL_023c: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_0241: dup
+		IL_0242: brfalse IL_028c
+
+		IL_0247: pop
+		IL_0248: ldloc.s 9
+		IL_024a: ldstr "push"
+		IL_024f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_0254: brtrue IL_028d
+
+		IL_0259: ldloc.s 9
+		IL_025b: ldc.i4.1
+		IL_025c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0261: brfalse IL_028d
+
+		IL_0266: ldloc.s 9
+		IL_0268: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_026d: ldc.r8 3
+		IL_0276: box [System.Runtime]System.Double
+		IL_027b: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+		IL_0280: box [System.Runtime]System.Double
+		IL_0285: stloc.s 9
+		IL_0287: br IL_02a9
+
+		IL_028c: pop
+
+		IL_028d: ldloc.s 9
+		IL_028f: ldstr "push"
+		IL_0294: ldc.r8 3
+		IL_029d: box [System.Runtime]System.Double
+		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02a7: stloc.s 9
+
+		IL_02a9: ldloc.s 8
+		IL_02ab: ldloc.s 9
+		IL_02ad: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02b2: pop
+		IL_02b3: ldloc.3
+		IL_02b4: ldstr "push"
+		IL_02b9: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_02be: stloc.s 11
+		IL_02c0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02c5: stloc.s 5
+		IL_02c7: ldc.i4.1
+		IL_02c8: newarr [System.Runtime]System.Object
+		IL_02cd: dup
+		IL_02ce: ldc.i4.0
+		IL_02cf: ldloc.0
+		IL_02d0: stelem.ref
+		IL_02d1: stloc.s 6
+		IL_02d3: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L29C8/FunctionObject::.ctor()
+		IL_02d8: ldc.i4.1
+		IL_02d9: conv.r8
+		IL_02da: ldstr ""
+		IL_02df: ldc.i4.0
+		IL_02e0: ldc.i4.1
+		IL_02e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L29C8/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L29C8/FunctionObject>(!!0)
+		IL_02eb: stloc.s 13
+		IL_02ed: ldloc.s 5
+		IL_02ef: ldstr "push"
+		IL_02f4: ldloc.s 13
+		IL_02f6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_02fb: pop
+		IL_02fc: ldloc.3
+		IL_02fd: ldloc.s 5
+		IL_02ff: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_0304: pop
+		IL_0305: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_030a: stloc.s 8
+		IL_030c: ldloc.3
+		IL_030d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0312: stloc.s 9
+		IL_0314: ldc.i4.1
+		IL_0315: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_031a: brfalse IL_0372
+
+		IL_031f: ldloc.s 9
+		IL_0321: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_0326: dup
+		IL_0327: brfalse IL_0371
+
+		IL_032c: pop
+		IL_032d: ldloc.s 9
+		IL_032f: ldstr "push"
+		IL_0334: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_0339: brtrue IL_0372
+
+		IL_033e: ldloc.s 9
+		IL_0340: ldc.i4.1
+		IL_0341: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0346: brfalse IL_0372
+
+		IL_034b: ldloc.s 9
+		IL_034d: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_0352: ldc.r8 4
+		IL_035b: box [System.Runtime]System.Double
+		IL_0360: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+		IL_0365: box [System.Runtime]System.Double
+		IL_036a: stloc.s 9
+		IL_036c: br IL_038e
+
+		IL_0371: pop
+
+		IL_0372: ldloc.s 9
+		IL_0374: ldstr "push"
+		IL_0379: ldc.r8 4
+		IL_0382: box [System.Runtime]System.Double
+		IL_0387: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_038c: stloc.s 9
+
+		IL_038e: ldloc.s 8
+		IL_0390: ldloc.s 9
+		IL_0392: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0397: pop
+		IL_0398: ldstr "Array"
+		IL_039d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03a2: ldstr "prototype"
+		IL_03a7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03ac: stloc.s 9
+		IL_03ae: ldloc.3
+		IL_03af: ldloc.s 9
+		IL_03b1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_03b6: pop
+		IL_03b7: ldstr "Array"
+		IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03c1: ldstr "prototype"
+		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_03cb: stloc.s 9
+		IL_03cd: ldc.i4.1
+		IL_03ce: newarr [System.Runtime]System.Object
+		IL_03d3: dup
+		IL_03d4: ldc.i4.0
+		IL_03d5: ldloc.0
+		IL_03d6: stelem.ref
+		IL_03d7: stloc.s 6
+		IL_03d9: newobj instance void Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L36C23/FunctionObject::.ctor()
+		IL_03de: ldc.i4.1
+		IL_03df: conv.r8
+		IL_03e0: ldstr ""
+		IL_03e5: ldc.i4.0
+		IL_03e6: ldc.i4.1
+		IL_03e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_ReceiverCandidate_GuardedOverrides/FunctionExpression_L36C23/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03ec: stloc.s 14
+		IL_03ee: ldloc.s 9
+		IL_03f0: ldstr "push"
+		IL_03f5: ldloc.s 14
+		IL_03f7: ldc.i4.1
+		IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_03fd: pop
+		IL_03fe: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0403: stloc.s 8
+		IL_0405: ldloc.3
+		IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_040b: stloc.s 9
+		IL_040d: ldc.i4.1
+		IL_040e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0413: brfalse IL_046b
+
+		IL_0418: ldloc.s 9
+		IL_041a: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_041f: dup
+		IL_0420: brfalse IL_046a
+
+		IL_0425: pop
+		IL_0426: ldloc.s 9
+		IL_0428: ldstr "push"
+		IL_042d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_0432: brtrue IL_046b
+
+		IL_0437: ldloc.s 9
+		IL_0439: ldc.i4.1
+		IL_043a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_043f: brfalse IL_046b
+
+		IL_0444: ldloc.s 9
+		IL_0446: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+		IL_044b: ldc.r8 5
+		IL_0454: box [System.Runtime]System.Double
+		IL_0459: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+		IL_045e: box [System.Runtime]System.Double
+		IL_0463: stloc.s 9
+		IL_0465: br IL_0487
+
+		IL_046a: pop
+
+		IL_046b: ldloc.s 9
+		IL_046d: ldstr "push"
+		IL_0472: ldc.r8 5
+		IL_047b: box [System.Runtime]System.Double
+		IL_0480: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0485: stloc.s 9
+
+		IL_0487: ldloc.s 8
+		IL_0489: ldloc.s 9
+		IL_048b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0490: pop
+		IL_0491: ret
+	} // end of method Array_ReceiverCandidate_GuardedOverrides::__js_module_init__
+
+} // end of class Modules.Array_ReceiverCandidate_GuardedOverrides
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Array_ReceiverCandidate_GuardedOverrides::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateMethodAndAccessor_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateMethodAndAccessor_Log.verified.txt
@@ -656,7 +656,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 574 (0x23e)
+		// Code size: 612 (0x264)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassPrivateMethodAndAccessor_Log/Scope,
@@ -810,65 +810,79 @@
 		IL_018f: stloc.s 4
 		IL_0191: ldc.i4.0
 		IL_0192: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0197: brfalse IL_01c0
+		IL_0197: brfalse IL_01d3
 
 		IL_019c: ldloc.s 4
 		IL_019e: isinst [System.Runtime]System.String
 		IL_01a3: dup
-		IL_01a4: brfalse IL_01bf
+		IL_01a4: brtrue IL_01bc
 
-		IL_01a9: ldstr "#double"
-		IL_01ae: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-		IL_01b3: box [System.Runtime]System.Boolean
-		IL_01b8: stloc.s 4
-		IL_01ba: br IL_01d3
+		IL_01a9: pop
+		IL_01aa: ldloc.s 4
+		IL_01ac: ldstr "includes"
+		IL_01b1: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_01b6: dup
+		IL_01b7: brfalse IL_01d2
 
-		IL_01bf: pop
+		IL_01bc: ldstr "#double"
+		IL_01c1: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_01c6: box [System.Runtime]System.Boolean
+		IL_01cb: stloc.s 4
+		IL_01cd: br IL_01e6
 
-		IL_01c0: ldloc.s 4
-		IL_01c2: ldstr "includes"
-		IL_01c7: ldstr "#double"
-		IL_01cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d1: stloc.s 4
+		IL_01d2: pop
 
-		IL_01d3: ldloc.s 8
-		IL_01d5: ldloc.s 4
-		IL_01d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01dc: pop
-		IL_01dd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01e2: stloc.s 8
-		IL_01e4: ldloc.2
-		IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01ef: stloc.s 4
-		IL_01f1: ldc.i4.0
-		IL_01f2: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_01f7: brfalse IL_0220
+		IL_01d3: ldloc.s 4
+		IL_01d5: ldstr "includes"
+		IL_01da: ldstr "#double"
+		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01e4: stloc.s 4
 
-		IL_01fc: ldloc.s 4
-		IL_01fe: isinst [System.Runtime]System.String
-		IL_0203: dup
-		IL_0204: brfalse IL_021f
+		IL_01e6: ldloc.s 8
+		IL_01e8: ldloc.s 4
+		IL_01ea: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01ef: pop
+		IL_01f0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01f5: stloc.s 8
+		IL_01f7: ldloc.2
+		IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0202: stloc.s 4
+		IL_0204: ldc.i4.0
+		IL_0205: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_020a: brfalse IL_0246
 
-		IL_0209: ldstr "#secret"
-		IL_020e: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-		IL_0213: box [System.Runtime]System.Boolean
-		IL_0218: stloc.s 4
-		IL_021a: br IL_0233
+		IL_020f: ldloc.s 4
+		IL_0211: isinst [System.Runtime]System.String
+		IL_0216: dup
+		IL_0217: brtrue IL_022f
 
-		IL_021f: pop
+		IL_021c: pop
+		IL_021d: ldloc.s 4
+		IL_021f: ldstr "includes"
+		IL_0224: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_0229: dup
+		IL_022a: brfalse IL_0245
 
-		IL_0220: ldloc.s 4
-		IL_0222: ldstr "includes"
-		IL_0227: ldstr "#secret"
-		IL_022c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0231: stloc.s 4
+		IL_022f: ldstr "#secret"
+		IL_0234: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_0239: box [System.Runtime]System.Boolean
+		IL_023e: stloc.s 4
+		IL_0240: br IL_0259
 
-		IL_0233: ldloc.s 8
-		IL_0235: ldloc.s 4
-		IL_0237: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_023c: pop
-		IL_023d: ret
+		IL_0245: pop
+
+		IL_0246: ldloc.s 4
+		IL_0248: ldstr "includes"
+		IL_024d: ldstr "#secret"
+		IL_0252: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0257: stloc.s 4
+
+		IL_0259: ldloc.s 8
+		IL_025b: ldloc.s 4
+		IL_025d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0262: pop
+		IL_0263: ret
 	} // end of method Classes_ClassPrivateMethodAndAccessor_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateMethodAndAccessor_Log

--- a/tests/Jroc.Tests/CliTests.cs
+++ b/tests/Jroc.Tests/CliTests.cs
@@ -194,6 +194,10 @@ namespace Jroc.Tests
                 // Assert
                 Assert.Equal(0, code);
                 Assert.True(string.IsNullOrWhiteSpace(stderr), $"Unexpected stderr: {stderr}");
+                Assert.DoesNotContain(
+                    "[ReceiverFlow]",
+                    stdout,
+                    StringComparison.Ordinal);
 
                 var baseName = Path.GetFileNameWithoutExtension(jsFile);
                 var dllPath = Path.Combine(outDir, baseName + ".dll");
@@ -216,7 +220,16 @@ namespace Jroc.Tests
             var tempRoot = Path.Combine(Path.GetTempPath(), "jroc_cli_test_" + Guid.NewGuid().ToString("n"));
             Directory.CreateDirectory(tempRoot);
             var jsFile = Path.Combine(tempRoot, "simple.js");
-            File.WriteAllText(jsFile, "\"use strict\";\nconsole.log('x is', 3);");
+            File.WriteAllText(
+                jsFile,
+                """
+                "use strict";
+                let receiver = true ? [] : { push(value) { return value; } };
+                for (let index = 0; index < 1; index++) {
+                    receiver.push(index);
+                }
+                console.log('x is', 3);
+                """);
             var outDir = Path.Combine(tempRoot, "out");
             var diagnosticFile = Path.Combine(tempRoot, "diagnostics.log");
 
@@ -228,11 +241,14 @@ namespace Jroc.Tests
                 Assert.True(string.IsNullOrWhiteSpace(stderr), $"Unexpected stderr: {stderr}");
                 Assert.Contains("Compilation succeeded", stdout, StringComparison.OrdinalIgnoreCase);
                 Assert.DoesNotContain("[TwoPhase]", stdout, StringComparison.OrdinalIgnoreCase);
+                Assert.DoesNotContain("[ReceiverFlow]", stdout, StringComparison.Ordinal);
 
                 Assert.True(File.Exists(diagnosticFile), $"Missing diagnostics file: {diagnosticFile}");
                 var diagnostics = File.ReadAllText(diagnosticFile);
                 Assert.Contains("[TwoPhase]", diagnostics, StringComparison.OrdinalIgnoreCase);
                 Assert.Contains("Build the symbol tables", diagnostics, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("[ReceiverFlow]", diagnostics, StringComparison.Ordinal);
+                Assert.Contains("action=guarded", diagnostics, StringComparison.Ordinal);
             }
             finally
             {
@@ -279,6 +295,67 @@ namespace Jroc.Tests
             finally
             {
                 try { Directory.Delete(tempRoot, recursive: true); } catch { /* ignore */ }
+            }
+        }
+
+        [Fact]
+        public void Convert_Verbose_ExplainsReceiverFlowDecisions()
+        {
+            var tempRoot = Path.Combine(
+                Path.GetTempPath(),
+                "jroc_cli_test_" + Guid.NewGuid().ToString("n"));
+            Directory.CreateDirectory(tempRoot);
+            var jsFile = Path.Combine(tempRoot, "receiver-flow.js");
+            File.WriteAllText(
+                jsFile,
+                """
+                let useArray = true;
+                let receiver = useArray ? [] : {
+                    push(value) { return value; }
+                };
+                receiver.push(0);
+                for (let index = 0; index < 1; index++) {
+                    receiver.push(index);
+                }
+                """);
+            var outDir = Path.Combine(tempRoot, "out");
+
+            try
+            {
+                var (code, stdout, stderr) =
+                    RunOutOfProc(jsFile, "-o", outDir, "-v");
+
+                Assert.Equal(0, code);
+                Assert.True(
+                    string.IsNullOrWhiteSpace(stderr),
+                    $"Unexpected stderr: {stderr}");
+                Assert.Contains(
+                    "[ReceiverFlow] scope=receiver_flow",
+                    stdout,
+                    StringComparison.Ordinal);
+                Assert.Contains(
+                    "member=push",
+                    stdout,
+                    StringComparison.Ordinal);
+                Assert.Contains(
+                    "action=retained-generic(cold)",
+                    stdout,
+                    StringComparison.Ordinal);
+                Assert.Contains(
+                    "action=guarded",
+                    stdout,
+                    StringComparison.Ordinal);
+            }
+            finally
+            {
+                try
+                {
+                    Directory.Delete(tempRoot, recursive: true);
+                }
+                catch
+                {
+                    // Best-effort cleanup.
+                }
             }
         }
 

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_ImportMeta_Basic.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_ImportMeta_Basic.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 496 (0x1f0)
+		// Code size: 533 (0x215)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_ImportMeta_Basic/Scope,
@@ -119,120 +119,134 @@
 		IL_00af: stloc.s 5
 		IL_00b1: ldc.i4.0
 		IL_00b2: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_00b7: brfalse IL_00e0
+		IL_00b7: brfalse IL_00f3
 
 		IL_00bc: ldloc.s 5
 		IL_00be: isinst [System.Runtime]System.String
 		IL_00c3: dup
-		IL_00c4: brfalse IL_00df
+		IL_00c4: brtrue IL_00dc
 
-		IL_00c9: ldstr "file://"
-		IL_00ce: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-		IL_00d3: box [System.Runtime]System.Boolean
-		IL_00d8: stloc.s 5
-		IL_00da: br IL_00f3
+		IL_00c9: pop
+		IL_00ca: ldloc.s 5
+		IL_00cc: ldstr "startsWith"
+		IL_00d1: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_00d6: dup
+		IL_00d7: brfalse IL_00f2
 
-		IL_00df: pop
+		IL_00dc: ldstr "file://"
+		IL_00e1: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+		IL_00e6: box [System.Runtime]System.Boolean
+		IL_00eb: stloc.s 5
+		IL_00ed: br IL_0106
 
-		IL_00e0: ldloc.s 5
-		IL_00e2: ldstr "startsWith"
-		IL_00e7: ldstr "file://"
-		IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00f1: stloc.s 5
+		IL_00f2: pop
 
-		IL_00f3: ldloc.2
-		IL_00f4: ldloc.s 5
-		IL_00f6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00fb: pop
-		IL_00fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0101: stloc.2
-		IL_0102: ldarg.3
-		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
-		IL_0108: stloc.s 5
-		IL_010a: ldloc.s 5
-		IL_010c: ldstr "url"
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0116: stloc.s 5
-		IL_0118: ldloc.1
-		IL_0119: ldloc.s 5
-		IL_011b: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
-		IL_0120: stloc.s 5
-		IL_0122: ldloc.s 5
-		IL_0124: ldarg.3
-		IL_0125: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_012a: stloc.s 6
-		IL_012c: ldloc.s 6
-		IL_012e: box [System.Runtime]System.Boolean
-		IL_0133: stloc.s 7
-		IL_0135: ldloc.2
-		IL_0136: ldloc.s 7
-		IL_0138: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_013d: pop
-		IL_013e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0143: stloc.2
-		IL_0144: ldloc.1
-		IL_0145: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URL()
-		IL_014a: stloc.s 5
-		IL_014c: ldarg.3
-		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
-		IL_0152: stloc.3
-		IL_0153: ldloc.3
-		IL_0154: ldstr "url"
-		IL_0159: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_015e: stloc.3
-		IL_015f: ldloc.s 5
-		IL_0161: dup
-		IL_0162: ldstr "./fixtures/demo.txt"
-		IL_0167: ldloc.3
-		IL_0168: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
-		IL_016d: stloc.3
-		IL_016e: ldloc.1
-		IL_016f: ldloc.3
-		IL_0170: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
-		IL_0175: stloc.3
-		IL_0176: ldloc.3
-		IL_0177: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_017c: ldstr "split"
-		IL_0181: ldstr "\\"
-		IL_0186: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_018b: stloc.3
-		IL_018c: ldloc.3
-		IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0192: ldstr "join"
-		IL_0197: ldstr "/"
-		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01a1: stloc.3
-		IL_01a2: ldloc.3
-		IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01a8: stloc.3
-		IL_01a9: ldc.i4.0
-		IL_01aa: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_01af: brfalse IL_01d6
+		IL_00f3: ldloc.s 5
+		IL_00f5: ldstr "startsWith"
+		IL_00fa: ldstr "file://"
+		IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0104: stloc.s 5
 
-		IL_01b4: ldloc.3
-		IL_01b5: isinst [System.Runtime]System.String
-		IL_01ba: dup
-		IL_01bb: brfalse IL_01d5
+		IL_0106: ldloc.2
+		IL_0107: ldloc.s 5
+		IL_0109: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_010e: pop
+		IL_010f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0114: stloc.2
+		IL_0115: ldarg.3
+		IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
+		IL_011b: stloc.s 5
+		IL_011d: ldloc.s 5
+		IL_011f: ldstr "url"
+		IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0129: stloc.s 5
+		IL_012b: ldloc.1
+		IL_012c: ldloc.s 5
+		IL_012e: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
+		IL_0133: stloc.s 5
+		IL_0135: ldloc.s 5
+		IL_0137: ldarg.3
+		IL_0138: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_013d: stloc.s 6
+		IL_013f: ldloc.s 6
+		IL_0141: box [System.Runtime]System.Boolean
+		IL_0146: stloc.s 7
+		IL_0148: ldloc.2
+		IL_0149: ldloc.s 7
+		IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0150: pop
+		IL_0151: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0156: stloc.2
+		IL_0157: ldloc.1
+		IL_0158: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::get_URL()
+		IL_015d: stloc.s 5
+		IL_015f: ldarg.3
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetImportMeta(object)
+		IL_0165: stloc.3
+		IL_0166: ldloc.3
+		IL_0167: ldstr "url"
+		IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0171: stloc.3
+		IL_0172: ldloc.s 5
+		IL_0174: dup
+		IL_0175: ldstr "./fixtures/demo.txt"
+		IL_017a: ldloc.3
+		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
+		IL_0180: stloc.3
+		IL_0181: ldloc.1
+		IL_0182: ldloc.3
+		IL_0183: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
+		IL_0188: stloc.3
+		IL_0189: ldloc.3
+		IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_018f: ldstr "split"
+		IL_0194: ldstr "\\"
+		IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_019e: stloc.3
+		IL_019f: ldloc.3
+		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01a5: ldstr "join"
+		IL_01aa: ldstr "/"
+		IL_01af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b4: stloc.3
+		IL_01b5: ldloc.3
+		IL_01b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01bb: stloc.3
+		IL_01bc: ldc.i4.0
+		IL_01bd: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_01c2: brfalse IL_01fb
 
-		IL_01c0: ldstr "/fixtures/demo.txt"
-		IL_01c5: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
-		IL_01ca: box [System.Runtime]System.Boolean
-		IL_01cf: stloc.3
-		IL_01d0: br IL_01e7
+		IL_01c7: ldloc.3
+		IL_01c8: isinst [System.Runtime]System.String
+		IL_01cd: dup
+		IL_01ce: brtrue IL_01e5
 
-		IL_01d5: pop
+		IL_01d3: pop
+		IL_01d4: ldloc.3
+		IL_01d5: ldstr "endsWith"
+		IL_01da: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_01df: dup
+		IL_01e0: brfalse IL_01fa
 
-		IL_01d6: ldloc.3
-		IL_01d7: ldstr "endsWith"
-		IL_01dc: ldstr "/fixtures/demo.txt"
-		IL_01e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01e6: stloc.3
+		IL_01e5: ldstr "/fixtures/demo.txt"
+		IL_01ea: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
+		IL_01ef: box [System.Runtime]System.Boolean
+		IL_01f4: stloc.3
+		IL_01f5: br IL_020c
 
-		IL_01e7: ldloc.2
-		IL_01e8: ldloc.3
-		IL_01e9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ee: pop
-		IL_01ef: ret
+		IL_01fa: pop
+
+		IL_01fb: ldloc.3
+		IL_01fc: ldstr "endsWith"
+		IL_0201: ldstr "/fixtures/demo.txt"
+		IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_020b: stloc.3
+
+		IL_020c: ldloc.2
+		IL_020d: ldloc.3
+		IL_020e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0213: pop
+		IL_0214: ret
 	} // end of method CommonJS_ImportMeta_Basic::__js_module_init__
 
 } // end of class Modules.CommonJS_ImportMeta_Basic

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_BoundFunctionObject_UnifiedTargets.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_BoundFunctionObject_UnifiedTargets.verified.txt
@@ -794,7 +794,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1757 (0x6dd)
+		// Code size: 1776 (0x6f0)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Function_BoundFunctionObject_UnifiedTargets/Scope,
@@ -1067,366 +1067,373 @@
 		IL_02d2: stloc.s 23
 		IL_02d4: ldc.i4.0
 		IL_02d5: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_02da: brfalse IL_0303
+		IL_02da: brfalse IL_0316
 
 		IL_02df: ldloc.s 23
 		IL_02e1: isinst [System.Runtime]System.String
 		IL_02e6: dup
-		IL_02e7: brfalse IL_0302
+		IL_02e7: brtrue IL_02ff
 
-		IL_02ec: ldstr "bound add"
-		IL_02f1: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-		IL_02f6: box [System.Runtime]System.Boolean
-		IL_02fb: stloc.s 23
-		IL_02fd: br IL_0316
+		IL_02ec: pop
+		IL_02ed: ldloc.s 23
+		IL_02ef: ldstr "includes"
+		IL_02f4: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_02f9: dup
+		IL_02fa: brfalse IL_0315
 
-		IL_0302: pop
+		IL_02ff: ldstr "bound add"
+		IL_0304: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_0309: box [System.Runtime]System.Boolean
+		IL_030e: stloc.s 23
+		IL_0310: br IL_0329
 
-		IL_0303: ldloc.s 23
-		IL_0305: ldstr "includes"
-		IL_030a: ldstr "bound add"
-		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0314: stloc.s 23
+		IL_0315: pop
 
-		IL_0316: ldloc.s 18
-		IL_0318: ldstr "toString"
-		IL_031d: ldloc.s 23
-		IL_031f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0324: pop
-		IL_0325: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_032a: stloc.s 17
-		IL_032c: ldloc.s 17
-		IL_032e: ldstr "value"
-		IL_0333: ldc.r8 5
-		IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, float64)
-		IL_0341: pop
-		IL_0342: ldc.i4.1
-		IL_0343: newarr [System.Runtime]System.Object
-		IL_0348: dup
-		IL_0349: ldc.i4.0
-		IL_034a: ldloc.0
-		IL_034b: stelem.ref
-		IL_034c: stloc.s 16
-		IL_034e: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject::.ctor()
-		IL_0353: ldc.i4.1
-		IL_0354: conv.r8
-		IL_0355: ldstr ""
-		IL_035a: ldc.i4.0
-		IL_035b: ldc.i4.1
-		IL_035c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0361: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject>(!!0)
-		IL_0366: stloc.s 30
-		IL_0368: ldloc.s 17
-		IL_036a: ldstr "method"
-		IL_036f: ldloc.s 30
-		IL_0371: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0376: pop
-		IL_0377: ldloc.s 17
-		IL_0379: stloc.s 4
-		IL_037b: ldloc.s 4
+		IL_0316: ldloc.s 23
+		IL_0318: ldstr "includes"
+		IL_031d: ldstr "bound add"
+		IL_0322: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0327: stloc.s 23
+
+		IL_0329: ldloc.s 18
+		IL_032b: ldstr "toString"
+		IL_0330: ldloc.s 23
+		IL_0332: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0337: pop
+		IL_0338: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_033d: stloc.s 17
+		IL_033f: ldloc.s 17
+		IL_0341: ldstr "value"
+		IL_0346: ldc.r8 5
+		IL_034f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, float64)
+		IL_0354: pop
+		IL_0355: ldc.i4.1
+		IL_0356: newarr [System.Runtime]System.Object
+		IL_035b: dup
+		IL_035c: ldc.i4.0
+		IL_035d: ldloc.0
+		IL_035e: stelem.ref
+		IL_035f: stloc.s 16
+		IL_0361: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject::.ctor()
+		IL_0366: ldc.i4.1
+		IL_0367: conv.r8
+		IL_0368: ldstr ""
+		IL_036d: ldc.i4.0
+		IL_036e: ldc.i4.1
+		IL_036f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0374: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject>(!!0)
+		IL_0379: stloc.s 30
+		IL_037b: ldloc.s 17
 		IL_037d: ldstr "method"
-		IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0387: stloc.s 23
-		IL_0389: ldloc.s 23
-		IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0390: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0395: dup
-		IL_0396: ldstr "value"
-		IL_039b: ldc.r8 20
-		IL_03a4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_03a9: stloc.s 17
-		IL_03ab: ldstr "bind"
-		IL_03b0: ldloc.s 17
-		IL_03b2: ldc.r8 2
-		IL_03bb: box [System.Runtime]System.Double
-		IL_03c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_03c5: stloc.s 5
-		IL_03c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03cc: stloc.s 18
-		IL_03ce: ldloc.s 5
-		IL_03d0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_03da: stloc.s 23
-		IL_03dc: ldloc.s 5
-		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_03e3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03e8: dup
-		IL_03e9: ldstr "value"
-		IL_03ee: ldc.r8 100
-		IL_03f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_03fc: stloc.s 17
-		IL_03fe: ldstr "call"
-		IL_0403: ldloc.s 17
-		IL_0405: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_040a: stloc.s 22
-		IL_040c: ldloc.s 18
-		IL_040e: ldstr "method"
-		IL_0413: ldloc.s 23
-		IL_0415: ldloc.s 22
-		IL_0417: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_041c: pop
-		IL_041d: ldc.i4.1
-		IL_041e: newarr [System.Runtime]System.Object
-		IL_0423: dup
-		IL_0424: ldc.i4.0
-		IL_0425: ldloc.0
-		IL_0426: stelem.ref
-		IL_0427: stloc.s 16
-		IL_0429: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject::.ctor()
-		IL_042e: ldc.i4.1
-		IL_042f: conv.r8
-		IL_0430: ldstr ""
-		IL_0435: ldc.i4.0
-		IL_0436: ldc.i4.0
-		IL_0437: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_043c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject>(!!0)
-		IL_0441: stloc.s 31
-		IL_0443: ldloc.s 31
-		IL_0445: ldstr "arrow"
-		IL_044a: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_044f: stloc.s 6
-		IL_0451: ldloc.s 6
-		IL_0453: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0458: ldstr "bind"
-		IL_045d: ldc.i4.0
-		IL_045e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-		IL_0463: ldc.r8 4
-		IL_046c: box [System.Runtime]System.Double
-		IL_0471: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0476: stloc.s 7
-		IL_0478: ldc.i4.0
-		IL_0479: box [System.Runtime]System.Boolean
-		IL_047e: stloc.s 8
+		IL_0382: ldloc.s 30
+		IL_0384: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0389: pop
+		IL_038a: ldloc.s 17
+		IL_038c: stloc.s 4
+		IL_038e: ldloc.s 4
+		IL_0390: ldstr "method"
+		IL_0395: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_039a: stloc.s 23
+		IL_039c: ldloc.s 23
+		IL_039e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03a3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03a8: dup
+		IL_03a9: ldstr "value"
+		IL_03ae: ldc.r8 20
+		IL_03b7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_03bc: stloc.s 17
+		IL_03be: ldstr "bind"
+		IL_03c3: ldloc.s 17
+		IL_03c5: ldc.r8 2
+		IL_03ce: box [System.Runtime]System.Double
+		IL_03d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_03d8: stloc.s 5
+		IL_03da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03df: stloc.s 18
+		IL_03e1: ldloc.s 5
+		IL_03e3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03e8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_03ed: stloc.s 23
+		IL_03ef: ldloc.s 5
+		IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03f6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03fb: dup
+		IL_03fc: ldstr "value"
+		IL_0401: ldc.r8 100
+		IL_040a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_040f: stloc.s 17
+		IL_0411: ldstr "call"
+		IL_0416: ldloc.s 17
+		IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_041d: stloc.s 22
+		IL_041f: ldloc.s 18
+		IL_0421: ldstr "method"
+		IL_0426: ldloc.s 23
+		IL_0428: ldloc.s 22
+		IL_042a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_042f: pop
+		IL_0430: ldc.i4.1
+		IL_0431: newarr [System.Runtime]System.Object
+		IL_0436: dup
+		IL_0437: ldc.i4.0
+		IL_0438: ldloc.0
+		IL_0439: stelem.ref
+		IL_043a: stloc.s 16
+		IL_043c: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject::.ctor()
+		IL_0441: ldc.i4.1
+		IL_0442: conv.r8
+		IL_0443: ldstr ""
+		IL_0448: ldc.i4.0
+		IL_0449: ldc.i4.0
+		IL_044a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_044f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject>(!!0)
+		IL_0454: stloc.s 31
+		IL_0456: ldloc.s 31
+		IL_0458: ldstr "arrow"
+		IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_0462: stloc.s 6
+		IL_0464: ldloc.s 6
+		IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_046b: ldstr "bind"
+		IL_0470: ldc.i4.0
+		IL_0471: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+		IL_0476: ldc.r8 4
+		IL_047f: box [System.Runtime]System.Double
+		IL_0484: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0489: stloc.s 7
+		IL_048b: ldc.i4.0
+		IL_048c: box [System.Runtime]System.Boolean
+		IL_0491: stloc.s 8
 		.try
 		{
-			IL_0480: nop
-			IL_0481: ldstr "Reflect"
-			IL_0486: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_048b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0490: ldc.i4.0
-			IL_0491: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0496: stloc.s 21
-			IL_0498: ldstr "construct"
-			IL_049d: ldloc.s 7
-			IL_049f: ldloc.s 21
-			IL_04a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_04a6: pop
-			IL_04a7: leave IL_050b
+			IL_0493: nop
+			IL_0494: ldstr "Reflect"
+			IL_0499: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_049e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04a3: ldc.i4.0
+			IL_04a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_04a9: stloc.s 21
+			IL_04ab: ldstr "construct"
+			IL_04b0: ldloc.s 7
+			IL_04b2: ldloc.s 21
+			IL_04b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_04b9: pop
+			IL_04ba: leave IL_051e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_04ac: stloc.s 9
-			IL_04ae: ldloc.s 9
-			IL_04b0: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_04b5: dup
-			IL_04b6: brtrue IL_04cc
+			IL_04bf: stloc.s 9
+			IL_04c1: ldloc.s 9
+			IL_04c3: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_04c8: dup
+			IL_04c9: brtrue IL_04df
 
-			IL_04bb: pop
-			IL_04bc: ldloc.s 9
-			IL_04be: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_04c3: dup
-			IL_04c4: brtrue IL_04d8
+			IL_04ce: pop
+			IL_04cf: ldloc.s 9
+			IL_04d1: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_04d6: dup
+			IL_04d7: brtrue IL_04eb
 
-			IL_04c9: pop
-			IL_04ca: rethrow
+			IL_04dc: pop
+			IL_04dd: rethrow
 
-			IL_04cc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_04d1: stloc.s 10
-			IL_04d3: br IL_04da
+			IL_04df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_04e4: stloc.s 10
+			IL_04e6: br IL_04ed
 
-			IL_04d8: stloc.s 10
+			IL_04eb: stloc.s 10
 
-			IL_04da: ldloc.s 10
-			IL_04dc: stloc.s 11
-			IL_04de: ldloc.s 11
-			IL_04e0: stloc.s 22
-			IL_04e2: ldstr "TypeError"
-			IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04ec: stloc.s 23
-			IL_04ee: ldloc.s 22
-			IL_04f0: ldloc.s 23
-			IL_04f2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_04f7: stloc.s 28
-			IL_04f9: ldloc.s 28
-			IL_04fb: box [System.Runtime]System.Boolean
-			IL_0500: stloc.s 29
-			IL_0502: ldloc.s 29
-			IL_0504: stloc.s 8
-			IL_0506: leave IL_050b
+			IL_04ed: ldloc.s 10
+			IL_04ef: stloc.s 11
+			IL_04f1: ldloc.s 11
+			IL_04f3: stloc.s 22
+			IL_04f5: ldstr "TypeError"
+			IL_04fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04ff: stloc.s 23
+			IL_0501: ldloc.s 22
+			IL_0503: ldloc.s 23
+			IL_0505: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_050a: stloc.s 28
+			IL_050c: ldloc.s 28
+			IL_050e: box [System.Runtime]System.Boolean
+			IL_0513: stloc.s 29
+			IL_0515: ldloc.s 29
+			IL_0517: stloc.s 8
+			IL_0519: leave IL_051e
 		} // end handler
 
-		IL_050b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0510: stloc.s 18
-		IL_0512: ldloc.s 7
-		IL_0514: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0519: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_051e: stloc.s 23
-		IL_0520: ldloc.s 18
-		IL_0522: ldstr "arrow"
-		IL_0527: ldloc.s 23
-		IL_0529: ldloc.s 8
-		IL_052b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0530: pop
-		IL_0531: ldc.i4.1
-		IL_0532: newarr [System.Runtime]System.Object
-		IL_0537: dup
-		IL_0538: ldc.i4.0
-		IL_0539: ldloc.0
-		IL_053a: stelem.ref
-		IL_053b: stloc.s 16
-		IL_053d: ldtoken Modules.Function_BoundFunctionObject_UnifiedTargets/Box
-		IL_0542: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0547: ldtoken Modules.Function_BoundFunctionObject_UnifiedTargets/Box
-		IL_054c: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0551: stloc.s 32
-		IL_0553: ldloc.s 16
-		IL_0555: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/Box/Scope_ctor/FunctionObject::.ctor(object[])
-		IL_055a: ldloc.s 32
-		IL_055c: ldloc.s 16
-		IL_055e: ldc.i4.2
-		IL_055f: conv.r8
-		IL_0560: ldc.i4.0
-		IL_0561: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0566: castclass Modules.Function_BoundFunctionObject_UnifiedTargets/Box/Scope_ctor/FunctionObject
-		IL_056b: stloc.s 33
-		IL_056d: ldloc.s 33
-		IL_056f: stloc.s 12
-		IL_0571: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0576: dup
-		IL_0577: ldstr "ignored"
-		IL_057c: ldc.i4.1
-		IL_057d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-		IL_0582: stloc.s 17
-		IL_0584: ldloc.s 12
-		IL_0586: ldstr "bind"
-		IL_058b: ldloc.s 17
-		IL_058d: ldc.r8 7
-		IL_0596: box [System.Runtime]System.Double
-		IL_059b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_05a0: stloc.s 13
-		IL_05a2: ldloc.s 13
-		IL_05a4: dup
-		IL_05a5: ldc.r8 8
-		IL_05ae: box [System.Runtime]System.Double
-		IL_05b3: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_05b8: stloc.s 14
-		IL_05ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05bf: stloc.s 18
-		IL_05c1: ldloc.s 14
-		IL_05c3: ldstr "total"
-		IL_05c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05cd: stloc.s 23
-		IL_05cf: ldloc.s 14
-		IL_05d1: ldstr "seenNewTarget"
-		IL_05d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05db: stloc.s 22
-		IL_05dd: ldloc.s 22
-		IL_05df: ldloc.s 12
-		IL_05e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_05e6: stloc.s 28
-		IL_05e8: ldloc.s 28
-		IL_05ea: box [System.Runtime]System.Boolean
-		IL_05ef: stloc.s 29
-		IL_05f1: ldloc.s 14
-		IL_05f3: ldloc.s 12
-		IL_05f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_05fa: stloc.s 28
-		IL_05fc: ldloc.s 28
-		IL_05fe: box [System.Runtime]System.Boolean
-		IL_0603: stloc.s 27
-		IL_0605: ldloc.s 14
-		IL_0607: ldloc.s 13
-		IL_0609: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_060e: stloc.s 28
-		IL_0610: ldloc.s 28
-		IL_0612: box [System.Runtime]System.Boolean
-		IL_0617: stloc.s 26
-		IL_0619: ldloc.s 13
-		IL_061b: ldstr "name"
-		IL_0620: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0625: stloc.s 22
-		IL_0627: ldloc.s 13
-		IL_0629: ldstr "length"
-		IL_062e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0633: stloc.s 20
-		IL_0635: ldloc.s 13
-		IL_0637: ldstr "prototype"
-		IL_063c: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
-		IL_0641: box [System.Runtime]System.Boolean
-		IL_0646: stloc.s 25
-		IL_0648: ldloc.s 18
-		IL_064a: ldc.i4.8
-		IL_064b: newarr [System.Runtime]System.Object
-		IL_0650: dup
-		IL_0651: ldc.i4.0
-		IL_0652: ldstr "class"
-		IL_0657: stelem.ref
-		IL_0658: dup
-		IL_0659: ldc.i4.1
-		IL_065a: ldloc.s 23
-		IL_065c: stelem.ref
-		IL_065d: dup
-		IL_065e: ldc.i4.2
-		IL_065f: ldloc.s 29
-		IL_0661: stelem.ref
-		IL_0662: dup
-		IL_0663: ldc.i4.3
-		IL_0664: ldloc.s 27
-		IL_0666: stelem.ref
-		IL_0667: dup
-		IL_0668: ldc.i4.4
-		IL_0669: ldloc.s 26
-		IL_066b: stelem.ref
-		IL_066c: dup
-		IL_066d: ldc.i4.5
-		IL_066e: ldloc.s 22
-		IL_0670: stelem.ref
-		IL_0671: dup
-		IL_0672: ldc.i4.6
-		IL_0673: ldloc.s 20
-		IL_0675: stelem.ref
-		IL_0676: dup
-		IL_0677: ldc.i4.7
-		IL_0678: ldloc.s 25
-		IL_067a: stelem.ref
-		IL_067b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0680: pop
-		IL_0681: ldc.i4.1
-		IL_0682: newarr [System.Runtime]System.Object
-		IL_0687: dup
-		IL_0688: ldc.i4.0
-		IL_0689: ldloc.0
-		IL_068a: stelem.ref
-		IL_068b: stloc.s 16
-		IL_068d: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject::.ctor()
-		IL_0692: ldc.i4.0
-		IL_0693: conv.r8
-		IL_0694: ldstr ""
-		IL_0699: ldc.i4.0
-		IL_069a: ldc.i4.1
-		IL_069b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_06a0: stloc.s 34
-		IL_06a2: ldloc.2
-		IL_06a3: ldstr "call"
-		IL_06a8: ldloc.s 34
-		IL_06aa: ldc.i4.1
-		IL_06ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_06b0: pop
-		IL_06b1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_06b6: stloc.s 18
-		IL_06b8: ldloc.2
-		IL_06b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_06be: ldstr "call"
-		IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_06c8: stloc.s 20
-		IL_06ca: ldloc.s 18
-		IL_06cc: ldstr "override"
-		IL_06d1: ldloc.s 20
-		IL_06d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_06d8: pop
-		IL_06d9: ldnull
-		IL_06da: stloc.s 15
-		IL_06dc: ret
+		IL_051e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0523: stloc.s 18
+		IL_0525: ldloc.s 7
+		IL_0527: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_052c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0531: stloc.s 23
+		IL_0533: ldloc.s 18
+		IL_0535: ldstr "arrow"
+		IL_053a: ldloc.s 23
+		IL_053c: ldloc.s 8
+		IL_053e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0543: pop
+		IL_0544: ldc.i4.1
+		IL_0545: newarr [System.Runtime]System.Object
+		IL_054a: dup
+		IL_054b: ldc.i4.0
+		IL_054c: ldloc.0
+		IL_054d: stelem.ref
+		IL_054e: stloc.s 16
+		IL_0550: ldtoken Modules.Function_BoundFunctionObject_UnifiedTargets/Box
+		IL_0555: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_055a: ldtoken Modules.Function_BoundFunctionObject_UnifiedTargets/Box
+		IL_055f: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0564: stloc.s 32
+		IL_0566: ldloc.s 16
+		IL_0568: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/Box/Scope_ctor/FunctionObject::.ctor(object[])
+		IL_056d: ldloc.s 32
+		IL_056f: ldloc.s 16
+		IL_0571: ldc.i4.2
+		IL_0572: conv.r8
+		IL_0573: ldc.i4.0
+		IL_0574: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_0579: castclass Modules.Function_BoundFunctionObject_UnifiedTargets/Box/Scope_ctor/FunctionObject
+		IL_057e: stloc.s 33
+		IL_0580: ldloc.s 33
+		IL_0582: stloc.s 12
+		IL_0584: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0589: dup
+		IL_058a: ldstr "ignored"
+		IL_058f: ldc.i4.1
+		IL_0590: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0595: stloc.s 17
+		IL_0597: ldloc.s 12
+		IL_0599: ldstr "bind"
+		IL_059e: ldloc.s 17
+		IL_05a0: ldc.r8 7
+		IL_05a9: box [System.Runtime]System.Double
+		IL_05ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_05b3: stloc.s 13
+		IL_05b5: ldloc.s 13
+		IL_05b7: dup
+		IL_05b8: ldc.r8 8
+		IL_05c1: box [System.Runtime]System.Double
+		IL_05c6: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_05cb: stloc.s 14
+		IL_05cd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05d2: stloc.s 18
+		IL_05d4: ldloc.s 14
+		IL_05d6: ldstr "total"
+		IL_05db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05e0: stloc.s 23
+		IL_05e2: ldloc.s 14
+		IL_05e4: ldstr "seenNewTarget"
+		IL_05e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05ee: stloc.s 22
+		IL_05f0: ldloc.s 22
+		IL_05f2: ldloc.s 12
+		IL_05f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_05f9: stloc.s 28
+		IL_05fb: ldloc.s 28
+		IL_05fd: box [System.Runtime]System.Boolean
+		IL_0602: stloc.s 29
+		IL_0604: ldloc.s 14
+		IL_0606: ldloc.s 12
+		IL_0608: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_060d: stloc.s 28
+		IL_060f: ldloc.s 28
+		IL_0611: box [System.Runtime]System.Boolean
+		IL_0616: stloc.s 27
+		IL_0618: ldloc.s 14
+		IL_061a: ldloc.s 13
+		IL_061c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0621: stloc.s 28
+		IL_0623: ldloc.s 28
+		IL_0625: box [System.Runtime]System.Boolean
+		IL_062a: stloc.s 26
+		IL_062c: ldloc.s 13
+		IL_062e: ldstr "name"
+		IL_0633: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0638: stloc.s 22
+		IL_063a: ldloc.s 13
+		IL_063c: ldstr "length"
+		IL_0641: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0646: stloc.s 20
+		IL_0648: ldloc.s 13
+		IL_064a: ldstr "prototype"
+		IL_064f: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::hasOwn(object, object)
+		IL_0654: box [System.Runtime]System.Boolean
+		IL_0659: stloc.s 25
+		IL_065b: ldloc.s 18
+		IL_065d: ldc.i4.8
+		IL_065e: newarr [System.Runtime]System.Object
+		IL_0663: dup
+		IL_0664: ldc.i4.0
+		IL_0665: ldstr "class"
+		IL_066a: stelem.ref
+		IL_066b: dup
+		IL_066c: ldc.i4.1
+		IL_066d: ldloc.s 23
+		IL_066f: stelem.ref
+		IL_0670: dup
+		IL_0671: ldc.i4.2
+		IL_0672: ldloc.s 29
+		IL_0674: stelem.ref
+		IL_0675: dup
+		IL_0676: ldc.i4.3
+		IL_0677: ldloc.s 27
+		IL_0679: stelem.ref
+		IL_067a: dup
+		IL_067b: ldc.i4.4
+		IL_067c: ldloc.s 26
+		IL_067e: stelem.ref
+		IL_067f: dup
+		IL_0680: ldc.i4.5
+		IL_0681: ldloc.s 22
+		IL_0683: stelem.ref
+		IL_0684: dup
+		IL_0685: ldc.i4.6
+		IL_0686: ldloc.s 20
+		IL_0688: stelem.ref
+		IL_0689: dup
+		IL_068a: ldc.i4.7
+		IL_068b: ldloc.s 25
+		IL_068d: stelem.ref
+		IL_068e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0693: pop
+		IL_0694: ldc.i4.1
+		IL_0695: newarr [System.Runtime]System.Object
+		IL_069a: dup
+		IL_069b: ldc.i4.0
+		IL_069c: ldloc.0
+		IL_069d: stelem.ref
+		IL_069e: stloc.s 16
+		IL_06a0: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject::.ctor()
+		IL_06a5: ldc.i4.0
+		IL_06a6: conv.r8
+		IL_06a7: ldstr ""
+		IL_06ac: ldc.i4.0
+		IL_06ad: ldc.i4.1
+		IL_06ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_06b3: stloc.s 34
+		IL_06b5: ldloc.2
+		IL_06b6: ldstr "call"
+		IL_06bb: ldloc.s 34
+		IL_06bd: ldc.i4.1
+		IL_06be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_06c3: pop
+		IL_06c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_06c9: stloc.s 18
+		IL_06cb: ldloc.2
+		IL_06cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_06d1: ldstr "call"
+		IL_06d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_06db: stloc.s 20
+		IL_06dd: ldloc.s 18
+		IL_06df: ldstr "override"
+		IL_06e4: ldloc.s 20
+		IL_06e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_06eb: pop
+		IL_06ec: ldnull
+		IL_06ed: stloc.s 15
+		IL_06ef: ret
 	} // end of method Function_BoundFunctionObject_UnifiedTargets::__js_module_init__
 
 } // end of class Modules.Function_BoundFunctionObject_UnifiedTargets

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableReflection_ProxyIntegration.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableReflection_ProxyIntegration.verified.txt
@@ -1782,7 +1782,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 3002 (0xbba)
+		// Code size: 3040 (0xbe0)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallableReflection_ProxyIntegration/Scope,
@@ -2129,852 +2129,866 @@
 		IL_02fa: stloc.s 42
 		IL_02fc: ldc.i4.0
 		IL_02fd: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0302: brfalse IL_032b
+		IL_0302: brfalse IL_033e
 
 		IL_0307: ldloc.s 42
 		IL_0309: isinst [System.Runtime]System.String
 		IL_030e: dup
-		IL_030f: brfalse IL_032a
+		IL_030f: brtrue IL_0327
 
-		IL_0314: ldstr "name"
-		IL_0319: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-		IL_031e: box [System.Runtime]System.Boolean
-		IL_0323: stloc.s 42
-		IL_0325: br IL_033e
+		IL_0314: pop
+		IL_0315: ldloc.s 42
+		IL_0317: ldstr "includes"
+		IL_031c: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_0321: dup
+		IL_0322: brfalse IL_033d
 
-		IL_032a: pop
+		IL_0327: ldstr "name"
+		IL_032c: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_0331: box [System.Runtime]System.Boolean
+		IL_0336: stloc.s 42
+		IL_0338: br IL_0351
 
-		IL_032b: ldloc.s 42
-		IL_032d: ldstr "includes"
-		IL_0332: ldstr "name"
-		IL_0337: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_033c: stloc.s 42
+		IL_033d: pop
 
-		IL_033e: ldloc.0
-		IL_033f: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0344: stloc.s 36
-		IL_0346: ldloc.s 36
-		IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
-		IL_034d: stloc.s 36
-		IL_034f: ldloc.s 36
-		IL_0351: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0356: stloc.s 36
-		IL_0358: ldc.i4.0
-		IL_0359: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_035e: brfalse IL_0387
+		IL_033e: ldloc.s 42
+		IL_0340: ldstr "includes"
+		IL_0345: ldstr "name"
+		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_034f: stloc.s 42
 
-		IL_0363: ldloc.s 36
-		IL_0365: isinst [System.Runtime]System.String
-		IL_036a: dup
-		IL_036b: brfalse IL_0386
+		IL_0351: ldloc.0
+		IL_0352: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0357: stloc.s 36
+		IL_0359: ldloc.s 36
+		IL_035b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyNames(object)
+		IL_0360: stloc.s 36
+		IL_0362: ldloc.s 36
+		IL_0364: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0369: stloc.s 36
+		IL_036b: ldc.i4.0
+		IL_036c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0371: brfalse IL_03ad
 
-		IL_0370: ldstr "length"
-		IL_0375: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-		IL_037a: box [System.Runtime]System.Boolean
-		IL_037f: stloc.s 36
-		IL_0381: br IL_039a
+		IL_0376: ldloc.s 36
+		IL_0378: isinst [System.Runtime]System.String
+		IL_037d: dup
+		IL_037e: brtrue IL_0396
 
-		IL_0386: pop
+		IL_0383: pop
+		IL_0384: ldloc.s 36
+		IL_0386: ldstr "includes"
+		IL_038b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_0390: dup
+		IL_0391: brfalse IL_03ac
 
-		IL_0387: ldloc.s 36
-		IL_0389: ldstr "includes"
-		IL_038e: ldstr "length"
-		IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0398: stloc.s 36
+		IL_0396: ldstr "length"
+		IL_039b: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_03a0: box [System.Runtime]System.Boolean
+		IL_03a5: stloc.s 36
+		IL_03a7: br IL_03c0
 
-		IL_039a: ldloc.s 40
-		IL_039c: ldc.i4.4
-		IL_039d: newarr [System.Runtime]System.Object
-		IL_03a2: dup
-		IL_03a3: ldc.i4.0
-		IL_03a4: ldstr "keys"
-		IL_03a9: stelem.ref
-		IL_03aa: dup
-		IL_03ab: ldc.i4.1
-		IL_03ac: ldloc.s 46
-		IL_03ae: stelem.ref
-		IL_03af: dup
-		IL_03b0: ldc.i4.2
-		IL_03b1: ldloc.s 42
-		IL_03b3: stelem.ref
-		IL_03b4: dup
-		IL_03b5: ldc.i4.3
-		IL_03b6: ldloc.s 36
-		IL_03b8: stelem.ref
-		IL_03b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_03be: pop
-		IL_03bf: ldloc.0
-		IL_03c0: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_03c5: stloc.s 36
-		IL_03c7: ldloc.s 36
-		IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-		IL_03ce: pop
-		IL_03cf: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03d4: stloc.s 40
-		IL_03d6: ldloc.0
-		IL_03d7: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_03dc: stloc.s 36
-		IL_03de: ldloc.s 36
-		IL_03e0: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_03e5: box [System.Runtime]System.Boolean
-		IL_03ea: stloc.s 45
-		IL_03ec: ldloc.2
-		IL_03ed: ldstr "get"
-		IL_03f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03f7: stloc.s 36
-		IL_03f9: ldloc.s 36
-		IL_03fb: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_0400: box [System.Runtime]System.Boolean
-		IL_0405: stloc.s 44
-		IL_0407: ldloc.s 40
-		IL_0409: ldstr "integrity"
-		IL_040e: ldloc.s 45
-		IL_0410: ldloc.s 44
-		IL_0412: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0417: pop
-		IL_0418: ldloc.2
-		IL_0419: ldstr "get"
-		IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0423: stloc.s 36
-		IL_0425: ldloc.s 36
-		IL_0427: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
-		IL_042c: pop
-		IL_042d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0432: stloc.s 40
-		IL_0434: ldloc.2
-		IL_0435: ldstr "get"
-		IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_043f: stloc.s 36
-		IL_0441: ldloc.s 36
-		IL_0443: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
-		IL_0448: box [System.Runtime]System.Boolean
-		IL_044d: stloc.s 44
-		IL_044f: ldloc.s 40
-		IL_0451: ldstr "frozenFunction"
-		IL_0456: ldloc.s 44
-		IL_0458: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_045d: pop
-		IL_045e: nop
-		IL_045f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0464: dup
-		IL_0465: ldstr "marker"
-		IL_046a: ldstr "custom-function-prototype"
-		IL_046f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0474: stloc.s 4
-		IL_0476: ldloc.1
-		IL_0477: ldloc.s 4
-		IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_047e: pop
-		IL_047f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0484: stloc.s 40
-		IL_0486: ldloc.1
-		IL_0487: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
-		IL_048c: stloc.s 36
-		IL_048e: ldloc.s 36
-		IL_0490: ldloc.s 4
-		IL_0492: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0497: stloc.s 43
-		IL_0499: ldloc.s 43
-		IL_049b: box [System.Runtime]System.Boolean
-		IL_04a0: stloc.s 44
-		IL_04a2: ldloc.1
-		IL_04a3: ldstr "marker"
-		IL_04a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04ad: stloc.s 36
-		IL_04af: ldloc.s 40
-		IL_04b1: ldstr "prototypeMutation"
-		IL_04b6: ldloc.s 44
-		IL_04b8: ldloc.s 36
-		IL_04ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_04bf: pop
-		IL_04c0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_04c5: stloc.s 40
-		IL_04c7: ldloc.0
-		IL_04c8: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_04cd: stloc.s 36
-		IL_04cf: ldloc.s 36
-		IL_04d1: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_04d6: stloc.s 36
-		IL_04d8: ldloc.s 36
-		IL_04da: ldnull
-		IL_04db: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_04e0: stloc.s 43
-		IL_04e2: ldloc.s 43
-		IL_04e4: box [System.Runtime]System.Boolean
-		IL_04e9: stloc.s 44
-		IL_04eb: ldloc.0
-		IL_04ec: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_04f1: stloc.s 36
-		IL_04f3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_04f8: dup
-		IL_04f9: ldstr "target"
+		IL_03ac: pop
+
+		IL_03ad: ldloc.s 36
+		IL_03af: ldstr "includes"
+		IL_03b4: ldstr "length"
+		IL_03b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03be: stloc.s 36
+
+		IL_03c0: ldloc.s 40
+		IL_03c2: ldc.i4.4
+		IL_03c3: newarr [System.Runtime]System.Object
+		IL_03c8: dup
+		IL_03c9: ldc.i4.0
+		IL_03ca: ldstr "keys"
+		IL_03cf: stelem.ref
+		IL_03d0: dup
+		IL_03d1: ldc.i4.1
+		IL_03d2: ldloc.s 46
+		IL_03d4: stelem.ref
+		IL_03d5: dup
+		IL_03d6: ldc.i4.2
+		IL_03d7: ldloc.s 42
+		IL_03d9: stelem.ref
+		IL_03da: dup
+		IL_03db: ldc.i4.3
+		IL_03dc: ldloc.s 36
+		IL_03de: stelem.ref
+		IL_03df: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_03e4: pop
+		IL_03e5: ldloc.0
+		IL_03e6: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_03eb: stloc.s 36
+		IL_03ed: ldloc.s 36
+		IL_03ef: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+		IL_03f4: pop
+		IL_03f5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03fa: stloc.s 40
+		IL_03fc: ldloc.0
+		IL_03fd: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0402: stloc.s 36
+		IL_0404: ldloc.s 36
+		IL_0406: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_040b: box [System.Runtime]System.Boolean
+		IL_0410: stloc.s 45
+		IL_0412: ldloc.2
+		IL_0413: ldstr "get"
+		IL_0418: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_041d: stloc.s 36
+		IL_041f: ldloc.s 36
+		IL_0421: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_0426: box [System.Runtime]System.Boolean
+		IL_042b: stloc.s 44
+		IL_042d: ldloc.s 40
+		IL_042f: ldstr "integrity"
+		IL_0434: ldloc.s 45
+		IL_0436: ldloc.s 44
+		IL_0438: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_043d: pop
+		IL_043e: ldloc.2
+		IL_043f: ldstr "get"
+		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0449: stloc.s 36
+		IL_044b: ldloc.s 36
+		IL_044d: call object [JavaScriptRuntime]JavaScriptRuntime.Object::freeze(object)
+		IL_0452: pop
+		IL_0453: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0458: stloc.s 40
+		IL_045a: ldloc.2
+		IL_045b: ldstr "get"
+		IL_0460: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0465: stloc.s 36
+		IL_0467: ldloc.s 36
+		IL_0469: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isFrozen(object)
+		IL_046e: box [System.Runtime]System.Boolean
+		IL_0473: stloc.s 44
+		IL_0475: ldloc.s 40
+		IL_0477: ldstr "frozenFunction"
+		IL_047c: ldloc.s 44
+		IL_047e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0483: pop
+		IL_0484: nop
+		IL_0485: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_048a: dup
+		IL_048b: ldstr "marker"
+		IL_0490: ldstr "custom-function-prototype"
+		IL_0495: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_049a: stloc.s 4
+		IL_049c: ldloc.1
+		IL_049d: ldloc.s 4
+		IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_04a4: pop
+		IL_04a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04aa: stloc.s 40
+		IL_04ac: ldloc.1
+		IL_04ad: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getPrototypeOf(object)
+		IL_04b2: stloc.s 36
+		IL_04b4: ldloc.s 36
+		IL_04b6: ldloc.s 4
+		IL_04b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_04bd: stloc.s 43
+		IL_04bf: ldloc.s 43
+		IL_04c1: box [System.Runtime]System.Boolean
+		IL_04c6: stloc.s 44
+		IL_04c8: ldloc.1
+		IL_04c9: ldstr "marker"
+		IL_04ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04d3: stloc.s 36
+		IL_04d5: ldloc.s 40
+		IL_04d7: ldstr "prototypeMutation"
+		IL_04dc: ldloc.s 44
+		IL_04de: ldloc.s 36
+		IL_04e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_04e5: pop
+		IL_04e6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04eb: stloc.s 40
+		IL_04ed: ldloc.0
+		IL_04ee: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_04f3: stloc.s 36
+		IL_04f5: ldloc.s 36
+		IL_04f7: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_04fc: stloc.s 36
 		IL_04fe: ldloc.s 36
-		IL_0500: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0505: stloc.s 37
-		IL_0507: ldloc.s 37
-		IL_0509: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
-		IL_050e: stloc.s 36
-		IL_0510: ldloc.s 36
-		IL_0512: ldstr "{}"
-		IL_0517: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_051c: stloc.s 43
-		IL_051e: ldloc.s 43
-		IL_0520: box [System.Runtime]System.Boolean
-		IL_0525: stloc.s 45
-		IL_0527: ldloc.s 40
-		IL_0529: ldstr "json"
-		IL_052e: ldloc.s 44
-		IL_0530: ldloc.s 45
-		IL_0532: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0537: pop
-		IL_0538: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_053d: stloc.s 37
-		IL_053f: ldc.i4.1
-		IL_0540: newarr [System.Runtime]System.Object
-		IL_0545: dup
-		IL_0546: ldc.i4.0
-		IL_0547: ldloc.0
-		IL_0548: stelem.ref
-		IL_0549: stloc.s 33
-		IL_054b: ldloc.s 33
-		IL_054d: ldc.i4.0
-		IL_054e: ldelem.ref
-		IL_054f: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
-		IL_0554: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
-		IL_0559: ldc.i4.3
-		IL_055a: conv.r8
-		IL_055b: ldstr ""
-		IL_0560: ldc.i4.0
-		IL_0561: ldc.i4.1
-		IL_0562: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0567: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject>(!!0)
-		IL_056c: stloc.s 47
-		IL_056e: ldloc.s 37
-		IL_0570: ldstr "apply"
-		IL_0575: ldloc.s 47
-		IL_0577: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_057c: pop
-		IL_057d: ldloc.0
-		IL_057e: ldloc.s 37
-		IL_0580: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::applyHandler
-		IL_0585: ldloc.0
-		IL_0586: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_058b: stloc.s 36
-		IL_058d: ldloc.0
-		IL_058e: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::applyHandler
-		IL_0593: ldstr "Cannot access 'applyHandler' before initialization"
-		IL_0598: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-		IL_059d: stloc.s 42
-		IL_059f: ldloc.s 36
-		IL_05a1: ldloc.s 42
-		IL_05a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_05a8: stloc.s 5
-		IL_05aa: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_05af: dup
-		IL_05b0: ldstr "base"
-		IL_05b5: ldc.r8 10
-		IL_05be: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_05c3: dup
-		IL_05c4: ldstr "method"
-		IL_05c9: ldloc.s 5
-		IL_05cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_05d0: stloc.s 6
-		IL_05d2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05d7: stloc.s 40
-		IL_05d9: ldloc.s 5
-		IL_05db: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_05e0: stloc.s 41
-		IL_05e2: ldloc.s 6
-		IL_05e4: ldstr "method"
-		IL_05e9: ldc.r8 5
-		IL_05f2: box [System.Runtime]System.Double
-		IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_05fc: stloc.s 42
-		IL_05fe: ldloc.0
-		IL_05ff: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0604: stloc.s 36
-		IL_0606: ldloc.s 5
-		IL_0608: ldloc.s 36
-		IL_060a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-		IL_060f: stloc.s 43
-		IL_0611: ldloc.s 43
-		IL_0613: box [System.Runtime]System.Boolean
-		IL_0618: stloc.s 45
-		IL_061a: ldloc.s 40
-		IL_061c: ldc.i4.4
-		IL_061d: newarr [System.Runtime]System.Object
-		IL_0622: dup
-		IL_0623: ldc.i4.0
-		IL_0624: ldstr "apply"
-		IL_0629: stelem.ref
-		IL_062a: dup
-		IL_062b: ldc.i4.1
-		IL_062c: ldloc.s 41
-		IL_062e: stelem.ref
-		IL_062f: dup
-		IL_0630: ldc.i4.2
-		IL_0631: ldloc.s 42
-		IL_0633: stelem.ref
-		IL_0634: dup
-		IL_0635: ldc.i4.3
-		IL_0636: ldloc.s 45
-		IL_0638: stelem.ref
-		IL_0639: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_063e: pop
-		IL_063f: ldloc.0
-		IL_0640: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0645: stloc.s 42
-		IL_0647: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_064c: stloc.s 37
-		IL_064e: ldloc.s 42
-		IL_0650: ldloc.s 37
-		IL_0652: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_0657: stloc.s 7
-		IL_0659: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_065e: stloc.s 40
-		IL_0660: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0665: dup
-		IL_0666: ldstr "base"
-		IL_066b: ldc.r8 20
-		IL_0674: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0679: stloc.s 37
-		IL_067b: ldloc.s 7
-		IL_067d: ldstr "call"
-		IL_0682: ldloc.s 37
-		IL_0684: ldc.r8 2
-		IL_068d: box [System.Runtime]System.Double
-		IL_0692: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0697: stloc.s 42
-		IL_0699: ldloc.s 40
-		IL_069b: ldstr "fallback"
-		IL_06a0: ldloc.s 42
-		IL_06a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_06a7: pop
-		IL_06a8: nop
-		IL_06a9: ldloc.0
-		IL_06aa: ldnull
-		IL_06ab: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
-		IL_06b0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_06b5: stloc.s 37
-		IL_06b7: ldc.i4.1
-		IL_06b8: newarr [System.Runtime]System.Object
-		IL_06bd: dup
-		IL_06be: ldc.i4.0
-		IL_06bf: ldloc.0
-		IL_06c0: stelem.ref
-		IL_06c1: stloc.s 33
-		IL_06c3: ldloc.s 33
-		IL_06c5: ldc.i4.0
-		IL_06c6: ldelem.ref
-		IL_06c7: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
-		IL_06cc: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
-		IL_06d1: ldc.i4.3
-		IL_06d2: conv.r8
-		IL_06d3: ldstr ""
-		IL_06d8: ldc.i4.0
-		IL_06d9: ldc.i4.1
-		IL_06da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_06df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject>(!!0)
-		IL_06e4: stloc.s 48
-		IL_06e6: ldloc.s 37
-		IL_06e8: ldstr "construct"
-		IL_06ed: ldloc.s 48
-		IL_06ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_06f4: pop
-		IL_06f5: ldloc.s 37
-		IL_06f7: stloc.s 8
-		IL_06f9: ldloc.0
-		IL_06fa: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::Constructor
-		IL_06ff: stloc.s 42
-		IL_0701: ldloc.s 42
-		IL_0703: ldloc.s 8
-		IL_0705: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_070a: stloc.s 49
-		IL_070c: ldloc.0
-		IL_070d: ldloc.s 49
-		IL_070f: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
-		IL_0714: ldloc.0
-		IL_0715: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
-		IL_071a: castclass [JavaScriptRuntime]JavaScriptRuntime.Proxy
-		IL_071f: stloc.s 49
-		IL_0721: ldloc.s 49
-		IL_0723: dup
-		IL_0724: ldc.r8 12
-		IL_072d: box [System.Runtime]System.Double
-		IL_0732: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
-		IL_0737: stloc.s 9
-		IL_0739: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_073e: stloc.s 40
-		IL_0740: ldloc.0
-		IL_0741: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
-		IL_0746: castclass [JavaScriptRuntime]JavaScriptRuntime.Proxy
-		IL_074b: stloc.s 49
-		IL_074d: ldloc.s 49
-		IL_074f: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
-		IL_0754: stloc.s 41
-		IL_0756: ldloc.s 9
-		IL_0758: ldstr "targetMatches"
-		IL_075d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0762: stloc.s 42
-		IL_0764: ldloc.s 9
-		IL_0766: ldstr "argument"
-		IL_076b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0770: stloc.s 36
-		IL_0772: ldloc.s 9
-		IL_0774: ldstr "newTargetMatches"
-		IL_0779: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_077e: stloc.s 46
-		IL_0780: ldloc.s 40
-		IL_0782: ldc.i4.5
-		IL_0783: newarr [System.Runtime]System.Object
-		IL_0788: dup
-		IL_0789: ldc.i4.0
-		IL_078a: ldstr "construct"
-		IL_078f: stelem.ref
-		IL_0790: dup
-		IL_0791: ldc.i4.1
-		IL_0792: ldloc.s 41
-		IL_0794: stelem.ref
-		IL_0795: dup
-		IL_0796: ldc.i4.2
-		IL_0797: ldloc.s 42
-		IL_0799: stelem.ref
-		IL_079a: dup
-		IL_079b: ldc.i4.3
-		IL_079c: ldloc.s 36
-		IL_079e: stelem.ref
-		IL_079f: dup
-		IL_07a0: ldc.i4.4
-		IL_07a1: ldloc.s 46
-		IL_07a3: stelem.ref
-		IL_07a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_07a9: pop
-		IL_07aa: ldloc.0
-		IL_07ab: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::Constructor
-		IL_07b0: stloc.s 46
-		IL_07b2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_07b7: stloc.s 37
-		IL_07b9: ldc.i4.1
-		IL_07ba: newarr [System.Runtime]System.Object
-		IL_07bf: dup
-		IL_07c0: ldc.i4.0
-		IL_07c1: ldloc.0
-		IL_07c2: stelem.ref
-		IL_07c3: stloc.s 33
-		IL_07c5: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject::.ctor()
-		IL_07ca: ldc.i4.0
-		IL_07cb: conv.r8
-		IL_07cc: ldstr ""
-		IL_07d1: ldc.i4.0
-		IL_07d2: ldc.i4.1
-		IL_07d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_07d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject>(!!0)
-		IL_07dd: stloc.s 50
-		IL_07df: ldloc.s 37
-		IL_07e1: ldstr "construct"
-		IL_07e6: ldloc.s 50
-		IL_07e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_07ed: pop
-		IL_07ee: ldloc.s 46
-		IL_07f0: ldloc.s 37
-		IL_07f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_07f7: stloc.s 10
-		IL_07f9: ldc.i4.0
-		IL_07fa: box [System.Runtime]System.Boolean
-		IL_07ff: stloc.s 11
+		IL_0500: ldnull
+		IL_0501: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0506: stloc.s 43
+		IL_0508: ldloc.s 43
+		IL_050a: box [System.Runtime]System.Boolean
+		IL_050f: stloc.s 44
+		IL_0511: ldloc.0
+		IL_0512: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_0517: stloc.s 36
+		IL_0519: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_051e: dup
+		IL_051f: ldstr "target"
+		IL_0524: ldloc.s 36
+		IL_0526: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_052b: stloc.s 37
+		IL_052d: ldloc.s 37
+		IL_052f: call object [JavaScriptRuntime]JavaScriptRuntime.JSON::Stringify(object)
+		IL_0534: stloc.s 36
+		IL_0536: ldloc.s 36
+		IL_0538: ldstr "{}"
+		IL_053d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0542: stloc.s 43
+		IL_0544: ldloc.s 43
+		IL_0546: box [System.Runtime]System.Boolean
+		IL_054b: stloc.s 45
+		IL_054d: ldloc.s 40
+		IL_054f: ldstr "json"
+		IL_0554: ldloc.s 44
+		IL_0556: ldloc.s 45
+		IL_0558: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_055d: pop
+		IL_055e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0563: stloc.s 37
+		IL_0565: ldc.i4.1
+		IL_0566: newarr [System.Runtime]System.Object
+		IL_056b: dup
+		IL_056c: ldc.i4.0
+		IL_056d: ldloc.0
+		IL_056e: stelem.ref
+		IL_056f: stloc.s 33
+		IL_0571: ldloc.s 33
+		IL_0573: ldc.i4.0
+		IL_0574: ldelem.ref
+		IL_0575: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
+		IL_057a: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
+		IL_057f: ldc.i4.3
+		IL_0580: conv.r8
+		IL_0581: ldstr ""
+		IL_0586: ldc.i4.0
+		IL_0587: ldc.i4.1
+		IL_0588: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_058d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject>(!!0)
+		IL_0592: stloc.s 47
+		IL_0594: ldloc.s 37
+		IL_0596: ldstr "apply"
+		IL_059b: ldloc.s 47
+		IL_059d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_05a2: pop
+		IL_05a3: ldloc.0
+		IL_05a4: ldloc.s 37
+		IL_05a6: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::applyHandler
+		IL_05ab: ldloc.0
+		IL_05ac: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_05b1: stloc.s 36
+		IL_05b3: ldloc.0
+		IL_05b4: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::applyHandler
+		IL_05b9: ldstr "Cannot access 'applyHandler' before initialization"
+		IL_05be: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+		IL_05c3: stloc.s 42
+		IL_05c5: ldloc.s 36
+		IL_05c7: ldloc.s 42
+		IL_05c9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_05ce: stloc.s 5
+		IL_05d0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_05d5: dup
+		IL_05d6: ldstr "base"
+		IL_05db: ldc.r8 10
+		IL_05e4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_05e9: dup
+		IL_05ea: ldstr "method"
+		IL_05ef: ldloc.s 5
+		IL_05f1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_05f6: stloc.s 6
+		IL_05f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05fd: stloc.s 40
+		IL_05ff: ldloc.s 5
+		IL_0601: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_0606: stloc.s 41
+		IL_0608: ldloc.s 6
+		IL_060a: ldstr "method"
+		IL_060f: ldc.r8 5
+		IL_0618: box [System.Runtime]System.Double
+		IL_061d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0622: stloc.s 42
+		IL_0624: ldloc.0
+		IL_0625: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_062a: stloc.s 36
+		IL_062c: ldloc.s 5
+		IL_062e: ldloc.s 36
+		IL_0630: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+		IL_0635: stloc.s 43
+		IL_0637: ldloc.s 43
+		IL_0639: box [System.Runtime]System.Boolean
+		IL_063e: stloc.s 45
+		IL_0640: ldloc.s 40
+		IL_0642: ldc.i4.4
+		IL_0643: newarr [System.Runtime]System.Object
+		IL_0648: dup
+		IL_0649: ldc.i4.0
+		IL_064a: ldstr "apply"
+		IL_064f: stelem.ref
+		IL_0650: dup
+		IL_0651: ldc.i4.1
+		IL_0652: ldloc.s 41
+		IL_0654: stelem.ref
+		IL_0655: dup
+		IL_0656: ldc.i4.2
+		IL_0657: ldloc.s 42
+		IL_0659: stelem.ref
+		IL_065a: dup
+		IL_065b: ldc.i4.3
+		IL_065c: ldloc.s 45
+		IL_065e: stelem.ref
+		IL_065f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0664: pop
+		IL_0665: ldloc.0
+		IL_0666: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_066b: stloc.s 42
+		IL_066d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0672: stloc.s 37
+		IL_0674: ldloc.s 42
+		IL_0676: ldloc.s 37
+		IL_0678: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_067d: stloc.s 7
+		IL_067f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0684: stloc.s 40
+		IL_0686: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_068b: dup
+		IL_068c: ldstr "base"
+		IL_0691: ldc.r8 20
+		IL_069a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_069f: stloc.s 37
+		IL_06a1: ldloc.s 7
+		IL_06a3: ldstr "call"
+		IL_06a8: ldloc.s 37
+		IL_06aa: ldc.r8 2
+		IL_06b3: box [System.Runtime]System.Double
+		IL_06b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_06bd: stloc.s 42
+		IL_06bf: ldloc.s 40
+		IL_06c1: ldstr "fallback"
+		IL_06c6: ldloc.s 42
+		IL_06c8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_06cd: pop
+		IL_06ce: nop
+		IL_06cf: ldloc.0
+		IL_06d0: ldnull
+		IL_06d1: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
+		IL_06d6: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_06db: stloc.s 37
+		IL_06dd: ldc.i4.1
+		IL_06de: newarr [System.Runtime]System.Object
+		IL_06e3: dup
+		IL_06e4: ldc.i4.0
+		IL_06e5: ldloc.0
+		IL_06e6: stelem.ref
+		IL_06e7: stloc.s 33
+		IL_06e9: ldloc.s 33
+		IL_06eb: ldc.i4.0
+		IL_06ec: ldelem.ref
+		IL_06ed: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
+		IL_06f2: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
+		IL_06f7: ldc.i4.3
+		IL_06f8: conv.r8
+		IL_06f9: ldstr ""
+		IL_06fe: ldc.i4.0
+		IL_06ff: ldc.i4.1
+		IL_0700: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0705: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject>(!!0)
+		IL_070a: stloc.s 48
+		IL_070c: ldloc.s 37
+		IL_070e: ldstr "construct"
+		IL_0713: ldloc.s 48
+		IL_0715: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_071a: pop
+		IL_071b: ldloc.s 37
+		IL_071d: stloc.s 8
+		IL_071f: ldloc.0
+		IL_0720: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::Constructor
+		IL_0725: stloc.s 42
+		IL_0727: ldloc.s 42
+		IL_0729: ldloc.s 8
+		IL_072b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_0730: stloc.s 49
+		IL_0732: ldloc.0
+		IL_0733: ldloc.s 49
+		IL_0735: stfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
+		IL_073a: ldloc.0
+		IL_073b: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
+		IL_0740: castclass [JavaScriptRuntime]JavaScriptRuntime.Proxy
+		IL_0745: stloc.s 49
+		IL_0747: ldloc.s 49
+		IL_0749: dup
+		IL_074a: ldc.r8 12
+		IL_0753: box [System.Runtime]System.Double
+		IL_0758: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_075d: stloc.s 9
+		IL_075f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0764: stloc.s 40
+		IL_0766: ldloc.0
+		IL_0767: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::constructProxy
+		IL_076c: castclass [JavaScriptRuntime]JavaScriptRuntime.Proxy
+		IL_0771: stloc.s 49
+		IL_0773: ldloc.s 49
+		IL_0775: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_077a: stloc.s 41
+		IL_077c: ldloc.s 9
+		IL_077e: ldstr "targetMatches"
+		IL_0783: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0788: stloc.s 42
+		IL_078a: ldloc.s 9
+		IL_078c: ldstr "argument"
+		IL_0791: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0796: stloc.s 36
+		IL_0798: ldloc.s 9
+		IL_079a: ldstr "newTargetMatches"
+		IL_079f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07a4: stloc.s 46
+		IL_07a6: ldloc.s 40
+		IL_07a8: ldc.i4.5
+		IL_07a9: newarr [System.Runtime]System.Object
+		IL_07ae: dup
+		IL_07af: ldc.i4.0
+		IL_07b0: ldstr "construct"
+		IL_07b5: stelem.ref
+		IL_07b6: dup
+		IL_07b7: ldc.i4.1
+		IL_07b8: ldloc.s 41
+		IL_07ba: stelem.ref
+		IL_07bb: dup
+		IL_07bc: ldc.i4.2
+		IL_07bd: ldloc.s 42
+		IL_07bf: stelem.ref
+		IL_07c0: dup
+		IL_07c1: ldc.i4.3
+		IL_07c2: ldloc.s 36
+		IL_07c4: stelem.ref
+		IL_07c5: dup
+		IL_07c6: ldc.i4.4
+		IL_07c7: ldloc.s 46
+		IL_07c9: stelem.ref
+		IL_07ca: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_07cf: pop
+		IL_07d0: ldloc.0
+		IL_07d1: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::Constructor
+		IL_07d6: stloc.s 46
+		IL_07d8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_07dd: stloc.s 37
+		IL_07df: ldc.i4.1
+		IL_07e0: newarr [System.Runtime]System.Object
+		IL_07e5: dup
+		IL_07e6: ldc.i4.0
+		IL_07e7: ldloc.0
+		IL_07e8: stelem.ref
+		IL_07e9: stloc.s 33
+		IL_07eb: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject::.ctor()
+		IL_07f0: ldc.i4.0
+		IL_07f1: conv.r8
+		IL_07f2: ldstr ""
+		IL_07f7: ldc.i4.0
+		IL_07f8: ldc.i4.1
+		IL_07f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_07fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject>(!!0)
+		IL_0803: stloc.s 50
+		IL_0805: ldloc.s 37
+		IL_0807: ldstr "construct"
+		IL_080c: ldloc.s 50
+		IL_080e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0813: pop
+		IL_0814: ldloc.s 46
+		IL_0816: ldloc.s 37
+		IL_0818: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_081d: stloc.s 10
+		IL_081f: ldc.i4.0
+		IL_0820: box [System.Runtime]System.Boolean
+		IL_0825: stloc.s 11
 		.try
 		{
-			IL_0801: nop
-			IL_0802: ldloc.s 10
-			IL_0804: dup
-			IL_0805: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
-			IL_080a: pop
-			IL_080b: leave IL_086f
+			IL_0827: nop
+			IL_0828: ldloc.s 10
+			IL_082a: dup
+			IL_082b: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+			IL_0830: pop
+			IL_0831: leave IL_0895
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0810: stloc.s 12
-			IL_0812: ldloc.s 12
-			IL_0814: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0819: dup
-			IL_081a: brtrue IL_0830
+			IL_0836: stloc.s 12
+			IL_0838: ldloc.s 12
+			IL_083a: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_083f: dup
+			IL_0840: brtrue IL_0856
 
-			IL_081f: pop
-			IL_0820: ldloc.s 12
-			IL_0822: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0827: dup
-			IL_0828: brtrue IL_083c
+			IL_0845: pop
+			IL_0846: ldloc.s 12
+			IL_0848: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_084d: dup
+			IL_084e: brtrue IL_0862
 
-			IL_082d: pop
-			IL_082e: rethrow
+			IL_0853: pop
+			IL_0854: rethrow
 
-			IL_0830: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0835: stloc.s 13
-			IL_0837: br IL_083e
+			IL_0856: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_085b: stloc.s 13
+			IL_085d: br IL_0864
 
-			IL_083c: stloc.s 13
+			IL_0862: stloc.s 13
 
-			IL_083e: ldloc.s 13
-			IL_0840: stloc.s 14
-			IL_0842: ldloc.s 14
-			IL_0844: stloc.s 46
-			IL_0846: ldstr "TypeError"
-			IL_084b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0850: stloc.s 36
-			IL_0852: ldloc.s 46
-			IL_0854: ldloc.s 36
-			IL_0856: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_085b: stloc.s 43
-			IL_085d: ldloc.s 43
-			IL_085f: box [System.Runtime]System.Boolean
-			IL_0864: stloc.s 45
-			IL_0866: ldloc.s 45
-			IL_0868: stloc.s 11
-			IL_086a: leave IL_086f
+			IL_0864: ldloc.s 13
+			IL_0866: stloc.s 14
+			IL_0868: ldloc.s 14
+			IL_086a: stloc.s 46
+			IL_086c: ldstr "TypeError"
+			IL_0871: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0876: stloc.s 36
+			IL_0878: ldloc.s 46
+			IL_087a: ldloc.s 36
+			IL_087c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0881: stloc.s 43
+			IL_0883: ldloc.s 43
+			IL_0885: box [System.Runtime]System.Boolean
+			IL_088a: stloc.s 45
+			IL_088c: ldloc.s 45
+			IL_088e: stloc.s 11
+			IL_0890: leave IL_0895
 		} // end handler
 
-		IL_086f: ldloc.0
-		IL_0870: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
-		IL_0875: stloc.s 36
-		IL_0877: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_087c: dup
-		IL_087d: ldstr "apply"
-		IL_0882: ldc.r8 1
-		IL_088b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0890: stloc.s 37
-		IL_0892: ldloc.s 36
-		IL_0894: ldloc.s 37
-		IL_0896: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_089b: stloc.s 15
-		IL_089d: ldc.i4.0
-		IL_089e: box [System.Runtime]System.Boolean
-		IL_08a3: stloc.s 16
+		IL_0895: ldloc.0
+		IL_0896: ldfld object Modules.Function_CallableReflection_ProxyIntegration/Scope::target
+		IL_089b: stloc.s 36
+		IL_089d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_08a2: dup
+		IL_08a3: ldstr "apply"
+		IL_08a8: ldc.r8 1
+		IL_08b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_08b6: stloc.s 37
+		IL_08b8: ldloc.s 36
+		IL_08ba: ldloc.s 37
+		IL_08bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_08c1: stloc.s 15
+		IL_08c3: ldc.i4.0
+		IL_08c4: box [System.Runtime]System.Boolean
+		IL_08c9: stloc.s 16
 		.try
 		{
-			IL_08a5: nop
-			IL_08a6: ldloc.s 15
-			IL_08a8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-			IL_08ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-			IL_08b2: pop
-			IL_08b3: leave IL_0917
+			IL_08cb: nop
+			IL_08cc: ldloc.s 15
+			IL_08ce: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_08d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_08d8: pop
+			IL_08d9: leave IL_093d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_08b8: stloc.s 17
-			IL_08ba: ldloc.s 17
-			IL_08bc: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_08c1: dup
-			IL_08c2: brtrue IL_08d8
+			IL_08de: stloc.s 17
+			IL_08e0: ldloc.s 17
+			IL_08e2: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_08e7: dup
+			IL_08e8: brtrue IL_08fe
 
-			IL_08c7: pop
-			IL_08c8: ldloc.s 17
-			IL_08ca: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_08cf: dup
-			IL_08d0: brtrue IL_08e4
+			IL_08ed: pop
+			IL_08ee: ldloc.s 17
+			IL_08f0: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_08f5: dup
+			IL_08f6: brtrue IL_090a
 
-			IL_08d5: pop
-			IL_08d6: rethrow
+			IL_08fb: pop
+			IL_08fc: rethrow
 
-			IL_08d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_08dd: stloc.s 18
-			IL_08df: br IL_08e6
+			IL_08fe: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0903: stloc.s 18
+			IL_0905: br IL_090c
 
-			IL_08e4: stloc.s 18
+			IL_090a: stloc.s 18
 
-			IL_08e6: ldloc.s 18
-			IL_08e8: stloc.s 19
-			IL_08ea: ldloc.s 19
-			IL_08ec: stloc.s 36
-			IL_08ee: ldstr "TypeError"
-			IL_08f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_08f8: stloc.s 46
-			IL_08fa: ldloc.s 36
-			IL_08fc: ldloc.s 46
-			IL_08fe: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0903: stloc.s 43
-			IL_0905: ldloc.s 43
-			IL_0907: box [System.Runtime]System.Boolean
-			IL_090c: stloc.s 45
-			IL_090e: ldloc.s 45
-			IL_0910: stloc.s 16
-			IL_0912: leave IL_0917
+			IL_090c: ldloc.s 18
+			IL_090e: stloc.s 19
+			IL_0910: ldloc.s 19
+			IL_0912: stloc.s 36
+			IL_0914: ldstr "TypeError"
+			IL_0919: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_091e: stloc.s 46
+			IL_0920: ldloc.s 36
+			IL_0922: ldloc.s 46
+			IL_0924: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0929: stloc.s 43
+			IL_092b: ldloc.s 43
+			IL_092d: box [System.Runtime]System.Boolean
+			IL_0932: stloc.s 45
+			IL_0934: ldloc.s 45
+			IL_0936: stloc.s 16
+			IL_0938: leave IL_093d
 		} // end handler
 
-		IL_0917: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_091c: stloc.s 40
-		IL_091e: ldloc.s 40
-		IL_0920: ldstr "invalidTraps"
-		IL_0925: ldloc.s 11
-		IL_0927: ldloc.s 16
-		IL_0929: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_092e: pop
-		IL_092f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0934: stloc.s 20
-		IL_0936: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_093b: stloc.s 37
-		IL_093d: ldc.i4.1
-		IL_093e: newarr [System.Runtime]System.Object
-		IL_0943: dup
-		IL_0944: ldc.i4.0
-		IL_0945: ldloc.0
-		IL_0946: stelem.ref
-		IL_0947: stloc.s 33
-		IL_0949: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject::.ctor()
-		IL_094e: ldc.i4.1
-		IL_094f: conv.r8
-		IL_0950: ldstr ""
-		IL_0955: ldc.i4.0
-		IL_0956: ldc.i4.1
-		IL_0957: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_095c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject>(!!0)
-		IL_0961: stloc.s 51
-		IL_0963: ldloc.s 37
-		IL_0965: ldstr "isExtensible"
-		IL_096a: ldloc.s 51
-		IL_096c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0971: pop
-		IL_0972: ldc.i4.1
-		IL_0973: newarr [System.Runtime]System.Object
-		IL_0978: dup
-		IL_0979: ldc.i4.0
-		IL_097a: ldloc.0
-		IL_097b: stelem.ref
-		IL_097c: stloc.s 33
-		IL_097e: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject::.ctor()
-		IL_0983: ldc.i4.1
-		IL_0984: conv.r8
-		IL_0985: ldstr ""
-		IL_098a: ldc.i4.0
-		IL_098b: ldc.i4.1
-		IL_098c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0991: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject>(!!0)
-		IL_0996: stloc.s 52
-		IL_0998: ldloc.s 37
-		IL_099a: ldstr "preventExtensions"
-		IL_099f: ldloc.s 52
-		IL_09a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_09a6: pop
-		IL_09a7: ldloc.s 37
-		IL_09a9: stloc.s 21
-		IL_09ab: ldloc.s 20
-		IL_09ad: ldloc.s 21
-		IL_09af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-		IL_09b4: stloc.s 22
-		IL_09b6: ldloc.s 22
-		IL_09b8: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_09bd: stloc.s 23
-		IL_09bf: ldloc.s 22
-		IL_09c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-		IL_09c6: pop
-		IL_09c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_09cc: stloc.s 40
-		IL_09ce: ldloc.s 23
-		IL_09d0: box [System.Runtime]System.Boolean
-		IL_09d5: stloc.s 45
-		IL_09d7: ldloc.s 22
-		IL_09d9: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_09de: box [System.Runtime]System.Boolean
-		IL_09e3: stloc.s 44
-		IL_09e5: ldloc.s 20
-		IL_09e7: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-		IL_09ec: box [System.Runtime]System.Boolean
-		IL_09f1: stloc.s 53
-		IL_09f3: ldloc.s 40
-		IL_09f5: ldc.i4.4
-		IL_09f6: newarr [System.Runtime]System.Object
-		IL_09fb: dup
-		IL_09fc: ldc.i4.0
-		IL_09fd: ldstr "proxyIntegrity"
-		IL_0a02: stelem.ref
-		IL_0a03: dup
-		IL_0a04: ldc.i4.1
-		IL_0a05: ldloc.s 45
-		IL_0a07: stelem.ref
-		IL_0a08: dup
-		IL_0a09: ldc.i4.2
-		IL_0a0a: ldloc.s 44
-		IL_0a0c: stelem.ref
-		IL_0a0d: dup
-		IL_0a0e: ldc.i4.3
-		IL_0a0f: ldloc.s 53
-		IL_0a11: stelem.ref
-		IL_0a12: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
-		IL_0a17: pop
-		IL_0a18: ldc.i4.0
-		IL_0a19: box [System.Runtime]System.Boolean
-		IL_0a1e: stloc.s 24
+		IL_093d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0942: stloc.s 40
+		IL_0944: ldloc.s 40
+		IL_0946: ldstr "invalidTraps"
+		IL_094b: ldloc.s 11
+		IL_094d: ldloc.s 16
+		IL_094f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0954: pop
+		IL_0955: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_095a: stloc.s 20
+		IL_095c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0961: stloc.s 37
+		IL_0963: ldc.i4.1
+		IL_0964: newarr [System.Runtime]System.Object
+		IL_0969: dup
+		IL_096a: ldc.i4.0
+		IL_096b: ldloc.0
+		IL_096c: stelem.ref
+		IL_096d: stloc.s 33
+		IL_096f: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject::.ctor()
+		IL_0974: ldc.i4.1
+		IL_0975: conv.r8
+		IL_0976: ldstr ""
+		IL_097b: ldc.i4.0
+		IL_097c: ldc.i4.1
+		IL_097d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0982: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject>(!!0)
+		IL_0987: stloc.s 51
+		IL_0989: ldloc.s 37
+		IL_098b: ldstr "isExtensible"
+		IL_0990: ldloc.s 51
+		IL_0992: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0997: pop
+		IL_0998: ldc.i4.1
+		IL_0999: newarr [System.Runtime]System.Object
+		IL_099e: dup
+		IL_099f: ldc.i4.0
+		IL_09a0: ldloc.0
+		IL_09a1: stelem.ref
+		IL_09a2: stloc.s 33
+		IL_09a4: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject::.ctor()
+		IL_09a9: ldc.i4.1
+		IL_09aa: conv.r8
+		IL_09ab: ldstr ""
+		IL_09b0: ldc.i4.0
+		IL_09b1: ldc.i4.1
+		IL_09b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_09b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject>(!!0)
+		IL_09bc: stloc.s 52
+		IL_09be: ldloc.s 37
+		IL_09c0: ldstr "preventExtensions"
+		IL_09c5: ldloc.s 52
+		IL_09c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_09cc: pop
+		IL_09cd: ldloc.s 37
+		IL_09cf: stloc.s 21
+		IL_09d1: ldloc.s 20
+		IL_09d3: ldloc.s 21
+		IL_09d5: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_09da: stloc.s 22
+		IL_09dc: ldloc.s 22
+		IL_09de: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_09e3: stloc.s 23
+		IL_09e5: ldloc.s 22
+		IL_09e7: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+		IL_09ec: pop
+		IL_09ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_09f2: stloc.s 40
+		IL_09f4: ldloc.s 23
+		IL_09f6: box [System.Runtime]System.Boolean
+		IL_09fb: stloc.s 45
+		IL_09fd: ldloc.s 22
+		IL_09ff: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_0a04: box [System.Runtime]System.Boolean
+		IL_0a09: stloc.s 44
+		IL_0a0b: ldloc.s 20
+		IL_0a0d: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+		IL_0a12: box [System.Runtime]System.Boolean
+		IL_0a17: stloc.s 53
+		IL_0a19: ldloc.s 40
+		IL_0a1b: ldc.i4.4
+		IL_0a1c: newarr [System.Runtime]System.Object
+		IL_0a21: dup
+		IL_0a22: ldc.i4.0
+		IL_0a23: ldstr "proxyIntegrity"
+		IL_0a28: stelem.ref
+		IL_0a29: dup
+		IL_0a2a: ldc.i4.1
+		IL_0a2b: ldloc.s 45
+		IL_0a2d: stelem.ref
+		IL_0a2e: dup
+		IL_0a2f: ldc.i4.2
+		IL_0a30: ldloc.s 44
+		IL_0a32: stelem.ref
+		IL_0a33: dup
+		IL_0a34: ldc.i4.3
+		IL_0a35: ldloc.s 53
+		IL_0a37: stelem.ref
+		IL_0a38: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object[])
+		IL_0a3d: pop
+		IL_0a3e: ldc.i4.0
+		IL_0a3f: box [System.Runtime]System.Boolean
+		IL_0a44: stloc.s 24
 		.try
 		{
-			IL_0a20: nop
-			IL_0a21: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0a26: stloc.s 37
-			IL_0a28: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0a2d: stloc.s 54
-			IL_0a2f: ldc.i4.1
-			IL_0a30: newarr [System.Runtime]System.Object
-			IL_0a35: dup
-			IL_0a36: ldc.i4.0
-			IL_0a37: ldloc.0
-			IL_0a38: stelem.ref
-			IL_0a39: stloc.s 33
-			IL_0a3b: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject::.ctor()
-			IL_0a40: ldc.i4.0
-			IL_0a41: conv.r8
-			IL_0a42: ldstr ""
-			IL_0a47: ldc.i4.0
-			IL_0a48: ldc.i4.1
-			IL_0a49: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0a4e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject>(!!0)
-			IL_0a53: stloc.s 55
-			IL_0a55: ldloc.s 54
-			IL_0a57: ldstr "isExtensible"
-			IL_0a5c: ldloc.s 55
-			IL_0a5e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0a63: pop
-			IL_0a64: ldloc.s 37
-			IL_0a66: ldloc.s 54
-			IL_0a68: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-			IL_0a6d: stloc.s 49
-			IL_0a6f: ldloc.s 49
-			IL_0a71: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
-			IL_0a76: pop
-			IL_0a77: leave IL_0adb
+			IL_0a46: nop
+			IL_0a47: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0a4c: stloc.s 37
+			IL_0a4e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0a53: stloc.s 54
+			IL_0a55: ldc.i4.1
+			IL_0a56: newarr [System.Runtime]System.Object
+			IL_0a5b: dup
+			IL_0a5c: ldc.i4.0
+			IL_0a5d: ldloc.0
+			IL_0a5e: stelem.ref
+			IL_0a5f: stloc.s 33
+			IL_0a61: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject::.ctor()
+			IL_0a66: ldc.i4.0
+			IL_0a67: conv.r8
+			IL_0a68: ldstr ""
+			IL_0a6d: ldc.i4.0
+			IL_0a6e: ldc.i4.1
+			IL_0a6f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0a74: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject>(!!0)
+			IL_0a79: stloc.s 55
+			IL_0a7b: ldloc.s 54
+			IL_0a7d: ldstr "isExtensible"
+			IL_0a82: ldloc.s 55
+			IL_0a84: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0a89: pop
+			IL_0a8a: ldloc.s 37
+			IL_0a8c: ldloc.s 54
+			IL_0a8e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+			IL_0a93: stloc.s 49
+			IL_0a95: ldloc.s 49
+			IL_0a97: call bool [JavaScriptRuntime]JavaScriptRuntime.Object::isExtensible(object)
+			IL_0a9c: pop
+			IL_0a9d: leave IL_0b01
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0a7c: stloc.s 25
-			IL_0a7e: ldloc.s 25
-			IL_0a80: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0a85: dup
-			IL_0a86: brtrue IL_0a9c
+			IL_0aa2: stloc.s 25
+			IL_0aa4: ldloc.s 25
+			IL_0aa6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0aab: dup
+			IL_0aac: brtrue IL_0ac2
 
-			IL_0a8b: pop
-			IL_0a8c: ldloc.s 25
-			IL_0a8e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0a93: dup
-			IL_0a94: brtrue IL_0aa8
+			IL_0ab1: pop
+			IL_0ab2: ldloc.s 25
+			IL_0ab4: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0ab9: dup
+			IL_0aba: brtrue IL_0ace
 
-			IL_0a99: pop
-			IL_0a9a: rethrow
+			IL_0abf: pop
+			IL_0ac0: rethrow
 
-			IL_0a9c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0aa1: stloc.s 26
-			IL_0aa3: br IL_0aaa
+			IL_0ac2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0ac7: stloc.s 26
+			IL_0ac9: br IL_0ad0
 
-			IL_0aa8: stloc.s 26
+			IL_0ace: stloc.s 26
 
-			IL_0aaa: ldloc.s 26
-			IL_0aac: stloc.s 27
-			IL_0aae: ldloc.s 27
-			IL_0ab0: stloc.s 46
-			IL_0ab2: ldstr "TypeError"
-			IL_0ab7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0abc: stloc.s 36
-			IL_0abe: ldloc.s 46
-			IL_0ac0: ldloc.s 36
-			IL_0ac2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0ac7: stloc.s 43
-			IL_0ac9: ldloc.s 43
-			IL_0acb: box [System.Runtime]System.Boolean
-			IL_0ad0: stloc.s 53
-			IL_0ad2: ldloc.s 53
-			IL_0ad4: stloc.s 24
-			IL_0ad6: leave IL_0adb
+			IL_0ad0: ldloc.s 26
+			IL_0ad2: stloc.s 27
+			IL_0ad4: ldloc.s 27
+			IL_0ad6: stloc.s 46
+			IL_0ad8: ldstr "TypeError"
+			IL_0add: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0ae2: stloc.s 36
+			IL_0ae4: ldloc.s 46
+			IL_0ae6: ldloc.s 36
+			IL_0ae8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0aed: stloc.s 43
+			IL_0aef: ldloc.s 43
+			IL_0af1: box [System.Runtime]System.Boolean
+			IL_0af6: stloc.s 53
+			IL_0af8: ldloc.s 53
+			IL_0afa: stloc.s 24
+			IL_0afc: leave IL_0b01
 		} // end handler
 
-		IL_0adb: ldc.i4.0
-		IL_0adc: box [System.Runtime]System.Boolean
-		IL_0ae1: stloc.s 28
+		IL_0b01: ldc.i4.0
+		IL_0b02: box [System.Runtime]System.Boolean
+		IL_0b07: stloc.s 28
 		.try
 		{
-			IL_0ae3: nop
-			IL_0ae4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0ae9: stloc.s 54
-			IL_0aeb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0af0: stloc.s 37
-			IL_0af2: ldc.i4.1
-			IL_0af3: newarr [System.Runtime]System.Object
-			IL_0af8: dup
-			IL_0af9: ldc.i4.0
-			IL_0afa: ldloc.0
-			IL_0afb: stelem.ref
-			IL_0afc: stloc.s 33
-			IL_0afe: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject::.ctor()
-			IL_0b03: ldc.i4.0
-			IL_0b04: conv.r8
-			IL_0b05: ldstr ""
-			IL_0b0a: ldc.i4.0
-			IL_0b0b: ldc.i4.1
-			IL_0b0c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_0b11: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject>(!!0)
-			IL_0b16: stloc.s 56
-			IL_0b18: ldloc.s 37
-			IL_0b1a: ldstr "preventExtensions"
-			IL_0b1f: ldloc.s 56
-			IL_0b21: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_0b26: pop
-			IL_0b27: ldloc.s 54
-			IL_0b29: ldloc.s 37
-			IL_0b2b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
-			IL_0b30: stloc.s 49
-			IL_0b32: ldloc.s 49
-			IL_0b34: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
-			IL_0b39: pop
-			IL_0b3a: leave IL_0b9e
+			IL_0b09: nop
+			IL_0b0a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0b0f: stloc.s 54
+			IL_0b11: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0b16: stloc.s 37
+			IL_0b18: ldc.i4.1
+			IL_0b19: newarr [System.Runtime]System.Object
+			IL_0b1e: dup
+			IL_0b1f: ldc.i4.0
+			IL_0b20: ldloc.0
+			IL_0b21: stelem.ref
+			IL_0b22: stloc.s 33
+			IL_0b24: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject::.ctor()
+			IL_0b29: ldc.i4.0
+			IL_0b2a: conv.r8
+			IL_0b2b: ldstr ""
+			IL_0b30: ldc.i4.0
+			IL_0b31: ldc.i4.1
+			IL_0b32: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0b37: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject>(!!0)
+			IL_0b3c: stloc.s 56
+			IL_0b3e: ldloc.s 37
+			IL_0b40: ldstr "preventExtensions"
+			IL_0b45: ldloc.s 56
+			IL_0b47: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0b4c: pop
+			IL_0b4d: ldloc.s 54
+			IL_0b4f: ldloc.s 37
+			IL_0b51: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+			IL_0b56: stloc.s 49
+			IL_0b58: ldloc.s 49
+			IL_0b5a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::preventExtensions(object)
+			IL_0b5f: pop
+			IL_0b60: leave IL_0bc4
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0b3f: stloc.s 29
-			IL_0b41: ldloc.s 29
-			IL_0b43: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0b48: dup
-			IL_0b49: brtrue IL_0b5f
+			IL_0b65: stloc.s 29
+			IL_0b67: ldloc.s 29
+			IL_0b69: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0b6e: dup
+			IL_0b6f: brtrue IL_0b85
 
-			IL_0b4e: pop
-			IL_0b4f: ldloc.s 29
-			IL_0b51: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0b56: dup
-			IL_0b57: brtrue IL_0b6b
+			IL_0b74: pop
+			IL_0b75: ldloc.s 29
+			IL_0b77: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0b7c: dup
+			IL_0b7d: brtrue IL_0b91
 
-			IL_0b5c: pop
-			IL_0b5d: rethrow
+			IL_0b82: pop
+			IL_0b83: rethrow
 
-			IL_0b5f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0b64: stloc.s 30
-			IL_0b66: br IL_0b6d
+			IL_0b85: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0b8a: stloc.s 30
+			IL_0b8c: br IL_0b93
 
-			IL_0b6b: stloc.s 30
+			IL_0b91: stloc.s 30
 
-			IL_0b6d: ldloc.s 30
-			IL_0b6f: stloc.s 31
-			IL_0b71: ldloc.s 31
-			IL_0b73: stloc.s 36
-			IL_0b75: ldstr "TypeError"
-			IL_0b7a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0b7f: stloc.s 46
-			IL_0b81: ldloc.s 36
-			IL_0b83: ldloc.s 46
-			IL_0b85: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0b8a: stloc.s 43
-			IL_0b8c: ldloc.s 43
-			IL_0b8e: box [System.Runtime]System.Boolean
-			IL_0b93: stloc.s 53
-			IL_0b95: ldloc.s 53
-			IL_0b97: stloc.s 28
-			IL_0b99: leave IL_0b9e
+			IL_0b93: ldloc.s 30
+			IL_0b95: stloc.s 31
+			IL_0b97: ldloc.s 31
+			IL_0b99: stloc.s 36
+			IL_0b9b: ldstr "TypeError"
+			IL_0ba0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0ba5: stloc.s 46
+			IL_0ba7: ldloc.s 36
+			IL_0ba9: ldloc.s 46
+			IL_0bab: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0bb0: stloc.s 43
+			IL_0bb2: ldloc.s 43
+			IL_0bb4: box [System.Runtime]System.Boolean
+			IL_0bb9: stloc.s 53
+			IL_0bbb: ldloc.s 53
+			IL_0bbd: stloc.s 28
+			IL_0bbf: leave IL_0bc4
 		} // end handler
 
-		IL_0b9e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0ba3: stloc.s 40
-		IL_0ba5: ldloc.s 40
-		IL_0ba7: ldstr "proxyIntegrityInvariants"
-		IL_0bac: ldloc.s 24
-		IL_0bae: ldloc.s 28
-		IL_0bb0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-		IL_0bb5: pop
-		IL_0bb6: ldnull
-		IL_0bb7: stloc.s 32
-		IL_0bb9: ret
+		IL_0bc4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0bc9: stloc.s 40
+		IL_0bcb: ldloc.s 40
+		IL_0bcd: ldstr "proxyIntegrityInvariants"
+		IL_0bd2: ldloc.s 24
+		IL_0bd4: ldloc.s 28
+		IL_0bd6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+		IL_0bdb: pop
+		IL_0bdc: ldnull
+		IL_0bdd: stloc.s 32
+		IL_0bdf: ret
 	} // end of method Function_CallableReflection_ProxyIntegration::__js_module_init__
 
 } // end of class Modules.Function_CallableReflection_ProxyIntegration

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ExplicitReceiverAbi.verified.txt
@@ -771,7 +771,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 2316 (0x90c)
+		// Code size: 2335 (0x91f)
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Function_ExplicitReceiverAbi/Scope,
@@ -1078,495 +1078,502 @@
 		IL_03d1: stloc.s 26
 		IL_03d3: ldc.i4.0
 		IL_03d4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_03d9: brfalse IL_0402
+		IL_03d9: brfalse IL_0415
 
 		IL_03de: ldloc.s 26
 		IL_03e0: isinst [System.Runtime]System.String
 		IL_03e5: dup
-		IL_03e6: brfalse IL_0401
+		IL_03e6: brtrue IL_03fe
 
-		IL_03eb: ldstr "function"
-		IL_03f0: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-		IL_03f5: box [System.Runtime]System.Double
-		IL_03fa: stloc.s 26
-		IL_03fc: br IL_0415
+		IL_03eb: pop
+		IL_03ec: ldloc.s 26
+		IL_03ee: ldstr "indexOf"
+		IL_03f3: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_03f8: dup
+		IL_03f9: brfalse IL_0414
 
-		IL_0401: pop
+		IL_03fe: ldstr "function"
+		IL_0403: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_0408: box [System.Runtime]System.Double
+		IL_040d: stloc.s 26
+		IL_040f: br IL_0428
 
-		IL_0402: ldloc.s 26
-		IL_0404: ldstr "indexOf"
-		IL_0409: ldstr "function"
-		IL_040e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0413: stloc.s 26
+		IL_0414: pop
 
 		IL_0415: ldloc.s 26
-		IL_0417: ldc.r8 0.0
-		IL_0420: box [System.Runtime]System.Double
-		IL_0425: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_042a: stloc.s 27
-		IL_042c: ldloc.s 27
-		IL_042e: box [System.Runtime]System.Boolean
-		IL_0433: stloc.s 28
-		IL_0435: ldloc.s 23
-		IL_0437: ldloc.s 28
-		IL_0439: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_043e: pop
+		IL_0417: ldstr "indexOf"
+		IL_041c: ldstr "function"
+		IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0426: stloc.s 26
+
+		IL_0428: ldloc.s 26
+		IL_042a: ldc.r8 0.0
+		IL_0433: box [System.Runtime]System.Double
+		IL_0438: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_043d: stloc.s 27
+		IL_043f: ldloc.s 27
+		IL_0441: box [System.Runtime]System.Boolean
+		IL_0446: stloc.s 28
+		IL_0448: ldloc.s 23
+		IL_044a: ldloc.s 28
+		IL_044c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0451: pop
 		.try
 		{
-			IL_043f: nop
-			IL_0440: ldstr "Function"
-			IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_044a: ldstr "prototype"
-			IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0454: stloc.s 26
-			IL_0456: ldloc.s 26
-			IL_0458: ldstr "apply"
-			IL_045d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0462: stloc.s 26
-			IL_0464: ldloc.s 26
-			IL_0466: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_046b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0470: stloc.s 24
-			IL_0472: ldstr "call"
-			IL_0477: ldloc.s 24
-			IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_047e: pop
-			IL_047f: leave IL_04ed
-		} // end .try
-		catch [System.Runtime]System.Exception
-		{
-			IL_0484: stloc.3
-			IL_0485: ldloc.3
-			IL_0486: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_048b: dup
-			IL_048c: brtrue IL_04a1
-
+			IL_0452: nop
+			IL_0453: ldstr "Function"
+			IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_045d: ldstr "prototype"
+			IL_0462: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0467: stloc.s 26
+			IL_0469: ldloc.s 26
+			IL_046b: ldstr "apply"
+			IL_0470: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0475: stloc.s 26
+			IL_0477: ldloc.s 26
+			IL_0479: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_047e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0483: stloc.s 24
+			IL_0485: ldstr "call"
+			IL_048a: ldloc.s 24
+			IL_048c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
 			IL_0491: pop
-			IL_0492: ldloc.3
-			IL_0493: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0498: dup
-			IL_0499: brtrue IL_04ad
-
-			IL_049e: pop
-			IL_049f: rethrow
-
-			IL_04a1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_04a6: stloc.s 4
-			IL_04a8: br IL_04af
-
-			IL_04ad: stloc.s 4
-
-			IL_04af: ldloc.s 4
-			IL_04b1: stloc.s 5
-			IL_04b3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04b8: stloc.s 23
-			IL_04ba: ldloc.s 5
-			IL_04bc: stloc.s 26
-			IL_04be: ldstr "TypeError"
-			IL_04c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04c8: stloc.s 29
-			IL_04ca: ldloc.s 26
-			IL_04cc: ldloc.s 29
-			IL_04ce: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_04d3: stloc.s 27
-			IL_04d5: ldloc.s 27
-			IL_04d7: box [System.Runtime]System.Boolean
-			IL_04dc: stloc.s 28
-			IL_04de: ldloc.s 23
-			IL_04e0: ldloc.s 28
-			IL_04e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04e7: pop
-			IL_04e8: leave IL_04ed
-		} // end handler
-		.try
-		{
-			IL_04ed: nop
-			IL_04ee: ldstr "Function"
-			IL_04f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_04f8: ldstr "prototype"
-			IL_04fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0502: stloc.s 29
-			IL_0504: ldloc.s 29
-			IL_0506: ldstr "call"
-			IL_050b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0510: stloc.s 29
-			IL_0512: ldloc.s 29
-			IL_0514: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0519: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_051e: stloc.s 24
-			IL_0520: ldstr "call"
-			IL_0525: ldloc.s 24
-			IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_052c: pop
-			IL_052d: leave IL_059e
+			IL_0492: leave IL_0500
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0532: stloc.s 6
-			IL_0534: ldloc.s 6
-			IL_0536: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_053b: dup
-			IL_053c: brtrue IL_0552
+			IL_0497: stloc.3
+			IL_0498: ldloc.3
+			IL_0499: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_049e: dup
+			IL_049f: brtrue IL_04b4
 
-			IL_0541: pop
-			IL_0542: ldloc.s 6
-			IL_0544: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0549: dup
-			IL_054a: brtrue IL_055e
+			IL_04a4: pop
+			IL_04a5: ldloc.3
+			IL_04a6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_04ab: dup
+			IL_04ac: brtrue IL_04c0
 
-			IL_054f: pop
-			IL_0550: rethrow
+			IL_04b1: pop
+			IL_04b2: rethrow
 
-			IL_0552: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0557: stloc.s 7
-			IL_0559: br IL_0560
+			IL_04b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_04b9: stloc.s 4
+			IL_04bb: br IL_04c2
 
-			IL_055e: stloc.s 7
+			IL_04c0: stloc.s 4
 
-			IL_0560: ldloc.s 7
-			IL_0562: stloc.s 8
-			IL_0564: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0569: stloc.s 23
-			IL_056b: ldloc.s 8
-			IL_056d: stloc.s 29
-			IL_056f: ldstr "TypeError"
-			IL_0574: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0579: stloc.s 26
-			IL_057b: ldloc.s 29
-			IL_057d: ldloc.s 26
-			IL_057f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0584: stloc.s 27
-			IL_0586: ldloc.s 27
-			IL_0588: box [System.Runtime]System.Boolean
-			IL_058d: stloc.s 28
-			IL_058f: ldloc.s 23
-			IL_0591: ldloc.s 28
-			IL_0593: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0598: pop
-			IL_0599: leave IL_059e
+			IL_04c2: ldloc.s 4
+			IL_04c4: stloc.s 5
+			IL_04c6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04cb: stloc.s 23
+			IL_04cd: ldloc.s 5
+			IL_04cf: stloc.s 26
+			IL_04d1: ldstr "TypeError"
+			IL_04d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_04db: stloc.s 29
+			IL_04dd: ldloc.s 26
+			IL_04df: ldloc.s 29
+			IL_04e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_04e6: stloc.s 27
+			IL_04e8: ldloc.s 27
+			IL_04ea: box [System.Runtime]System.Boolean
+			IL_04ef: stloc.s 28
+			IL_04f1: ldloc.s 23
+			IL_04f3: ldloc.s 28
+			IL_04f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04fa: pop
+			IL_04fb: leave IL_0500
 		} // end handler
 		.try
 		{
-			IL_059e: nop
-			IL_059f: ldstr "Function"
-			IL_05a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05a9: ldstr "prototype"
-			IL_05ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05b3: stloc.s 26
-			IL_05b5: ldloc.s 26
-			IL_05b7: ldstr "bind"
-			IL_05bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05c1: stloc.s 26
-			IL_05c3: ldloc.s 26
-			IL_05c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05ca: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_05cf: stloc.s 24
-			IL_05d1: ldstr "call"
-			IL_05d6: ldloc.s 24
-			IL_05d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_05dd: pop
-			IL_05de: leave IL_064f
+			IL_0500: nop
+			IL_0501: ldstr "Function"
+			IL_0506: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_050b: ldstr "prototype"
+			IL_0510: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0515: stloc.s 29
+			IL_0517: ldloc.s 29
+			IL_0519: ldstr "call"
+			IL_051e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0523: stloc.s 29
+			IL_0525: ldloc.s 29
+			IL_0527: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_052c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0531: stloc.s 24
+			IL_0533: ldstr "call"
+			IL_0538: ldloc.s 24
+			IL_053a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_053f: pop
+			IL_0540: leave IL_05b1
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_05e3: stloc.s 9
-			IL_05e5: ldloc.s 9
-			IL_05e7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_05ec: dup
-			IL_05ed: brtrue IL_0603
+			IL_0545: stloc.s 6
+			IL_0547: ldloc.s 6
+			IL_0549: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_054e: dup
+			IL_054f: brtrue IL_0565
 
-			IL_05f2: pop
-			IL_05f3: ldloc.s 9
-			IL_05f5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_05fa: dup
-			IL_05fb: brtrue IL_060f
+			IL_0554: pop
+			IL_0555: ldloc.s 6
+			IL_0557: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_055c: dup
+			IL_055d: brtrue IL_0571
 
-			IL_0600: pop
-			IL_0601: rethrow
+			IL_0562: pop
+			IL_0563: rethrow
 
-			IL_0603: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0608: stloc.s 10
-			IL_060a: br IL_0611
+			IL_0565: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_056a: stloc.s 7
+			IL_056c: br IL_0573
 
-			IL_060f: stloc.s 10
+			IL_0571: stloc.s 7
 
-			IL_0611: ldloc.s 10
-			IL_0613: stloc.s 11
-			IL_0615: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_061a: stloc.s 23
-			IL_061c: ldloc.s 11
-			IL_061e: stloc.s 26
-			IL_0620: ldstr "TypeError"
-			IL_0625: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_062a: stloc.s 29
-			IL_062c: ldloc.s 26
-			IL_062e: ldloc.s 29
-			IL_0630: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0635: stloc.s 27
-			IL_0637: ldloc.s 27
-			IL_0639: box [System.Runtime]System.Boolean
-			IL_063e: stloc.s 28
-			IL_0640: ldloc.s 23
-			IL_0642: ldloc.s 28
-			IL_0644: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0649: pop
-			IL_064a: leave IL_064f
+			IL_0573: ldloc.s 7
+			IL_0575: stloc.s 8
+			IL_0577: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_057c: stloc.s 23
+			IL_057e: ldloc.s 8
+			IL_0580: stloc.s 29
+			IL_0582: ldstr "TypeError"
+			IL_0587: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_058c: stloc.s 26
+			IL_058e: ldloc.s 29
+			IL_0590: ldloc.s 26
+			IL_0592: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0597: stloc.s 27
+			IL_0599: ldloc.s 27
+			IL_059b: box [System.Runtime]System.Boolean
+			IL_05a0: stloc.s 28
+			IL_05a2: ldloc.s 23
+			IL_05a4: ldloc.s 28
+			IL_05a6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_05ab: pop
+			IL_05ac: leave IL_05b1
 		} // end handler
 		.try
 		{
-			IL_064f: nop
-			IL_0650: ldstr "Function"
-			IL_0655: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_065a: ldstr "prototype"
-			IL_065f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0664: stloc.s 29
-			IL_0666: ldloc.s 29
-			IL_0668: ldstr "toString"
-			IL_066d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0672: stloc.s 29
-			IL_0674: ldloc.s 29
-			IL_0676: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_067b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0680: stloc.s 24
-			IL_0682: ldstr "call"
-			IL_0687: ldloc.s 24
-			IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_068e: pop
-			IL_068f: leave IL_0700
+			IL_05b1: nop
+			IL_05b2: ldstr "Function"
+			IL_05b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05bc: ldstr "prototype"
+			IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05c6: stloc.s 26
+			IL_05c8: ldloc.s 26
+			IL_05ca: ldstr "bind"
+			IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_05d4: stloc.s 26
+			IL_05d6: ldloc.s 26
+			IL_05d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05dd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_05e2: stloc.s 24
+			IL_05e4: ldstr "call"
+			IL_05e9: ldloc.s 24
+			IL_05eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_05f0: pop
+			IL_05f1: leave IL_0662
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0694: stloc.s 12
-			IL_0696: ldloc.s 12
-			IL_0698: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_069d: dup
-			IL_069e: brtrue IL_06b4
+			IL_05f6: stloc.s 9
+			IL_05f8: ldloc.s 9
+			IL_05fa: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_05ff: dup
+			IL_0600: brtrue IL_0616
 
-			IL_06a3: pop
-			IL_06a4: ldloc.s 12
-			IL_06a6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_06ab: dup
-			IL_06ac: brtrue IL_06c0
+			IL_0605: pop
+			IL_0606: ldloc.s 9
+			IL_0608: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_060d: dup
+			IL_060e: brtrue IL_0622
 
-			IL_06b1: pop
-			IL_06b2: rethrow
+			IL_0613: pop
+			IL_0614: rethrow
 
-			IL_06b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_06b9: stloc.s 13
-			IL_06bb: br IL_06c2
+			IL_0616: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_061b: stloc.s 10
+			IL_061d: br IL_0624
 
-			IL_06c0: stloc.s 13
+			IL_0622: stloc.s 10
 
-			IL_06c2: ldloc.s 13
-			IL_06c4: stloc.s 14
-			IL_06c6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_06cb: stloc.s 23
-			IL_06cd: ldloc.s 14
-			IL_06cf: stloc.s 29
-			IL_06d1: ldstr "TypeError"
-			IL_06d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_06db: stloc.s 26
-			IL_06dd: ldloc.s 29
-			IL_06df: ldloc.s 26
-			IL_06e1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_06e6: stloc.s 27
-			IL_06e8: ldloc.s 27
-			IL_06ea: box [System.Runtime]System.Boolean
-			IL_06ef: stloc.s 28
-			IL_06f1: ldloc.s 23
-			IL_06f3: ldloc.s 28
-			IL_06f5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_06fa: pop
-			IL_06fb: leave IL_0700
+			IL_0624: ldloc.s 10
+			IL_0626: stloc.s 11
+			IL_0628: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_062d: stloc.s 23
+			IL_062f: ldloc.s 11
+			IL_0631: stloc.s 26
+			IL_0633: ldstr "TypeError"
+			IL_0638: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_063d: stloc.s 29
+			IL_063f: ldloc.s 26
+			IL_0641: ldloc.s 29
+			IL_0643: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0648: stloc.s 27
+			IL_064a: ldloc.s 27
+			IL_064c: box [System.Runtime]System.Boolean
+			IL_0651: stloc.s 28
+			IL_0653: ldloc.s 23
+			IL_0655: ldloc.s 28
+			IL_0657: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_065c: pop
+			IL_065d: leave IL_0662
 		} // end handler
 		.try
 		{
-			IL_0700: nop
-			IL_0701: ldloc.1
-			IL_0702: ldstr "caller"
-			IL_0707: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_070c: pop
-			IL_070d: leave IL_077e
+			IL_0662: nop
+			IL_0663: ldstr "Function"
+			IL_0668: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_066d: ldstr "prototype"
+			IL_0672: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0677: stloc.s 29
+			IL_0679: ldloc.s 29
+			IL_067b: ldstr "toString"
+			IL_0680: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0685: stloc.s 29
+			IL_0687: ldloc.s 29
+			IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_068e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0693: stloc.s 24
+			IL_0695: ldstr "call"
+			IL_069a: ldloc.s 24
+			IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_06a1: pop
+			IL_06a2: leave IL_0713
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0712: stloc.s 15
-			IL_0714: ldloc.s 15
-			IL_0716: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_071b: dup
-			IL_071c: brtrue IL_0732
+			IL_06a7: stloc.s 12
+			IL_06a9: ldloc.s 12
+			IL_06ab: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_06b0: dup
+			IL_06b1: brtrue IL_06c7
 
-			IL_0721: pop
-			IL_0722: ldloc.s 15
-			IL_0724: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0729: dup
-			IL_072a: brtrue IL_073e
+			IL_06b6: pop
+			IL_06b7: ldloc.s 12
+			IL_06b9: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_06be: dup
+			IL_06bf: brtrue IL_06d3
 
-			IL_072f: pop
-			IL_0730: rethrow
+			IL_06c4: pop
+			IL_06c5: rethrow
 
-			IL_0732: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0737: stloc.s 16
-			IL_0739: br IL_0740
+			IL_06c7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_06cc: stloc.s 13
+			IL_06ce: br IL_06d5
 
-			IL_073e: stloc.s 16
+			IL_06d3: stloc.s 13
 
-			IL_0740: ldloc.s 16
-			IL_0742: stloc.s 17
-			IL_0744: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0749: stloc.s 23
-			IL_074b: ldloc.s 17
-			IL_074d: stloc.s 26
-			IL_074f: ldstr "TypeError"
-			IL_0754: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0759: stloc.s 29
-			IL_075b: ldloc.s 26
-			IL_075d: ldloc.s 29
-			IL_075f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_0764: stloc.s 27
-			IL_0766: ldloc.s 27
-			IL_0768: box [System.Runtime]System.Boolean
-			IL_076d: stloc.s 28
-			IL_076f: ldloc.s 23
-			IL_0771: ldloc.s 28
-			IL_0773: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0778: pop
-			IL_0779: leave IL_077e
+			IL_06d5: ldloc.s 13
+			IL_06d7: stloc.s 14
+			IL_06d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_06de: stloc.s 23
+			IL_06e0: ldloc.s 14
+			IL_06e2: stloc.s 29
+			IL_06e4: ldstr "TypeError"
+			IL_06e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_06ee: stloc.s 26
+			IL_06f0: ldloc.s 29
+			IL_06f2: ldloc.s 26
+			IL_06f4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_06f9: stloc.s 27
+			IL_06fb: ldloc.s 27
+			IL_06fd: box [System.Runtime]System.Boolean
+			IL_0702: stloc.s 28
+			IL_0704: ldloc.s 23
+			IL_0706: ldloc.s 28
+			IL_0708: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_070d: pop
+			IL_070e: leave IL_0713
 		} // end handler
 		.try
 		{
-			IL_077e: nop
-			IL_077f: ldloc.1
-			IL_0780: ldstr "arguments"
-			IL_0785: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_078a: pop
-			IL_078b: leave IL_07fc
+			IL_0713: nop
+			IL_0714: ldloc.1
+			IL_0715: ldstr "caller"
+			IL_071a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_071f: pop
+			IL_0720: leave IL_0791
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0790: stloc.s 18
-			IL_0792: ldloc.s 18
-			IL_0794: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0799: dup
-			IL_079a: brtrue IL_07b0
+			IL_0725: stloc.s 15
+			IL_0727: ldloc.s 15
+			IL_0729: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_072e: dup
+			IL_072f: brtrue IL_0745
 
-			IL_079f: pop
-			IL_07a0: ldloc.s 18
-			IL_07a2: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_07a7: dup
-			IL_07a8: brtrue IL_07bc
+			IL_0734: pop
+			IL_0735: ldloc.s 15
+			IL_0737: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_073c: dup
+			IL_073d: brtrue IL_0751
 
-			IL_07ad: pop
-			IL_07ae: rethrow
+			IL_0742: pop
+			IL_0743: rethrow
 
-			IL_07b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_07b5: stloc.s 19
-			IL_07b7: br IL_07be
+			IL_0745: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_074a: stloc.s 16
+			IL_074c: br IL_0753
 
-			IL_07bc: stloc.s 19
+			IL_0751: stloc.s 16
 
-			IL_07be: ldloc.s 19
-			IL_07c0: stloc.s 20
-			IL_07c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_07c7: stloc.s 23
-			IL_07c9: ldloc.s 20
-			IL_07cb: stloc.s 29
-			IL_07cd: ldstr "TypeError"
-			IL_07d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_07d7: stloc.s 26
-			IL_07d9: ldloc.s 29
-			IL_07db: ldloc.s 26
-			IL_07dd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
-			IL_07e2: stloc.s 27
-			IL_07e4: ldloc.s 27
-			IL_07e6: box [System.Runtime]System.Boolean
-			IL_07eb: stloc.s 28
-			IL_07ed: ldloc.s 23
-			IL_07ef: ldloc.s 28
-			IL_07f1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_07f6: pop
-			IL_07f7: leave IL_07fc
+			IL_0753: ldloc.s 16
+			IL_0755: stloc.s 17
+			IL_0757: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_075c: stloc.s 23
+			IL_075e: ldloc.s 17
+			IL_0760: stloc.s 26
+			IL_0762: ldstr "TypeError"
+			IL_0767: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_076c: stloc.s 29
+			IL_076e: ldloc.s 26
+			IL_0770: ldloc.s 29
+			IL_0772: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_0777: stloc.s 27
+			IL_0779: ldloc.s 27
+			IL_077b: box [System.Runtime]System.Boolean
+			IL_0780: stloc.s 28
+			IL_0782: ldloc.s 23
+			IL_0784: ldloc.s 28
+			IL_0786: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_078b: pop
+			IL_078c: leave IL_0791
+		} // end handler
+		.try
+		{
+			IL_0791: nop
+			IL_0792: ldloc.1
+			IL_0793: ldstr "arguments"
+			IL_0798: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_079d: pop
+			IL_079e: leave IL_080f
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_07a3: stloc.s 18
+			IL_07a5: ldloc.s 18
+			IL_07a7: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_07ac: dup
+			IL_07ad: brtrue IL_07c3
+
+			IL_07b2: pop
+			IL_07b3: ldloc.s 18
+			IL_07b5: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_07ba: dup
+			IL_07bb: brtrue IL_07cf
+
+			IL_07c0: pop
+			IL_07c1: rethrow
+
+			IL_07c3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_07c8: stloc.s 19
+			IL_07ca: br IL_07d1
+
+			IL_07cf: stloc.s 19
+
+			IL_07d1: ldloc.s 19
+			IL_07d3: stloc.s 20
+			IL_07d5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07da: stloc.s 23
+			IL_07dc: ldloc.s 20
+			IL_07de: stloc.s 29
+			IL_07e0: ldstr "TypeError"
+			IL_07e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_07ea: stloc.s 26
+			IL_07ec: ldloc.s 29
+			IL_07ee: ldloc.s 26
+			IL_07f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_07f5: stloc.s 27
+			IL_07f7: ldloc.s 27
+			IL_07f9: box [System.Runtime]System.Boolean
+			IL_07fe: stloc.s 28
+			IL_0800: ldloc.s 23
+			IL_0802: ldloc.s 28
+			IL_0804: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0809: pop
+			IL_080a: leave IL_080f
 		} // end handler
 
-		IL_07fc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0801: stloc.s 23
-		IL_0803: ldstr "Function"
-		IL_0808: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_080d: ldstr "prototype"
-		IL_0812: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0817: stloc.s 26
-		IL_0819: ldloc.s 26
-		IL_081b: ldstr "apply"
-		IL_0820: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0825: stloc.s 26
-		IL_0827: ldloc.s 26
-		IL_0829: ldstr "length"
-		IL_082e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0833: stloc.s 26
-		IL_0835: ldloc.s 23
-		IL_0837: ldloc.s 26
-		IL_0839: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_083e: pop
-		IL_083f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0844: stloc.s 23
-		IL_0846: ldstr "Function"
-		IL_084b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0850: ldstr "prototype"
-		IL_0855: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_085a: stloc.s 26
-		IL_085c: ldloc.s 26
-		IL_085e: ldstr "call"
-		IL_0863: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0868: stloc.s 26
-		IL_086a: ldloc.s 26
-		IL_086c: ldstr "length"
-		IL_0871: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0876: stloc.s 26
-		IL_0878: ldloc.s 23
-		IL_087a: ldloc.s 26
-		IL_087c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0881: pop
-		IL_0882: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0887: stloc.s 23
-		IL_0889: ldstr "Function"
-		IL_088e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0893: ldstr "prototype"
-		IL_0898: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_089d: stloc.s 26
-		IL_089f: ldloc.s 26
-		IL_08a1: ldstr "bind"
-		IL_08a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08ab: stloc.s 26
-		IL_08ad: ldloc.s 26
-		IL_08af: ldstr "length"
-		IL_08b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08b9: stloc.s 26
-		IL_08bb: ldloc.s 23
-		IL_08bd: ldloc.s 26
-		IL_08bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_08c4: pop
-		IL_08c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_08ca: stloc.s 23
-		IL_08cc: ldstr "Function"
-		IL_08d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_08d6: ldstr "prototype"
-		IL_08db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08e0: stloc.s 26
-		IL_08e2: ldloc.s 26
-		IL_08e4: ldstr "toString"
-		IL_08e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08ee: stloc.s 26
-		IL_08f0: ldloc.s 26
-		IL_08f2: ldstr "length"
-		IL_08f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_08fc: stloc.s 26
-		IL_08fe: ldloc.s 23
-		IL_0900: ldloc.s 26
-		IL_0902: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0907: pop
-		IL_0908: ldnull
-		IL_0909: stloc.s 21
-		IL_090b: ret
+		IL_080f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0814: stloc.s 23
+		IL_0816: ldstr "Function"
+		IL_081b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0820: ldstr "prototype"
+		IL_0825: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_082a: stloc.s 26
+		IL_082c: ldloc.s 26
+		IL_082e: ldstr "apply"
+		IL_0833: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0838: stloc.s 26
+		IL_083a: ldloc.s 26
+		IL_083c: ldstr "length"
+		IL_0841: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0846: stloc.s 26
+		IL_0848: ldloc.s 23
+		IL_084a: ldloc.s 26
+		IL_084c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0851: pop
+		IL_0852: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0857: stloc.s 23
+		IL_0859: ldstr "Function"
+		IL_085e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0863: ldstr "prototype"
+		IL_0868: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_086d: stloc.s 26
+		IL_086f: ldloc.s 26
+		IL_0871: ldstr "call"
+		IL_0876: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_087b: stloc.s 26
+		IL_087d: ldloc.s 26
+		IL_087f: ldstr "length"
+		IL_0884: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0889: stloc.s 26
+		IL_088b: ldloc.s 23
+		IL_088d: ldloc.s 26
+		IL_088f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0894: pop
+		IL_0895: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_089a: stloc.s 23
+		IL_089c: ldstr "Function"
+		IL_08a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08a6: ldstr "prototype"
+		IL_08ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08b0: stloc.s 26
+		IL_08b2: ldloc.s 26
+		IL_08b4: ldstr "bind"
+		IL_08b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08be: stloc.s 26
+		IL_08c0: ldloc.s 26
+		IL_08c2: ldstr "length"
+		IL_08c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08cc: stloc.s 26
+		IL_08ce: ldloc.s 23
+		IL_08d0: ldloc.s 26
+		IL_08d2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_08d7: pop
+		IL_08d8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_08dd: stloc.s 23
+		IL_08df: ldstr "Function"
+		IL_08e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08e9: ldstr "prototype"
+		IL_08ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08f3: stloc.s 26
+		IL_08f5: ldloc.s 26
+		IL_08f7: ldstr "toString"
+		IL_08fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0901: stloc.s 26
+		IL_0903: ldloc.s 26
+		IL_0905: ldstr "length"
+		IL_090a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_090f: stloc.s 26
+		IL_0911: ldloc.s 23
+		IL_0913: ldloc.s 26
+		IL_0915: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_091a: pop
+		IL_091b: ldnull
+		IL_091c: stloc.s 21
+		IL_091e: ret
 	} // end of method Function_ExplicitReceiverAbi::__js_module_init__
 
 } // end of class Modules.Function_ExplicitReceiverAbi

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous.verified.txt
@@ -181,7 +181,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 203 (0xcb)
+		// Code size: 222 (0xde)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/Scope,
@@ -233,42 +233,49 @@
 		IL_005d: stloc.s 4
 		IL_005f: ldc.i4.0
 		IL_0060: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0065: brfalse IL_008e
+		IL_0065: brfalse IL_00a1
 
 		IL_006a: ldloc.s 4
 		IL_006c: isinst [System.Runtime]System.String
 		IL_0071: dup
-		IL_0072: brfalse IL_008d
+		IL_0072: brtrue IL_008a
 
-		IL_0077: ldstr "DynamicFunction_L12C34"
-		IL_007c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-		IL_0081: box [System.Runtime]System.Double
-		IL_0086: stloc.s 4
-		IL_0088: br IL_00a1
+		IL_0077: pop
+		IL_0078: ldloc.s 4
+		IL_007a: ldstr "indexOf"
+		IL_007f: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_0084: dup
+		IL_0085: brfalse IL_00a0
 
-		IL_008d: pop
+		IL_008a: ldstr "DynamicFunction_L12C34"
+		IL_008f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_0094: box [System.Runtime]System.Double
+		IL_0099: stloc.s 4
+		IL_009b: br IL_00b4
 
-		IL_008e: ldloc.s 4
-		IL_0090: ldstr "indexOf"
-		IL_0095: ldstr "DynamicFunction_L12C34"
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009f: stloc.s 4
+		IL_00a0: pop
 
 		IL_00a1: ldloc.s 4
-		IL_00a3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_00a8: ldc.r8 0.0
-		IL_00b1: clt
-		IL_00b3: ldc.i4.0
-		IL_00b4: ceq
-		IL_00b6: stloc.s 5
-		IL_00b8: ldloc.s 5
-		IL_00ba: box [System.Runtime]System.Boolean
-		IL_00bf: stloc.s 6
-		IL_00c1: ldloc.3
-		IL_00c2: ldloc.s 6
-		IL_00c4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c9: pop
-		IL_00ca: ret
+		IL_00a3: ldstr "indexOf"
+		IL_00a8: ldstr "DynamicFunction_L12C34"
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b2: stloc.s 4
+
+		IL_00b4: ldloc.s 4
+		IL_00b6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_00bb: ldc.r8 0.0
+		IL_00c4: clt
+		IL_00c6: ldc.i4.0
+		IL_00c7: ceq
+		IL_00c9: stloc.s 5
+		IL_00cb: ldloc.s 5
+		IL_00cd: box [System.Runtime]System.Boolean
+		IL_00d2: stloc.s 6
+		IL_00d4: ldloc.3
+		IL_00d5: ldloc.s 6
+		IL_00d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00dc: pop
+		IL_00dd: ret
 	} // end of method Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous::__js_module_init__
 
 } // end of class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ToString_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ToString_Basic.verified.txt
@@ -198,7 +198,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 366 (0x16e)
+		// Code size: 404 (0x194)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Prototype_ToString_Basic/Scope,
@@ -262,82 +262,96 @@
 		IL_0084: stloc.s 4
 		IL_0086: ldc.i4.0
 		IL_0087: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_008c: brfalse IL_00b5
+		IL_008c: brfalse IL_00c8
 
 		IL_0091: ldloc.s 4
 		IL_0093: isinst [System.Runtime]System.String
 		IL_0098: dup
-		IL_0099: brfalse IL_00b4
+		IL_0099: brtrue IL_00b1
 
-		IL_009e: ldstr "function"
-		IL_00a3: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-		IL_00a8: box [System.Runtime]System.Double
-		IL_00ad: stloc.s 4
-		IL_00af: br IL_00c8
+		IL_009e: pop
+		IL_009f: ldloc.s 4
+		IL_00a1: ldstr "indexOf"
+		IL_00a6: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_00ab: dup
+		IL_00ac: brfalse IL_00c7
 
-		IL_00b4: pop
+		IL_00b1: ldstr "function"
+		IL_00b6: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_00bb: box [System.Runtime]System.Double
+		IL_00c0: stloc.s 4
+		IL_00c2: br IL_00db
 
-		IL_00b5: ldloc.s 4
-		IL_00b7: ldstr "indexOf"
-		IL_00bc: ldstr "function"
-		IL_00c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00c6: stloc.s 4
+		IL_00c7: pop
 
 		IL_00c8: ldloc.s 4
-		IL_00ca: ldc.r8 0.0
-		IL_00d3: box [System.Runtime]System.Double
-		IL_00d8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00dd: stloc.s 7
-		IL_00df: ldloc.s 7
-		IL_00e1: box [System.Runtime]System.Boolean
-		IL_00e6: stloc.s 8
-		IL_00e8: ldloc.s 5
-		IL_00ea: ldloc.s 8
-		IL_00ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00f1: pop
-		IL_00f2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00f7: stloc.s 5
-		IL_00f9: ldloc.2
-		IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00ff: stloc.s 4
-		IL_0101: ldc.i4.0
-		IL_0102: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0107: brfalse IL_0130
+		IL_00ca: ldstr "indexOf"
+		IL_00cf: ldstr "function"
+		IL_00d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00d9: stloc.s 4
 
-		IL_010c: ldloc.s 4
-		IL_010e: isinst [System.Runtime]System.String
-		IL_0113: dup
-		IL_0114: brfalse IL_012f
+		IL_00db: ldloc.s 4
+		IL_00dd: ldc.r8 0.0
+		IL_00e6: box [System.Runtime]System.Double
+		IL_00eb: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00f0: stloc.s 7
+		IL_00f2: ldloc.s 7
+		IL_00f4: box [System.Runtime]System.Boolean
+		IL_00f9: stloc.s 8
+		IL_00fb: ldloc.s 5
+		IL_00fd: ldloc.s 8
+		IL_00ff: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0104: pop
+		IL_0105: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010a: stloc.s 5
+		IL_010c: ldloc.2
+		IL_010d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0112: stloc.s 4
+		IL_0114: ldc.i4.0
+		IL_0115: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_011a: brfalse IL_0156
 
-		IL_0119: ldstr "[native code]"
-		IL_011e: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-		IL_0123: box [System.Runtime]System.Double
-		IL_0128: stloc.s 4
-		IL_012a: br IL_0143
+		IL_011f: ldloc.s 4
+		IL_0121: isinst [System.Runtime]System.String
+		IL_0126: dup
+		IL_0127: brtrue IL_013f
 
-		IL_012f: pop
+		IL_012c: pop
+		IL_012d: ldloc.s 4
+		IL_012f: ldstr "indexOf"
+		IL_0134: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_0139: dup
+		IL_013a: brfalse IL_0155
 
-		IL_0130: ldloc.s 4
-		IL_0132: ldstr "indexOf"
-		IL_0137: ldstr "[native code]"
-		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0141: stloc.s 4
+		IL_013f: ldstr "[native code]"
+		IL_0144: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_0149: box [System.Runtime]System.Double
+		IL_014e: stloc.s 4
+		IL_0150: br IL_0169
 
-		IL_0143: ldloc.s 4
-		IL_0145: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_014a: ldc.r8 0.0
-		IL_0153: clt
-		IL_0155: ldc.i4.0
-		IL_0156: ceq
-		IL_0158: stloc.s 7
-		IL_015a: ldloc.s 7
-		IL_015c: box [System.Runtime]System.Boolean
-		IL_0161: stloc.s 8
-		IL_0163: ldloc.s 5
-		IL_0165: ldloc.s 8
-		IL_0167: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_016c: pop
-		IL_016d: ret
+		IL_0155: pop
+
+		IL_0156: ldloc.s 4
+		IL_0158: ldstr "indexOf"
+		IL_015d: ldstr "[native code]"
+		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0167: stloc.s 4
+
+		IL_0169: ldloc.s 4
+		IL_016b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0170: ldc.r8 0.0
+		IL_0179: clt
+		IL_017b: ldc.i4.0
+		IL_017c: ceq
+		IL_017e: stloc.s 7
+		IL_0180: ldloc.s 7
+		IL_0182: box [System.Runtime]System.Boolean
+		IL_0187: stloc.s 8
+		IL_0189: ldloc.s 5
+		IL_018b: ldloc.s 8
+		IL_018d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0192: pop
+		IL_0193: ret
 	} // end of method Function_Prototype_ToString_Basic::__js_module_init__
 
 } // end of class Modules.Function_Prototype_ToString_Basic

--- a/tests/Jroc.Tests/Hosting/JavaScript/stringGuardRealmIsolation.js
+++ b/tests/Jroc.Tests/Hosting/JavaScript/stringGuardRealmIsolation.js
@@ -4,6 +4,10 @@ exports.callTrim = function (value) {
     return value.trim();
 };
 
+exports.createString = function (value) {
+    return new String(value);
+};
+
 exports.overrideTrim = function (result) {
     String.prototype.trim = function () {
         return result;

--- a/tests/Jroc.Tests/Hosting/ModuleLoadTests.cs
+++ b/tests/Jroc.Tests/Hosting/ModuleLoadTests.cs
@@ -260,12 +260,20 @@ public class ModuleLoadTests
 
         Assert.Equal("first", (string)firstExports.callTrim("  first  "));
         Assert.Equal("second", (string)secondExports.callTrim("  second  "));
+        object firstStringObject =
+            firstExports.createString("  first-object  ");
+        Assert.Equal(
+            "first-object",
+            (string)firstExports.callTrim(firstStringObject));
 
         firstExports.overrideTrim("first-override");
 
         Assert.Equal(
             "first-override",
             (string)firstExports.callTrim("  first  "));
+        Assert.Equal(
+            "first-override",
+            (string)firstExports.callTrim(firstStringObject));
         Assert.Equal("second", (string)secondExports.callTrim("  second  "));
     }
 

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
@@ -44,7 +44,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1050 (0x41a)
+		// Code size: 1126 (0x466)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ImportMeta_Url/Scope,
@@ -202,200 +202,228 @@
 		IL_01c8: stloc.s 6
 		IL_01ca: ldc.i4.0
 		IL_01cb: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_01d0: brfalse IL_01f9
+		IL_01d0: brfalse IL_020c
 
 		IL_01d5: ldloc.s 6
 		IL_01d7: isinst [System.Runtime]System.String
 		IL_01dc: dup
-		IL_01dd: brfalse IL_01f8
+		IL_01dd: brtrue IL_01f5
 
-		IL_01e2: ldstr "file://"
-		IL_01e7: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-		IL_01ec: box [System.Runtime]System.Boolean
-		IL_01f1: stloc.s 6
-		IL_01f3: br IL_020c
+		IL_01e2: pop
+		IL_01e3: ldloc.s 6
+		IL_01e5: ldstr "startsWith"
+		IL_01ea: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_01ef: dup
+		IL_01f0: brfalse IL_020b
 
-		IL_01f8: pop
+		IL_01f5: ldstr "file://"
+		IL_01fa: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+		IL_01ff: box [System.Runtime]System.Boolean
+		IL_0204: stloc.s 6
+		IL_0206: br IL_021f
 
-		IL_01f9: ldloc.s 6
-		IL_01fb: ldstr "startsWith"
-		IL_0200: ldstr "file://"
-		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_020a: stloc.s 6
+		IL_020b: pop
 
-		IL_020c: ldloc.s 8
-		IL_020e: ldstr "main has file url:"
-		IL_0213: ldloc.s 6
-		IL_0215: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_021a: pop
-		IL_021b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0220: stloc.s 8
-		IL_0222: ldarg.3
-		IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0228: ldstr "split"
-		IL_022d: ldstr "\\"
-		IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0237: stloc.s 6
-		IL_0239: ldloc.s 6
-		IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0240: ldstr "join"
-		IL_0245: ldstr "/"
-		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_024f: stloc.s 6
-		IL_0251: ldloc.2
-		IL_0252: ldloc.s 6
-		IL_0254: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0259: stloc.s 9
-		IL_025b: ldloc.s 9
-		IL_025d: box [System.Runtime]System.Boolean
-		IL_0262: stloc.s 10
-		IL_0264: ldloc.s 8
-		IL_0266: ldstr "main path matches filename:"
-		IL_026b: ldloc.s 10
-		IL_026d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0272: pop
-		IL_0273: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0278: stloc.s 8
-		IL_027a: ldloc.3
-		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0280: stloc.s 6
-		IL_0282: ldc.i4.0
-		IL_0283: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0288: brfalse IL_02b1
+		IL_020c: ldloc.s 6
+		IL_020e: ldstr "startsWith"
+		IL_0213: ldstr "file://"
+		IL_0218: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_021d: stloc.s 6
 
-		IL_028d: ldloc.s 6
-		IL_028f: isinst [System.Runtime]System.String
-		IL_0294: dup
-		IL_0295: brfalse IL_02b0
+		IL_021f: ldloc.s 8
+		IL_0221: ldstr "main has file url:"
+		IL_0226: ldloc.s 6
+		IL_0228: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_022d: pop
+		IL_022e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0233: stloc.s 8
+		IL_0235: ldarg.3
+		IL_0236: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_023b: ldstr "split"
+		IL_0240: ldstr "\\"
+		IL_0245: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024a: stloc.s 6
+		IL_024c: ldloc.s 6
+		IL_024e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0253: ldstr "join"
+		IL_0258: ldstr "/"
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0262: stloc.s 6
+		IL_0264: ldloc.2
+		IL_0265: ldloc.s 6
+		IL_0267: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_026c: stloc.s 9
+		IL_026e: ldloc.s 9
+		IL_0270: box [System.Runtime]System.Boolean
+		IL_0275: stloc.s 10
+		IL_0277: ldloc.s 8
+		IL_0279: ldstr "main path matches filename:"
+		IL_027e: ldloc.s 10
+		IL_0280: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0285: pop
+		IL_0286: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_028b: stloc.s 8
+		IL_028d: ldloc.3
+		IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0293: stloc.s 6
+		IL_0295: ldc.i4.0
+		IL_0296: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_029b: brfalse IL_02d7
 
-		IL_029a: ldstr "/fixtures/main.txt"
-		IL_029f: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
-		IL_02a4: box [System.Runtime]System.Boolean
-		IL_02a9: stloc.s 6
-		IL_02ab: br IL_02c4
+		IL_02a0: ldloc.s 6
+		IL_02a2: isinst [System.Runtime]System.String
+		IL_02a7: dup
+		IL_02a8: brtrue IL_02c0
 
-		IL_02b0: pop
+		IL_02ad: pop
+		IL_02ae: ldloc.s 6
+		IL_02b0: ldstr "endsWith"
+		IL_02b5: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_02ba: dup
+		IL_02bb: brfalse IL_02d6
 
-		IL_02b1: ldloc.s 6
-		IL_02b3: ldstr "endsWith"
-		IL_02b8: ldstr "/fixtures/main.txt"
-		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02c2: stloc.s 6
+		IL_02c0: ldstr "/fixtures/main.txt"
+		IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
+		IL_02ca: box [System.Runtime]System.Boolean
+		IL_02cf: stloc.s 6
+		IL_02d1: br IL_02ea
 
-		IL_02c4: ldloc.s 8
-		IL_02c6: ldstr "main asset path:"
-		IL_02cb: ldloc.s 6
-		IL_02cd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02d2: pop
-		IL_02d3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02d8: stloc.s 8
-		IL_02da: ldloc.0
-		IL_02db: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
-		IL_02e0: stloc.s 6
-		IL_02e2: ldloc.s 6
-		IL_02e4: ldstr "importedUrlHasFileScheme"
-		IL_02e9: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
-		IL_02ee: stloc.s 6
-		IL_02f0: ldloc.s 8
-		IL_02f2: ldstr "lib has file url:"
-		IL_02f7: ldloc.s 6
-		IL_02f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_02fe: pop
-		IL_02ff: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0304: stloc.s 8
-		IL_0306: ldloc.s 4
-		IL_0308: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_030d: stloc.s 6
-		IL_030f: ldc.i4.0
-		IL_0310: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0315: brfalse IL_033e
+		IL_02d6: pop
 
-		IL_031a: ldloc.s 6
-		IL_031c: isinst [System.Runtime]System.String
-		IL_0321: dup
-		IL_0322: brfalse IL_033d
+		IL_02d7: ldloc.s 6
+		IL_02d9: ldstr "endsWith"
+		IL_02de: ldstr "/fixtures/main.txt"
+		IL_02e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02e8: stloc.s 6
 
-		IL_0327: ldstr "/Import_ImportMeta_Url_Lib"
-		IL_032c: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
-		IL_0331: box [System.Runtime]System.Boolean
-		IL_0336: stloc.s 6
-		IL_0338: br IL_0351
+		IL_02ea: ldloc.s 8
+		IL_02ec: ldstr "main asset path:"
+		IL_02f1: ldloc.s 6
+		IL_02f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_02f8: pop
+		IL_02f9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02fe: stloc.s 8
+		IL_0300: ldloc.0
+		IL_0301: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
+		IL_0306: stloc.s 6
+		IL_0308: ldloc.s 6
+		IL_030a: ldstr "importedUrlHasFileScheme"
+		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
+		IL_0314: stloc.s 6
+		IL_0316: ldloc.s 8
+		IL_0318: ldstr "lib has file url:"
+		IL_031d: ldloc.s 6
+		IL_031f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0324: pop
+		IL_0325: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_032a: stloc.s 8
+		IL_032c: ldloc.s 4
+		IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0333: stloc.s 6
+		IL_0335: ldc.i4.0
+		IL_0336: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_033b: brfalse IL_0377
 
-		IL_033d: pop
+		IL_0340: ldloc.s 6
+		IL_0342: isinst [System.Runtime]System.String
+		IL_0347: dup
+		IL_0348: brtrue IL_0360
 
-		IL_033e: ldloc.s 6
-		IL_0340: ldstr "endsWith"
-		IL_0345: ldstr "/Import_ImportMeta_Url_Lib"
-		IL_034a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_034f: stloc.s 6
+		IL_034d: pop
+		IL_034e: ldloc.s 6
+		IL_0350: ldstr "endsWith"
+		IL_0355: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_035a: dup
+		IL_035b: brfalse IL_0376
 
-		IL_0351: ldloc.s 8
-		IL_0353: ldstr "lib path:"
-		IL_0358: ldloc.s 6
-		IL_035a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_035f: pop
-		IL_0360: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0365: stloc.s 8
-		IL_0367: ldloc.s 5
-		IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_036e: stloc.s 6
-		IL_0370: ldc.i4.0
-		IL_0371: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0376: brfalse IL_039f
+		IL_0360: ldstr "/Import_ImportMeta_Url_Lib"
+		IL_0365: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
+		IL_036a: box [System.Runtime]System.Boolean
+		IL_036f: stloc.s 6
+		IL_0371: br IL_038a
 
-		IL_037b: ldloc.s 6
-		IL_037d: isinst [System.Runtime]System.String
-		IL_0382: dup
-		IL_0383: brfalse IL_039e
+		IL_0376: pop
 
-		IL_0388: ldstr "/fixtures/lib.txt"
-		IL_038d: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
-		IL_0392: box [System.Runtime]System.Boolean
-		IL_0397: stloc.s 6
-		IL_0399: br IL_03b2
+		IL_0377: ldloc.s 6
+		IL_0379: ldstr "endsWith"
+		IL_037e: ldstr "/Import_ImportMeta_Url_Lib"
+		IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0388: stloc.s 6
 
-		IL_039e: pop
+		IL_038a: ldloc.s 8
+		IL_038c: ldstr "lib path:"
+		IL_0391: ldloc.s 6
+		IL_0393: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0398: pop
+		IL_0399: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_039e: stloc.s 8
+		IL_03a0: ldloc.s 5
+		IL_03a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03a7: stloc.s 6
+		IL_03a9: ldc.i4.0
+		IL_03aa: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_03af: brfalse IL_03eb
 
-		IL_039f: ldloc.s 6
-		IL_03a1: ldstr "endsWith"
-		IL_03a6: ldstr "/fixtures/lib.txt"
-		IL_03ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03b0: stloc.s 6
+		IL_03b4: ldloc.s 6
+		IL_03b6: isinst [System.Runtime]System.String
+		IL_03bb: dup
+		IL_03bc: brtrue IL_03d4
 
-		IL_03b2: ldloc.s 8
-		IL_03b4: ldstr "lib asset path:"
-		IL_03b9: ldloc.s 6
-		IL_03bb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_03c0: pop
-		IL_03c1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03c6: stloc.s 8
-		IL_03c8: ldloc.0
-		IL_03c9: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
-		IL_03ce: stloc.s 6
-		IL_03d0: ldloc.s 6
-		IL_03d2: ldstr "importedModuleFilenameMatches"
-		IL_03d7: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
-		IL_03dc: stloc.s 6
-		IL_03de: ldloc.s 8
-		IL_03e0: ldstr "lib module.filename:"
-		IL_03e5: ldloc.s 6
-		IL_03e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_03ec: pop
-		IL_03ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_03f2: stloc.s 8
-		IL_03f4: ldloc.0
-		IL_03f5: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
-		IL_03fa: stloc.s 6
-		IL_03fc: ldloc.s 6
-		IL_03fe: ldstr "importedModulePathMatches"
-		IL_0403: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
-		IL_0408: stloc.s 6
-		IL_040a: ldloc.s 8
-		IL_040c: ldstr "lib module.path:"
-		IL_0411: ldloc.s 6
-		IL_0413: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0418: pop
-		IL_0419: ret
+		IL_03c1: pop
+		IL_03c2: ldloc.s 6
+		IL_03c4: ldstr "endsWith"
+		IL_03c9: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_03ce: dup
+		IL_03cf: brfalse IL_03ea
+
+		IL_03d4: ldstr "/fixtures/lib.txt"
+		IL_03d9: call bool [JavaScriptRuntime]JavaScriptRuntime.String::EndsWith(string, string)
+		IL_03de: box [System.Runtime]System.Boolean
+		IL_03e3: stloc.s 6
+		IL_03e5: br IL_03fe
+
+		IL_03ea: pop
+
+		IL_03eb: ldloc.s 6
+		IL_03ed: ldstr "endsWith"
+		IL_03f2: ldstr "/fixtures/lib.txt"
+		IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03fc: stloc.s 6
+
+		IL_03fe: ldloc.s 8
+		IL_0400: ldstr "lib asset path:"
+		IL_0405: ldloc.s 6
+		IL_0407: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_040c: pop
+		IL_040d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0412: stloc.s 8
+		IL_0414: ldloc.0
+		IL_0415: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
+		IL_041a: stloc.s 6
+		IL_041c: ldloc.s 6
+		IL_041e: ldstr "importedModuleFilenameMatches"
+		IL_0423: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
+		IL_0428: stloc.s 6
+		IL_042a: ldloc.s 8
+		IL_042c: ldstr "lib module.filename:"
+		IL_0431: ldloc.s 6
+		IL_0433: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0438: pop
+		IL_0439: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_043e: stloc.s 8
+		IL_0440: ldloc.0
+		IL_0441: ldfld object Modules.Import_ImportMeta_Url/Scope::'*esm-src:./Import_ImportMeta_Url_Lib.mjs'
+		IL_0446: stloc.s 6
+		IL_0448: ldloc.s 6
+		IL_044a: ldstr "importedModulePathMatches"
+		IL_044f: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::GetImport(object, string)
+		IL_0454: stloc.s 6
+		IL_0456: ldloc.s 8
+		IL_0458: ldstr "lib module.path:"
+		IL_045d: ldloc.s 6
+		IL_045f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0464: pop
+		IL_0465: ret
 	} // end of method Import_ImportMeta_Url::__js_module_init__
 
 } // end of class Modules.Import_ImportMeta_Url
@@ -435,7 +463,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 400 (0x190)
+		// Code size: 419 (0x1a3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ImportMeta_Url_Lib/Scope,
@@ -486,89 +514,96 @@
 		IL_0079: stloc.s 5
 		IL_007b: ldc.i4.0
 		IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0081: brfalse IL_00a9
+		IL_0081: brfalse IL_00bc
 
 		IL_0086: ldloc.s 5
 		IL_0088: isinst [System.Runtime]System.String
 		IL_008d: dup
-		IL_008e: brfalse IL_00a8
+		IL_008e: brtrue IL_00a6
 
-		IL_0093: ldstr "file://"
-		IL_0098: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-		IL_009d: box [System.Runtime]System.Boolean
-		IL_00a2: stloc.2
-		IL_00a3: br IL_00bb
+		IL_0093: pop
+		IL_0094: ldloc.s 5
+		IL_0096: ldstr "startsWith"
+		IL_009b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_00a0: dup
+		IL_00a1: brfalse IL_00bb
 
-		IL_00a8: pop
+		IL_00a6: ldstr "file://"
+		IL_00ab: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+		IL_00b0: box [System.Runtime]System.Boolean
+		IL_00b5: stloc.2
+		IL_00b6: br IL_00ce
 
-		IL_00a9: ldloc.s 5
-		IL_00ab: ldstr "startsWith"
-		IL_00b0: ldstr "file://"
-		IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ba: stloc.2
+		IL_00bb: pop
 
-		IL_00bb: ldstr "Import_ImportMeta_Url_Lib"
-		IL_00c0: ldstr "importedUrlHasFileScheme"
-		IL_00c5: ldloc.2
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::SetLocalExport(string, string, object)
-		IL_00cb: pop
-		IL_00cc: ldarg.2
-		IL_00cd: ldstr "filename"
-		IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00d7: stloc.s 5
-		IL_00d9: ldloc.s 5
-		IL_00db: ldarg.3
-		IL_00dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_00e1: stloc.3
-		IL_00e2: ldloc.3
-		IL_00e3: box [System.Runtime]System.Boolean
-		IL_00e8: stloc.s 6
-		IL_00ea: ldstr "Import_ImportMeta_Url_Lib"
-		IL_00ef: ldstr "importedModuleFilenameMatches"
-		IL_00f4: ldloc.s 6
-		IL_00f6: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::SetLocalExport(string, string, object)
-		IL_00fb: pop
-		IL_00fc: ldarg.2
-		IL_00fd: ldstr "path"
-		IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0107: stloc.s 5
-		IL_0109: ldloc.s 5
-		IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0110: ldstr "split"
-		IL_0115: ldstr "\\"
-		IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011f: stloc.s 5
-		IL_0121: ldloc.s 5
-		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0128: ldstr "join"
-		IL_012d: ldstr "/"
-		IL_0132: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0137: stloc.s 5
-		IL_0139: ldarg.s __dirname
-		IL_013b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0140: ldstr "split"
-		IL_0145: ldstr "\\"
-		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_014f: stloc.s 7
-		IL_0151: ldloc.s 7
-		IL_0153: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0158: ldstr "join"
-		IL_015d: ldstr "/"
-		IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0167: stloc.s 7
-		IL_0169: ldloc.s 5
-		IL_016b: ldloc.s 7
-		IL_016d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0172: stloc.s 4
-		IL_0174: ldloc.s 4
-		IL_0176: box [System.Runtime]System.Boolean
-		IL_017b: stloc.s 6
-		IL_017d: ldstr "Import_ImportMeta_Url_Lib"
-		IL_0182: ldstr "importedModulePathMatches"
-		IL_0187: ldloc.s 6
-		IL_0189: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::SetLocalExport(string, string, object)
-		IL_018e: pop
-		IL_018f: ret
+		IL_00bc: ldloc.s 5
+		IL_00be: ldstr "startsWith"
+		IL_00c3: ldstr "file://"
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00cd: stloc.2
+
+		IL_00ce: ldstr "Import_ImportMeta_Url_Lib"
+		IL_00d3: ldstr "importedUrlHasFileScheme"
+		IL_00d8: ldloc.2
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::SetLocalExport(string, string, object)
+		IL_00de: pop
+		IL_00df: ldarg.2
+		IL_00e0: ldstr "filename"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00ea: stloc.s 5
+		IL_00ec: ldloc.s 5
+		IL_00ee: ldarg.3
+		IL_00ef: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_00f4: stloc.3
+		IL_00f5: ldloc.3
+		IL_00f6: box [System.Runtime]System.Boolean
+		IL_00fb: stloc.s 6
+		IL_00fd: ldstr "Import_ImportMeta_Url_Lib"
+		IL_0102: ldstr "importedModuleFilenameMatches"
+		IL_0107: ldloc.s 6
+		IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::SetLocalExport(string, string, object)
+		IL_010e: pop
+		IL_010f: ldarg.2
+		IL_0110: ldstr "path"
+		IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_011a: stloc.s 5
+		IL_011c: ldloc.s 5
+		IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0123: ldstr "split"
+		IL_0128: ldstr "\\"
+		IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0132: stloc.s 5
+		IL_0134: ldloc.s 5
+		IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_013b: ldstr "join"
+		IL_0140: ldstr "/"
+		IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_014a: stloc.s 5
+		IL_014c: ldarg.s __dirname
+		IL_014e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0153: ldstr "split"
+		IL_0158: ldstr "\\"
+		IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0162: stloc.s 7
+		IL_0164: ldloc.s 7
+		IL_0166: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_016b: ldstr "join"
+		IL_0170: ldstr "/"
+		IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_017a: stloc.s 7
+		IL_017c: ldloc.s 5
+		IL_017e: ldloc.s 7
+		IL_0180: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0185: stloc.s 4
+		IL_0187: ldloc.s 4
+		IL_0189: box [System.Runtime]System.Boolean
+		IL_018e: stloc.s 6
+		IL_0190: ldstr "Import_ImportMeta_Url_Lib"
+		IL_0195: ldstr "importedModulePathMatches"
+		IL_019a: ldloc.s 6
+		IL_019c: call object [JavaScriptRuntime]JavaScriptRuntime.Modules.ESM.EsModuleLinker::SetLocalExport(string, string, object)
+		IL_01a1: pop
+		IL_01a2: ret
 	} // end of method Import_ImportMeta_Url_Lib::__js_module_init__
 
 } // end of class Modules.Import_ImportMeta_Url_Lib

--- a/tests/Jroc.Tests/Integration/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Integration/ExecutionTests.cs
@@ -19,6 +19,9 @@ namespace Jroc.Tests.Integration
         public Task Compile_Performance_Dromaeo_Object_Regexp() => ExecutionTest(nameof(Compile_Performance_Dromaeo_Object_Regexp), preferOutOfProc: true);
 
         [Fact]
+        public Task Compile_Performance_Dromaeo_Object_String() => ExecutionTest(nameof(Compile_Performance_Dromaeo_Object_String), preferOutOfProc: true);
+
+        [Fact]
         public async Task Compile_Scripts_ExtractEcma262SectionHtml_UrlMode()
         {
             await using var server = await LoopbackEcma262Server.StartAsync();

--- a/tests/Jroc.Tests/Integration/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Integration/GeneratorTests.cs
@@ -41,6 +41,9 @@ namespace Jroc.Tests.Integration
         public Task Compile_Performance_Dromaeo_Object_Regexp() => GenerateTest(nameof(Compile_Performance_Dromaeo_Object_Regexp));
 
         [Fact]
+        public Task Compile_Performance_Dromaeo_Object_String() => GenerateTest(nameof(Compile_Performance_Dromaeo_Object_String));
+
+        [Fact]
         public Task Compile_Performance_PrimeJavaScript() => GenerateTest(nameof(Compile_Performance_PrimeJavaScript));
     }
 }

--- a/tests/Jroc.Tests/Integration/Snapshots/ExecutionTests.Compile_Performance_Dromaeo_Object_String.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/ExecutionTests.Compile_Performance_Dromaeo_Object_String.verified.txt
@@ -1,0 +1,1 @@
+﻿emptyString

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
@@ -1002,7 +1002,7 @@
 				74 61 54 6f 6b 65 6e 51 00 00 02
 			)
 			// Header size: 12
-			// Code size: 557 (0x22d)
+			// Code size: 576 (0x240)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1055,7 +1055,7 @@
 				IL_005f: ldloc.s 5
 				IL_0061: ldarg.2
 				IL_0062: clt
-				IL_0064: brfalse IL_0221
+				IL_0064: brfalse IL_0234
 
 				IL_0069: ldarg.0
 				IL_006a: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::randomChar
@@ -1158,7 +1158,7 @@
 					IL_015f: ldloc.s 5
 					IL_0161: ldloc.s 9
 					IL_0163: clt
-					IL_0165: brfalse IL_01fd
+					IL_0165: brfalse IL_0210
 
 					IL_016a: ldloc.0
 					IL_016b: ldloc.3
@@ -1184,60 +1184,67 @@
 					IL_01a3: stloc.s 11
 					IL_01a5: ldc.i4.0
 					IL_01a6: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-					IL_01ab: brfalse IL_01ce
+					IL_01ab: brfalse IL_01e1
 
 					IL_01b0: ldloc.s 7
 					IL_01b2: isinst [System.Runtime]System.String
 					IL_01b7: dup
-					IL_01b8: brfalse IL_01cd
+					IL_01b8: brtrue IL_01d0
 
-					IL_01bd: ldloc.s 10
-					IL_01bf: ldloc.s 11
-					IL_01c1: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-					IL_01c6: stloc.s 7
-					IL_01c8: br IL_01e0
+					IL_01bd: pop
+					IL_01be: ldloc.s 7
+					IL_01c0: ldstr "substring"
+					IL_01c5: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+					IL_01ca: dup
+					IL_01cb: brfalse IL_01e0
 
-					IL_01cd: pop
+					IL_01d0: ldloc.s 10
+					IL_01d2: ldloc.s 11
+					IL_01d4: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+					IL_01d9: stloc.s 7
+					IL_01db: br IL_01f3
 
-					IL_01ce: ldloc.s 7
-					IL_01d0: ldstr "substring"
-					IL_01d5: ldloc.s 10
-					IL_01d7: ldloc.s 11
-					IL_01d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-					IL_01de: stloc.s 7
+					IL_01e0: pop
 
-					IL_01e0: ldarg.0
 					IL_01e1: ldloc.s 7
-					IL_01e3: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
-					IL_01e8: ldloc.3
-					IL_01e9: ldc.r8 100
-					IL_01f2: add
-					IL_01f3: stloc.s 9
-					IL_01f5: ldloc.s 9
-					IL_01f7: stloc.3
-					IL_01f8: br IL_014e
+					IL_01e3: ldstr "substring"
+					IL_01e8: ldloc.s 10
+					IL_01ea: ldloc.s 11
+					IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+					IL_01f1: stloc.s 7
+
+					IL_01f3: ldarg.0
+					IL_01f4: ldloc.s 7
+					IL_01f6: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::'ret'
+					IL_01fb: ldloc.3
+					IL_01fc: ldc.r8 100
+					IL_0205: add
+					IL_0206: stloc.s 9
+					IL_0208: ldloc.s 9
+					IL_020a: stloc.3
+					IL_020b: br IL_014e
 				// end loop
 
-				IL_01fd: ldarg.0
-				IL_01fe: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-				IL_0203: stloc.s 7
-				IL_0205: ldloc.s 7
-				IL_0207: ldloc.1
-				IL_0208: ldloc.0
-				IL_0209: ldc.i4.1
-				IL_020a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-				IL_020f: pop
-				IL_0210: ldloc.1
-				IL_0211: ldc.r8 1
-				IL_021a: add
-				IL_021b: stloc.1
-				IL_021c: br IL_005c
+				IL_0210: ldarg.0
+				IL_0211: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+				IL_0216: stloc.s 7
+				IL_0218: ldloc.s 7
+				IL_021a: ldloc.1
+				IL_021b: ldloc.0
+				IL_021c: ldc.i4.1
+				IL_021d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+				IL_0222: pop
+				IL_0223: ldloc.1
+				IL_0224: ldc.r8 1
+				IL_022d: add
+				IL_022e: stloc.1
+				IL_022f: br IL_005c
 			// end loop
 
-			IL_0221: ldarg.0
-			IL_0222: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
-			IL_0227: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-			IL_022c: ret
+			IL_0234: ldarg.0
+			IL_0235: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::testStrings
+			IL_023a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_023f: ret
 		} // end of method generateTestStrings::__js_call__
 
 	} // end of class generateTestStrings
@@ -11116,7 +11123,7 @@
 					01 00 00 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 56 (0x38)
+				// Code size: 74 (0x4a)
 				.maxstack 8
 				.locals init (
 					[0] object
@@ -11127,26 +11134,33 @@
 				IL_0006: stloc.0
 				IL_0007: ldc.i4.0
 				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_000d: brfalse IL_002a
+				IL_000d: brfalse IL_003c
 
 				IL_0012: ldloc.0
 				IL_0013: isinst [System.Runtime]System.String
 				IL_0018: dup
-				IL_0019: brfalse IL_0029
+				IL_0019: brtrue IL_0030
 
-				IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
-				IL_0023: stloc.0
-				IL_0024: br IL_0036
+				IL_001e: pop
+				IL_001f: ldloc.0
+				IL_0020: ldstr "toUpperCase"
+				IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_002a: dup
+				IL_002b: brfalse IL_003b
 
-				IL_0029: pop
-
-				IL_002a: ldloc.0
-				IL_002b: ldstr "toUpperCase"
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0030: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
 				IL_0035: stloc.0
+				IL_0036: br IL_0048
 
-				IL_0036: ldloc.0
-				IL_0037: ret
+				IL_003b: pop
+
+				IL_003c: ldloc.0
+				IL_003d: ldstr "toUpperCase"
+				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0047: stloc.0
+
+				IL_0048: ldloc.0
+				IL_0049: ret
 			} // end of method FunctionExpression_L302C33::__js_call__
 
 		} // end of class FunctionExpression_L302C33

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
@@ -14305,7 +14305,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 4834 (0x12e2)
+		// Code size: 4915 (0x1333)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope,
@@ -14542,7 +14542,7 @@
 			IL_015b: ldloc.s 10
 			IL_015d: ldc.r8 16384
 			IL_0166: clt
-			IL_0168: brfalse IL_01ae
+			IL_0168: brfalse IL_01ff
 
 			IL_016d: ldloc.0
 			IL_016e: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
@@ -14553,1862 +14553,1893 @@
 			IL_0180: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_0185: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
 			IL_018a: stloc.s 12
-			IL_018c: ldloc.s 11
-			IL_018e: ldstr "push"
-			IL_0193: ldloc.s 12
-			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_019a: pop
-			IL_019b: ldloc.s 5
-			IL_019d: ldc.r8 1
-			IL_01a6: add
-			IL_01a7: stloc.s 5
-			IL_01a9: br IL_0157
+			IL_018c: ldc.i4.1
+			IL_018d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0192: brfalse IL_01dd
+
+			IL_0197: ldloc.s 11
+			IL_0199: isinst [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_019e: dup
+			IL_019f: brfalse IL_01dc
+
+			IL_01a4: pop
+			IL_01a5: ldloc.s 11
+			IL_01a7: ldstr "push"
+			IL_01ac: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_01b1: brtrue IL_01dd
+
+			IL_01b6: ldloc.s 11
+			IL_01b8: ldc.i4.1
+			IL_01b9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01be: brfalse IL_01dd
+
+			IL_01c3: ldloc.s 11
+			IL_01c5: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+			IL_01ca: ldloc.s 12
+			IL_01cc: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+			IL_01d1: box [System.Runtime]System.Double
+			IL_01d6: pop
+			IL_01d7: br IL_01ec
+
+			IL_01dc: pop
+
+			IL_01dd: ldloc.s 11
+			IL_01df: ldstr "push"
+			IL_01e4: ldloc.s 12
+			IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01eb: pop
+
+			IL_01ec: ldloc.s 5
+			IL_01ee: ldc.r8 1
+			IL_01f7: add
+			IL_01f8: stloc.s 5
+			IL_01fa: br IL_0157
 		// end loop
 
-		IL_01ae: ldloc.0
-		IL_01af: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01b9: ldstr "join"
-		IL_01be: ldstr ""
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c8: stloc.s 12
-		IL_01ca: ldloc.0
-		IL_01cb: ldloc.s 12
-		IL_01cd: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_01d2: ldloc.0
-		IL_01d3: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_01d8: stloc.s 12
-		IL_01da: ldloc.0
-		IL_01db: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_01e0: stloc.s 11
-		IL_01e2: ldloc.s 12
-		IL_01e4: ldloc.s 11
-		IL_01e6: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_01eb: stloc.s 13
-		IL_01ed: ldloc.0
-		IL_01ee: ldloc.s 13
-		IL_01f0: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_01f5: ldloc.0
-		IL_01f6: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_01fb: stloc.s 11
-		IL_01fd: ldloc.0
-		IL_01fe: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_0203: stloc.s 12
-		IL_0205: ldloc.s 11
-		IL_0207: ldloc.s 12
-		IL_0209: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-		IL_020e: stloc.s 13
-		IL_0210: ldloc.0
-		IL_0211: ldloc.s 13
-		IL_0213: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
-		IL_0218: nop
-		IL_0219: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_021e: stloc.s 6
-		IL_0220: ldc.i4.1
-		IL_0221: newarr [System.Runtime]System.Object
-		IL_0226: dup
-		IL_0227: ldc.i4.0
-		IL_0228: ldloc.0
-		IL_0229: stelem.ref
-		IL_022a: stloc.s 14
-		IL_022c: ldloc.s 14
-		IL_022e: ldc.i4.0
-		IL_022f: ldelem.ref
-		IL_0230: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0235: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_023a: ldc.i4.0
-		IL_023b: conv.r8
-		IL_023c: ldstr ""
-		IL_0241: ldc.i4.0
-		IL_0242: ldc.i4.1
-		IL_0243: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0248: stloc.s 15
-		IL_024a: ldloc.3
-		IL_024b: ldloc.s 6
-		IL_024d: ldloc.s 15
-		IL_024f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0254: pop
-		IL_0255: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_025a: stloc.s 6
-		IL_025c: ldc.i4.1
-		IL_025d: newarr [System.Runtime]System.Object
-		IL_0262: dup
-		IL_0263: ldc.i4.0
-		IL_0264: ldloc.0
-		IL_0265: stelem.ref
-		IL_0266: stloc.s 14
-		IL_0268: ldloc.s 14
-		IL_026a: ldc.i4.0
-		IL_026b: ldelem.ref
-		IL_026c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0271: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0276: ldc.i4.0
-		IL_0277: conv.r8
-		IL_0278: ldstr ""
-		IL_027d: ldc.i4.0
-		IL_027e: ldc.i4.1
-		IL_027f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0284: stloc.s 16
-		IL_0286: ldloc.s 4
-		IL_0288: ldloc.s 6
-		IL_028a: ldstr "Compiled Object Empty Split"
-		IL_028f: ldloc.s 16
-		IL_0291: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0296: pop
-		IL_0297: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_029c: stloc.s 6
-		IL_029e: ldc.i4.1
-		IL_029f: newarr [System.Runtime]System.Object
-		IL_02a4: dup
-		IL_02a5: ldc.i4.0
-		IL_02a6: ldloc.0
-		IL_02a7: stelem.ref
-		IL_02a8: stloc.s 14
-		IL_02aa: ldloc.s 14
-		IL_02ac: ldc.i4.0
-		IL_02ad: ldelem.ref
-		IL_02ae: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_02b3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_02b8: ldc.i4.0
-		IL_02b9: conv.r8
-		IL_02ba: ldstr ""
-		IL_02bf: ldc.i4.0
-		IL_02c0: ldc.i4.1
-		IL_02c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02c6: stloc.s 17
-		IL_02c8: ldloc.3
-		IL_02c9: ldloc.s 6
-		IL_02cb: ldloc.s 17
-		IL_02cd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_02d2: pop
-		IL_02d3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_02d8: stloc.s 6
-		IL_02da: ldc.i4.1
-		IL_02db: newarr [System.Runtime]System.Object
-		IL_02e0: dup
-		IL_02e1: ldc.i4.0
-		IL_02e2: ldloc.0
-		IL_02e3: stelem.ref
-		IL_02e4: stloc.s 14
-		IL_02e6: ldloc.s 14
-		IL_02e8: ldc.i4.0
-		IL_02e9: ldelem.ref
-		IL_02ea: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_02ef: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_02f4: ldc.i4.0
-		IL_02f5: conv.r8
-		IL_02f6: ldstr ""
-		IL_02fb: ldc.i4.0
-		IL_02fc: ldc.i4.1
-		IL_02fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0302: stloc.s 18
-		IL_0304: ldloc.s 4
-		IL_0306: ldloc.s 6
-		IL_0308: ldstr "Compiled Object Char Split"
-		IL_030d: ldloc.s 18
-		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0314: pop
-		IL_0315: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_031a: stloc.s 6
-		IL_031c: ldc.i4.1
-		IL_031d: newarr [System.Runtime]System.Object
-		IL_0322: dup
-		IL_0323: ldc.i4.0
-		IL_0324: ldloc.0
-		IL_0325: stelem.ref
-		IL_0326: stloc.s 14
-		IL_0328: ldloc.s 14
-		IL_032a: ldc.i4.0
-		IL_032b: ldelem.ref
-		IL_032c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0331: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0336: ldc.i4.0
-		IL_0337: conv.r8
-		IL_0338: ldstr ""
-		IL_033d: ldc.i4.0
-		IL_033e: ldc.i4.1
-		IL_033f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0344: stloc.s 19
-		IL_0346: ldloc.3
-		IL_0347: ldloc.s 6
-		IL_0349: ldloc.s 19
-		IL_034b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0350: pop
-		IL_0351: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0356: stloc.s 6
-		IL_0358: ldc.i4.1
-		IL_0359: newarr [System.Runtime]System.Object
-		IL_035e: dup
-		IL_035f: ldc.i4.0
-		IL_0360: ldloc.0
-		IL_0361: stelem.ref
-		IL_0362: stloc.s 14
-		IL_0364: ldloc.s 14
-		IL_0366: ldc.i4.0
-		IL_0367: ldelem.ref
-		IL_0368: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_036d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0372: ldc.i4.0
-		IL_0373: conv.r8
-		IL_0374: ldstr ""
-		IL_0379: ldc.i4.0
-		IL_037a: ldc.i4.1
-		IL_037b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0380: stloc.s 20
-		IL_0382: ldloc.s 4
-		IL_0384: ldloc.s 6
-		IL_0386: ldstr "Compiled Object Variable Split"
-		IL_038b: ldloc.s 20
-		IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0392: pop
-		IL_0393: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0398: stloc.s 6
-		IL_039a: ldc.i4.1
-		IL_039b: newarr [System.Runtime]System.Object
-		IL_03a0: dup
-		IL_03a1: ldc.i4.0
-		IL_03a2: ldloc.0
-		IL_03a3: stelem.ref
-		IL_03a4: stloc.s 14
-		IL_03a6: ldloc.s 14
-		IL_03a8: ldc.i4.0
-		IL_03a9: ldelem.ref
-		IL_03aa: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_03af: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_03b4: ldc.i4.0
-		IL_03b5: conv.r8
-		IL_03b6: ldstr ""
-		IL_03bb: ldc.i4.0
-		IL_03bc: ldc.i4.1
-		IL_03bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03c2: stloc.s 21
-		IL_03c4: ldloc.3
-		IL_03c5: ldloc.s 6
-		IL_03c7: ldloc.s 21
-		IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_03ce: pop
-		IL_03cf: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_03d4: stloc.s 6
-		IL_03d6: ldc.i4.1
-		IL_03d7: newarr [System.Runtime]System.Object
-		IL_03dc: dup
-		IL_03dd: ldc.i4.0
-		IL_03de: ldloc.0
-		IL_03df: stelem.ref
-		IL_03e0: stloc.s 14
-		IL_03e2: ldloc.s 14
-		IL_03e4: ldc.i4.0
-		IL_03e5: ldelem.ref
-		IL_03e6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_03eb: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_03f0: ldc.i4.0
-		IL_03f1: conv.r8
-		IL_03f2: ldstr ""
-		IL_03f7: ldc.i4.0
-		IL_03f8: ldc.i4.1
-		IL_03f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_03fe: stloc.s 22
-		IL_0400: ldloc.s 4
-		IL_0402: ldloc.s 6
-		IL_0404: ldstr "Compiled Match"
-		IL_0409: ldloc.s 22
-		IL_040b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0410: pop
-		IL_0411: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0416: stloc.s 6
-		IL_0418: ldc.i4.1
-		IL_0419: newarr [System.Runtime]System.Object
-		IL_041e: dup
-		IL_041f: ldc.i4.0
-		IL_0420: ldloc.0
-		IL_0421: stelem.ref
-		IL_0422: stloc.s 14
-		IL_0424: ldloc.s 14
-		IL_0426: ldc.i4.0
-		IL_0427: ldelem.ref
-		IL_0428: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_042d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0432: ldc.i4.0
-		IL_0433: conv.r8
-		IL_0434: ldstr ""
-		IL_0439: ldc.i4.0
-		IL_043a: ldc.i4.1
-		IL_043b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0440: stloc.s 23
-		IL_0442: ldloc.3
-		IL_0443: ldloc.s 6
-		IL_0445: ldloc.s 23
-		IL_0447: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_044c: pop
-		IL_044d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0452: stloc.s 6
-		IL_0454: ldc.i4.1
-		IL_0455: newarr [System.Runtime]System.Object
-		IL_045a: dup
-		IL_045b: ldc.i4.0
-		IL_045c: ldloc.0
-		IL_045d: stelem.ref
-		IL_045e: stloc.s 14
-		IL_0460: ldloc.s 14
-		IL_0462: ldc.i4.0
-		IL_0463: ldelem.ref
-		IL_0464: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0469: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_046e: ldc.i4.0
-		IL_046f: conv.r8
-		IL_0470: ldstr ""
-		IL_0475: ldc.i4.0
-		IL_0476: ldc.i4.1
-		IL_0477: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_047c: stloc.s 24
-		IL_047e: ldloc.s 4
-		IL_0480: ldloc.s 6
-		IL_0482: ldstr "Compiled Test"
-		IL_0487: ldloc.s 24
-		IL_0489: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_048e: pop
-		IL_048f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0494: stloc.s 6
-		IL_0496: ldc.i4.1
-		IL_0497: newarr [System.Runtime]System.Object
-		IL_049c: dup
-		IL_049d: ldc.i4.0
-		IL_049e: ldloc.0
-		IL_049f: stelem.ref
-		IL_04a0: stloc.s 14
-		IL_04a2: ldloc.s 14
-		IL_04a4: ldc.i4.0
-		IL_04a5: ldelem.ref
-		IL_04a6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_04ab: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_04b0: ldc.i4.0
-		IL_04b1: conv.r8
-		IL_04b2: ldstr ""
-		IL_04b7: ldc.i4.0
-		IL_04b8: ldc.i4.1
-		IL_04b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_04be: stloc.s 25
-		IL_04c0: ldloc.3
-		IL_04c1: ldloc.s 6
-		IL_04c3: ldloc.s 25
-		IL_04c5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_04ca: pop
-		IL_04cb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_04d0: stloc.s 6
-		IL_04d2: ldc.i4.1
-		IL_04d3: newarr [System.Runtime]System.Object
-		IL_04d8: dup
-		IL_04d9: ldc.i4.0
-		IL_04da: ldloc.0
-		IL_04db: stelem.ref
-		IL_04dc: stloc.s 14
-		IL_04de: ldloc.s 14
-		IL_04e0: ldc.i4.0
-		IL_04e1: ldelem.ref
-		IL_04e2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_04e7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_04ec: ldc.i4.0
-		IL_04ed: conv.r8
-		IL_04ee: ldstr ""
-		IL_04f3: ldc.i4.0
-		IL_04f4: ldc.i4.1
-		IL_04f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_04fa: stloc.s 26
-		IL_04fc: ldloc.s 4
-		IL_04fe: ldloc.s 6
-		IL_0500: ldstr "Compiled Empty Replace"
-		IL_0505: ldloc.s 26
-		IL_0507: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_050c: pop
-		IL_050d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0512: stloc.s 6
-		IL_0514: ldc.i4.1
-		IL_0515: newarr [System.Runtime]System.Object
-		IL_051a: dup
-		IL_051b: ldc.i4.0
-		IL_051c: ldloc.0
-		IL_051d: stelem.ref
-		IL_051e: stloc.s 14
-		IL_0520: ldloc.s 14
-		IL_0522: ldc.i4.0
-		IL_0523: ldelem.ref
-		IL_0524: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0529: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_052e: ldc.i4.0
-		IL_052f: conv.r8
-		IL_0530: ldstr ""
-		IL_0535: ldc.i4.0
-		IL_0536: ldc.i4.1
-		IL_0537: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_053c: stloc.s 27
-		IL_053e: ldloc.3
-		IL_053f: ldloc.s 6
-		IL_0541: ldloc.s 27
-		IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0548: pop
-		IL_0549: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_054e: stloc.s 6
-		IL_0550: ldc.i4.1
-		IL_0551: newarr [System.Runtime]System.Object
-		IL_0556: dup
-		IL_0557: ldc.i4.0
-		IL_0558: ldloc.0
-		IL_0559: stelem.ref
-		IL_055a: stloc.s 14
-		IL_055c: ldloc.s 14
-		IL_055e: ldc.i4.0
-		IL_055f: ldelem.ref
-		IL_0560: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0565: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_056a: ldc.i4.0
-		IL_056b: conv.r8
-		IL_056c: ldstr ""
-		IL_0571: ldc.i4.0
-		IL_0572: ldc.i4.1
-		IL_0573: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0578: stloc.s 28
-		IL_057a: ldloc.s 4
-		IL_057c: ldloc.s 6
-		IL_057e: ldstr "Compiled 12 Char Replace"
-		IL_0583: ldloc.s 28
-		IL_0585: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_058a: pop
-		IL_058b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0590: stloc.s 6
-		IL_0592: ldc.i4.1
-		IL_0593: newarr [System.Runtime]System.Object
-		IL_0598: dup
-		IL_0599: ldc.i4.0
-		IL_059a: ldloc.0
-		IL_059b: stelem.ref
-		IL_059c: stloc.s 14
-		IL_059e: ldloc.s 14
-		IL_05a0: ldc.i4.0
-		IL_05a1: ldelem.ref
-		IL_05a2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_05a7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_05ac: ldc.i4.0
-		IL_05ad: conv.r8
-		IL_05ae: ldstr ""
-		IL_05b3: ldc.i4.0
-		IL_05b4: ldc.i4.1
-		IL_05b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05ba: stloc.s 29
-		IL_05bc: ldloc.3
-		IL_05bd: ldloc.s 6
-		IL_05bf: ldloc.s 29
-		IL_05c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_05c6: pop
-		IL_05c7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_05cc: stloc.s 6
-		IL_05ce: ldc.i4.1
-		IL_05cf: newarr [System.Runtime]System.Object
-		IL_05d4: dup
-		IL_05d5: ldc.i4.0
-		IL_05d6: ldloc.0
-		IL_05d7: stelem.ref
-		IL_05d8: stloc.s 14
-		IL_05da: ldloc.s 14
-		IL_05dc: ldc.i4.0
-		IL_05dd: ldelem.ref
-		IL_05de: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_05e3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_05e8: ldc.i4.0
-		IL_05e9: conv.r8
-		IL_05ea: ldstr ""
-		IL_05ef: ldc.i4.0
-		IL_05f0: ldc.i4.1
-		IL_05f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_05f6: stloc.s 30
-		IL_05f8: ldloc.s 4
-		IL_05fa: ldloc.s 6
-		IL_05fc: ldstr "Compiled Object Match"
-		IL_0601: ldloc.s 30
-		IL_0603: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0608: pop
-		IL_0609: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_060e: stloc.s 6
-		IL_0610: ldc.i4.1
-		IL_0611: newarr [System.Runtime]System.Object
-		IL_0616: dup
-		IL_0617: ldc.i4.0
-		IL_0618: ldloc.0
-		IL_0619: stelem.ref
-		IL_061a: stloc.s 14
-		IL_061c: ldloc.s 14
-		IL_061e: ldc.i4.0
-		IL_061f: ldelem.ref
-		IL_0620: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0625: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_062a: ldc.i4.0
-		IL_062b: conv.r8
-		IL_062c: ldstr ""
-		IL_0631: ldc.i4.0
-		IL_0632: ldc.i4.1
-		IL_0633: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0638: stloc.s 31
-		IL_063a: ldloc.3
-		IL_063b: ldloc.s 6
-		IL_063d: ldloc.s 31
-		IL_063f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0644: pop
-		IL_0645: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_064a: stloc.s 6
-		IL_064c: ldc.i4.1
-		IL_064d: newarr [System.Runtime]System.Object
-		IL_0652: dup
-		IL_0653: ldc.i4.0
-		IL_0654: ldloc.0
-		IL_0655: stelem.ref
-		IL_0656: stloc.s 14
-		IL_0658: ldloc.s 14
-		IL_065a: ldc.i4.0
-		IL_065b: ldelem.ref
-		IL_065c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0661: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0666: ldc.i4.0
-		IL_0667: conv.r8
-		IL_0668: ldstr ""
-		IL_066d: ldc.i4.0
-		IL_066e: ldc.i4.1
-		IL_066f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0674: stloc.s 32
-		IL_0676: ldloc.s 4
-		IL_0678: ldloc.s 6
-		IL_067a: ldstr "Compiled Object Test"
-		IL_067f: ldloc.s 32
-		IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0686: pop
-		IL_0687: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_068c: stloc.s 6
-		IL_068e: ldc.i4.1
-		IL_068f: newarr [System.Runtime]System.Object
-		IL_0694: dup
-		IL_0695: ldc.i4.0
-		IL_0696: ldloc.0
-		IL_0697: stelem.ref
-		IL_0698: stloc.s 14
-		IL_069a: ldloc.s 14
-		IL_069c: ldc.i4.0
-		IL_069d: ldelem.ref
-		IL_069e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_06a3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_06a8: ldc.i4.0
-		IL_06a9: conv.r8
-		IL_06aa: ldstr ""
-		IL_06af: ldc.i4.0
-		IL_06b0: ldc.i4.1
-		IL_06b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_06b6: stloc.s 33
-		IL_06b8: ldloc.3
-		IL_06b9: ldloc.s 6
-		IL_06bb: ldloc.s 33
-		IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_06c2: pop
-		IL_06c3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_06c8: stloc.s 6
-		IL_06ca: ldc.i4.1
-		IL_06cb: newarr [System.Runtime]System.Object
-		IL_06d0: dup
-		IL_06d1: ldc.i4.0
-		IL_06d2: ldloc.0
-		IL_06d3: stelem.ref
-		IL_06d4: stloc.s 14
-		IL_06d6: ldloc.s 14
-		IL_06d8: ldc.i4.0
-		IL_06d9: ldelem.ref
-		IL_06da: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_06df: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_06e4: ldc.i4.0
-		IL_06e5: conv.r8
-		IL_06e6: ldstr ""
-		IL_06eb: ldc.i4.0
-		IL_06ec: ldc.i4.1
-		IL_06ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_06f2: stloc.s 34
-		IL_06f4: ldloc.s 4
-		IL_06f6: ldloc.s 6
-		IL_06f8: ldstr "Compiled Object Empty Replace"
-		IL_06fd: ldloc.s 34
-		IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0704: pop
-		IL_0705: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_070a: stloc.s 6
-		IL_070c: ldc.i4.1
-		IL_070d: newarr [System.Runtime]System.Object
-		IL_0712: dup
-		IL_0713: ldc.i4.0
-		IL_0714: ldloc.0
-		IL_0715: stelem.ref
-		IL_0716: stloc.s 14
-		IL_0718: ldloc.s 14
-		IL_071a: ldc.i4.0
-		IL_071b: ldelem.ref
-		IL_071c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0721: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0726: ldc.i4.0
-		IL_0727: conv.r8
-		IL_0728: ldstr ""
-		IL_072d: ldc.i4.0
-		IL_072e: ldc.i4.1
-		IL_072f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0734: stloc.s 35
-		IL_0736: ldloc.3
-		IL_0737: ldloc.s 6
-		IL_0739: ldloc.s 35
-		IL_073b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0740: pop
-		IL_0741: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0746: stloc.s 6
-		IL_0748: ldc.i4.1
-		IL_0749: newarr [System.Runtime]System.Object
-		IL_074e: dup
-		IL_074f: ldc.i4.0
-		IL_0750: ldloc.0
-		IL_0751: stelem.ref
-		IL_0752: stloc.s 14
-		IL_0754: ldloc.s 14
-		IL_0756: ldc.i4.0
-		IL_0757: ldelem.ref
-		IL_0758: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_075d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0762: ldc.i4.0
-		IL_0763: conv.r8
-		IL_0764: ldstr ""
-		IL_0769: ldc.i4.0
-		IL_076a: ldc.i4.1
-		IL_076b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0770: stloc.s 36
-		IL_0772: ldloc.s 4
-		IL_0774: ldloc.s 6
-		IL_0776: ldstr "Compiled Object 12 Char Replace"
-		IL_077b: ldloc.s 36
-		IL_077d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0782: pop
-		IL_0783: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0788: stloc.s 6
-		IL_078a: ldc.i4.1
-		IL_078b: newarr [System.Runtime]System.Object
-		IL_0790: dup
-		IL_0791: ldc.i4.0
-		IL_0792: ldloc.0
-		IL_0793: stelem.ref
-		IL_0794: stloc.s 14
-		IL_0796: ldloc.s 14
-		IL_0798: ldc.i4.0
-		IL_0799: ldelem.ref
-		IL_079a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_079f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_07a4: ldc.i4.0
-		IL_07a5: conv.r8
-		IL_07a6: ldstr ""
-		IL_07ab: ldc.i4.0
-		IL_07ac: ldc.i4.1
-		IL_07ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_07b2: stloc.s 37
-		IL_07b4: ldloc.3
-		IL_07b5: ldloc.s 6
-		IL_07b7: ldloc.s 37
-		IL_07b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_07be: pop
-		IL_07bf: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_07c4: stloc.s 6
-		IL_07c6: ldc.i4.1
-		IL_07c7: newarr [System.Runtime]System.Object
-		IL_07cc: dup
-		IL_07cd: ldc.i4.0
-		IL_07ce: ldloc.0
-		IL_07cf: stelem.ref
-		IL_07d0: stloc.s 14
-		IL_07d2: ldloc.s 14
-		IL_07d4: ldc.i4.0
-		IL_07d5: ldelem.ref
-		IL_07d6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_07db: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_07e0: ldc.i4.0
-		IL_07e1: conv.r8
-		IL_07e2: ldstr ""
-		IL_07e7: ldc.i4.0
-		IL_07e8: ldc.i4.1
-		IL_07e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_07ee: stloc.s 38
-		IL_07f0: ldloc.s 4
-		IL_07f2: ldloc.s 6
-		IL_07f4: ldstr "Compiled Object 12 Char Replace Function"
-		IL_07f9: ldloc.s 38
-		IL_07fb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0800: pop
-		IL_0801: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0806: stloc.s 6
-		IL_0808: ldc.i4.1
-		IL_0809: newarr [System.Runtime]System.Object
-		IL_080e: dup
-		IL_080f: ldc.i4.0
-		IL_0810: ldloc.0
-		IL_0811: stelem.ref
-		IL_0812: stloc.s 14
-		IL_0814: ldloc.s 14
-		IL_0816: ldc.i4.0
-		IL_0817: ldelem.ref
-		IL_0818: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_081d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0822: ldc.i4.0
-		IL_0823: conv.r8
-		IL_0824: ldstr ""
-		IL_0829: ldc.i4.0
-		IL_082a: ldc.i4.1
-		IL_082b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0830: stloc.s 39
-		IL_0832: ldloc.3
-		IL_0833: ldloc.s 6
-		IL_0835: ldloc.s 39
-		IL_0837: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_083c: pop
-		IL_083d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0842: stloc.s 6
-		IL_0844: ldc.i4.1
-		IL_0845: newarr [System.Runtime]System.Object
-		IL_084a: dup
-		IL_084b: ldc.i4.0
-		IL_084c: ldloc.0
-		IL_084d: stelem.ref
-		IL_084e: stloc.s 14
-		IL_0850: ldloc.s 14
-		IL_0852: ldc.i4.0
-		IL_0853: ldelem.ref
-		IL_0854: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0859: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_085e: ldc.i4.0
-		IL_085f: conv.r8
-		IL_0860: ldstr ""
-		IL_0865: ldc.i4.0
-		IL_0866: ldc.i4.1
-		IL_0867: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_086c: stloc.s 40
-		IL_086e: ldloc.s 4
-		IL_0870: ldloc.s 6
-		IL_0872: ldstr "Compiled Variable Match"
-		IL_0877: ldloc.s 40
-		IL_0879: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_087e: pop
-		IL_087f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0884: stloc.s 6
-		IL_0886: ldc.i4.1
-		IL_0887: newarr [System.Runtime]System.Object
-		IL_088c: dup
-		IL_088d: ldc.i4.0
-		IL_088e: ldloc.0
-		IL_088f: stelem.ref
-		IL_0890: stloc.s 14
-		IL_0892: ldloc.s 14
-		IL_0894: ldc.i4.0
-		IL_0895: ldelem.ref
-		IL_0896: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_089b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_08a0: ldc.i4.0
-		IL_08a1: conv.r8
-		IL_08a2: ldstr ""
-		IL_08a7: ldc.i4.0
-		IL_08a8: ldc.i4.1
-		IL_08a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_08ae: stloc.s 41
-		IL_08b0: ldloc.3
-		IL_08b1: ldloc.s 6
-		IL_08b3: ldloc.s 41
-		IL_08b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_08ba: pop
-		IL_08bb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_08c0: stloc.s 6
-		IL_08c2: ldc.i4.1
-		IL_08c3: newarr [System.Runtime]System.Object
-		IL_08c8: dup
-		IL_08c9: ldc.i4.0
-		IL_08ca: ldloc.0
-		IL_08cb: stelem.ref
-		IL_08cc: stloc.s 14
-		IL_08ce: ldloc.s 14
-		IL_08d0: ldc.i4.0
-		IL_08d1: ldelem.ref
-		IL_08d2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_08d7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_08dc: ldc.i4.0
-		IL_08dd: conv.r8
-		IL_08de: ldstr ""
-		IL_08e3: ldc.i4.0
-		IL_08e4: ldc.i4.1
-		IL_08e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_08ea: stloc.s 42
-		IL_08ec: ldloc.s 4
-		IL_08ee: ldloc.s 6
-		IL_08f0: ldstr "Compiled Variable Test"
-		IL_08f5: ldloc.s 42
-		IL_08f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_08fc: pop
-		IL_08fd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0902: stloc.s 6
-		IL_0904: ldc.i4.1
-		IL_0905: newarr [System.Runtime]System.Object
-		IL_090a: dup
-		IL_090b: ldc.i4.0
-		IL_090c: ldloc.0
-		IL_090d: stelem.ref
-		IL_090e: stloc.s 14
-		IL_0910: ldloc.s 14
-		IL_0912: ldc.i4.0
-		IL_0913: ldelem.ref
-		IL_0914: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0919: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_091e: ldc.i4.0
-		IL_091f: conv.r8
-		IL_0920: ldstr ""
-		IL_0925: ldc.i4.0
-		IL_0926: ldc.i4.1
-		IL_0927: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_092c: stloc.s 43
-		IL_092e: ldloc.3
-		IL_092f: ldloc.s 6
-		IL_0931: ldloc.s 43
-		IL_0933: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0938: pop
-		IL_0939: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_093e: stloc.s 6
-		IL_0940: ldc.i4.1
-		IL_0941: newarr [System.Runtime]System.Object
-		IL_0946: dup
-		IL_0947: ldc.i4.0
-		IL_0948: ldloc.0
-		IL_0949: stelem.ref
-		IL_094a: stloc.s 14
-		IL_094c: ldloc.s 14
-		IL_094e: ldc.i4.0
-		IL_094f: ldelem.ref
-		IL_0950: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0955: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_095a: ldc.i4.0
-		IL_095b: conv.r8
-		IL_095c: ldstr ""
-		IL_0961: ldc.i4.0
-		IL_0962: ldc.i4.1
-		IL_0963: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0968: stloc.s 44
-		IL_096a: ldloc.s 4
-		IL_096c: ldloc.s 6
-		IL_096e: ldstr "Compiled Variable Empty Replace"
-		IL_0973: ldloc.s 44
-		IL_0975: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_097a: pop
-		IL_097b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0980: stloc.s 6
-		IL_0982: ldc.i4.1
-		IL_0983: newarr [System.Runtime]System.Object
-		IL_0988: dup
-		IL_0989: ldc.i4.0
-		IL_098a: ldloc.0
-		IL_098b: stelem.ref
-		IL_098c: stloc.s 14
-		IL_098e: ldloc.s 14
-		IL_0990: ldc.i4.0
-		IL_0991: ldelem.ref
-		IL_0992: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0997: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_099c: ldc.i4.0
-		IL_099d: conv.r8
-		IL_099e: ldstr ""
-		IL_09a3: ldc.i4.0
-		IL_09a4: ldc.i4.1
-		IL_09a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_09aa: stloc.s 45
-		IL_09ac: ldloc.3
-		IL_09ad: ldloc.s 6
-		IL_09af: ldloc.s 45
-		IL_09b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_09b6: pop
-		IL_09b7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_09bc: stloc.s 6
-		IL_09be: ldc.i4.1
-		IL_09bf: newarr [System.Runtime]System.Object
-		IL_09c4: dup
-		IL_09c5: ldc.i4.0
-		IL_09c6: ldloc.0
-		IL_09c7: stelem.ref
-		IL_09c8: stloc.s 14
-		IL_09ca: ldloc.s 14
-		IL_09cc: ldc.i4.0
-		IL_09cd: ldelem.ref
-		IL_09ce: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_09d3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_09d8: ldc.i4.0
-		IL_09d9: conv.r8
-		IL_09da: ldstr ""
-		IL_09df: ldc.i4.0
-		IL_09e0: ldc.i4.1
-		IL_09e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_09e6: stloc.s 46
-		IL_09e8: ldloc.s 4
-		IL_09ea: ldloc.s 6
-		IL_09ec: ldstr "Compiled Variable 12 Char Replace"
-		IL_09f1: ldloc.s 46
-		IL_09f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_09f8: pop
-		IL_09f9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_09fe: stloc.s 6
-		IL_0a00: ldc.i4.1
-		IL_0a01: newarr [System.Runtime]System.Object
-		IL_0a06: dup
-		IL_0a07: ldc.i4.0
-		IL_0a08: ldloc.0
-		IL_0a09: stelem.ref
-		IL_0a0a: stloc.s 14
-		IL_0a0c: ldloc.s 14
-		IL_0a0e: ldc.i4.0
-		IL_0a0f: ldelem.ref
-		IL_0a10: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a15: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0a1a: ldc.i4.0
-		IL_0a1b: conv.r8
-		IL_0a1c: ldstr ""
-		IL_0a21: ldc.i4.0
-		IL_0a22: ldc.i4.1
-		IL_0a23: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0a28: stloc.s 47
-		IL_0a2a: ldloc.3
-		IL_0a2b: ldloc.s 6
-		IL_0a2d: ldloc.s 47
-		IL_0a2f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0a34: pop
-		IL_0a35: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0a3a: stloc.s 6
-		IL_0a3c: ldc.i4.1
-		IL_0a3d: newarr [System.Runtime]System.Object
-		IL_0a42: dup
-		IL_0a43: ldc.i4.0
-		IL_0a44: ldloc.0
-		IL_0a45: stelem.ref
-		IL_0a46: stloc.s 14
-		IL_0a48: ldloc.s 14
-		IL_0a4a: ldc.i4.0
-		IL_0a4b: ldelem.ref
-		IL_0a4c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a51: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0a56: ldc.i4.0
-		IL_0a57: conv.r8
-		IL_0a58: ldstr ""
-		IL_0a5d: ldc.i4.0
-		IL_0a5e: ldc.i4.1
-		IL_0a5f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0a64: stloc.s 48
-		IL_0a66: ldloc.s 4
-		IL_0a68: ldloc.s 6
-		IL_0a6a: ldstr "Compiled Variable Object Match"
-		IL_0a6f: ldloc.s 48
-		IL_0a71: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0a76: pop
-		IL_0a77: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0a7c: stloc.s 6
-		IL_0a7e: ldc.i4.1
-		IL_0a7f: newarr [System.Runtime]System.Object
-		IL_0a84: dup
-		IL_0a85: ldc.i4.0
-		IL_0a86: ldloc.0
-		IL_0a87: stelem.ref
-		IL_0a88: stloc.s 14
-		IL_0a8a: ldloc.s 14
-		IL_0a8c: ldc.i4.0
-		IL_0a8d: ldelem.ref
-		IL_0a8e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a93: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0a98: ldc.i4.0
-		IL_0a99: conv.r8
-		IL_0a9a: ldstr ""
-		IL_0a9f: ldc.i4.0
-		IL_0aa0: ldc.i4.1
-		IL_0aa1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0aa6: stloc.s 49
-		IL_0aa8: ldloc.3
-		IL_0aa9: ldloc.s 6
-		IL_0aab: ldloc.s 49
-		IL_0aad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0ab2: pop
-		IL_0ab3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0ab8: stloc.s 6
-		IL_0aba: ldc.i4.1
-		IL_0abb: newarr [System.Runtime]System.Object
-		IL_0ac0: dup
-		IL_0ac1: ldc.i4.0
-		IL_0ac2: ldloc.0
-		IL_0ac3: stelem.ref
-		IL_0ac4: stloc.s 14
-		IL_0ac6: ldloc.s 14
-		IL_0ac8: ldc.i4.0
-		IL_0ac9: ldelem.ref
-		IL_0aca: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0acf: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0ad4: ldc.i4.0
-		IL_0ad5: conv.r8
-		IL_0ad6: ldstr ""
-		IL_0adb: ldc.i4.0
-		IL_0adc: ldc.i4.1
-		IL_0add: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0ae2: stloc.s 50
-		IL_0ae4: ldloc.s 4
-		IL_0ae6: ldloc.s 6
-		IL_0ae8: ldstr "Compiled Variable Object Test"
-		IL_0aed: ldloc.s 50
-		IL_0aef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0af4: pop
-		IL_0af5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0afa: stloc.s 6
-		IL_0afc: ldc.i4.1
-		IL_0afd: newarr [System.Runtime]System.Object
-		IL_0b02: dup
-		IL_0b03: ldc.i4.0
-		IL_0b04: ldloc.0
-		IL_0b05: stelem.ref
-		IL_0b06: stloc.s 14
-		IL_0b08: ldloc.s 14
-		IL_0b0a: ldc.i4.0
-		IL_0b0b: ldelem.ref
-		IL_0b0c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b11: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0b16: ldc.i4.0
-		IL_0b17: conv.r8
-		IL_0b18: ldstr ""
-		IL_0b1d: ldc.i4.0
-		IL_0b1e: ldc.i4.1
-		IL_0b1f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0b24: stloc.s 51
-		IL_0b26: ldloc.3
-		IL_0b27: ldloc.s 6
-		IL_0b29: ldloc.s 51
-		IL_0b2b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0b30: pop
-		IL_0b31: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0b36: stloc.s 6
-		IL_0b38: ldc.i4.1
-		IL_0b39: newarr [System.Runtime]System.Object
-		IL_0b3e: dup
-		IL_0b3f: ldc.i4.0
-		IL_0b40: ldloc.0
-		IL_0b41: stelem.ref
-		IL_0b42: stloc.s 14
-		IL_0b44: ldloc.s 14
-		IL_0b46: ldc.i4.0
-		IL_0b47: ldelem.ref
-		IL_0b48: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b4d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0b52: ldc.i4.0
-		IL_0b53: conv.r8
-		IL_0b54: ldstr ""
-		IL_0b59: ldc.i4.0
-		IL_0b5a: ldc.i4.1
-		IL_0b5b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0b60: stloc.s 52
-		IL_0b62: ldloc.s 4
-		IL_0b64: ldloc.s 6
-		IL_0b66: ldstr "Compiled Variable Object Empty Replace"
-		IL_0b6b: ldloc.s 52
-		IL_0b6d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0b72: pop
-		IL_0b73: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0b78: stloc.s 6
-		IL_0b7a: ldc.i4.1
-		IL_0b7b: newarr [System.Runtime]System.Object
-		IL_0b80: dup
-		IL_0b81: ldc.i4.0
-		IL_0b82: ldloc.0
-		IL_0b83: stelem.ref
-		IL_0b84: stloc.s 14
-		IL_0b86: ldloc.s 14
-		IL_0b88: ldc.i4.0
-		IL_0b89: ldelem.ref
-		IL_0b8a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b8f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0b94: ldc.i4.0
-		IL_0b95: conv.r8
-		IL_0b96: ldstr ""
-		IL_0b9b: ldc.i4.0
-		IL_0b9c: ldc.i4.1
-		IL_0b9d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0ba2: stloc.s 53
-		IL_0ba4: ldloc.3
-		IL_0ba5: ldloc.s 6
-		IL_0ba7: ldloc.s 53
-		IL_0ba9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0bae: pop
-		IL_0baf: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0bb4: stloc.s 6
-		IL_0bb6: ldc.i4.1
-		IL_0bb7: newarr [System.Runtime]System.Object
-		IL_0bbc: dup
-		IL_0bbd: ldc.i4.0
-		IL_0bbe: ldloc.0
-		IL_0bbf: stelem.ref
-		IL_0bc0: stloc.s 14
-		IL_0bc2: ldloc.s 14
-		IL_0bc4: ldc.i4.0
-		IL_0bc5: ldelem.ref
-		IL_0bc6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0bcb: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0bd0: ldc.i4.0
-		IL_0bd1: conv.r8
-		IL_0bd2: ldstr ""
-		IL_0bd7: ldc.i4.0
-		IL_0bd8: ldc.i4.1
-		IL_0bd9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0bde: stloc.s 54
-		IL_0be0: ldloc.s 4
-		IL_0be2: ldloc.s 6
-		IL_0be4: ldstr "Compiled Variable Object 12 Char Replace"
-		IL_0be9: ldloc.s 54
-		IL_0beb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0bf0: pop
-		IL_0bf1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0bf6: stloc.s 6
-		IL_0bf8: ldc.i4.1
-		IL_0bf9: newarr [System.Runtime]System.Object
-		IL_0bfe: dup
-		IL_0bff: ldc.i4.0
-		IL_0c00: ldloc.0
-		IL_0c01: stelem.ref
-		IL_0c02: stloc.s 14
-		IL_0c04: ldloc.s 14
-		IL_0c06: ldc.i4.0
-		IL_0c07: ldelem.ref
-		IL_0c08: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c0d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0c12: ldc.i4.0
-		IL_0c13: conv.r8
-		IL_0c14: ldstr ""
-		IL_0c19: ldc.i4.0
-		IL_0c1a: ldc.i4.1
-		IL_0c1b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0c20: stloc.s 55
-		IL_0c22: ldloc.3
-		IL_0c23: ldloc.s 6
-		IL_0c25: ldloc.s 55
-		IL_0c27: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0c2c: pop
-		IL_0c2d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0c32: stloc.s 6
-		IL_0c34: ldc.i4.1
-		IL_0c35: newarr [System.Runtime]System.Object
-		IL_0c3a: dup
-		IL_0c3b: ldc.i4.0
-		IL_0c3c: ldloc.0
-		IL_0c3d: stelem.ref
-		IL_0c3e: stloc.s 14
-		IL_0c40: ldloc.s 14
-		IL_0c42: ldc.i4.0
-		IL_0c43: ldelem.ref
-		IL_0c44: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c49: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0c4e: ldc.i4.0
-		IL_0c4f: conv.r8
-		IL_0c50: ldstr ""
-		IL_0c55: ldc.i4.0
-		IL_0c56: ldc.i4.1
-		IL_0c57: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0c5c: stloc.s 56
-		IL_0c5e: ldloc.s 4
-		IL_0c60: ldloc.s 6
-		IL_0c62: ldstr "Compiled Variable Object 12 Char Replace Function"
-		IL_0c67: ldloc.s 56
-		IL_0c69: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0c6e: pop
-		IL_0c6f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0c74: stloc.s 6
-		IL_0c76: ldc.i4.1
-		IL_0c77: newarr [System.Runtime]System.Object
-		IL_0c7c: dup
-		IL_0c7d: ldc.i4.0
-		IL_0c7e: ldloc.0
-		IL_0c7f: stelem.ref
-		IL_0c80: stloc.s 14
-		IL_0c82: ldloc.s 14
-		IL_0c84: ldc.i4.0
-		IL_0c85: ldelem.ref
-		IL_0c86: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c8b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0c90: ldc.i4.0
-		IL_0c91: conv.r8
-		IL_0c92: ldstr ""
-		IL_0c97: ldc.i4.0
-		IL_0c98: ldc.i4.1
-		IL_0c99: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0c9e: stloc.s 57
-		IL_0ca0: ldloc.3
-		IL_0ca1: ldloc.s 6
-		IL_0ca3: ldloc.s 57
-		IL_0ca5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0caa: pop
-		IL_0cab: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0cb0: stloc.s 6
-		IL_0cb2: ldc.i4.1
-		IL_0cb3: newarr [System.Runtime]System.Object
-		IL_0cb8: dup
-		IL_0cb9: ldc.i4.0
-		IL_0cba: ldloc.0
-		IL_0cbb: stelem.ref
-		IL_0cbc: stloc.s 14
-		IL_0cbe: ldloc.s 14
-		IL_0cc0: ldc.i4.0
-		IL_0cc1: ldelem.ref
-		IL_0cc2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0cc7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0ccc: ldc.i4.0
-		IL_0ccd: conv.r8
-		IL_0cce: ldstr ""
-		IL_0cd3: ldc.i4.0
-		IL_0cd4: ldc.i4.1
-		IL_0cd5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0cda: stloc.s 58
-		IL_0cdc: ldloc.s 4
-		IL_0cde: ldloc.s 6
-		IL_0ce0: ldstr "Compiled Capture Match"
-		IL_0ce5: ldloc.s 58
-		IL_0ce7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0cec: pop
-		IL_0ced: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0cf2: stloc.s 6
-		IL_0cf4: ldc.i4.1
-		IL_0cf5: newarr [System.Runtime]System.Object
-		IL_0cfa: dup
-		IL_0cfb: ldc.i4.0
-		IL_0cfc: ldloc.0
-		IL_0cfd: stelem.ref
-		IL_0cfe: stloc.s 14
-		IL_0d00: ldloc.s 14
-		IL_0d02: ldc.i4.0
-		IL_0d03: ldelem.ref
-		IL_0d04: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d09: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0d0e: ldc.i4.0
-		IL_0d0f: conv.r8
-		IL_0d10: ldstr ""
-		IL_0d15: ldc.i4.0
-		IL_0d16: ldc.i4.1
-		IL_0d17: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0d1c: stloc.s 59
-		IL_0d1e: ldloc.3
-		IL_0d1f: ldloc.s 6
-		IL_0d21: ldloc.s 59
-		IL_0d23: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0d28: pop
-		IL_0d29: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0d2e: stloc.s 6
-		IL_0d30: ldc.i4.1
-		IL_0d31: newarr [System.Runtime]System.Object
-		IL_0d36: dup
-		IL_0d37: ldc.i4.0
-		IL_0d38: ldloc.0
-		IL_0d39: stelem.ref
-		IL_0d3a: stloc.s 14
-		IL_0d3c: ldloc.s 14
-		IL_0d3e: ldc.i4.0
-		IL_0d3f: ldelem.ref
-		IL_0d40: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d45: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0d4a: ldc.i4.0
-		IL_0d4b: conv.r8
-		IL_0d4c: ldstr ""
-		IL_0d51: ldc.i4.0
-		IL_0d52: ldc.i4.1
-		IL_0d53: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0d58: stloc.s 60
-		IL_0d5a: ldloc.s 4
-		IL_0d5c: ldloc.s 6
-		IL_0d5e: ldstr "Compiled Capture Replace"
-		IL_0d63: ldloc.s 60
-		IL_0d65: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0d6a: pop
-		IL_0d6b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0d70: stloc.s 6
-		IL_0d72: ldc.i4.1
-		IL_0d73: newarr [System.Runtime]System.Object
-		IL_0d78: dup
-		IL_0d79: ldc.i4.0
-		IL_0d7a: ldloc.0
-		IL_0d7b: stelem.ref
-		IL_0d7c: stloc.s 14
-		IL_0d7e: ldloc.s 14
-		IL_0d80: ldc.i4.0
-		IL_0d81: ldelem.ref
-		IL_0d82: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d87: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0d8c: ldc.i4.0
-		IL_0d8d: conv.r8
-		IL_0d8e: ldstr ""
-		IL_0d93: ldc.i4.0
-		IL_0d94: ldc.i4.1
-		IL_0d95: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0d9a: stloc.s 61
-		IL_0d9c: ldloc.3
-		IL_0d9d: ldloc.s 6
-		IL_0d9f: ldloc.s 61
-		IL_0da1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0da6: pop
-		IL_0da7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0dac: stloc.s 6
-		IL_0dae: ldc.i4.1
-		IL_0daf: newarr [System.Runtime]System.Object
-		IL_0db4: dup
-		IL_0db5: ldc.i4.0
-		IL_0db6: ldloc.0
-		IL_0db7: stelem.ref
-		IL_0db8: stloc.s 14
-		IL_0dba: ldloc.s 14
-		IL_0dbc: ldc.i4.0
-		IL_0dbd: ldelem.ref
-		IL_0dbe: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0dc3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0dc8: ldc.i4.0
-		IL_0dc9: conv.r8
-		IL_0dca: ldstr ""
-		IL_0dcf: ldc.i4.0
-		IL_0dd0: ldc.i4.1
-		IL_0dd1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0dd6: stloc.s 62
-		IL_0dd8: ldloc.s 4
-		IL_0dda: ldloc.s 6
-		IL_0ddc: ldstr "Compiled Capture Replace with Capture"
-		IL_0de1: ldloc.s 62
-		IL_0de3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0de8: pop
-		IL_0de9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0dee: stloc.s 6
-		IL_0df0: ldc.i4.1
-		IL_0df1: newarr [System.Runtime]System.Object
-		IL_0df6: dup
-		IL_0df7: ldc.i4.0
-		IL_0df8: ldloc.0
-		IL_0df9: stelem.ref
-		IL_0dfa: stloc.s 14
-		IL_0dfc: ldloc.s 14
-		IL_0dfe: ldc.i4.0
-		IL_0dff: ldelem.ref
-		IL_0e00: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e05: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0e0a: ldc.i4.0
-		IL_0e0b: conv.r8
-		IL_0e0c: ldstr ""
-		IL_0e11: ldc.i4.0
-		IL_0e12: ldc.i4.1
-		IL_0e13: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0e18: stloc.s 63
-		IL_0e1a: ldloc.3
-		IL_0e1b: ldloc.s 6
-		IL_0e1d: ldloc.s 63
-		IL_0e1f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0e24: pop
-		IL_0e25: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0e2a: stloc.s 6
-		IL_0e2c: ldc.i4.1
-		IL_0e2d: newarr [System.Runtime]System.Object
-		IL_0e32: dup
-		IL_0e33: ldc.i4.0
-		IL_0e34: ldloc.0
-		IL_0e35: stelem.ref
-		IL_0e36: stloc.s 14
-		IL_0e38: ldloc.s 14
-		IL_0e3a: ldc.i4.0
-		IL_0e3b: ldelem.ref
-		IL_0e3c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e41: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0e46: ldc.i4.0
-		IL_0e47: conv.r8
-		IL_0e48: ldstr ""
-		IL_0e4d: ldc.i4.0
-		IL_0e4e: ldc.i4.1
-		IL_0e4f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0e54: stloc.s 64
-		IL_0e56: ldloc.s 4
-		IL_0e58: ldloc.s 6
-		IL_0e5a: ldstr "Compiled Capture Replace with Capture Function"
-		IL_0e5f: ldloc.s 64
-		IL_0e61: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0e66: pop
-		IL_0e67: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0e6c: stloc.s 6
-		IL_0e6e: ldc.i4.1
-		IL_0e6f: newarr [System.Runtime]System.Object
-		IL_0e74: dup
-		IL_0e75: ldc.i4.0
-		IL_0e76: ldloc.0
-		IL_0e77: stelem.ref
-		IL_0e78: stloc.s 14
-		IL_0e7a: ldloc.s 14
-		IL_0e7c: ldc.i4.0
-		IL_0e7d: ldelem.ref
-		IL_0e7e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e83: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0e88: ldc.i4.0
-		IL_0e89: conv.r8
-		IL_0e8a: ldstr ""
-		IL_0e8f: ldc.i4.0
-		IL_0e90: ldc.i4.1
-		IL_0e91: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0e96: stloc.s 65
-		IL_0e98: ldloc.3
-		IL_0e99: ldloc.s 6
-		IL_0e9b: ldloc.s 65
-		IL_0e9d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0ea2: pop
-		IL_0ea3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0ea8: stloc.s 6
-		IL_0eaa: ldc.i4.1
-		IL_0eab: newarr [System.Runtime]System.Object
-		IL_0eb0: dup
-		IL_0eb1: ldc.i4.0
-		IL_0eb2: ldloc.0
-		IL_0eb3: stelem.ref
-		IL_0eb4: stloc.s 14
-		IL_0eb6: ldloc.s 14
-		IL_0eb8: ldc.i4.0
-		IL_0eb9: ldelem.ref
-		IL_0eba: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0ebf: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0ec4: ldc.i4.0
-		IL_0ec5: conv.r8
-		IL_0ec6: ldstr ""
-		IL_0ecb: ldc.i4.0
-		IL_0ecc: ldc.i4.1
-		IL_0ecd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0ed2: stloc.s 66
-		IL_0ed4: ldloc.s 4
-		IL_0ed6: ldloc.s 6
-		IL_0ed8: ldstr "Compiled Capture Replace with Upperase Capture Function"
-		IL_0edd: ldloc.s 66
-		IL_0edf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0ee4: pop
-		IL_0ee5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0eea: stloc.s 6
-		IL_0eec: ldc.i4.1
-		IL_0eed: newarr [System.Runtime]System.Object
-		IL_0ef2: dup
-		IL_0ef3: ldc.i4.0
-		IL_0ef4: ldloc.0
-		IL_0ef5: stelem.ref
-		IL_0ef6: stloc.s 14
-		IL_0ef8: ldloc.s 14
-		IL_0efa: ldc.i4.0
-		IL_0efb: ldelem.ref
-		IL_0efc: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f01: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0f06: ldc.i4.0
-		IL_0f07: conv.r8
-		IL_0f08: ldstr ""
-		IL_0f0d: ldc.i4.0
-		IL_0f0e: ldc.i4.1
-		IL_0f0f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0f14: stloc.s 67
-		IL_0f16: ldloc.3
-		IL_0f17: ldloc.s 6
-		IL_0f19: ldloc.s 67
-		IL_0f1b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0f20: pop
-		IL_0f21: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0f26: stloc.s 6
-		IL_0f28: ldc.i4.1
-		IL_0f29: newarr [System.Runtime]System.Object
-		IL_0f2e: dup
-		IL_0f2f: ldc.i4.0
-		IL_0f30: ldloc.0
-		IL_0f31: stelem.ref
-		IL_0f32: stloc.s 14
-		IL_0f34: ldloc.s 14
-		IL_0f36: ldc.i4.0
-		IL_0f37: ldelem.ref
-		IL_0f38: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f3d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0f42: ldc.i4.0
-		IL_0f43: conv.r8
-		IL_0f44: ldstr ""
-		IL_0f49: ldc.i4.0
-		IL_0f4a: ldc.i4.1
-		IL_0f4b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0f50: stloc.s 68
-		IL_0f52: ldloc.s 4
-		IL_0f54: ldloc.s 6
-		IL_0f56: ldstr "Uncompiled Match"
-		IL_0f5b: ldloc.s 68
-		IL_0f5d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0f62: pop
-		IL_0f63: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0f68: stloc.s 6
-		IL_0f6a: ldc.i4.1
-		IL_0f6b: newarr [System.Runtime]System.Object
-		IL_0f70: dup
-		IL_0f71: ldc.i4.0
-		IL_0f72: ldloc.0
-		IL_0f73: stelem.ref
-		IL_0f74: stloc.s 14
-		IL_0f76: ldloc.s 14
-		IL_0f78: ldc.i4.0
-		IL_0f79: ldelem.ref
-		IL_0f7a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f7f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0f84: ldc.i4.0
-		IL_0f85: conv.r8
-		IL_0f86: ldstr ""
-		IL_0f8b: ldc.i4.0
-		IL_0f8c: ldc.i4.1
-		IL_0f8d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0f92: stloc.s 69
-		IL_0f94: ldloc.3
-		IL_0f95: ldloc.s 6
-		IL_0f97: ldloc.s 69
-		IL_0f99: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0f9e: pop
-		IL_0f9f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0fa4: stloc.s 6
-		IL_0fa6: ldc.i4.1
-		IL_0fa7: newarr [System.Runtime]System.Object
-		IL_0fac: dup
-		IL_0fad: ldc.i4.0
-		IL_0fae: ldloc.0
-		IL_0faf: stelem.ref
-		IL_0fb0: stloc.s 14
-		IL_0fb2: ldloc.s 14
-		IL_0fb4: ldc.i4.0
-		IL_0fb5: ldelem.ref
-		IL_0fb6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0fbb: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_0fc0: ldc.i4.0
-		IL_0fc1: conv.r8
-		IL_0fc2: ldstr ""
-		IL_0fc7: ldc.i4.0
-		IL_0fc8: ldc.i4.1
-		IL_0fc9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0fce: stloc.s 70
-		IL_0fd0: ldloc.s 4
-		IL_0fd2: ldloc.s 6
-		IL_0fd4: ldstr "Uncompiled Test"
-		IL_0fd9: ldloc.s 70
-		IL_0fdb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_0fe0: pop
-		IL_0fe1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0fe6: stloc.s 6
-		IL_0fe8: ldc.i4.1
-		IL_0fe9: newarr [System.Runtime]System.Object
-		IL_0fee: dup
-		IL_0fef: ldc.i4.0
-		IL_0ff0: ldloc.0
-		IL_0ff1: stelem.ref
-		IL_0ff2: stloc.s 14
-		IL_0ff4: ldloc.s 14
-		IL_0ff6: ldc.i4.0
-		IL_0ff7: ldelem.ref
-		IL_0ff8: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0ffd: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_1002: ldc.i4.0
-		IL_1003: conv.r8
-		IL_1004: ldstr ""
-		IL_1009: ldc.i4.0
-		IL_100a: ldc.i4.1
-		IL_100b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1010: stloc.s 71
-		IL_1012: ldloc.3
-		IL_1013: ldloc.s 6
-		IL_1015: ldloc.s 71
-		IL_1017: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_101c: pop
-		IL_101d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_1022: stloc.s 6
-		IL_1024: ldc.i4.1
-		IL_1025: newarr [System.Runtime]System.Object
-		IL_102a: dup
-		IL_102b: ldc.i4.0
-		IL_102c: ldloc.0
-		IL_102d: stelem.ref
-		IL_102e: stloc.s 14
-		IL_1030: ldloc.s 14
-		IL_1032: ldc.i4.0
-		IL_1033: ldelem.ref
-		IL_1034: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1039: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_103e: ldc.i4.0
-		IL_103f: conv.r8
-		IL_1040: ldstr ""
-		IL_1045: ldc.i4.0
-		IL_1046: ldc.i4.1
-		IL_1047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_104c: stloc.s 72
-		IL_104e: ldloc.s 4
-		IL_1050: ldloc.s 6
-		IL_1052: ldstr "Uncompiled Empty Replace"
-		IL_1057: ldloc.s 72
-		IL_1059: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_105e: pop
-		IL_105f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_1064: stloc.s 6
-		IL_1066: ldc.i4.1
-		IL_1067: newarr [System.Runtime]System.Object
-		IL_106c: dup
-		IL_106d: ldc.i4.0
-		IL_106e: ldloc.0
-		IL_106f: stelem.ref
-		IL_1070: stloc.s 14
-		IL_1072: ldloc.s 14
-		IL_1074: ldc.i4.0
-		IL_1075: ldelem.ref
-		IL_1076: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_107b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_1080: ldc.i4.0
-		IL_1081: conv.r8
-		IL_1082: ldstr ""
-		IL_1087: ldc.i4.0
-		IL_1088: ldc.i4.1
-		IL_1089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_108e: stloc.s 73
-		IL_1090: ldloc.3
-		IL_1091: ldloc.s 6
-		IL_1093: ldloc.s 73
-		IL_1095: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_109a: pop
-		IL_109b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_10a0: stloc.s 6
-		IL_10a2: ldc.i4.1
-		IL_10a3: newarr [System.Runtime]System.Object
-		IL_10a8: dup
-		IL_10a9: ldc.i4.0
-		IL_10aa: ldloc.0
-		IL_10ab: stelem.ref
-		IL_10ac: stloc.s 14
-		IL_10ae: ldloc.s 14
-		IL_10b0: ldc.i4.0
-		IL_10b1: ldelem.ref
-		IL_10b2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_10b7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_10bc: ldc.i4.0
-		IL_10bd: conv.r8
-		IL_10be: ldstr ""
-		IL_10c3: ldc.i4.0
-		IL_10c4: ldc.i4.1
-		IL_10c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_10ca: stloc.s 74
-		IL_10cc: ldloc.s 4
-		IL_10ce: ldloc.s 6
-		IL_10d0: ldstr "Uncompiled 12 Char Replace"
-		IL_10d5: ldloc.s 74
-		IL_10d7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_10dc: pop
-		IL_10dd: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_10e2: stloc.s 6
-		IL_10e4: ldc.i4.1
-		IL_10e5: newarr [System.Runtime]System.Object
-		IL_10ea: dup
-		IL_10eb: ldc.i4.0
-		IL_10ec: ldloc.0
-		IL_10ed: stelem.ref
-		IL_10ee: stloc.s 14
-		IL_10f0: ldloc.s 14
-		IL_10f2: ldc.i4.0
-		IL_10f3: ldelem.ref
-		IL_10f4: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_10f9: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_10fe: ldc.i4.0
-		IL_10ff: conv.r8
-		IL_1100: ldstr ""
-		IL_1105: ldc.i4.0
-		IL_1106: ldc.i4.1
-		IL_1107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_110c: stloc.s 75
-		IL_110e: ldloc.3
-		IL_110f: ldloc.s 6
-		IL_1111: ldloc.s 75
-		IL_1113: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_1118: pop
-		IL_1119: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_111e: stloc.s 6
-		IL_1120: ldc.i4.1
-		IL_1121: newarr [System.Runtime]System.Object
-		IL_1126: dup
-		IL_1127: ldc.i4.0
-		IL_1128: ldloc.0
-		IL_1129: stelem.ref
-		IL_112a: stloc.s 14
-		IL_112c: ldloc.s 14
-		IL_112e: ldc.i4.0
-		IL_112f: ldelem.ref
-		IL_1130: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1135: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_113a: ldc.i4.0
-		IL_113b: conv.r8
-		IL_113c: ldstr ""
-		IL_1141: ldc.i4.0
-		IL_1142: ldc.i4.1
-		IL_1143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1148: stloc.s 76
-		IL_114a: ldloc.s 4
-		IL_114c: ldloc.s 6
-		IL_114e: ldstr "Uncompiled Object Match"
-		IL_1153: ldloc.s 76
-		IL_1155: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_115a: pop
-		IL_115b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_1160: stloc.s 6
-		IL_1162: ldc.i4.1
-		IL_1163: newarr [System.Runtime]System.Object
-		IL_1168: dup
-		IL_1169: ldc.i4.0
-		IL_116a: ldloc.0
-		IL_116b: stelem.ref
-		IL_116c: stloc.s 14
-		IL_116e: ldloc.s 14
-		IL_1170: ldc.i4.0
-		IL_1171: ldelem.ref
-		IL_1172: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1177: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_117c: ldc.i4.0
-		IL_117d: conv.r8
-		IL_117e: ldstr ""
-		IL_1183: ldc.i4.0
-		IL_1184: ldc.i4.1
-		IL_1185: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_118a: stloc.s 77
-		IL_118c: ldloc.3
-		IL_118d: ldloc.s 6
-		IL_118f: ldloc.s 77
-		IL_1191: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_1196: pop
-		IL_1197: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_119c: stloc.s 6
-		IL_119e: ldc.i4.1
-		IL_119f: newarr [System.Runtime]System.Object
-		IL_11a4: dup
-		IL_11a5: ldc.i4.0
-		IL_11a6: ldloc.0
-		IL_11a7: stelem.ref
-		IL_11a8: stloc.s 14
-		IL_11aa: ldloc.s 14
-		IL_11ac: ldc.i4.0
-		IL_11ad: ldelem.ref
-		IL_11ae: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_11b3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_11b8: ldc.i4.0
-		IL_11b9: conv.r8
-		IL_11ba: ldstr ""
-		IL_11bf: ldc.i4.0
-		IL_11c0: ldc.i4.1
-		IL_11c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_11c6: stloc.s 78
-		IL_11c8: ldloc.s 4
-		IL_11ca: ldloc.s 6
-		IL_11cc: ldstr "Uncompiled Object Test"
-		IL_11d1: ldloc.s 78
-		IL_11d3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_11d8: pop
-		IL_11d9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_11de: stloc.s 6
-		IL_11e0: ldc.i4.1
-		IL_11e1: newarr [System.Runtime]System.Object
-		IL_11e6: dup
-		IL_11e7: ldc.i4.0
-		IL_11e8: ldloc.0
-		IL_11e9: stelem.ref
-		IL_11ea: stloc.s 14
-		IL_11ec: ldloc.s 14
-		IL_11ee: ldc.i4.0
-		IL_11ef: ldelem.ref
-		IL_11f0: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_11f5: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_11fa: ldc.i4.0
-		IL_11fb: conv.r8
-		IL_11fc: ldstr ""
-		IL_1201: ldc.i4.0
-		IL_1202: ldc.i4.1
-		IL_1203: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1208: stloc.s 79
-		IL_120a: ldloc.3
-		IL_120b: ldloc.s 6
-		IL_120d: ldloc.s 79
-		IL_120f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_1214: pop
-		IL_1215: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_121a: stloc.s 6
-		IL_121c: ldc.i4.1
-		IL_121d: newarr [System.Runtime]System.Object
-		IL_1222: dup
-		IL_1223: ldc.i4.0
-		IL_1224: ldloc.0
-		IL_1225: stelem.ref
-		IL_1226: stloc.s 14
-		IL_1228: ldloc.s 14
-		IL_122a: ldc.i4.0
-		IL_122b: ldelem.ref
-		IL_122c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1231: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_1236: ldc.i4.0
-		IL_1237: conv.r8
-		IL_1238: ldstr ""
-		IL_123d: ldc.i4.0
-		IL_123e: ldc.i4.1
-		IL_123f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1244: stloc.s 80
-		IL_1246: ldloc.s 4
-		IL_1248: ldloc.s 6
-		IL_124a: ldstr "Uncompiled Object Empty Replace"
-		IL_124f: ldloc.s 80
-		IL_1251: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_1256: pop
-		IL_1257: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_125c: stloc.s 6
-		IL_125e: ldc.i4.1
-		IL_125f: newarr [System.Runtime]System.Object
-		IL_1264: dup
-		IL_1265: ldc.i4.0
-		IL_1266: ldloc.0
-		IL_1267: stelem.ref
-		IL_1268: stloc.s 14
-		IL_126a: ldloc.s 14
-		IL_126c: ldc.i4.0
-		IL_126d: ldelem.ref
-		IL_126e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1273: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_1278: ldc.i4.0
-		IL_1279: conv.r8
-		IL_127a: ldstr ""
-		IL_127f: ldc.i4.0
-		IL_1280: ldc.i4.1
-		IL_1281: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_1286: stloc.s 81
-		IL_1288: ldloc.3
-		IL_1289: ldloc.s 6
-		IL_128b: ldloc.s 81
-		IL_128d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_1292: pop
-		IL_1293: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_1298: stloc.s 6
-		IL_129a: ldc.i4.1
-		IL_129b: newarr [System.Runtime]System.Object
-		IL_12a0: dup
-		IL_12a1: ldc.i4.0
-		IL_12a2: ldloc.0
-		IL_12a3: stelem.ref
-		IL_12a4: stloc.s 14
-		IL_12a6: ldloc.s 14
-		IL_12a8: ldc.i4.0
-		IL_12a9: ldelem.ref
-		IL_12aa: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_12af: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
-		IL_12b4: ldc.i4.0
-		IL_12b5: conv.r8
-		IL_12b6: ldstr ""
-		IL_12bb: ldc.i4.0
-		IL_12bc: ldc.i4.1
-		IL_12bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_12c2: stloc.s 82
-		IL_12c4: ldloc.s 4
-		IL_12c6: ldloc.s 6
-		IL_12c8: ldstr "Uncompiled Object 12 Char Replace"
-		IL_12cd: ldloc.s 82
-		IL_12cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-		IL_12d4: pop
-		IL_12d5: ldloc.2
-		IL_12d6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_12db: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-		IL_12e0: pop
-		IL_12e1: ret
+		IL_01ff: ldloc.0
+		IL_0200: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_020a: ldstr "join"
+		IL_020f: ldstr ""
+		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0219: stloc.s 12
+		IL_021b: ldloc.0
+		IL_021c: ldloc.s 12
+		IL_021e: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0223: ldloc.0
+		IL_0224: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0229: stloc.s 12
+		IL_022b: ldloc.0
+		IL_022c: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0231: stloc.s 11
+		IL_0233: ldloc.s 12
+		IL_0235: ldloc.s 11
+		IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_023c: stloc.s 13
+		IL_023e: ldloc.0
+		IL_023f: ldloc.s 13
+		IL_0241: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0246: ldloc.0
+		IL_0247: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_024c: stloc.s 11
+		IL_024e: ldloc.0
+		IL_024f: ldfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0254: stloc.s 12
+		IL_0256: ldloc.s 11
+		IL_0258: ldloc.s 12
+		IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_025f: stloc.s 13
+		IL_0261: ldloc.0
+		IL_0262: ldloc.s 13
+		IL_0264: stfld object Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::str
+		IL_0269: nop
+		IL_026a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_026f: stloc.s 6
+		IL_0271: ldc.i4.1
+		IL_0272: newarr [System.Runtime]System.Object
+		IL_0277: dup
+		IL_0278: ldc.i4.0
+		IL_0279: ldloc.0
+		IL_027a: stelem.ref
+		IL_027b: stloc.s 14
+		IL_027d: ldloc.s 14
+		IL_027f: ldc.i4.0
+		IL_0280: ldelem.ref
+		IL_0281: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0286: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_028b: ldc.i4.0
+		IL_028c: conv.r8
+		IL_028d: ldstr ""
+		IL_0292: ldc.i4.0
+		IL_0293: ldc.i4.1
+		IL_0294: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0299: stloc.s 15
+		IL_029b: ldloc.3
+		IL_029c: ldloc.s 6
+		IL_029e: ldloc.s 15
+		IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_02a5: pop
+		IL_02a6: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02ab: stloc.s 6
+		IL_02ad: ldc.i4.1
+		IL_02ae: newarr [System.Runtime]System.Object
+		IL_02b3: dup
+		IL_02b4: ldc.i4.0
+		IL_02b5: ldloc.0
+		IL_02b6: stelem.ref
+		IL_02b7: stloc.s 14
+		IL_02b9: ldloc.s 14
+		IL_02bb: ldc.i4.0
+		IL_02bc: ldelem.ref
+		IL_02bd: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_02c2: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_02c7: ldc.i4.0
+		IL_02c8: conv.r8
+		IL_02c9: ldstr ""
+		IL_02ce: ldc.i4.0
+		IL_02cf: ldc.i4.1
+		IL_02d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02d5: stloc.s 16
+		IL_02d7: ldloc.s 4
+		IL_02d9: ldloc.s 6
+		IL_02db: ldstr "Compiled Object Empty Split"
+		IL_02e0: ldloc.s 16
+		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_02e7: pop
+		IL_02e8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02ed: stloc.s 6
+		IL_02ef: ldc.i4.1
+		IL_02f0: newarr [System.Runtime]System.Object
+		IL_02f5: dup
+		IL_02f6: ldc.i4.0
+		IL_02f7: ldloc.0
+		IL_02f8: stelem.ref
+		IL_02f9: stloc.s 14
+		IL_02fb: ldloc.s 14
+		IL_02fd: ldc.i4.0
+		IL_02fe: ldelem.ref
+		IL_02ff: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0304: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0309: ldc.i4.0
+		IL_030a: conv.r8
+		IL_030b: ldstr ""
+		IL_0310: ldc.i4.0
+		IL_0311: ldc.i4.1
+		IL_0312: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0317: stloc.s 17
+		IL_0319: ldloc.3
+		IL_031a: ldloc.s 6
+		IL_031c: ldloc.s 17
+		IL_031e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0323: pop
+		IL_0324: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0329: stloc.s 6
+		IL_032b: ldc.i4.1
+		IL_032c: newarr [System.Runtime]System.Object
+		IL_0331: dup
+		IL_0332: ldc.i4.0
+		IL_0333: ldloc.0
+		IL_0334: stelem.ref
+		IL_0335: stloc.s 14
+		IL_0337: ldloc.s 14
+		IL_0339: ldc.i4.0
+		IL_033a: ldelem.ref
+		IL_033b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0340: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0345: ldc.i4.0
+		IL_0346: conv.r8
+		IL_0347: ldstr ""
+		IL_034c: ldc.i4.0
+		IL_034d: ldc.i4.1
+		IL_034e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0353: stloc.s 18
+		IL_0355: ldloc.s 4
+		IL_0357: ldloc.s 6
+		IL_0359: ldstr "Compiled Object Char Split"
+		IL_035e: ldloc.s 18
+		IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0365: pop
+		IL_0366: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_036b: stloc.s 6
+		IL_036d: ldc.i4.1
+		IL_036e: newarr [System.Runtime]System.Object
+		IL_0373: dup
+		IL_0374: ldc.i4.0
+		IL_0375: ldloc.0
+		IL_0376: stelem.ref
+		IL_0377: stloc.s 14
+		IL_0379: ldloc.s 14
+		IL_037b: ldc.i4.0
+		IL_037c: ldelem.ref
+		IL_037d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0382: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0387: ldc.i4.0
+		IL_0388: conv.r8
+		IL_0389: ldstr ""
+		IL_038e: ldc.i4.0
+		IL_038f: ldc.i4.1
+		IL_0390: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0395: stloc.s 19
+		IL_0397: ldloc.3
+		IL_0398: ldloc.s 6
+		IL_039a: ldloc.s 19
+		IL_039c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_03a1: pop
+		IL_03a2: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03a7: stloc.s 6
+		IL_03a9: ldc.i4.1
+		IL_03aa: newarr [System.Runtime]System.Object
+		IL_03af: dup
+		IL_03b0: ldc.i4.0
+		IL_03b1: ldloc.0
+		IL_03b2: stelem.ref
+		IL_03b3: stloc.s 14
+		IL_03b5: ldloc.s 14
+		IL_03b7: ldc.i4.0
+		IL_03b8: ldelem.ref
+		IL_03b9: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_03be: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_03c3: ldc.i4.0
+		IL_03c4: conv.r8
+		IL_03c5: ldstr ""
+		IL_03ca: ldc.i4.0
+		IL_03cb: ldc.i4.1
+		IL_03cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03d1: stloc.s 20
+		IL_03d3: ldloc.s 4
+		IL_03d5: ldloc.s 6
+		IL_03d7: ldstr "Compiled Object Variable Split"
+		IL_03dc: ldloc.s 20
+		IL_03de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_03e3: pop
+		IL_03e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03e9: stloc.s 6
+		IL_03eb: ldc.i4.1
+		IL_03ec: newarr [System.Runtime]System.Object
+		IL_03f1: dup
+		IL_03f2: ldc.i4.0
+		IL_03f3: ldloc.0
+		IL_03f4: stelem.ref
+		IL_03f5: stloc.s 14
+		IL_03f7: ldloc.s 14
+		IL_03f9: ldc.i4.0
+		IL_03fa: ldelem.ref
+		IL_03fb: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0400: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0405: ldc.i4.0
+		IL_0406: conv.r8
+		IL_0407: ldstr ""
+		IL_040c: ldc.i4.0
+		IL_040d: ldc.i4.1
+		IL_040e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0413: stloc.s 21
+		IL_0415: ldloc.3
+		IL_0416: ldloc.s 6
+		IL_0418: ldloc.s 21
+		IL_041a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_041f: pop
+		IL_0420: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0425: stloc.s 6
+		IL_0427: ldc.i4.1
+		IL_0428: newarr [System.Runtime]System.Object
+		IL_042d: dup
+		IL_042e: ldc.i4.0
+		IL_042f: ldloc.0
+		IL_0430: stelem.ref
+		IL_0431: stloc.s 14
+		IL_0433: ldloc.s 14
+		IL_0435: ldc.i4.0
+		IL_0436: ldelem.ref
+		IL_0437: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_043c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0441: ldc.i4.0
+		IL_0442: conv.r8
+		IL_0443: ldstr ""
+		IL_0448: ldc.i4.0
+		IL_0449: ldc.i4.1
+		IL_044a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_044f: stloc.s 22
+		IL_0451: ldloc.s 4
+		IL_0453: ldloc.s 6
+		IL_0455: ldstr "Compiled Match"
+		IL_045a: ldloc.s 22
+		IL_045c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0461: pop
+		IL_0462: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0467: stloc.s 6
+		IL_0469: ldc.i4.1
+		IL_046a: newarr [System.Runtime]System.Object
+		IL_046f: dup
+		IL_0470: ldc.i4.0
+		IL_0471: ldloc.0
+		IL_0472: stelem.ref
+		IL_0473: stloc.s 14
+		IL_0475: ldloc.s 14
+		IL_0477: ldc.i4.0
+		IL_0478: ldelem.ref
+		IL_0479: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_047e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0483: ldc.i4.0
+		IL_0484: conv.r8
+		IL_0485: ldstr ""
+		IL_048a: ldc.i4.0
+		IL_048b: ldc.i4.1
+		IL_048c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0491: stloc.s 23
+		IL_0493: ldloc.3
+		IL_0494: ldloc.s 6
+		IL_0496: ldloc.s 23
+		IL_0498: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_049d: pop
+		IL_049e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04a3: stloc.s 6
+		IL_04a5: ldc.i4.1
+		IL_04a6: newarr [System.Runtime]System.Object
+		IL_04ab: dup
+		IL_04ac: ldc.i4.0
+		IL_04ad: ldloc.0
+		IL_04ae: stelem.ref
+		IL_04af: stloc.s 14
+		IL_04b1: ldloc.s 14
+		IL_04b3: ldc.i4.0
+		IL_04b4: ldelem.ref
+		IL_04b5: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_04ba: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_04bf: ldc.i4.0
+		IL_04c0: conv.r8
+		IL_04c1: ldstr ""
+		IL_04c6: ldc.i4.0
+		IL_04c7: ldc.i4.1
+		IL_04c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04cd: stloc.s 24
+		IL_04cf: ldloc.s 4
+		IL_04d1: ldloc.s 6
+		IL_04d3: ldstr "Compiled Test"
+		IL_04d8: ldloc.s 24
+		IL_04da: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_04df: pop
+		IL_04e0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04e5: stloc.s 6
+		IL_04e7: ldc.i4.1
+		IL_04e8: newarr [System.Runtime]System.Object
+		IL_04ed: dup
+		IL_04ee: ldc.i4.0
+		IL_04ef: ldloc.0
+		IL_04f0: stelem.ref
+		IL_04f1: stloc.s 14
+		IL_04f3: ldloc.s 14
+		IL_04f5: ldc.i4.0
+		IL_04f6: ldelem.ref
+		IL_04f7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_04fc: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0501: ldc.i4.0
+		IL_0502: conv.r8
+		IL_0503: ldstr ""
+		IL_0508: ldc.i4.0
+		IL_0509: ldc.i4.1
+		IL_050a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_050f: stloc.s 25
+		IL_0511: ldloc.3
+		IL_0512: ldloc.s 6
+		IL_0514: ldloc.s 25
+		IL_0516: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_051b: pop
+		IL_051c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0521: stloc.s 6
+		IL_0523: ldc.i4.1
+		IL_0524: newarr [System.Runtime]System.Object
+		IL_0529: dup
+		IL_052a: ldc.i4.0
+		IL_052b: ldloc.0
+		IL_052c: stelem.ref
+		IL_052d: stloc.s 14
+		IL_052f: ldloc.s 14
+		IL_0531: ldc.i4.0
+		IL_0532: ldelem.ref
+		IL_0533: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0538: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_053d: ldc.i4.0
+		IL_053e: conv.r8
+		IL_053f: ldstr ""
+		IL_0544: ldc.i4.0
+		IL_0545: ldc.i4.1
+		IL_0546: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_054b: stloc.s 26
+		IL_054d: ldloc.s 4
+		IL_054f: ldloc.s 6
+		IL_0551: ldstr "Compiled Empty Replace"
+		IL_0556: ldloc.s 26
+		IL_0558: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_055d: pop
+		IL_055e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0563: stloc.s 6
+		IL_0565: ldc.i4.1
+		IL_0566: newarr [System.Runtime]System.Object
+		IL_056b: dup
+		IL_056c: ldc.i4.0
+		IL_056d: ldloc.0
+		IL_056e: stelem.ref
+		IL_056f: stloc.s 14
+		IL_0571: ldloc.s 14
+		IL_0573: ldc.i4.0
+		IL_0574: ldelem.ref
+		IL_0575: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_057a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_057f: ldc.i4.0
+		IL_0580: conv.r8
+		IL_0581: ldstr ""
+		IL_0586: ldc.i4.0
+		IL_0587: ldc.i4.1
+		IL_0588: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_058d: stloc.s 27
+		IL_058f: ldloc.3
+		IL_0590: ldloc.s 6
+		IL_0592: ldloc.s 27
+		IL_0594: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0599: pop
+		IL_059a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_059f: stloc.s 6
+		IL_05a1: ldc.i4.1
+		IL_05a2: newarr [System.Runtime]System.Object
+		IL_05a7: dup
+		IL_05a8: ldc.i4.0
+		IL_05a9: ldloc.0
+		IL_05aa: stelem.ref
+		IL_05ab: stloc.s 14
+		IL_05ad: ldloc.s 14
+		IL_05af: ldc.i4.0
+		IL_05b0: ldelem.ref
+		IL_05b1: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_05b6: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_05bb: ldc.i4.0
+		IL_05bc: conv.r8
+		IL_05bd: ldstr ""
+		IL_05c2: ldc.i4.0
+		IL_05c3: ldc.i4.1
+		IL_05c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05c9: stloc.s 28
+		IL_05cb: ldloc.s 4
+		IL_05cd: ldloc.s 6
+		IL_05cf: ldstr "Compiled 12 Char Replace"
+		IL_05d4: ldloc.s 28
+		IL_05d6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_05db: pop
+		IL_05dc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05e1: stloc.s 6
+		IL_05e3: ldc.i4.1
+		IL_05e4: newarr [System.Runtime]System.Object
+		IL_05e9: dup
+		IL_05ea: ldc.i4.0
+		IL_05eb: ldloc.0
+		IL_05ec: stelem.ref
+		IL_05ed: stloc.s 14
+		IL_05ef: ldloc.s 14
+		IL_05f1: ldc.i4.0
+		IL_05f2: ldelem.ref
+		IL_05f3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_05f8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_05fd: ldc.i4.0
+		IL_05fe: conv.r8
+		IL_05ff: ldstr ""
+		IL_0604: ldc.i4.0
+		IL_0605: ldc.i4.1
+		IL_0606: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_060b: stloc.s 29
+		IL_060d: ldloc.3
+		IL_060e: ldloc.s 6
+		IL_0610: ldloc.s 29
+		IL_0612: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0617: pop
+		IL_0618: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_061d: stloc.s 6
+		IL_061f: ldc.i4.1
+		IL_0620: newarr [System.Runtime]System.Object
+		IL_0625: dup
+		IL_0626: ldc.i4.0
+		IL_0627: ldloc.0
+		IL_0628: stelem.ref
+		IL_0629: stloc.s 14
+		IL_062b: ldloc.s 14
+		IL_062d: ldc.i4.0
+		IL_062e: ldelem.ref
+		IL_062f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0634: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0639: ldc.i4.0
+		IL_063a: conv.r8
+		IL_063b: ldstr ""
+		IL_0640: ldc.i4.0
+		IL_0641: ldc.i4.1
+		IL_0642: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0647: stloc.s 30
+		IL_0649: ldloc.s 4
+		IL_064b: ldloc.s 6
+		IL_064d: ldstr "Compiled Object Match"
+		IL_0652: ldloc.s 30
+		IL_0654: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0659: pop
+		IL_065a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_065f: stloc.s 6
+		IL_0661: ldc.i4.1
+		IL_0662: newarr [System.Runtime]System.Object
+		IL_0667: dup
+		IL_0668: ldc.i4.0
+		IL_0669: ldloc.0
+		IL_066a: stelem.ref
+		IL_066b: stloc.s 14
+		IL_066d: ldloc.s 14
+		IL_066f: ldc.i4.0
+		IL_0670: ldelem.ref
+		IL_0671: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0676: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_067b: ldc.i4.0
+		IL_067c: conv.r8
+		IL_067d: ldstr ""
+		IL_0682: ldc.i4.0
+		IL_0683: ldc.i4.1
+		IL_0684: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0689: stloc.s 31
+		IL_068b: ldloc.3
+		IL_068c: ldloc.s 6
+		IL_068e: ldloc.s 31
+		IL_0690: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0695: pop
+		IL_0696: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_069b: stloc.s 6
+		IL_069d: ldc.i4.1
+		IL_069e: newarr [System.Runtime]System.Object
+		IL_06a3: dup
+		IL_06a4: ldc.i4.0
+		IL_06a5: ldloc.0
+		IL_06a6: stelem.ref
+		IL_06a7: stloc.s 14
+		IL_06a9: ldloc.s 14
+		IL_06ab: ldc.i4.0
+		IL_06ac: ldelem.ref
+		IL_06ad: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_06b2: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_06b7: ldc.i4.0
+		IL_06b8: conv.r8
+		IL_06b9: ldstr ""
+		IL_06be: ldc.i4.0
+		IL_06bf: ldc.i4.1
+		IL_06c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_06c5: stloc.s 32
+		IL_06c7: ldloc.s 4
+		IL_06c9: ldloc.s 6
+		IL_06cb: ldstr "Compiled Object Test"
+		IL_06d0: ldloc.s 32
+		IL_06d2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_06d7: pop
+		IL_06d8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_06dd: stloc.s 6
+		IL_06df: ldc.i4.1
+		IL_06e0: newarr [System.Runtime]System.Object
+		IL_06e5: dup
+		IL_06e6: ldc.i4.0
+		IL_06e7: ldloc.0
+		IL_06e8: stelem.ref
+		IL_06e9: stloc.s 14
+		IL_06eb: ldloc.s 14
+		IL_06ed: ldc.i4.0
+		IL_06ee: ldelem.ref
+		IL_06ef: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_06f4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_06f9: ldc.i4.0
+		IL_06fa: conv.r8
+		IL_06fb: ldstr ""
+		IL_0700: ldc.i4.0
+		IL_0701: ldc.i4.1
+		IL_0702: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0707: stloc.s 33
+		IL_0709: ldloc.3
+		IL_070a: ldloc.s 6
+		IL_070c: ldloc.s 33
+		IL_070e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0713: pop
+		IL_0714: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0719: stloc.s 6
+		IL_071b: ldc.i4.1
+		IL_071c: newarr [System.Runtime]System.Object
+		IL_0721: dup
+		IL_0722: ldc.i4.0
+		IL_0723: ldloc.0
+		IL_0724: stelem.ref
+		IL_0725: stloc.s 14
+		IL_0727: ldloc.s 14
+		IL_0729: ldc.i4.0
+		IL_072a: ldelem.ref
+		IL_072b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0730: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0735: ldc.i4.0
+		IL_0736: conv.r8
+		IL_0737: ldstr ""
+		IL_073c: ldc.i4.0
+		IL_073d: ldc.i4.1
+		IL_073e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0743: stloc.s 34
+		IL_0745: ldloc.s 4
+		IL_0747: ldloc.s 6
+		IL_0749: ldstr "Compiled Object Empty Replace"
+		IL_074e: ldloc.s 34
+		IL_0750: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0755: pop
+		IL_0756: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_075b: stloc.s 6
+		IL_075d: ldc.i4.1
+		IL_075e: newarr [System.Runtime]System.Object
+		IL_0763: dup
+		IL_0764: ldc.i4.0
+		IL_0765: ldloc.0
+		IL_0766: stelem.ref
+		IL_0767: stloc.s 14
+		IL_0769: ldloc.s 14
+		IL_076b: ldc.i4.0
+		IL_076c: ldelem.ref
+		IL_076d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0772: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0777: ldc.i4.0
+		IL_0778: conv.r8
+		IL_0779: ldstr ""
+		IL_077e: ldc.i4.0
+		IL_077f: ldc.i4.1
+		IL_0780: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0785: stloc.s 35
+		IL_0787: ldloc.3
+		IL_0788: ldloc.s 6
+		IL_078a: ldloc.s 35
+		IL_078c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0791: pop
+		IL_0792: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0797: stloc.s 6
+		IL_0799: ldc.i4.1
+		IL_079a: newarr [System.Runtime]System.Object
+		IL_079f: dup
+		IL_07a0: ldc.i4.0
+		IL_07a1: ldloc.0
+		IL_07a2: stelem.ref
+		IL_07a3: stloc.s 14
+		IL_07a5: ldloc.s 14
+		IL_07a7: ldc.i4.0
+		IL_07a8: ldelem.ref
+		IL_07a9: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_07ae: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_07b3: ldc.i4.0
+		IL_07b4: conv.r8
+		IL_07b5: ldstr ""
+		IL_07ba: ldc.i4.0
+		IL_07bb: ldc.i4.1
+		IL_07bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_07c1: stloc.s 36
+		IL_07c3: ldloc.s 4
+		IL_07c5: ldloc.s 6
+		IL_07c7: ldstr "Compiled Object 12 Char Replace"
+		IL_07cc: ldloc.s 36
+		IL_07ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_07d3: pop
+		IL_07d4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_07d9: stloc.s 6
+		IL_07db: ldc.i4.1
+		IL_07dc: newarr [System.Runtime]System.Object
+		IL_07e1: dup
+		IL_07e2: ldc.i4.0
+		IL_07e3: ldloc.0
+		IL_07e4: stelem.ref
+		IL_07e5: stloc.s 14
+		IL_07e7: ldloc.s 14
+		IL_07e9: ldc.i4.0
+		IL_07ea: ldelem.ref
+		IL_07eb: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_07f0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_07f5: ldc.i4.0
+		IL_07f6: conv.r8
+		IL_07f7: ldstr ""
+		IL_07fc: ldc.i4.0
+		IL_07fd: ldc.i4.1
+		IL_07fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0803: stloc.s 37
+		IL_0805: ldloc.3
+		IL_0806: ldloc.s 6
+		IL_0808: ldloc.s 37
+		IL_080a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_080f: pop
+		IL_0810: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0815: stloc.s 6
+		IL_0817: ldc.i4.1
+		IL_0818: newarr [System.Runtime]System.Object
+		IL_081d: dup
+		IL_081e: ldc.i4.0
+		IL_081f: ldloc.0
+		IL_0820: stelem.ref
+		IL_0821: stloc.s 14
+		IL_0823: ldloc.s 14
+		IL_0825: ldc.i4.0
+		IL_0826: ldelem.ref
+		IL_0827: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_082c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0831: ldc.i4.0
+		IL_0832: conv.r8
+		IL_0833: ldstr ""
+		IL_0838: ldc.i4.0
+		IL_0839: ldc.i4.1
+		IL_083a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_083f: stloc.s 38
+		IL_0841: ldloc.s 4
+		IL_0843: ldloc.s 6
+		IL_0845: ldstr "Compiled Object 12 Char Replace Function"
+		IL_084a: ldloc.s 38
+		IL_084c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0851: pop
+		IL_0852: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0857: stloc.s 6
+		IL_0859: ldc.i4.1
+		IL_085a: newarr [System.Runtime]System.Object
+		IL_085f: dup
+		IL_0860: ldc.i4.0
+		IL_0861: ldloc.0
+		IL_0862: stelem.ref
+		IL_0863: stloc.s 14
+		IL_0865: ldloc.s 14
+		IL_0867: ldc.i4.0
+		IL_0868: ldelem.ref
+		IL_0869: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_086e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0873: ldc.i4.0
+		IL_0874: conv.r8
+		IL_0875: ldstr ""
+		IL_087a: ldc.i4.0
+		IL_087b: ldc.i4.1
+		IL_087c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0881: stloc.s 39
+		IL_0883: ldloc.3
+		IL_0884: ldloc.s 6
+		IL_0886: ldloc.s 39
+		IL_0888: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_088d: pop
+		IL_088e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0893: stloc.s 6
+		IL_0895: ldc.i4.1
+		IL_0896: newarr [System.Runtime]System.Object
+		IL_089b: dup
+		IL_089c: ldc.i4.0
+		IL_089d: ldloc.0
+		IL_089e: stelem.ref
+		IL_089f: stloc.s 14
+		IL_08a1: ldloc.s 14
+		IL_08a3: ldc.i4.0
+		IL_08a4: ldelem.ref
+		IL_08a5: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_08aa: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_08af: ldc.i4.0
+		IL_08b0: conv.r8
+		IL_08b1: ldstr ""
+		IL_08b6: ldc.i4.0
+		IL_08b7: ldc.i4.1
+		IL_08b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_08bd: stloc.s 40
+		IL_08bf: ldloc.s 4
+		IL_08c1: ldloc.s 6
+		IL_08c3: ldstr "Compiled Variable Match"
+		IL_08c8: ldloc.s 40
+		IL_08ca: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_08cf: pop
+		IL_08d0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_08d5: stloc.s 6
+		IL_08d7: ldc.i4.1
+		IL_08d8: newarr [System.Runtime]System.Object
+		IL_08dd: dup
+		IL_08de: ldc.i4.0
+		IL_08df: ldloc.0
+		IL_08e0: stelem.ref
+		IL_08e1: stloc.s 14
+		IL_08e3: ldloc.s 14
+		IL_08e5: ldc.i4.0
+		IL_08e6: ldelem.ref
+		IL_08e7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_08ec: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_08f1: ldc.i4.0
+		IL_08f2: conv.r8
+		IL_08f3: ldstr ""
+		IL_08f8: ldc.i4.0
+		IL_08f9: ldc.i4.1
+		IL_08fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_08ff: stloc.s 41
+		IL_0901: ldloc.3
+		IL_0902: ldloc.s 6
+		IL_0904: ldloc.s 41
+		IL_0906: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_090b: pop
+		IL_090c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0911: stloc.s 6
+		IL_0913: ldc.i4.1
+		IL_0914: newarr [System.Runtime]System.Object
+		IL_0919: dup
+		IL_091a: ldc.i4.0
+		IL_091b: ldloc.0
+		IL_091c: stelem.ref
+		IL_091d: stloc.s 14
+		IL_091f: ldloc.s 14
+		IL_0921: ldc.i4.0
+		IL_0922: ldelem.ref
+		IL_0923: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0928: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_092d: ldc.i4.0
+		IL_092e: conv.r8
+		IL_092f: ldstr ""
+		IL_0934: ldc.i4.0
+		IL_0935: ldc.i4.1
+		IL_0936: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_093b: stloc.s 42
+		IL_093d: ldloc.s 4
+		IL_093f: ldloc.s 6
+		IL_0941: ldstr "Compiled Variable Test"
+		IL_0946: ldloc.s 42
+		IL_0948: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_094d: pop
+		IL_094e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0953: stloc.s 6
+		IL_0955: ldc.i4.1
+		IL_0956: newarr [System.Runtime]System.Object
+		IL_095b: dup
+		IL_095c: ldc.i4.0
+		IL_095d: ldloc.0
+		IL_095e: stelem.ref
+		IL_095f: stloc.s 14
+		IL_0961: ldloc.s 14
+		IL_0963: ldc.i4.0
+		IL_0964: ldelem.ref
+		IL_0965: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_096a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_096f: ldc.i4.0
+		IL_0970: conv.r8
+		IL_0971: ldstr ""
+		IL_0976: ldc.i4.0
+		IL_0977: ldc.i4.1
+		IL_0978: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_097d: stloc.s 43
+		IL_097f: ldloc.3
+		IL_0980: ldloc.s 6
+		IL_0982: ldloc.s 43
+		IL_0984: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0989: pop
+		IL_098a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_098f: stloc.s 6
+		IL_0991: ldc.i4.1
+		IL_0992: newarr [System.Runtime]System.Object
+		IL_0997: dup
+		IL_0998: ldc.i4.0
+		IL_0999: ldloc.0
+		IL_099a: stelem.ref
+		IL_099b: stloc.s 14
+		IL_099d: ldloc.s 14
+		IL_099f: ldc.i4.0
+		IL_09a0: ldelem.ref
+		IL_09a1: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_09a6: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_09ab: ldc.i4.0
+		IL_09ac: conv.r8
+		IL_09ad: ldstr ""
+		IL_09b2: ldc.i4.0
+		IL_09b3: ldc.i4.1
+		IL_09b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_09b9: stloc.s 44
+		IL_09bb: ldloc.s 4
+		IL_09bd: ldloc.s 6
+		IL_09bf: ldstr "Compiled Variable Empty Replace"
+		IL_09c4: ldloc.s 44
+		IL_09c6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_09cb: pop
+		IL_09cc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_09d1: stloc.s 6
+		IL_09d3: ldc.i4.1
+		IL_09d4: newarr [System.Runtime]System.Object
+		IL_09d9: dup
+		IL_09da: ldc.i4.0
+		IL_09db: ldloc.0
+		IL_09dc: stelem.ref
+		IL_09dd: stloc.s 14
+		IL_09df: ldloc.s 14
+		IL_09e1: ldc.i4.0
+		IL_09e2: ldelem.ref
+		IL_09e3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_09e8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_09ed: ldc.i4.0
+		IL_09ee: conv.r8
+		IL_09ef: ldstr ""
+		IL_09f4: ldc.i4.0
+		IL_09f5: ldc.i4.1
+		IL_09f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_09fb: stloc.s 45
+		IL_09fd: ldloc.3
+		IL_09fe: ldloc.s 6
+		IL_0a00: ldloc.s 45
+		IL_0a02: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0a07: pop
+		IL_0a08: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0a0d: stloc.s 6
+		IL_0a0f: ldc.i4.1
+		IL_0a10: newarr [System.Runtime]System.Object
+		IL_0a15: dup
+		IL_0a16: ldc.i4.0
+		IL_0a17: ldloc.0
+		IL_0a18: stelem.ref
+		IL_0a19: stloc.s 14
+		IL_0a1b: ldloc.s 14
+		IL_0a1d: ldc.i4.0
+		IL_0a1e: ldelem.ref
+		IL_0a1f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0a24: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0a29: ldc.i4.0
+		IL_0a2a: conv.r8
+		IL_0a2b: ldstr ""
+		IL_0a30: ldc.i4.0
+		IL_0a31: ldc.i4.1
+		IL_0a32: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0a37: stloc.s 46
+		IL_0a39: ldloc.s 4
+		IL_0a3b: ldloc.s 6
+		IL_0a3d: ldstr "Compiled Variable 12 Char Replace"
+		IL_0a42: ldloc.s 46
+		IL_0a44: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0a49: pop
+		IL_0a4a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0a4f: stloc.s 6
+		IL_0a51: ldc.i4.1
+		IL_0a52: newarr [System.Runtime]System.Object
+		IL_0a57: dup
+		IL_0a58: ldc.i4.0
+		IL_0a59: ldloc.0
+		IL_0a5a: stelem.ref
+		IL_0a5b: stloc.s 14
+		IL_0a5d: ldloc.s 14
+		IL_0a5f: ldc.i4.0
+		IL_0a60: ldelem.ref
+		IL_0a61: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0a66: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0a6b: ldc.i4.0
+		IL_0a6c: conv.r8
+		IL_0a6d: ldstr ""
+		IL_0a72: ldc.i4.0
+		IL_0a73: ldc.i4.1
+		IL_0a74: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0a79: stloc.s 47
+		IL_0a7b: ldloc.3
+		IL_0a7c: ldloc.s 6
+		IL_0a7e: ldloc.s 47
+		IL_0a80: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0a85: pop
+		IL_0a86: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0a8b: stloc.s 6
+		IL_0a8d: ldc.i4.1
+		IL_0a8e: newarr [System.Runtime]System.Object
+		IL_0a93: dup
+		IL_0a94: ldc.i4.0
+		IL_0a95: ldloc.0
+		IL_0a96: stelem.ref
+		IL_0a97: stloc.s 14
+		IL_0a99: ldloc.s 14
+		IL_0a9b: ldc.i4.0
+		IL_0a9c: ldelem.ref
+		IL_0a9d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0aa2: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0aa7: ldc.i4.0
+		IL_0aa8: conv.r8
+		IL_0aa9: ldstr ""
+		IL_0aae: ldc.i4.0
+		IL_0aaf: ldc.i4.1
+		IL_0ab0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0ab5: stloc.s 48
+		IL_0ab7: ldloc.s 4
+		IL_0ab9: ldloc.s 6
+		IL_0abb: ldstr "Compiled Variable Object Match"
+		IL_0ac0: ldloc.s 48
+		IL_0ac2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0ac7: pop
+		IL_0ac8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0acd: stloc.s 6
+		IL_0acf: ldc.i4.1
+		IL_0ad0: newarr [System.Runtime]System.Object
+		IL_0ad5: dup
+		IL_0ad6: ldc.i4.0
+		IL_0ad7: ldloc.0
+		IL_0ad8: stelem.ref
+		IL_0ad9: stloc.s 14
+		IL_0adb: ldloc.s 14
+		IL_0add: ldc.i4.0
+		IL_0ade: ldelem.ref
+		IL_0adf: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0ae4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0ae9: ldc.i4.0
+		IL_0aea: conv.r8
+		IL_0aeb: ldstr ""
+		IL_0af0: ldc.i4.0
+		IL_0af1: ldc.i4.1
+		IL_0af2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0af7: stloc.s 49
+		IL_0af9: ldloc.3
+		IL_0afa: ldloc.s 6
+		IL_0afc: ldloc.s 49
+		IL_0afe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0b03: pop
+		IL_0b04: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0b09: stloc.s 6
+		IL_0b0b: ldc.i4.1
+		IL_0b0c: newarr [System.Runtime]System.Object
+		IL_0b11: dup
+		IL_0b12: ldc.i4.0
+		IL_0b13: ldloc.0
+		IL_0b14: stelem.ref
+		IL_0b15: stloc.s 14
+		IL_0b17: ldloc.s 14
+		IL_0b19: ldc.i4.0
+		IL_0b1a: ldelem.ref
+		IL_0b1b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0b20: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0b25: ldc.i4.0
+		IL_0b26: conv.r8
+		IL_0b27: ldstr ""
+		IL_0b2c: ldc.i4.0
+		IL_0b2d: ldc.i4.1
+		IL_0b2e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0b33: stloc.s 50
+		IL_0b35: ldloc.s 4
+		IL_0b37: ldloc.s 6
+		IL_0b39: ldstr "Compiled Variable Object Test"
+		IL_0b3e: ldloc.s 50
+		IL_0b40: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0b45: pop
+		IL_0b46: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0b4b: stloc.s 6
+		IL_0b4d: ldc.i4.1
+		IL_0b4e: newarr [System.Runtime]System.Object
+		IL_0b53: dup
+		IL_0b54: ldc.i4.0
+		IL_0b55: ldloc.0
+		IL_0b56: stelem.ref
+		IL_0b57: stloc.s 14
+		IL_0b59: ldloc.s 14
+		IL_0b5b: ldc.i4.0
+		IL_0b5c: ldelem.ref
+		IL_0b5d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0b62: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0b67: ldc.i4.0
+		IL_0b68: conv.r8
+		IL_0b69: ldstr ""
+		IL_0b6e: ldc.i4.0
+		IL_0b6f: ldc.i4.1
+		IL_0b70: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0b75: stloc.s 51
+		IL_0b77: ldloc.3
+		IL_0b78: ldloc.s 6
+		IL_0b7a: ldloc.s 51
+		IL_0b7c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0b81: pop
+		IL_0b82: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0b87: stloc.s 6
+		IL_0b89: ldc.i4.1
+		IL_0b8a: newarr [System.Runtime]System.Object
+		IL_0b8f: dup
+		IL_0b90: ldc.i4.0
+		IL_0b91: ldloc.0
+		IL_0b92: stelem.ref
+		IL_0b93: stloc.s 14
+		IL_0b95: ldloc.s 14
+		IL_0b97: ldc.i4.0
+		IL_0b98: ldelem.ref
+		IL_0b99: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0b9e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0ba3: ldc.i4.0
+		IL_0ba4: conv.r8
+		IL_0ba5: ldstr ""
+		IL_0baa: ldc.i4.0
+		IL_0bab: ldc.i4.1
+		IL_0bac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0bb1: stloc.s 52
+		IL_0bb3: ldloc.s 4
+		IL_0bb5: ldloc.s 6
+		IL_0bb7: ldstr "Compiled Variable Object Empty Replace"
+		IL_0bbc: ldloc.s 52
+		IL_0bbe: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0bc3: pop
+		IL_0bc4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0bc9: stloc.s 6
+		IL_0bcb: ldc.i4.1
+		IL_0bcc: newarr [System.Runtime]System.Object
+		IL_0bd1: dup
+		IL_0bd2: ldc.i4.0
+		IL_0bd3: ldloc.0
+		IL_0bd4: stelem.ref
+		IL_0bd5: stloc.s 14
+		IL_0bd7: ldloc.s 14
+		IL_0bd9: ldc.i4.0
+		IL_0bda: ldelem.ref
+		IL_0bdb: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0be0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0be5: ldc.i4.0
+		IL_0be6: conv.r8
+		IL_0be7: ldstr ""
+		IL_0bec: ldc.i4.0
+		IL_0bed: ldc.i4.1
+		IL_0bee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0bf3: stloc.s 53
+		IL_0bf5: ldloc.3
+		IL_0bf6: ldloc.s 6
+		IL_0bf8: ldloc.s 53
+		IL_0bfa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0bff: pop
+		IL_0c00: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0c05: stloc.s 6
+		IL_0c07: ldc.i4.1
+		IL_0c08: newarr [System.Runtime]System.Object
+		IL_0c0d: dup
+		IL_0c0e: ldc.i4.0
+		IL_0c0f: ldloc.0
+		IL_0c10: stelem.ref
+		IL_0c11: stloc.s 14
+		IL_0c13: ldloc.s 14
+		IL_0c15: ldc.i4.0
+		IL_0c16: ldelem.ref
+		IL_0c17: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0c1c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0c21: ldc.i4.0
+		IL_0c22: conv.r8
+		IL_0c23: ldstr ""
+		IL_0c28: ldc.i4.0
+		IL_0c29: ldc.i4.1
+		IL_0c2a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0c2f: stloc.s 54
+		IL_0c31: ldloc.s 4
+		IL_0c33: ldloc.s 6
+		IL_0c35: ldstr "Compiled Variable Object 12 Char Replace"
+		IL_0c3a: ldloc.s 54
+		IL_0c3c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0c41: pop
+		IL_0c42: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0c47: stloc.s 6
+		IL_0c49: ldc.i4.1
+		IL_0c4a: newarr [System.Runtime]System.Object
+		IL_0c4f: dup
+		IL_0c50: ldc.i4.0
+		IL_0c51: ldloc.0
+		IL_0c52: stelem.ref
+		IL_0c53: stloc.s 14
+		IL_0c55: ldloc.s 14
+		IL_0c57: ldc.i4.0
+		IL_0c58: ldelem.ref
+		IL_0c59: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0c5e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0c63: ldc.i4.0
+		IL_0c64: conv.r8
+		IL_0c65: ldstr ""
+		IL_0c6a: ldc.i4.0
+		IL_0c6b: ldc.i4.1
+		IL_0c6c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0c71: stloc.s 55
+		IL_0c73: ldloc.3
+		IL_0c74: ldloc.s 6
+		IL_0c76: ldloc.s 55
+		IL_0c78: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0c7d: pop
+		IL_0c7e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0c83: stloc.s 6
+		IL_0c85: ldc.i4.1
+		IL_0c86: newarr [System.Runtime]System.Object
+		IL_0c8b: dup
+		IL_0c8c: ldc.i4.0
+		IL_0c8d: ldloc.0
+		IL_0c8e: stelem.ref
+		IL_0c8f: stloc.s 14
+		IL_0c91: ldloc.s 14
+		IL_0c93: ldc.i4.0
+		IL_0c94: ldelem.ref
+		IL_0c95: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0c9a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0c9f: ldc.i4.0
+		IL_0ca0: conv.r8
+		IL_0ca1: ldstr ""
+		IL_0ca6: ldc.i4.0
+		IL_0ca7: ldc.i4.1
+		IL_0ca8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0cad: stloc.s 56
+		IL_0caf: ldloc.s 4
+		IL_0cb1: ldloc.s 6
+		IL_0cb3: ldstr "Compiled Variable Object 12 Char Replace Function"
+		IL_0cb8: ldloc.s 56
+		IL_0cba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0cbf: pop
+		IL_0cc0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0cc5: stloc.s 6
+		IL_0cc7: ldc.i4.1
+		IL_0cc8: newarr [System.Runtime]System.Object
+		IL_0ccd: dup
+		IL_0cce: ldc.i4.0
+		IL_0ccf: ldloc.0
+		IL_0cd0: stelem.ref
+		IL_0cd1: stloc.s 14
+		IL_0cd3: ldloc.s 14
+		IL_0cd5: ldc.i4.0
+		IL_0cd6: ldelem.ref
+		IL_0cd7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0cdc: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0ce1: ldc.i4.0
+		IL_0ce2: conv.r8
+		IL_0ce3: ldstr ""
+		IL_0ce8: ldc.i4.0
+		IL_0ce9: ldc.i4.1
+		IL_0cea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0cef: stloc.s 57
+		IL_0cf1: ldloc.3
+		IL_0cf2: ldloc.s 6
+		IL_0cf4: ldloc.s 57
+		IL_0cf6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0cfb: pop
+		IL_0cfc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0d01: stloc.s 6
+		IL_0d03: ldc.i4.1
+		IL_0d04: newarr [System.Runtime]System.Object
+		IL_0d09: dup
+		IL_0d0a: ldc.i4.0
+		IL_0d0b: ldloc.0
+		IL_0d0c: stelem.ref
+		IL_0d0d: stloc.s 14
+		IL_0d0f: ldloc.s 14
+		IL_0d11: ldc.i4.0
+		IL_0d12: ldelem.ref
+		IL_0d13: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0d18: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0d1d: ldc.i4.0
+		IL_0d1e: conv.r8
+		IL_0d1f: ldstr ""
+		IL_0d24: ldc.i4.0
+		IL_0d25: ldc.i4.1
+		IL_0d26: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0d2b: stloc.s 58
+		IL_0d2d: ldloc.s 4
+		IL_0d2f: ldloc.s 6
+		IL_0d31: ldstr "Compiled Capture Match"
+		IL_0d36: ldloc.s 58
+		IL_0d38: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0d3d: pop
+		IL_0d3e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0d43: stloc.s 6
+		IL_0d45: ldc.i4.1
+		IL_0d46: newarr [System.Runtime]System.Object
+		IL_0d4b: dup
+		IL_0d4c: ldc.i4.0
+		IL_0d4d: ldloc.0
+		IL_0d4e: stelem.ref
+		IL_0d4f: stloc.s 14
+		IL_0d51: ldloc.s 14
+		IL_0d53: ldc.i4.0
+		IL_0d54: ldelem.ref
+		IL_0d55: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0d5a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0d5f: ldc.i4.0
+		IL_0d60: conv.r8
+		IL_0d61: ldstr ""
+		IL_0d66: ldc.i4.0
+		IL_0d67: ldc.i4.1
+		IL_0d68: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0d6d: stloc.s 59
+		IL_0d6f: ldloc.3
+		IL_0d70: ldloc.s 6
+		IL_0d72: ldloc.s 59
+		IL_0d74: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0d79: pop
+		IL_0d7a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0d7f: stloc.s 6
+		IL_0d81: ldc.i4.1
+		IL_0d82: newarr [System.Runtime]System.Object
+		IL_0d87: dup
+		IL_0d88: ldc.i4.0
+		IL_0d89: ldloc.0
+		IL_0d8a: stelem.ref
+		IL_0d8b: stloc.s 14
+		IL_0d8d: ldloc.s 14
+		IL_0d8f: ldc.i4.0
+		IL_0d90: ldelem.ref
+		IL_0d91: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0d96: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0d9b: ldc.i4.0
+		IL_0d9c: conv.r8
+		IL_0d9d: ldstr ""
+		IL_0da2: ldc.i4.0
+		IL_0da3: ldc.i4.1
+		IL_0da4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0da9: stloc.s 60
+		IL_0dab: ldloc.s 4
+		IL_0dad: ldloc.s 6
+		IL_0daf: ldstr "Compiled Capture Replace"
+		IL_0db4: ldloc.s 60
+		IL_0db6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0dbb: pop
+		IL_0dbc: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0dc1: stloc.s 6
+		IL_0dc3: ldc.i4.1
+		IL_0dc4: newarr [System.Runtime]System.Object
+		IL_0dc9: dup
+		IL_0dca: ldc.i4.0
+		IL_0dcb: ldloc.0
+		IL_0dcc: stelem.ref
+		IL_0dcd: stloc.s 14
+		IL_0dcf: ldloc.s 14
+		IL_0dd1: ldc.i4.0
+		IL_0dd2: ldelem.ref
+		IL_0dd3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0dd8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0ddd: ldc.i4.0
+		IL_0dde: conv.r8
+		IL_0ddf: ldstr ""
+		IL_0de4: ldc.i4.0
+		IL_0de5: ldc.i4.1
+		IL_0de6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0deb: stloc.s 61
+		IL_0ded: ldloc.3
+		IL_0dee: ldloc.s 6
+		IL_0df0: ldloc.s 61
+		IL_0df2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0df7: pop
+		IL_0df8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0dfd: stloc.s 6
+		IL_0dff: ldc.i4.1
+		IL_0e00: newarr [System.Runtime]System.Object
+		IL_0e05: dup
+		IL_0e06: ldc.i4.0
+		IL_0e07: ldloc.0
+		IL_0e08: stelem.ref
+		IL_0e09: stloc.s 14
+		IL_0e0b: ldloc.s 14
+		IL_0e0d: ldc.i4.0
+		IL_0e0e: ldelem.ref
+		IL_0e0f: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0e14: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0e19: ldc.i4.0
+		IL_0e1a: conv.r8
+		IL_0e1b: ldstr ""
+		IL_0e20: ldc.i4.0
+		IL_0e21: ldc.i4.1
+		IL_0e22: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0e27: stloc.s 62
+		IL_0e29: ldloc.s 4
+		IL_0e2b: ldloc.s 6
+		IL_0e2d: ldstr "Compiled Capture Replace with Capture"
+		IL_0e32: ldloc.s 62
+		IL_0e34: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0e39: pop
+		IL_0e3a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0e3f: stloc.s 6
+		IL_0e41: ldc.i4.1
+		IL_0e42: newarr [System.Runtime]System.Object
+		IL_0e47: dup
+		IL_0e48: ldc.i4.0
+		IL_0e49: ldloc.0
+		IL_0e4a: stelem.ref
+		IL_0e4b: stloc.s 14
+		IL_0e4d: ldloc.s 14
+		IL_0e4f: ldc.i4.0
+		IL_0e50: ldelem.ref
+		IL_0e51: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0e56: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0e5b: ldc.i4.0
+		IL_0e5c: conv.r8
+		IL_0e5d: ldstr ""
+		IL_0e62: ldc.i4.0
+		IL_0e63: ldc.i4.1
+		IL_0e64: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0e69: stloc.s 63
+		IL_0e6b: ldloc.3
+		IL_0e6c: ldloc.s 6
+		IL_0e6e: ldloc.s 63
+		IL_0e70: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0e75: pop
+		IL_0e76: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0e7b: stloc.s 6
+		IL_0e7d: ldc.i4.1
+		IL_0e7e: newarr [System.Runtime]System.Object
+		IL_0e83: dup
+		IL_0e84: ldc.i4.0
+		IL_0e85: ldloc.0
+		IL_0e86: stelem.ref
+		IL_0e87: stloc.s 14
+		IL_0e89: ldloc.s 14
+		IL_0e8b: ldc.i4.0
+		IL_0e8c: ldelem.ref
+		IL_0e8d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0e92: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0e97: ldc.i4.0
+		IL_0e98: conv.r8
+		IL_0e99: ldstr ""
+		IL_0e9e: ldc.i4.0
+		IL_0e9f: ldc.i4.1
+		IL_0ea0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0ea5: stloc.s 64
+		IL_0ea7: ldloc.s 4
+		IL_0ea9: ldloc.s 6
+		IL_0eab: ldstr "Compiled Capture Replace with Capture Function"
+		IL_0eb0: ldloc.s 64
+		IL_0eb2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0eb7: pop
+		IL_0eb8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0ebd: stloc.s 6
+		IL_0ebf: ldc.i4.1
+		IL_0ec0: newarr [System.Runtime]System.Object
+		IL_0ec5: dup
+		IL_0ec6: ldc.i4.0
+		IL_0ec7: ldloc.0
+		IL_0ec8: stelem.ref
+		IL_0ec9: stloc.s 14
+		IL_0ecb: ldloc.s 14
+		IL_0ecd: ldc.i4.0
+		IL_0ece: ldelem.ref
+		IL_0ecf: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0ed4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0ed9: ldc.i4.0
+		IL_0eda: conv.r8
+		IL_0edb: ldstr ""
+		IL_0ee0: ldc.i4.0
+		IL_0ee1: ldc.i4.1
+		IL_0ee2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0ee7: stloc.s 65
+		IL_0ee9: ldloc.3
+		IL_0eea: ldloc.s 6
+		IL_0eec: ldloc.s 65
+		IL_0eee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0ef3: pop
+		IL_0ef4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0ef9: stloc.s 6
+		IL_0efb: ldc.i4.1
+		IL_0efc: newarr [System.Runtime]System.Object
+		IL_0f01: dup
+		IL_0f02: ldc.i4.0
+		IL_0f03: ldloc.0
+		IL_0f04: stelem.ref
+		IL_0f05: stloc.s 14
+		IL_0f07: ldloc.s 14
+		IL_0f09: ldc.i4.0
+		IL_0f0a: ldelem.ref
+		IL_0f0b: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0f10: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0f15: ldc.i4.0
+		IL_0f16: conv.r8
+		IL_0f17: ldstr ""
+		IL_0f1c: ldc.i4.0
+		IL_0f1d: ldc.i4.1
+		IL_0f1e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0f23: stloc.s 66
+		IL_0f25: ldloc.s 4
+		IL_0f27: ldloc.s 6
+		IL_0f29: ldstr "Compiled Capture Replace with Upperase Capture Function"
+		IL_0f2e: ldloc.s 66
+		IL_0f30: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0f35: pop
+		IL_0f36: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0f3b: stloc.s 6
+		IL_0f3d: ldc.i4.1
+		IL_0f3e: newarr [System.Runtime]System.Object
+		IL_0f43: dup
+		IL_0f44: ldc.i4.0
+		IL_0f45: ldloc.0
+		IL_0f46: stelem.ref
+		IL_0f47: stloc.s 14
+		IL_0f49: ldloc.s 14
+		IL_0f4b: ldc.i4.0
+		IL_0f4c: ldelem.ref
+		IL_0f4d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0f52: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0f57: ldc.i4.0
+		IL_0f58: conv.r8
+		IL_0f59: ldstr ""
+		IL_0f5e: ldc.i4.0
+		IL_0f5f: ldc.i4.1
+		IL_0f60: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0f65: stloc.s 67
+		IL_0f67: ldloc.3
+		IL_0f68: ldloc.s 6
+		IL_0f6a: ldloc.s 67
+		IL_0f6c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0f71: pop
+		IL_0f72: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0f77: stloc.s 6
+		IL_0f79: ldc.i4.1
+		IL_0f7a: newarr [System.Runtime]System.Object
+		IL_0f7f: dup
+		IL_0f80: ldc.i4.0
+		IL_0f81: ldloc.0
+		IL_0f82: stelem.ref
+		IL_0f83: stloc.s 14
+		IL_0f85: ldloc.s 14
+		IL_0f87: ldc.i4.0
+		IL_0f88: ldelem.ref
+		IL_0f89: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0f8e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0f93: ldc.i4.0
+		IL_0f94: conv.r8
+		IL_0f95: ldstr ""
+		IL_0f9a: ldc.i4.0
+		IL_0f9b: ldc.i4.1
+		IL_0f9c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0fa1: stloc.s 68
+		IL_0fa3: ldloc.s 4
+		IL_0fa5: ldloc.s 6
+		IL_0fa7: ldstr "Uncompiled Match"
+		IL_0fac: ldloc.s 68
+		IL_0fae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0fb3: pop
+		IL_0fb4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0fb9: stloc.s 6
+		IL_0fbb: ldc.i4.1
+		IL_0fbc: newarr [System.Runtime]System.Object
+		IL_0fc1: dup
+		IL_0fc2: ldc.i4.0
+		IL_0fc3: ldloc.0
+		IL_0fc4: stelem.ref
+		IL_0fc5: stloc.s 14
+		IL_0fc7: ldloc.s 14
+		IL_0fc9: ldc.i4.0
+		IL_0fca: ldelem.ref
+		IL_0fcb: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_0fd0: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0fd5: ldc.i4.0
+		IL_0fd6: conv.r8
+		IL_0fd7: ldstr ""
+		IL_0fdc: ldc.i4.0
+		IL_0fdd: ldc.i4.1
+		IL_0fde: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0fe3: stloc.s 69
+		IL_0fe5: ldloc.3
+		IL_0fe6: ldloc.s 6
+		IL_0fe8: ldloc.s 69
+		IL_0fea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0fef: pop
+		IL_0ff0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0ff5: stloc.s 6
+		IL_0ff7: ldc.i4.1
+		IL_0ff8: newarr [System.Runtime]System.Object
+		IL_0ffd: dup
+		IL_0ffe: ldc.i4.0
+		IL_0fff: ldloc.0
+		IL_1000: stelem.ref
+		IL_1001: stloc.s 14
+		IL_1003: ldloc.s 14
+		IL_1005: ldc.i4.0
+		IL_1006: ldelem.ref
+		IL_1007: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_100c: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1011: ldc.i4.0
+		IL_1012: conv.r8
+		IL_1013: ldstr ""
+		IL_1018: ldc.i4.0
+		IL_1019: ldc.i4.1
+		IL_101a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_101f: stloc.s 70
+		IL_1021: ldloc.s 4
+		IL_1023: ldloc.s 6
+		IL_1025: ldstr "Uncompiled Test"
+		IL_102a: ldloc.s 70
+		IL_102c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_1031: pop
+		IL_1032: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_1037: stloc.s 6
+		IL_1039: ldc.i4.1
+		IL_103a: newarr [System.Runtime]System.Object
+		IL_103f: dup
+		IL_1040: ldc.i4.0
+		IL_1041: ldloc.0
+		IL_1042: stelem.ref
+		IL_1043: stloc.s 14
+		IL_1045: ldloc.s 14
+		IL_1047: ldc.i4.0
+		IL_1048: ldelem.ref
+		IL_1049: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_104e: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1053: ldc.i4.0
+		IL_1054: conv.r8
+		IL_1055: ldstr ""
+		IL_105a: ldc.i4.0
+		IL_105b: ldc.i4.1
+		IL_105c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_1061: stloc.s 71
+		IL_1063: ldloc.3
+		IL_1064: ldloc.s 6
+		IL_1066: ldloc.s 71
+		IL_1068: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_106d: pop
+		IL_106e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_1073: stloc.s 6
+		IL_1075: ldc.i4.1
+		IL_1076: newarr [System.Runtime]System.Object
+		IL_107b: dup
+		IL_107c: ldc.i4.0
+		IL_107d: ldloc.0
+		IL_107e: stelem.ref
+		IL_107f: stloc.s 14
+		IL_1081: ldloc.s 14
+		IL_1083: ldc.i4.0
+		IL_1084: ldelem.ref
+		IL_1085: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_108a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_108f: ldc.i4.0
+		IL_1090: conv.r8
+		IL_1091: ldstr ""
+		IL_1096: ldc.i4.0
+		IL_1097: ldc.i4.1
+		IL_1098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_109d: stloc.s 72
+		IL_109f: ldloc.s 4
+		IL_10a1: ldloc.s 6
+		IL_10a3: ldstr "Uncompiled Empty Replace"
+		IL_10a8: ldloc.s 72
+		IL_10aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_10af: pop
+		IL_10b0: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_10b5: stloc.s 6
+		IL_10b7: ldc.i4.1
+		IL_10b8: newarr [System.Runtime]System.Object
+		IL_10bd: dup
+		IL_10be: ldc.i4.0
+		IL_10bf: ldloc.0
+		IL_10c0: stelem.ref
+		IL_10c1: stloc.s 14
+		IL_10c3: ldloc.s 14
+		IL_10c5: ldc.i4.0
+		IL_10c6: ldelem.ref
+		IL_10c7: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_10cc: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_10d1: ldc.i4.0
+		IL_10d2: conv.r8
+		IL_10d3: ldstr ""
+		IL_10d8: ldc.i4.0
+		IL_10d9: ldc.i4.1
+		IL_10da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_10df: stloc.s 73
+		IL_10e1: ldloc.3
+		IL_10e2: ldloc.s 6
+		IL_10e4: ldloc.s 73
+		IL_10e6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_10eb: pop
+		IL_10ec: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_10f1: stloc.s 6
+		IL_10f3: ldc.i4.1
+		IL_10f4: newarr [System.Runtime]System.Object
+		IL_10f9: dup
+		IL_10fa: ldc.i4.0
+		IL_10fb: ldloc.0
+		IL_10fc: stelem.ref
+		IL_10fd: stloc.s 14
+		IL_10ff: ldloc.s 14
+		IL_1101: ldc.i4.0
+		IL_1102: ldelem.ref
+		IL_1103: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1108: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_110d: ldc.i4.0
+		IL_110e: conv.r8
+		IL_110f: ldstr ""
+		IL_1114: ldc.i4.0
+		IL_1115: ldc.i4.1
+		IL_1116: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_111b: stloc.s 74
+		IL_111d: ldloc.s 4
+		IL_111f: ldloc.s 6
+		IL_1121: ldstr "Uncompiled 12 Char Replace"
+		IL_1126: ldloc.s 74
+		IL_1128: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_112d: pop
+		IL_112e: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_1133: stloc.s 6
+		IL_1135: ldc.i4.1
+		IL_1136: newarr [System.Runtime]System.Object
+		IL_113b: dup
+		IL_113c: ldc.i4.0
+		IL_113d: ldloc.0
+		IL_113e: stelem.ref
+		IL_113f: stloc.s 14
+		IL_1141: ldloc.s 14
+		IL_1143: ldc.i4.0
+		IL_1144: ldelem.ref
+		IL_1145: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_114a: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_114f: ldc.i4.0
+		IL_1150: conv.r8
+		IL_1151: ldstr ""
+		IL_1156: ldc.i4.0
+		IL_1157: ldc.i4.1
+		IL_1158: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_115d: stloc.s 75
+		IL_115f: ldloc.3
+		IL_1160: ldloc.s 6
+		IL_1162: ldloc.s 75
+		IL_1164: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_1169: pop
+		IL_116a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_116f: stloc.s 6
+		IL_1171: ldc.i4.1
+		IL_1172: newarr [System.Runtime]System.Object
+		IL_1177: dup
+		IL_1178: ldc.i4.0
+		IL_1179: ldloc.0
+		IL_117a: stelem.ref
+		IL_117b: stloc.s 14
+		IL_117d: ldloc.s 14
+		IL_117f: ldc.i4.0
+		IL_1180: ldelem.ref
+		IL_1181: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1186: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_118b: ldc.i4.0
+		IL_118c: conv.r8
+		IL_118d: ldstr ""
+		IL_1192: ldc.i4.0
+		IL_1193: ldc.i4.1
+		IL_1194: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_1199: stloc.s 76
+		IL_119b: ldloc.s 4
+		IL_119d: ldloc.s 6
+		IL_119f: ldstr "Uncompiled Object Match"
+		IL_11a4: ldloc.s 76
+		IL_11a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_11ab: pop
+		IL_11ac: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_11b1: stloc.s 6
+		IL_11b3: ldc.i4.1
+		IL_11b4: newarr [System.Runtime]System.Object
+		IL_11b9: dup
+		IL_11ba: ldc.i4.0
+		IL_11bb: ldloc.0
+		IL_11bc: stelem.ref
+		IL_11bd: stloc.s 14
+		IL_11bf: ldloc.s 14
+		IL_11c1: ldc.i4.0
+		IL_11c2: ldelem.ref
+		IL_11c3: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_11c8: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_11cd: ldc.i4.0
+		IL_11ce: conv.r8
+		IL_11cf: ldstr ""
+		IL_11d4: ldc.i4.0
+		IL_11d5: ldc.i4.1
+		IL_11d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_11db: stloc.s 77
+		IL_11dd: ldloc.3
+		IL_11de: ldloc.s 6
+		IL_11e0: ldloc.s 77
+		IL_11e2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_11e7: pop
+		IL_11e8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_11ed: stloc.s 6
+		IL_11ef: ldc.i4.1
+		IL_11f0: newarr [System.Runtime]System.Object
+		IL_11f5: dup
+		IL_11f6: ldc.i4.0
+		IL_11f7: ldloc.0
+		IL_11f8: stelem.ref
+		IL_11f9: stloc.s 14
+		IL_11fb: ldloc.s 14
+		IL_11fd: ldc.i4.0
+		IL_11fe: ldelem.ref
+		IL_11ff: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1204: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1209: ldc.i4.0
+		IL_120a: conv.r8
+		IL_120b: ldstr ""
+		IL_1210: ldc.i4.0
+		IL_1211: ldc.i4.1
+		IL_1212: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_1217: stloc.s 78
+		IL_1219: ldloc.s 4
+		IL_121b: ldloc.s 6
+		IL_121d: ldstr "Uncompiled Object Test"
+		IL_1222: ldloc.s 78
+		IL_1224: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_1229: pop
+		IL_122a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_122f: stloc.s 6
+		IL_1231: ldc.i4.1
+		IL_1232: newarr [System.Runtime]System.Object
+		IL_1237: dup
+		IL_1238: ldc.i4.0
+		IL_1239: ldloc.0
+		IL_123a: stelem.ref
+		IL_123b: stloc.s 14
+		IL_123d: ldloc.s 14
+		IL_123f: ldc.i4.0
+		IL_1240: ldelem.ref
+		IL_1241: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1246: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_124b: ldc.i4.0
+		IL_124c: conv.r8
+		IL_124d: ldstr ""
+		IL_1252: ldc.i4.0
+		IL_1253: ldc.i4.1
+		IL_1254: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_1259: stloc.s 79
+		IL_125b: ldloc.3
+		IL_125c: ldloc.s 6
+		IL_125e: ldloc.s 79
+		IL_1260: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_1265: pop
+		IL_1266: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_126b: stloc.s 6
+		IL_126d: ldc.i4.1
+		IL_126e: newarr [System.Runtime]System.Object
+		IL_1273: dup
+		IL_1274: ldc.i4.0
+		IL_1275: ldloc.0
+		IL_1276: stelem.ref
+		IL_1277: stloc.s 14
+		IL_1279: ldloc.s 14
+		IL_127b: ldc.i4.0
+		IL_127c: ldelem.ref
+		IL_127d: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1282: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1287: ldc.i4.0
+		IL_1288: conv.r8
+		IL_1289: ldstr ""
+		IL_128e: ldc.i4.0
+		IL_128f: ldc.i4.1
+		IL_1290: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_1295: stloc.s 80
+		IL_1297: ldloc.s 4
+		IL_1299: ldloc.s 6
+		IL_129b: ldstr "Uncompiled Object Empty Replace"
+		IL_12a0: ldloc.s 80
+		IL_12a2: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_12a7: pop
+		IL_12a8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_12ad: stloc.s 6
+		IL_12af: ldc.i4.1
+		IL_12b0: newarr [System.Runtime]System.Object
+		IL_12b5: dup
+		IL_12b6: ldc.i4.0
+		IL_12b7: ldloc.0
+		IL_12b8: stelem.ref
+		IL_12b9: stloc.s 14
+		IL_12bb: ldloc.s 14
+		IL_12bd: ldc.i4.0
+		IL_12be: ldelem.ref
+		IL_12bf: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_12c4: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_12c9: ldc.i4.0
+		IL_12ca: conv.r8
+		IL_12cb: ldstr ""
+		IL_12d0: ldc.i4.0
+		IL_12d1: ldc.i4.1
+		IL_12d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_12d7: stloc.s 81
+		IL_12d9: ldloc.3
+		IL_12da: ldloc.s 6
+		IL_12dc: ldloc.s 81
+		IL_12de: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_12e3: pop
+		IL_12e4: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_12e9: stloc.s 6
+		IL_12eb: ldc.i4.1
+		IL_12ec: newarr [System.Runtime]System.Object
+		IL_12f1: dup
+		IL_12f2: ldc.i4.0
+		IL_12f3: ldloc.0
+		IL_12f4: stelem.ref
+		IL_12f5: stloc.s 14
+		IL_12f7: ldloc.s 14
+		IL_12f9: ldc.i4.0
+		IL_12fa: ldelem.ref
+		IL_12fb: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
+		IL_1300: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1305: ldc.i4.0
+		IL_1306: conv.r8
+		IL_1307: ldstr ""
+		IL_130c: ldc.i4.0
+		IL_130d: ldc.i4.1
+		IL_130e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_1313: stloc.s 82
+		IL_1315: ldloc.s 4
+		IL_1317: ldloc.s 6
+		IL_1319: ldstr "Uncompiled Object 12 Char Replace"
+		IL_131e: ldloc.s 82
+		IL_1320: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_1325: pop
+		IL_1326: ldloc.2
+		IL_1327: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_132c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_1331: pop
+		IL_1332: ret
 	} // end of method Compile_Performance_Dromaeo_Object_Regexp::__js_module_init__
 
 } // end of class Modules.Compile_Performance_Dromaeo_Object_Regexp

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_String.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_String.verified.txt
@@ -2443,7 +2443,7 @@
 				74 61 54 6f 6b 65 6e 1c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 448 (0x1c0)
+			// Code size: 520 (0x208)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -2466,7 +2466,7 @@
 				IL_0018: ldloc.1
 				IL_0019: ldloc.2
 				IL_001a: clt
-				IL_001c: brfalse IL_01be
+				IL_001c: brfalse IL_0206
 
 				IL_0021: ldarg.0
 				IL_0022: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
@@ -2474,144 +2474,172 @@
 				IL_002c: stloc.3
 				IL_002d: ldc.i4.0
 				IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0033: brfalse IL_005e
+				IL_0033: brfalse IL_0070
 
 				IL_0038: ldloc.3
 				IL_0039: isinst [System.Runtime]System.String
 				IL_003e: dup
-				IL_003f: brfalse IL_005d
+				IL_003f: brtrue IL_0056
 
-				IL_0044: ldc.r8 0.0
-				IL_004d: box [System.Runtime]System.Double
-				IL_0052: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-				IL_0057: stloc.3
-				IL_0058: br IL_0078
+				IL_0044: pop
+				IL_0045: ldloc.3
+				IL_0046: ldstr "charAt"
+				IL_004b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0050: dup
+				IL_0051: brfalse IL_006f
 
-				IL_005d: pop
+				IL_0056: ldc.r8 0.0
+				IL_005f: box [System.Runtime]System.Double
+				IL_0064: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+				IL_0069: stloc.3
+				IL_006a: br IL_008a
 
-				IL_005e: ldloc.3
-				IL_005f: ldstr "charAt"
-				IL_0064: ldc.r8 0.0
-				IL_006d: box [System.Runtime]System.Double
-				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0077: stloc.3
+				IL_006f: pop
 
-				IL_0078: ldarg.0
-				IL_0079: ldloc.3
-				IL_007a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_007f: ldarg.0
-				IL_0080: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_008a: stloc.3
-				IL_008b: ldarg.0
-				IL_008c: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0091: ldstr "length"
-				IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_009b: stloc.s 4
-				IL_009d: ldloc.s 4
-				IL_009f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00a4: ldc.r8 1
-				IL_00ad: sub
-				IL_00ae: stloc.2
-				IL_00af: ldloc.2
-				IL_00b0: box [System.Runtime]System.Double
-				IL_00b5: stloc.s 5
-				IL_00b7: ldc.i4.0
-				IL_00b8: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_00bd: brfalse IL_00dc
+				IL_0070: ldloc.3
+				IL_0071: ldstr "charAt"
+				IL_0076: ldc.r8 0.0
+				IL_007f: box [System.Runtime]System.Double
+				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0089: stloc.3
 
-				IL_00c2: ldloc.3
-				IL_00c3: isinst [System.Runtime]System.String
-				IL_00c8: dup
-				IL_00c9: brfalse IL_00db
+				IL_008a: ldarg.0
+				IL_008b: ldloc.3
+				IL_008c: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0091: ldarg.0
+				IL_0092: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_009c: stloc.3
+				IL_009d: ldarg.0
+				IL_009e: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_00a3: ldstr "length"
+				IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00ad: stloc.s 4
+				IL_00af: ldloc.s 4
+				IL_00b1: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00b6: ldc.r8 1
+				IL_00bf: sub
+				IL_00c0: stloc.2
+				IL_00c1: ldloc.2
+				IL_00c2: box [System.Runtime]System.Double
+				IL_00c7: stloc.s 5
+				IL_00c9: ldc.i4.0
+				IL_00ca: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_00cf: brfalse IL_0100
 
-				IL_00ce: ldloc.s 5
-				IL_00d0: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-				IL_00d5: stloc.3
-				IL_00d6: br IL_00ea
+				IL_00d4: ldloc.3
+				IL_00d5: isinst [System.Runtime]System.String
+				IL_00da: dup
+				IL_00db: brtrue IL_00f2
 
-				IL_00db: pop
+				IL_00e0: pop
+				IL_00e1: ldloc.3
+				IL_00e2: ldstr "charAt"
+				IL_00e7: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_00ec: dup
+				IL_00ed: brfalse IL_00ff
 
-				IL_00dc: ldloc.3
-				IL_00dd: ldstr "charAt"
-				IL_00e2: ldloc.s 5
-				IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00e9: stloc.3
+				IL_00f2: ldloc.s 5
+				IL_00f4: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+				IL_00f9: stloc.3
+				IL_00fa: br IL_010e
 
-				IL_00ea: ldarg.0
-				IL_00eb: ldloc.3
-				IL_00ec: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_00f1: ldarg.0
-				IL_00f2: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00fc: stloc.3
-				IL_00fd: ldc.i4.0
-				IL_00fe: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0103: brfalse IL_012e
+				IL_00ff: pop
 
-				IL_0108: ldloc.3
-				IL_0109: isinst [System.Runtime]System.String
-				IL_010e: dup
-				IL_010f: brfalse IL_012d
+				IL_0100: ldloc.3
+				IL_0101: ldstr "charAt"
+				IL_0106: ldloc.s 5
+				IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_010d: stloc.3
 
-				IL_0114: ldc.r8 15000
-				IL_011d: box [System.Runtime]System.Double
-				IL_0122: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-				IL_0127: stloc.3
-				IL_0128: br IL_0148
+				IL_010e: ldarg.0
+				IL_010f: ldloc.3
+				IL_0110: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0115: ldarg.0
+				IL_0116: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_011b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0120: stloc.3
+				IL_0121: ldc.i4.0
+				IL_0122: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0127: brfalse IL_0164
 
-				IL_012d: pop
+				IL_012c: ldloc.3
+				IL_012d: isinst [System.Runtime]System.String
+				IL_0132: dup
+				IL_0133: brtrue IL_014a
 
-				IL_012e: ldloc.3
-				IL_012f: ldstr "charAt"
-				IL_0134: ldc.r8 15000
-				IL_013d: box [System.Runtime]System.Double
-				IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0147: stloc.3
+				IL_0138: pop
+				IL_0139: ldloc.3
+				IL_013a: ldstr "charAt"
+				IL_013f: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0144: dup
+				IL_0145: brfalse IL_0163
 
-				IL_0148: ldarg.0
-				IL_0149: ldloc.3
-				IL_014a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_014f: ldarg.0
-				IL_0150: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_015a: stloc.3
-				IL_015b: ldc.i4.0
-				IL_015c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0161: brfalse IL_018c
+				IL_014a: ldc.r8 15000
+				IL_0153: box [System.Runtime]System.Double
+				IL_0158: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+				IL_015d: stloc.3
+				IL_015e: br IL_017e
 
-				IL_0166: ldloc.3
-				IL_0167: isinst [System.Runtime]System.String
-				IL_016c: dup
-				IL_016d: brfalse IL_018b
+				IL_0163: pop
 
-				IL_0172: ldc.r8 12000
-				IL_017b: box [System.Runtime]System.Double
-				IL_0180: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-				IL_0185: stloc.3
-				IL_0186: br IL_01a6
+				IL_0164: ldloc.3
+				IL_0165: ldstr "charAt"
+				IL_016a: ldc.r8 15000
+				IL_0173: box [System.Runtime]System.Double
+				IL_0178: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_017d: stloc.3
 
-				IL_018b: pop
+				IL_017e: ldarg.0
+				IL_017f: ldloc.3
+				IL_0180: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0185: ldarg.0
+				IL_0186: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0190: stloc.3
+				IL_0191: ldc.i4.0
+				IL_0192: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0197: brfalse IL_01d4
 
-				IL_018c: ldloc.3
-				IL_018d: ldstr "charAt"
-				IL_0192: ldc.r8 12000
-				IL_019b: box [System.Runtime]System.Double
-				IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_01a5: stloc.3
+				IL_019c: ldloc.3
+				IL_019d: isinst [System.Runtime]System.String
+				IL_01a2: dup
+				IL_01a3: brtrue IL_01ba
 
-				IL_01a6: ldarg.0
-				IL_01a7: ldloc.3
-				IL_01a8: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_01ad: ldloc.0
-				IL_01ae: ldc.r8 1
-				IL_01b7: add
-				IL_01b8: stloc.0
-				IL_01b9: br IL_000a
+				IL_01a8: pop
+				IL_01a9: ldloc.3
+				IL_01aa: ldstr "charAt"
+				IL_01af: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_01b4: dup
+				IL_01b5: brfalse IL_01d3
+
+				IL_01ba: ldc.r8 12000
+				IL_01c3: box [System.Runtime]System.Double
+				IL_01c8: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+				IL_01cd: stloc.3
+				IL_01ce: br IL_01ee
+
+				IL_01d3: pop
+
+				IL_01d4: ldloc.3
+				IL_01d5: ldstr "charAt"
+				IL_01da: ldc.r8 12000
+				IL_01e3: box [System.Runtime]System.Double
+				IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01ed: stloc.3
+
+				IL_01ee: ldarg.0
+				IL_01ef: ldloc.3
+				IL_01f0: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_01f5: ldloc.0
+				IL_01f6: ldc.r8 1
+				IL_01ff: add
+				IL_0200: stloc.0
+				IL_0201: br IL_000a
 			// end loop
 
-			IL_01be: ldnull
-			IL_01bf: ret
+			IL_0206: ldnull
+			IL_0207: ret
 		} // end of method FunctionExpression_L82C15::__js_call__
 
 	} // end of class FunctionExpression_L82C15
@@ -2775,13 +2803,14 @@
 				74 61 54 6f 6b 65 6e 1c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 218 (0xda)
+			// Code size: 230 (0xe6)
 			.maxstack 8
 			.locals init (
 				[0] float64,
 				[1] float64,
 				[2] float64,
-				[3] object
+				[3] object,
+				[4] object
 			)
 
 			IL_0000: ldc.r8 0.0
@@ -2796,67 +2825,77 @@
 				IL_0018: ldloc.1
 				IL_0019: ldloc.2
 				IL_001a: clt
-				IL_001c: brfalse IL_00d8
+				IL_001c: brfalse IL_00e4
 
 				IL_0021: ldarg.0
 				IL_0022: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0027: ldc.r8 0.0
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0035: stloc.3
-				IL_0036: ldarg.0
-				IL_0037: ldloc.3
-				IL_0038: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_003d: ldarg.0
-				IL_003e: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0043: ldarg.0
-				IL_0044: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0049: ldstr "length"
-				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0053: stloc.3
-				IL_0054: ldloc.3
-				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_005a: ldc.r8 1
-				IL_0063: sub
-				IL_0064: stloc.2
-				IL_0065: ldloc.2
-				IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_006b: stloc.3
-				IL_006c: ldarg.0
-				IL_006d: ldloc.3
-				IL_006e: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_0073: ldarg.0
-				IL_0074: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0079: ldc.r8 15000
-				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0087: stloc.3
-				IL_0088: ldarg.0
-				IL_0089: ldloc.3
-				IL_008a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_008f: ldarg.0
-				IL_0090: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0095: ldc.r8 10000
-				IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00a3: stloc.3
-				IL_00a4: ldarg.0
-				IL_00a5: ldloc.3
-				IL_00a6: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_00ab: ldarg.0
-				IL_00ac: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_00b1: ldc.r8 5000
-				IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_00bf: stloc.3
-				IL_00c0: ldarg.0
-				IL_00c1: ldloc.3
-				IL_00c2: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_00c7: ldloc.0
-				IL_00c8: ldc.r8 1
-				IL_00d1: add
-				IL_00d2: stloc.0
-				IL_00d3: br IL_000a
+				IL_0027: stloc.3
+				IL_0028: ldloc.3
+				IL_0029: ldc.r8 0.0
+				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetStringElementWithFallback(object, float64)
+				IL_0037: stloc.3
+				IL_0038: ldarg.0
+				IL_0039: ldloc.3
+				IL_003a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_003f: ldarg.0
+				IL_0040: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0045: stloc.3
+				IL_0046: ldarg.0
+				IL_0047: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_004c: ldstr "length"
+				IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0056: stloc.s 4
+				IL_0058: ldloc.s 4
+				IL_005a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005f: ldc.r8 1
+				IL_0068: sub
+				IL_0069: stloc.2
+				IL_006a: ldloc.3
+				IL_006b: ldloc.2
+				IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetStringElementWithFallback(object, float64)
+				IL_0071: stloc.3
+				IL_0072: ldarg.0
+				IL_0073: ldloc.3
+				IL_0074: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0079: ldarg.0
+				IL_007a: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_007f: stloc.3
+				IL_0080: ldloc.3
+				IL_0081: ldc.r8 15000
+				IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetStringElementWithFallback(object, float64)
+				IL_008f: stloc.3
+				IL_0090: ldarg.0
+				IL_0091: ldloc.3
+				IL_0092: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0097: ldarg.0
+				IL_0098: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_009d: stloc.3
+				IL_009e: ldloc.3
+				IL_009f: ldc.r8 10000
+				IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetStringElementWithFallback(object, float64)
+				IL_00ad: stloc.3
+				IL_00ae: ldarg.0
+				IL_00af: ldloc.3
+				IL_00b0: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_00b5: ldarg.0
+				IL_00b6: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_00bb: stloc.3
+				IL_00bc: ldloc.3
+				IL_00bd: ldc.r8 5000
+				IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetStringElementWithFallback(object, float64)
+				IL_00cb: stloc.3
+				IL_00cc: ldarg.0
+				IL_00cd: ldloc.3
+				IL_00ce: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_00d3: ldloc.0
+				IL_00d4: ldc.r8 1
+				IL_00dd: add
+				IL_00de: stloc.0
+				IL_00df: br IL_000a
 			// end loop
 
-			IL_00d8: ldnull
-			IL_00d9: ret
+			IL_00e4: ldnull
+			IL_00e5: ret
 		} // end of method FunctionExpression_L91C17::__js_call__
 
 	} // end of class FunctionExpression_L91C17
@@ -3020,7 +3059,7 @@
 				74 61 54 6f 6b 65 6e 1c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 567 (0x237)
+			// Code size: 657 (0x291)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -3043,7 +3082,7 @@
 				IL_0018: ldloc.1
 				IL_0019: ldloc.2
 				IL_001a: clt
-				IL_001c: brfalse IL_0235
+				IL_001c: brfalse IL_028f
 
 				IL_0021: ldarg.0
 				IL_0022: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
@@ -3051,180 +3090,215 @@
 				IL_002c: stloc.3
 				IL_002d: ldc.i4.0
 				IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0033: brfalse IL_0063
+				IL_0033: brfalse IL_0075
 
 				IL_0038: ldloc.3
 				IL_0039: isinst [System.Runtime]System.String
 				IL_003e: dup
-				IL_003f: brfalse IL_0062
+				IL_003f: brtrue IL_0056
 
-				IL_0044: ldc.r8 0.0
-				IL_004d: box [System.Runtime]System.Double
-				IL_0052: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
-				IL_0057: box [System.Runtime]System.Double
-				IL_005c: stloc.3
-				IL_005d: br IL_007d
+				IL_0044: pop
+				IL_0045: ldloc.3
+				IL_0046: ldstr "charCodeAt"
+				IL_004b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0050: dup
+				IL_0051: brfalse IL_0074
 
-				IL_0062: pop
+				IL_0056: ldc.r8 0.0
+				IL_005f: box [System.Runtime]System.Double
+				IL_0064: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+				IL_0069: box [System.Runtime]System.Double
+				IL_006e: stloc.3
+				IL_006f: br IL_008f
 
-				IL_0063: ldloc.3
-				IL_0064: ldstr "charCodeAt"
-				IL_0069: ldc.r8 0.0
-				IL_0072: box [System.Runtime]System.Double
-				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_007c: stloc.3
+				IL_0074: pop
 
-				IL_007d: ldarg.0
-				IL_007e: ldloc.3
-				IL_007f: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_0084: ldarg.0
-				IL_0085: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_008f: stloc.3
-				IL_0090: ldarg.0
-				IL_0091: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0096: ldstr "length"
-				IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_00a0: stloc.s 4
-				IL_00a2: ldloc.s 4
-				IL_00a4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00a9: ldc.r8 1
-				IL_00b2: sub
-				IL_00b3: stloc.2
-				IL_00b4: ldloc.2
-				IL_00b5: box [System.Runtime]System.Double
-				IL_00ba: stloc.s 5
-				IL_00bc: ldc.i4.0
-				IL_00bd: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_00c2: brfalse IL_00e6
+				IL_0075: ldloc.3
+				IL_0076: ldstr "charCodeAt"
+				IL_007b: ldc.r8 0.0
+				IL_0084: box [System.Runtime]System.Double
+				IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_008e: stloc.3
 
-				IL_00c7: ldloc.3
-				IL_00c8: isinst [System.Runtime]System.String
-				IL_00cd: dup
-				IL_00ce: brfalse IL_00e5
+				IL_008f: ldarg.0
+				IL_0090: ldloc.3
+				IL_0091: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0096: ldarg.0
+				IL_0097: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00a1: stloc.3
+				IL_00a2: ldarg.0
+				IL_00a3: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_00a8: ldstr "length"
+				IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00b2: stloc.s 4
+				IL_00b4: ldloc.s 4
+				IL_00b6: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00bb: ldc.r8 1
+				IL_00c4: sub
+				IL_00c5: stloc.2
+				IL_00c6: ldloc.2
+				IL_00c7: box [System.Runtime]System.Double
+				IL_00cc: stloc.s 5
+				IL_00ce: ldc.i4.0
+				IL_00cf: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_00d4: brfalse IL_010a
 
-				IL_00d3: ldloc.s 5
-				IL_00d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
-				IL_00da: box [System.Runtime]System.Double
-				IL_00df: stloc.3
-				IL_00e0: br IL_00f4
+				IL_00d9: ldloc.3
+				IL_00da: isinst [System.Runtime]System.String
+				IL_00df: dup
+				IL_00e0: brtrue IL_00f7
 
 				IL_00e5: pop
-
 				IL_00e6: ldloc.3
 				IL_00e7: ldstr "charCodeAt"
-				IL_00ec: ldloc.s 5
-				IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00f3: stloc.3
+				IL_00ec: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_00f1: dup
+				IL_00f2: brfalse IL_0109
 
-				IL_00f4: ldarg.0
-				IL_00f5: ldloc.3
-				IL_00f6: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_00fb: ldarg.0
-				IL_00fc: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0106: stloc.3
-				IL_0107: ldc.i4.0
-				IL_0108: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_010d: brfalse IL_013d
+				IL_00f7: ldloc.s 5
+				IL_00f9: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+				IL_00fe: box [System.Runtime]System.Double
+				IL_0103: stloc.3
+				IL_0104: br IL_0118
 
-				IL_0112: ldloc.3
-				IL_0113: isinst [System.Runtime]System.String
-				IL_0118: dup
-				IL_0119: brfalse IL_013c
+				IL_0109: pop
 
-				IL_011e: ldc.r8 15000
-				IL_0127: box [System.Runtime]System.Double
-				IL_012c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
-				IL_0131: box [System.Runtime]System.Double
-				IL_0136: stloc.3
-				IL_0137: br IL_0157
+				IL_010a: ldloc.3
+				IL_010b: ldstr "charCodeAt"
+				IL_0110: ldloc.s 5
+				IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0117: stloc.3
 
-				IL_013c: pop
+				IL_0118: ldarg.0
+				IL_0119: ldloc.3
+				IL_011a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_011f: ldarg.0
+				IL_0120: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_012a: stloc.3
+				IL_012b: ldc.i4.0
+				IL_012c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0131: brfalse IL_0173
 
-				IL_013d: ldloc.3
-				IL_013e: ldstr "charCodeAt"
-				IL_0143: ldc.r8 15000
-				IL_014c: box [System.Runtime]System.Double
-				IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0156: stloc.3
+				IL_0136: ldloc.3
+				IL_0137: isinst [System.Runtime]System.String
+				IL_013c: dup
+				IL_013d: brtrue IL_0154
 
-				IL_0157: ldarg.0
-				IL_0158: ldloc.3
-				IL_0159: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_015e: ldarg.0
-				IL_015f: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0169: stloc.3
-				IL_016a: ldc.i4.0
-				IL_016b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0170: brfalse IL_01a0
+				IL_0142: pop
+				IL_0143: ldloc.3
+				IL_0144: ldstr "charCodeAt"
+				IL_0149: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_014e: dup
+				IL_014f: brfalse IL_0172
 
-				IL_0175: ldloc.3
-				IL_0176: isinst [System.Runtime]System.String
-				IL_017b: dup
-				IL_017c: brfalse IL_019f
+				IL_0154: ldc.r8 15000
+				IL_015d: box [System.Runtime]System.Double
+				IL_0162: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+				IL_0167: box [System.Runtime]System.Double
+				IL_016c: stloc.3
+				IL_016d: br IL_018d
 
-				IL_0181: ldc.r8 10000
-				IL_018a: box [System.Runtime]System.Double
-				IL_018f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
-				IL_0194: box [System.Runtime]System.Double
-				IL_0199: stloc.3
-				IL_019a: br IL_01ba
+				IL_0172: pop
 
-				IL_019f: pop
+				IL_0173: ldloc.3
+				IL_0174: ldstr "charCodeAt"
+				IL_0179: ldc.r8 15000
+				IL_0182: box [System.Runtime]System.Double
+				IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_018c: stloc.3
 
-				IL_01a0: ldloc.3
-				IL_01a1: ldstr "charCodeAt"
-				IL_01a6: ldc.r8 10000
-				IL_01af: box [System.Runtime]System.Double
-				IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_01b9: stloc.3
+				IL_018d: ldarg.0
+				IL_018e: ldloc.3
+				IL_018f: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0194: ldarg.0
+				IL_0195: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_019a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_019f: stloc.3
+				IL_01a0: ldc.i4.0
+				IL_01a1: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_01a6: brfalse IL_01e8
 
-				IL_01ba: ldarg.0
-				IL_01bb: ldloc.3
-				IL_01bc: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_01c1: ldarg.0
-				IL_01c2: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01cc: stloc.3
-				IL_01cd: ldc.i4.0
-				IL_01ce: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_01d3: brfalse IL_0203
+				IL_01ab: ldloc.3
+				IL_01ac: isinst [System.Runtime]System.String
+				IL_01b1: dup
+				IL_01b2: brtrue IL_01c9
 
-				IL_01d8: ldloc.3
-				IL_01d9: isinst [System.Runtime]System.String
-				IL_01de: dup
-				IL_01df: brfalse IL_0202
+				IL_01b7: pop
+				IL_01b8: ldloc.3
+				IL_01b9: ldstr "charCodeAt"
+				IL_01be: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_01c3: dup
+				IL_01c4: brfalse IL_01e7
 
-				IL_01e4: ldc.r8 5000
-				IL_01ed: box [System.Runtime]System.Double
-				IL_01f2: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+				IL_01c9: ldc.r8 10000
+				IL_01d2: box [System.Runtime]System.Double
+				IL_01d7: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+				IL_01dc: box [System.Runtime]System.Double
+				IL_01e1: stloc.3
+				IL_01e2: br IL_0202
+
+				IL_01e7: pop
+
+				IL_01e8: ldloc.3
+				IL_01e9: ldstr "charCodeAt"
+				IL_01ee: ldc.r8 10000
 				IL_01f7: box [System.Runtime]System.Double
-				IL_01fc: stloc.3
-				IL_01fd: br IL_021d
+				IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0201: stloc.3
 
-				IL_0202: pop
-
+				IL_0202: ldarg.0
 				IL_0203: ldloc.3
-				IL_0204: ldstr "charCodeAt"
-				IL_0209: ldc.r8 5000
-				IL_0212: box [System.Runtime]System.Double
-				IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_021c: stloc.3
+				IL_0204: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0209: ldarg.0
+				IL_020a: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0214: stloc.3
+				IL_0215: ldc.i4.0
+				IL_0216: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_021b: brfalse IL_025d
 
-				IL_021d: ldarg.0
-				IL_021e: ldloc.3
-				IL_021f: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_0224: ldloc.0
-				IL_0225: ldc.r8 1
-				IL_022e: add
-				IL_022f: stloc.0
-				IL_0230: br IL_000a
+				IL_0220: ldloc.3
+				IL_0221: isinst [System.Runtime]System.String
+				IL_0226: dup
+				IL_0227: brtrue IL_023e
+
+				IL_022c: pop
+				IL_022d: ldloc.3
+				IL_022e: ldstr "charCodeAt"
+				IL_0233: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0238: dup
+				IL_0239: brfalse IL_025c
+
+				IL_023e: ldc.r8 5000
+				IL_0247: box [System.Runtime]System.Double
+				IL_024c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+				IL_0251: box [System.Runtime]System.Double
+				IL_0256: stloc.3
+				IL_0257: br IL_0277
+
+				IL_025c: pop
+
+				IL_025d: ldloc.3
+				IL_025e: ldstr "charCodeAt"
+				IL_0263: ldc.r8 5000
+				IL_026c: box [System.Runtime]System.Double
+				IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0276: stloc.3
+
+				IL_0277: ldarg.0
+				IL_0278: ldloc.3
+				IL_0279: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_027e: ldloc.0
+				IL_027f: ldc.r8 1
+				IL_0288: add
+				IL_0289: stloc.0
+				IL_028a: br IL_000a
 			// end loop
 
-			IL_0235: ldnull
-			IL_0236: ret
+			IL_028f: ldnull
+			IL_0290: ret
 		} // end of method FunctionExpression_L101C19::__js_call__
 
 	} // end of class FunctionExpression_L101C19
@@ -3388,7 +3462,7 @@
 				74 61 54 6f 6b 65 6e 1c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 376 (0x178)
+			// Code size: 448 (0x1c0)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -3409,7 +3483,7 @@
 				IL_0018: ldloc.1
 				IL_0019: ldloc.2
 				IL_001a: clt
-				IL_001c: brfalse IL_0176
+				IL_001c: brfalse IL_01be
 
 				IL_0021: ldarg.0
 				IL_0022: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
@@ -3417,129 +3491,157 @@
 				IL_002c: stloc.3
 				IL_002d: ldc.i4.0
 				IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0033: brfalse IL_005a
+				IL_0033: brfalse IL_006c
 
 				IL_0038: ldloc.3
 				IL_0039: isinst [System.Runtime]System.String
 				IL_003e: dup
-				IL_003f: brfalse IL_0059
+				IL_003f: brtrue IL_0056
 
-				IL_0044: ldstr "a"
-				IL_0049: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-				IL_004e: box [System.Runtime]System.Double
-				IL_0053: stloc.3
-				IL_0054: br IL_006b
+				IL_0044: pop
+				IL_0045: ldloc.3
+				IL_0046: ldstr "indexOf"
+				IL_004b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0050: dup
+				IL_0051: brfalse IL_006b
 
-				IL_0059: pop
+				IL_0056: ldstr "a"
+				IL_005b: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+				IL_0060: box [System.Runtime]System.Double
+				IL_0065: stloc.3
+				IL_0066: br IL_007d
 
-				IL_005a: ldloc.3
-				IL_005b: ldstr "indexOf"
-				IL_0060: ldstr "a"
-				IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_006a: stloc.3
+				IL_006b: pop
 
-				IL_006b: ldarg.0
 				IL_006c: ldloc.3
-				IL_006d: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_0072: ldarg.0
-				IL_0073: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_007d: stloc.3
-				IL_007e: ldc.i4.0
-				IL_007f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0084: brfalse IL_00ab
+				IL_006d: ldstr "indexOf"
+				IL_0072: ldstr "a"
+				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_007c: stloc.3
 
-				IL_0089: ldloc.3
-				IL_008a: isinst [System.Runtime]System.String
-				IL_008f: dup
-				IL_0090: brfalse IL_00aa
+				IL_007d: ldarg.0
+				IL_007e: ldloc.3
+				IL_007f: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0084: ldarg.0
+				IL_0085: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_008f: stloc.3
+				IL_0090: ldc.i4.0
+				IL_0091: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0096: brfalse IL_00cf
 
-				IL_0095: ldstr "b"
-				IL_009a: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-				IL_009f: box [System.Runtime]System.Double
-				IL_00a4: stloc.3
-				IL_00a5: br IL_00bc
+				IL_009b: ldloc.3
+				IL_009c: isinst [System.Runtime]System.String
+				IL_00a1: dup
+				IL_00a2: brtrue IL_00b9
 
-				IL_00aa: pop
+				IL_00a7: pop
+				IL_00a8: ldloc.3
+				IL_00a9: ldstr "indexOf"
+				IL_00ae: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_00b3: dup
+				IL_00b4: brfalse IL_00ce
 
-				IL_00ab: ldloc.3
-				IL_00ac: ldstr "indexOf"
-				IL_00b1: ldstr "b"
-				IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00bb: stloc.3
+				IL_00b9: ldstr "b"
+				IL_00be: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+				IL_00c3: box [System.Runtime]System.Double
+				IL_00c8: stloc.3
+				IL_00c9: br IL_00e0
 
-				IL_00bc: ldarg.0
-				IL_00bd: ldloc.3
-				IL_00be: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_00c3: ldarg.0
-				IL_00c4: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00ce: stloc.3
-				IL_00cf: ldc.i4.0
-				IL_00d0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_00d5: brfalse IL_00fc
+				IL_00ce: pop
 
-				IL_00da: ldloc.3
-				IL_00db: isinst [System.Runtime]System.String
-				IL_00e0: dup
-				IL_00e1: brfalse IL_00fb
+				IL_00cf: ldloc.3
+				IL_00d0: ldstr "indexOf"
+				IL_00d5: ldstr "b"
+				IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00df: stloc.3
 
-				IL_00e6: ldstr "c"
-				IL_00eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-				IL_00f0: box [System.Runtime]System.Double
-				IL_00f5: stloc.3
-				IL_00f6: br IL_010d
+				IL_00e0: ldarg.0
+				IL_00e1: ldloc.3
+				IL_00e2: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_00e7: ldarg.0
+				IL_00e8: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00f2: stloc.3
+				IL_00f3: ldc.i4.0
+				IL_00f4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_00f9: brfalse IL_0132
 
-				IL_00fb: pop
+				IL_00fe: ldloc.3
+				IL_00ff: isinst [System.Runtime]System.String
+				IL_0104: dup
+				IL_0105: brtrue IL_011c
 
-				IL_00fc: ldloc.3
-				IL_00fd: ldstr "indexOf"
-				IL_0102: ldstr "c"
-				IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_010c: stloc.3
+				IL_010a: pop
+				IL_010b: ldloc.3
+				IL_010c: ldstr "indexOf"
+				IL_0111: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0116: dup
+				IL_0117: brfalse IL_0131
 
-				IL_010d: ldarg.0
-				IL_010e: ldloc.3
-				IL_010f: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_0114: ldarg.0
-				IL_0115: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_011f: stloc.3
-				IL_0120: ldc.i4.0
-				IL_0121: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0126: brfalse IL_014d
+				IL_011c: ldstr "c"
+				IL_0121: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+				IL_0126: box [System.Runtime]System.Double
+				IL_012b: stloc.3
+				IL_012c: br IL_0143
 
-				IL_012b: ldloc.3
-				IL_012c: isinst [System.Runtime]System.String
-				IL_0131: dup
-				IL_0132: brfalse IL_014c
+				IL_0131: pop
 
-				IL_0137: ldstr "d"
-				IL_013c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-				IL_0141: box [System.Runtime]System.Double
-				IL_0146: stloc.3
-				IL_0147: br IL_015e
+				IL_0132: ldloc.3
+				IL_0133: ldstr "indexOf"
+				IL_0138: ldstr "c"
+				IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0142: stloc.3
 
-				IL_014c: pop
+				IL_0143: ldarg.0
+				IL_0144: ldloc.3
+				IL_0145: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_014a: ldarg.0
+				IL_014b: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0155: stloc.3
+				IL_0156: ldc.i4.0
+				IL_0157: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_015c: brfalse IL_0195
 
-				IL_014d: ldloc.3
-				IL_014e: ldstr "indexOf"
-				IL_0153: ldstr "d"
-				IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_015d: stloc.3
+				IL_0161: ldloc.3
+				IL_0162: isinst [System.Runtime]System.String
+				IL_0167: dup
+				IL_0168: brtrue IL_017f
 
-				IL_015e: ldarg.0
-				IL_015f: ldloc.3
-				IL_0160: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_0165: ldloc.0
-				IL_0166: ldc.r8 1
-				IL_016f: add
-				IL_0170: stloc.0
-				IL_0171: br IL_000a
+				IL_016d: pop
+				IL_016e: ldloc.3
+				IL_016f: ldstr "indexOf"
+				IL_0174: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0179: dup
+				IL_017a: brfalse IL_0194
+
+				IL_017f: ldstr "d"
+				IL_0184: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+				IL_0189: box [System.Runtime]System.Double
+				IL_018e: stloc.3
+				IL_018f: br IL_01a6
+
+				IL_0194: pop
+
+				IL_0195: ldloc.3
+				IL_0196: ldstr "indexOf"
+				IL_019b: ldstr "d"
+				IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01a5: stloc.3
+
+				IL_01a6: ldarg.0
+				IL_01a7: ldloc.3
+				IL_01a8: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_01ad: ldloc.0
+				IL_01ae: ldc.r8 1
+				IL_01b7: add
+				IL_01b8: stloc.0
+				IL_01b9: br IL_000a
 			// end loop
 
-			IL_0176: ldnull
-			IL_0177: ret
+			IL_01be: ldnull
+			IL_01bf: ret
 		} // end of method FunctionExpression_L113C16::__js_call__
 
 	} // end of class FunctionExpression_L113C16
@@ -3703,7 +3805,7 @@
 				74 61 54 6f 6b 65 6e 1c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 376 (0x178)
+			// Code size: 448 (0x1c0)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -3724,7 +3826,7 @@
 				IL_0018: ldloc.1
 				IL_0019: ldloc.2
 				IL_001a: clt
-				IL_001c: brfalse IL_0176
+				IL_001c: brfalse IL_01be
 
 				IL_0021: ldarg.0
 				IL_0022: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
@@ -3732,129 +3834,157 @@
 				IL_002c: stloc.3
 				IL_002d: ldc.i4.0
 				IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0033: brfalse IL_005a
+				IL_0033: brfalse IL_006c
 
 				IL_0038: ldloc.3
 				IL_0039: isinst [System.Runtime]System.String
 				IL_003e: dup
-				IL_003f: brfalse IL_0059
+				IL_003f: brtrue IL_0056
 
-				IL_0044: ldstr "a"
-				IL_0049: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
-				IL_004e: box [System.Runtime]System.Double
-				IL_0053: stloc.3
-				IL_0054: br IL_006b
+				IL_0044: pop
+				IL_0045: ldloc.3
+				IL_0046: ldstr "lastIndexOf"
+				IL_004b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0050: dup
+				IL_0051: brfalse IL_006b
 
-				IL_0059: pop
+				IL_0056: ldstr "a"
+				IL_005b: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+				IL_0060: box [System.Runtime]System.Double
+				IL_0065: stloc.3
+				IL_0066: br IL_007d
 
-				IL_005a: ldloc.3
-				IL_005b: ldstr "lastIndexOf"
-				IL_0060: ldstr "a"
-				IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_006a: stloc.3
+				IL_006b: pop
 
-				IL_006b: ldarg.0
 				IL_006c: ldloc.3
-				IL_006d: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_0072: ldarg.0
-				IL_0073: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_007d: stloc.3
-				IL_007e: ldc.i4.0
-				IL_007f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0084: brfalse IL_00ab
+				IL_006d: ldstr "lastIndexOf"
+				IL_0072: ldstr "a"
+				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_007c: stloc.3
 
-				IL_0089: ldloc.3
-				IL_008a: isinst [System.Runtime]System.String
-				IL_008f: dup
-				IL_0090: brfalse IL_00aa
+				IL_007d: ldarg.0
+				IL_007e: ldloc.3
+				IL_007f: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0084: ldarg.0
+				IL_0085: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_008f: stloc.3
+				IL_0090: ldc.i4.0
+				IL_0091: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0096: brfalse IL_00cf
 
-				IL_0095: ldstr "b"
-				IL_009a: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
-				IL_009f: box [System.Runtime]System.Double
-				IL_00a4: stloc.3
-				IL_00a5: br IL_00bc
+				IL_009b: ldloc.3
+				IL_009c: isinst [System.Runtime]System.String
+				IL_00a1: dup
+				IL_00a2: brtrue IL_00b9
 
-				IL_00aa: pop
+				IL_00a7: pop
+				IL_00a8: ldloc.3
+				IL_00a9: ldstr "lastIndexOf"
+				IL_00ae: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_00b3: dup
+				IL_00b4: brfalse IL_00ce
 
-				IL_00ab: ldloc.3
-				IL_00ac: ldstr "lastIndexOf"
-				IL_00b1: ldstr "b"
-				IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00bb: stloc.3
+				IL_00b9: ldstr "b"
+				IL_00be: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+				IL_00c3: box [System.Runtime]System.Double
+				IL_00c8: stloc.3
+				IL_00c9: br IL_00e0
 
-				IL_00bc: ldarg.0
-				IL_00bd: ldloc.3
-				IL_00be: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_00c3: ldarg.0
-				IL_00c4: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00ce: stloc.3
-				IL_00cf: ldc.i4.0
-				IL_00d0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_00d5: brfalse IL_00fc
+				IL_00ce: pop
 
-				IL_00da: ldloc.3
-				IL_00db: isinst [System.Runtime]System.String
-				IL_00e0: dup
-				IL_00e1: brfalse IL_00fb
+				IL_00cf: ldloc.3
+				IL_00d0: ldstr "lastIndexOf"
+				IL_00d5: ldstr "b"
+				IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00df: stloc.3
 
-				IL_00e6: ldstr "c"
-				IL_00eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
-				IL_00f0: box [System.Runtime]System.Double
-				IL_00f5: stloc.3
-				IL_00f6: br IL_010d
+				IL_00e0: ldarg.0
+				IL_00e1: ldloc.3
+				IL_00e2: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_00e7: ldarg.0
+				IL_00e8: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_00ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00f2: stloc.3
+				IL_00f3: ldc.i4.0
+				IL_00f4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_00f9: brfalse IL_0132
 
-				IL_00fb: pop
+				IL_00fe: ldloc.3
+				IL_00ff: isinst [System.Runtime]System.String
+				IL_0104: dup
+				IL_0105: brtrue IL_011c
 
-				IL_00fc: ldloc.3
-				IL_00fd: ldstr "lastIndexOf"
-				IL_0102: ldstr "c"
-				IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_010c: stloc.3
+				IL_010a: pop
+				IL_010b: ldloc.3
+				IL_010c: ldstr "lastIndexOf"
+				IL_0111: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0116: dup
+				IL_0117: brfalse IL_0131
 
-				IL_010d: ldarg.0
-				IL_010e: ldloc.3
-				IL_010f: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_0114: ldarg.0
-				IL_0115: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_011f: stloc.3
-				IL_0120: ldc.i4.0
-				IL_0121: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0126: brfalse IL_014d
+				IL_011c: ldstr "c"
+				IL_0121: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+				IL_0126: box [System.Runtime]System.Double
+				IL_012b: stloc.3
+				IL_012c: br IL_0143
 
-				IL_012b: ldloc.3
-				IL_012c: isinst [System.Runtime]System.String
-				IL_0131: dup
-				IL_0132: brfalse IL_014c
+				IL_0131: pop
 
-				IL_0137: ldstr "d"
-				IL_013c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
-				IL_0141: box [System.Runtime]System.Double
-				IL_0146: stloc.3
-				IL_0147: br IL_015e
+				IL_0132: ldloc.3
+				IL_0133: ldstr "lastIndexOf"
+				IL_0138: ldstr "c"
+				IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0142: stloc.3
 
-				IL_014c: pop
+				IL_0143: ldarg.0
+				IL_0144: ldloc.3
+				IL_0145: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_014a: ldarg.0
+				IL_014b: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0155: stloc.3
+				IL_0156: ldc.i4.0
+				IL_0157: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_015c: brfalse IL_0195
 
-				IL_014d: ldloc.3
-				IL_014e: ldstr "lastIndexOf"
-				IL_0153: ldstr "d"
-				IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_015d: stloc.3
+				IL_0161: ldloc.3
+				IL_0162: isinst [System.Runtime]System.String
+				IL_0167: dup
+				IL_0168: brtrue IL_017f
 
-				IL_015e: ldarg.0
-				IL_015f: ldloc.3
-				IL_0160: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_0165: ldloc.0
-				IL_0166: ldc.r8 1
-				IL_016f: add
-				IL_0170: stloc.0
-				IL_0171: br IL_000a
+				IL_016d: pop
+				IL_016e: ldloc.3
+				IL_016f: ldstr "lastIndexOf"
+				IL_0174: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0179: dup
+				IL_017a: brfalse IL_0194
+
+				IL_017f: ldstr "d"
+				IL_0184: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+				IL_0189: box [System.Runtime]System.Double
+				IL_018e: stloc.3
+				IL_018f: br IL_01a6
+
+				IL_0194: pop
+
+				IL_0195: ldloc.3
+				IL_0196: ldstr "lastIndexOf"
+				IL_019b: ldstr "d"
+				IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01a5: stloc.3
+
+				IL_01a6: ldarg.0
+				IL_01a7: ldloc.3
+				IL_01a8: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_01ad: ldloc.0
+				IL_01ae: ldc.r8 1
+				IL_01b7: add
+				IL_01b8: stloc.0
+				IL_01b9: br IL_000a
 			// end loop
 
-			IL_0176: ldnull
-			IL_0177: ret
+			IL_01be: ldnull
+			IL_01bf: ret
 		} // end of method FunctionExpression_L122C20::__js_call__
 
 	} // end of class FunctionExpression_L122C20
@@ -4018,7 +4148,7 @@
 				74 61 54 6f 6b 65 6e 1c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 708 (0x2c4)
+			// Code size: 816 (0x330)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -4041,7 +4171,7 @@
 				IL_0018: ldloc.1
 				IL_0019: ldloc.2
 				IL_001a: clt
-				IL_001c: brfalse IL_02c2
+				IL_001c: brfalse IL_032e
 
 				IL_0021: ldarg.0
 				IL_0022: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
@@ -4049,227 +4179,269 @@
 				IL_002c: stloc.3
 				IL_002d: ldc.i4.0
 				IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0033: brfalse IL_005e
+				IL_0033: brfalse IL_0070
 
 				IL_0038: ldloc.3
 				IL_0039: isinst [System.Runtime]System.String
 				IL_003e: dup
-				IL_003f: brfalse IL_005d
+				IL_003f: brtrue IL_0056
 
-				IL_0044: ldc.r8 0.0
-				IL_004d: box [System.Runtime]System.Double
-				IL_0052: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
-				IL_0057: stloc.3
-				IL_0058: br IL_0078
+				IL_0044: pop
+				IL_0045: ldloc.3
+				IL_0046: ldstr "slice"
+				IL_004b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0050: dup
+				IL_0051: brfalse IL_006f
 
-				IL_005d: pop
+				IL_0056: ldc.r8 0.0
+				IL_005f: box [System.Runtime]System.Double
+				IL_0064: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
+				IL_0069: stloc.3
+				IL_006a: br IL_008a
 
-				IL_005e: ldloc.3
-				IL_005f: ldstr "slice"
-				IL_0064: ldc.r8 0.0
-				IL_006d: box [System.Runtime]System.Double
-				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0077: stloc.3
+				IL_006f: pop
 
-				IL_0078: ldarg.0
-				IL_0079: ldloc.3
-				IL_007a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_007f: ldarg.0
-				IL_0080: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_008a: stloc.3
-				IL_008b: ldc.i4.0
-				IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0091: brfalse IL_00ca
+				IL_0070: ldloc.3
+				IL_0071: ldstr "slice"
+				IL_0076: ldc.r8 0.0
+				IL_007f: box [System.Runtime]System.Double
+				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0089: stloc.3
 
-				IL_0096: ldloc.3
-				IL_0097: isinst [System.Runtime]System.String
-				IL_009c: dup
-				IL_009d: brfalse IL_00c9
+				IL_008a: ldarg.0
+				IL_008b: ldloc.3
+				IL_008c: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0091: ldarg.0
+				IL_0092: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_009c: stloc.3
+				IL_009d: ldc.i4.0
+				IL_009e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_00a3: brfalse IL_00ee
 
-				IL_00a2: ldc.r8 0.0
-				IL_00ab: box [System.Runtime]System.Double
-				IL_00b0: ldc.r8 5
-				IL_00b9: box [System.Runtime]System.Double
-				IL_00be: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
-				IL_00c3: stloc.3
-				IL_00c4: br IL_00f2
+				IL_00a8: ldloc.3
+				IL_00a9: isinst [System.Runtime]System.String
+				IL_00ae: dup
+				IL_00af: brtrue IL_00c6
 
-				IL_00c9: pop
+				IL_00b4: pop
+				IL_00b5: ldloc.3
+				IL_00b6: ldstr "slice"
+				IL_00bb: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_00c0: dup
+				IL_00c1: brfalse IL_00ed
 
-				IL_00ca: ldloc.3
-				IL_00cb: ldstr "slice"
-				IL_00d0: ldc.r8 0.0
-				IL_00d9: box [System.Runtime]System.Double
-				IL_00de: ldc.r8 5
-				IL_00e7: box [System.Runtime]System.Double
-				IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_00f1: stloc.3
+				IL_00c6: ldc.r8 0.0
+				IL_00cf: box [System.Runtime]System.Double
+				IL_00d4: ldc.r8 5
+				IL_00dd: box [System.Runtime]System.Double
+				IL_00e2: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+				IL_00e7: stloc.3
+				IL_00e8: br IL_0116
 
-				IL_00f2: ldarg.0
-				IL_00f3: ldloc.3
-				IL_00f4: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_00f9: ldarg.0
-				IL_00fa: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0104: stloc.3
-				IL_0105: ldc.r8 1
-				IL_010e: neg
-				IL_010f: stloc.2
-				IL_0110: ldloc.2
-				IL_0111: box [System.Runtime]System.Double
-				IL_0116: stloc.s 4
-				IL_0118: ldc.i4.0
-				IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_011e: brfalse IL_013d
+				IL_00ed: pop
 
-				IL_0123: ldloc.3
-				IL_0124: isinst [System.Runtime]System.String
-				IL_0129: dup
-				IL_012a: brfalse IL_013c
+				IL_00ee: ldloc.3
+				IL_00ef: ldstr "slice"
+				IL_00f4: ldc.r8 0.0
+				IL_00fd: box [System.Runtime]System.Double
+				IL_0102: ldc.r8 5
+				IL_010b: box [System.Runtime]System.Double
+				IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0115: stloc.3
 
-				IL_012f: ldloc.s 4
-				IL_0131: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
-				IL_0136: stloc.3
-				IL_0137: br IL_014b
+				IL_0116: ldarg.0
+				IL_0117: ldloc.3
+				IL_0118: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_011d: ldarg.0
+				IL_011e: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0128: stloc.3
+				IL_0129: ldc.r8 1
+				IL_0132: neg
+				IL_0133: stloc.2
+				IL_0134: ldloc.2
+				IL_0135: box [System.Runtime]System.Double
+				IL_013a: stloc.s 4
+				IL_013c: ldc.i4.0
+				IL_013d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0142: brfalse IL_0173
 
-				IL_013c: pop
+				IL_0147: ldloc.3
+				IL_0148: isinst [System.Runtime]System.String
+				IL_014d: dup
+				IL_014e: brtrue IL_0165
 
-				IL_013d: ldloc.3
-				IL_013e: ldstr "slice"
-				IL_0143: ldloc.s 4
-				IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_014a: stloc.3
+				IL_0153: pop
+				IL_0154: ldloc.3
+				IL_0155: ldstr "slice"
+				IL_015a: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_015f: dup
+				IL_0160: brfalse IL_0172
 
-				IL_014b: ldarg.0
-				IL_014c: ldloc.3
-				IL_014d: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_0152: ldarg.0
-				IL_0153: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_015d: stloc.3
-				IL_015e: ldc.r8 6
-				IL_0167: neg
-				IL_0168: stloc.2
-				IL_0169: ldloc.2
-				IL_016a: box [System.Runtime]System.Double
-				IL_016f: stloc.s 4
-				IL_0171: ldc.r8 1
-				IL_017a: neg
-				IL_017b: stloc.2
-				IL_017c: ldloc.2
-				IL_017d: box [System.Runtime]System.Double
-				IL_0182: stloc.s 5
-				IL_0184: ldc.i4.0
-				IL_0185: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_018a: brfalse IL_01ab
+				IL_0165: ldloc.s 4
+				IL_0167: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
+				IL_016c: stloc.3
+				IL_016d: br IL_0181
 
-				IL_018f: ldloc.3
-				IL_0190: isinst [System.Runtime]System.String
-				IL_0195: dup
-				IL_0196: brfalse IL_01aa
+				IL_0172: pop
 
-				IL_019b: ldloc.s 4
-				IL_019d: ldloc.s 5
-				IL_019f: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
-				IL_01a4: stloc.3
-				IL_01a5: br IL_01bb
+				IL_0173: ldloc.3
+				IL_0174: ldstr "slice"
+				IL_0179: ldloc.s 4
+				IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0180: stloc.3
 
-				IL_01aa: pop
+				IL_0181: ldarg.0
+				IL_0182: ldloc.3
+				IL_0183: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0188: ldarg.0
+				IL_0189: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0193: stloc.3
+				IL_0194: ldc.r8 6
+				IL_019d: neg
+				IL_019e: stloc.2
+				IL_019f: ldloc.2
+				IL_01a0: box [System.Runtime]System.Double
+				IL_01a5: stloc.s 4
+				IL_01a7: ldc.r8 1
+				IL_01b0: neg
+				IL_01b1: stloc.2
+				IL_01b2: ldloc.2
+				IL_01b3: box [System.Runtime]System.Double
+				IL_01b8: stloc.s 5
+				IL_01ba: ldc.i4.0
+				IL_01bb: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_01c0: brfalse IL_01f3
 
-				IL_01ab: ldloc.3
-				IL_01ac: ldstr "slice"
-				IL_01b1: ldloc.s 4
-				IL_01b3: ldloc.s 5
-				IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_01ba: stloc.3
+				IL_01c5: ldloc.3
+				IL_01c6: isinst [System.Runtime]System.String
+				IL_01cb: dup
+				IL_01cc: brtrue IL_01e3
 
-				IL_01bb: ldarg.0
-				IL_01bc: ldloc.3
-				IL_01bd: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_01c2: ldarg.0
-				IL_01c3: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01cd: stloc.3
-				IL_01ce: ldc.i4.0
-				IL_01cf: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_01d4: brfalse IL_020d
+				IL_01d1: pop
+				IL_01d2: ldloc.3
+				IL_01d3: ldstr "slice"
+				IL_01d8: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_01dd: dup
+				IL_01de: brfalse IL_01f2
 
-				IL_01d9: ldloc.3
-				IL_01da: isinst [System.Runtime]System.String
-				IL_01df: dup
-				IL_01e0: brfalse IL_020c
+				IL_01e3: ldloc.s 4
+				IL_01e5: ldloc.s 5
+				IL_01e7: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+				IL_01ec: stloc.3
+				IL_01ed: br IL_0203
 
-				IL_01e5: ldc.r8 15000
-				IL_01ee: box [System.Runtime]System.Double
-				IL_01f3: ldc.r8 15005
-				IL_01fc: box [System.Runtime]System.Double
-				IL_0201: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
-				IL_0206: stloc.3
-				IL_0207: br IL_0235
+				IL_01f2: pop
 
-				IL_020c: pop
+				IL_01f3: ldloc.3
+				IL_01f4: ldstr "slice"
+				IL_01f9: ldloc.s 4
+				IL_01fb: ldloc.s 5
+				IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0202: stloc.3
 
-				IL_020d: ldloc.3
-				IL_020e: ldstr "slice"
-				IL_0213: ldc.r8 15000
-				IL_021c: box [System.Runtime]System.Double
-				IL_0221: ldc.r8 15005
-				IL_022a: box [System.Runtime]System.Double
-				IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0234: stloc.3
+				IL_0203: ldarg.0
+				IL_0204: ldloc.3
+				IL_0205: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_020a: ldarg.0
+				IL_020b: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0215: stloc.3
+				IL_0216: ldc.i4.0
+				IL_0217: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_021c: brfalse IL_0267
 
-				IL_0235: ldarg.0
-				IL_0236: ldloc.3
-				IL_0237: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_023c: ldarg.0
-				IL_023d: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0247: stloc.3
-				IL_0248: ldc.r8 1
-				IL_0251: neg
-				IL_0252: stloc.2
-				IL_0253: ldloc.2
-				IL_0254: box [System.Runtime]System.Double
-				IL_0259: stloc.s 5
-				IL_025b: ldc.i4.0
-				IL_025c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0261: brfalse IL_028e
+				IL_0221: ldloc.3
+				IL_0222: isinst [System.Runtime]System.String
+				IL_0227: dup
+				IL_0228: brtrue IL_023f
 
-				IL_0266: ldloc.3
-				IL_0267: isinst [System.Runtime]System.String
-				IL_026c: dup
-				IL_026d: brfalse IL_028d
+				IL_022d: pop
+				IL_022e: ldloc.3
+				IL_022f: ldstr "slice"
+				IL_0234: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0239: dup
+				IL_023a: brfalse IL_0266
 
-				IL_0272: ldc.r8 12000
-				IL_027b: box [System.Runtime]System.Double
-				IL_0280: ldloc.s 5
-				IL_0282: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
-				IL_0287: stloc.3
-				IL_0288: br IL_02aa
+				IL_023f: ldc.r8 15000
+				IL_0248: box [System.Runtime]System.Double
+				IL_024d: ldc.r8 15005
+				IL_0256: box [System.Runtime]System.Double
+				IL_025b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+				IL_0260: stloc.3
+				IL_0261: br IL_028f
 
-				IL_028d: pop
+				IL_0266: pop
 
-				IL_028e: ldloc.3
-				IL_028f: ldstr "slice"
-				IL_0294: ldc.r8 12000
-				IL_029d: box [System.Runtime]System.Double
-				IL_02a2: ldloc.s 5
-				IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_02a9: stloc.3
+				IL_0267: ldloc.3
+				IL_0268: ldstr "slice"
+				IL_026d: ldc.r8 15000
+				IL_0276: box [System.Runtime]System.Double
+				IL_027b: ldc.r8 15005
+				IL_0284: box [System.Runtime]System.Double
+				IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_028e: stloc.3
 
-				IL_02aa: ldarg.0
-				IL_02ab: ldloc.3
-				IL_02ac: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_02b1: ldloc.0
-				IL_02b2: ldc.r8 1
-				IL_02bb: add
-				IL_02bc: stloc.0
-				IL_02bd: br IL_000a
+				IL_028f: ldarg.0
+				IL_0290: ldloc.3
+				IL_0291: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0296: ldarg.0
+				IL_0297: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02a1: stloc.3
+				IL_02a2: ldc.r8 1
+				IL_02ab: neg
+				IL_02ac: stloc.2
+				IL_02ad: ldloc.2
+				IL_02ae: box [System.Runtime]System.Double
+				IL_02b3: stloc.s 5
+				IL_02b5: ldc.i4.0
+				IL_02b6: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_02bb: brfalse IL_02fa
+
+				IL_02c0: ldloc.3
+				IL_02c1: isinst [System.Runtime]System.String
+				IL_02c6: dup
+				IL_02c7: brtrue IL_02de
+
+				IL_02cc: pop
+				IL_02cd: ldloc.3
+				IL_02ce: ldstr "slice"
+				IL_02d3: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_02d8: dup
+				IL_02d9: brfalse IL_02f9
+
+				IL_02de: ldc.r8 12000
+				IL_02e7: box [System.Runtime]System.Double
+				IL_02ec: ldloc.s 5
+				IL_02ee: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+				IL_02f3: stloc.3
+				IL_02f4: br IL_0316
+
+				IL_02f9: pop
+
+				IL_02fa: ldloc.3
+				IL_02fb: ldstr "slice"
+				IL_0300: ldc.r8 12000
+				IL_0309: box [System.Runtime]System.Double
+				IL_030e: ldloc.s 5
+				IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0315: stloc.3
+
+				IL_0316: ldarg.0
+				IL_0317: ldloc.3
+				IL_0318: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_031d: ldloc.0
+				IL_031e: ldc.r8 1
+				IL_0327: add
+				IL_0328: stloc.0
+				IL_0329: br IL_000a
 			// end loop
 
-			IL_02c2: ldnull
-			IL_02c3: ret
+			IL_032e: ldnull
+			IL_032f: ret
 		} // end of method FunctionExpression_L133C14::__js_call__
 
 	} // end of class FunctionExpression_L133C14
@@ -4433,7 +4605,7 @@
 				74 61 54 6f 6b 65 6e 1c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 718 (0x2ce)
+			// Code size: 826 (0x33a)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -4455,7 +4627,7 @@
 				IL_0018: ldloc.1
 				IL_0019: ldloc.2
 				IL_001a: clt
-				IL_001c: brfalse IL_02cc
+				IL_001c: brfalse IL_0338
 
 				IL_0021: ldarg.0
 				IL_0022: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
@@ -4463,219 +4635,261 @@
 				IL_002c: stloc.3
 				IL_002d: ldc.i4.0
 				IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0033: brfalse IL_005e
+				IL_0033: brfalse IL_0070
 
 				IL_0038: ldloc.3
 				IL_0039: isinst [System.Runtime]System.String
 				IL_003e: dup
-				IL_003f: brfalse IL_005d
+				IL_003f: brtrue IL_0056
 
-				IL_0044: ldc.r8 0.0
-				IL_004d: box [System.Runtime]System.Double
-				IL_0052: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object)
-				IL_0057: stloc.3
-				IL_0058: br IL_0078
+				IL_0044: pop
+				IL_0045: ldloc.3
+				IL_0046: ldstr "substr"
+				IL_004b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0050: dup
+				IL_0051: brfalse IL_006f
 
-				IL_005d: pop
+				IL_0056: ldc.r8 0.0
+				IL_005f: box [System.Runtime]System.Double
+				IL_0064: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object)
+				IL_0069: stloc.3
+				IL_006a: br IL_008a
 
-				IL_005e: ldloc.3
-				IL_005f: ldstr "substr"
-				IL_0064: ldc.r8 0.0
-				IL_006d: box [System.Runtime]System.Double
-				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0077: stloc.3
+				IL_006f: pop
 
-				IL_0078: ldarg.0
-				IL_0079: ldloc.3
-				IL_007a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_007f: ldarg.0
-				IL_0080: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_008a: stloc.3
-				IL_008b: ldc.i4.0
-				IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0091: brfalse IL_00ca
+				IL_0070: ldloc.3
+				IL_0071: ldstr "substr"
+				IL_0076: ldc.r8 0.0
+				IL_007f: box [System.Runtime]System.Double
+				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0089: stloc.3
 
-				IL_0096: ldloc.3
-				IL_0097: isinst [System.Runtime]System.String
-				IL_009c: dup
-				IL_009d: brfalse IL_00c9
+				IL_008a: ldarg.0
+				IL_008b: ldloc.3
+				IL_008c: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0091: ldarg.0
+				IL_0092: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_009c: stloc.3
+				IL_009d: ldc.i4.0
+				IL_009e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_00a3: brfalse IL_00ee
 
-				IL_00a2: ldc.r8 0.0
-				IL_00ab: box [System.Runtime]System.Double
-				IL_00b0: ldc.r8 5
-				IL_00b9: box [System.Runtime]System.Double
-				IL_00be: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object, object)
-				IL_00c3: stloc.3
-				IL_00c4: br IL_00f2
+				IL_00a8: ldloc.3
+				IL_00a9: isinst [System.Runtime]System.String
+				IL_00ae: dup
+				IL_00af: brtrue IL_00c6
 
-				IL_00c9: pop
+				IL_00b4: pop
+				IL_00b5: ldloc.3
+				IL_00b6: ldstr "substr"
+				IL_00bb: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_00c0: dup
+				IL_00c1: brfalse IL_00ed
 
-				IL_00ca: ldloc.3
-				IL_00cb: ldstr "substr"
-				IL_00d0: ldc.r8 0.0
-				IL_00d9: box [System.Runtime]System.Double
-				IL_00de: ldc.r8 5
-				IL_00e7: box [System.Runtime]System.Double
-				IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_00f1: stloc.3
+				IL_00c6: ldc.r8 0.0
+				IL_00cf: box [System.Runtime]System.Double
+				IL_00d4: ldc.r8 5
+				IL_00dd: box [System.Runtime]System.Double
+				IL_00e2: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object, object)
+				IL_00e7: stloc.3
+				IL_00e8: br IL_0116
 
-				IL_00f2: ldarg.0
-				IL_00f3: ldloc.3
-				IL_00f4: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_00f9: ldarg.0
-				IL_00fa: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0104: stloc.3
-				IL_0105: ldc.r8 1
-				IL_010e: neg
-				IL_010f: stloc.2
-				IL_0110: ldloc.2
-				IL_0111: box [System.Runtime]System.Double
-				IL_0116: stloc.s 4
-				IL_0118: ldc.i4.0
-				IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_011e: brfalse IL_013d
+				IL_00ed: pop
 
-				IL_0123: ldloc.3
-				IL_0124: isinst [System.Runtime]System.String
-				IL_0129: dup
-				IL_012a: brfalse IL_013c
+				IL_00ee: ldloc.3
+				IL_00ef: ldstr "substr"
+				IL_00f4: ldc.r8 0.0
+				IL_00fd: box [System.Runtime]System.Double
+				IL_0102: ldc.r8 5
+				IL_010b: box [System.Runtime]System.Double
+				IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0115: stloc.3
 
-				IL_012f: ldloc.s 4
-				IL_0131: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object)
-				IL_0136: stloc.3
-				IL_0137: br IL_014b
+				IL_0116: ldarg.0
+				IL_0117: ldloc.3
+				IL_0118: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_011d: ldarg.0
+				IL_011e: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0128: stloc.3
+				IL_0129: ldc.r8 1
+				IL_0132: neg
+				IL_0133: stloc.2
+				IL_0134: ldloc.2
+				IL_0135: box [System.Runtime]System.Double
+				IL_013a: stloc.s 4
+				IL_013c: ldc.i4.0
+				IL_013d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0142: brfalse IL_0173
 
-				IL_013c: pop
+				IL_0147: ldloc.3
+				IL_0148: isinst [System.Runtime]System.String
+				IL_014d: dup
+				IL_014e: brtrue IL_0165
 
-				IL_013d: ldloc.3
-				IL_013e: ldstr "substr"
-				IL_0143: ldloc.s 4
-				IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_014a: stloc.3
+				IL_0153: pop
+				IL_0154: ldloc.3
+				IL_0155: ldstr "substr"
+				IL_015a: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_015f: dup
+				IL_0160: brfalse IL_0172
 
-				IL_014b: ldarg.0
-				IL_014c: ldloc.3
-				IL_014d: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_0152: ldarg.0
-				IL_0153: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_015d: stloc.3
-				IL_015e: ldc.r8 6
-				IL_0167: neg
-				IL_0168: stloc.2
-				IL_0169: ldloc.2
-				IL_016a: box [System.Runtime]System.Double
-				IL_016f: stloc.s 4
-				IL_0171: ldc.i4.0
-				IL_0172: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0177: brfalse IL_01a4
+				IL_0165: ldloc.s 4
+				IL_0167: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object)
+				IL_016c: stloc.3
+				IL_016d: br IL_0181
 
-				IL_017c: ldloc.3
-				IL_017d: isinst [System.Runtime]System.String
-				IL_0182: dup
-				IL_0183: brfalse IL_01a3
+				IL_0172: pop
 
-				IL_0188: ldloc.s 4
-				IL_018a: ldc.r8 1
-				IL_0193: box [System.Runtime]System.Double
-				IL_0198: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object, object)
-				IL_019d: stloc.3
-				IL_019e: br IL_01c0
+				IL_0173: ldloc.3
+				IL_0174: ldstr "substr"
+				IL_0179: ldloc.s 4
+				IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0180: stloc.3
 
-				IL_01a3: pop
+				IL_0181: ldarg.0
+				IL_0182: ldloc.3
+				IL_0183: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0188: ldarg.0
+				IL_0189: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0193: stloc.3
+				IL_0194: ldc.r8 6
+				IL_019d: neg
+				IL_019e: stloc.2
+				IL_019f: ldloc.2
+				IL_01a0: box [System.Runtime]System.Double
+				IL_01a5: stloc.s 4
+				IL_01a7: ldc.i4.0
+				IL_01a8: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_01ad: brfalse IL_01ec
 
-				IL_01a4: ldloc.3
-				IL_01a5: ldstr "substr"
-				IL_01aa: ldloc.s 4
-				IL_01ac: ldc.r8 1
-				IL_01b5: box [System.Runtime]System.Double
-				IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_01bf: stloc.3
+				IL_01b2: ldloc.3
+				IL_01b3: isinst [System.Runtime]System.String
+				IL_01b8: dup
+				IL_01b9: brtrue IL_01d0
 
-				IL_01c0: ldarg.0
-				IL_01c1: ldloc.3
-				IL_01c2: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_01c7: ldarg.0
-				IL_01c8: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01d2: stloc.3
-				IL_01d3: ldc.i4.0
-				IL_01d4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_01d9: brfalse IL_0212
+				IL_01be: pop
+				IL_01bf: ldloc.3
+				IL_01c0: ldstr "substr"
+				IL_01c5: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_01ca: dup
+				IL_01cb: brfalse IL_01eb
 
-				IL_01de: ldloc.3
-				IL_01df: isinst [System.Runtime]System.String
-				IL_01e4: dup
-				IL_01e5: brfalse IL_0211
+				IL_01d0: ldloc.s 4
+				IL_01d2: ldc.r8 1
+				IL_01db: box [System.Runtime]System.Double
+				IL_01e0: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object, object)
+				IL_01e5: stloc.3
+				IL_01e6: br IL_0208
 
-				IL_01ea: ldc.r8 15000
-				IL_01f3: box [System.Runtime]System.Double
-				IL_01f8: ldc.r8 5
-				IL_0201: box [System.Runtime]System.Double
-				IL_0206: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object, object)
-				IL_020b: stloc.3
-				IL_020c: br IL_023a
+				IL_01eb: pop
 
-				IL_0211: pop
+				IL_01ec: ldloc.3
+				IL_01ed: ldstr "substr"
+				IL_01f2: ldloc.s 4
+				IL_01f4: ldc.r8 1
+				IL_01fd: box [System.Runtime]System.Double
+				IL_0202: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0207: stloc.3
 
-				IL_0212: ldloc.3
-				IL_0213: ldstr "substr"
-				IL_0218: ldc.r8 15000
-				IL_0221: box [System.Runtime]System.Double
-				IL_0226: ldc.r8 5
-				IL_022f: box [System.Runtime]System.Double
-				IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0239: stloc.3
+				IL_0208: ldarg.0
+				IL_0209: ldloc.3
+				IL_020a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_020f: ldarg.0
+				IL_0210: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_021a: stloc.3
+				IL_021b: ldc.i4.0
+				IL_021c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0221: brfalse IL_026c
 
-				IL_023a: ldarg.0
-				IL_023b: ldloc.3
-				IL_023c: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_0241: ldarg.0
-				IL_0242: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_024c: stloc.3
-				IL_024d: ldc.i4.0
-				IL_024e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0253: brfalse IL_028c
+				IL_0226: ldloc.3
+				IL_0227: isinst [System.Runtime]System.String
+				IL_022c: dup
+				IL_022d: brtrue IL_0244
 
-				IL_0258: ldloc.3
-				IL_0259: isinst [System.Runtime]System.String
-				IL_025e: dup
-				IL_025f: brfalse IL_028b
+				IL_0232: pop
+				IL_0233: ldloc.3
+				IL_0234: ldstr "substr"
+				IL_0239: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_023e: dup
+				IL_023f: brfalse IL_026b
 
-				IL_0264: ldc.r8 12000
-				IL_026d: box [System.Runtime]System.Double
-				IL_0272: ldc.r8 5
+				IL_0244: ldc.r8 15000
+				IL_024d: box [System.Runtime]System.Double
+				IL_0252: ldc.r8 5
+				IL_025b: box [System.Runtime]System.Double
+				IL_0260: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object, object)
+				IL_0265: stloc.3
+				IL_0266: br IL_0294
+
+				IL_026b: pop
+
+				IL_026c: ldloc.3
+				IL_026d: ldstr "substr"
+				IL_0272: ldc.r8 15000
 				IL_027b: box [System.Runtime]System.Double
-				IL_0280: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object, object)
-				IL_0285: stloc.3
-				IL_0286: br IL_02b4
+				IL_0280: ldc.r8 5
+				IL_0289: box [System.Runtime]System.Double
+				IL_028e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0293: stloc.3
 
-				IL_028b: pop
+				IL_0294: ldarg.0
+				IL_0295: ldloc.3
+				IL_0296: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_029b: ldarg.0
+				IL_029c: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02a6: stloc.3
+				IL_02a7: ldc.i4.0
+				IL_02a8: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_02ad: brfalse IL_02f8
 
-				IL_028c: ldloc.3
-				IL_028d: ldstr "substr"
-				IL_0292: ldc.r8 12000
-				IL_029b: box [System.Runtime]System.Double
-				IL_02a0: ldc.r8 5
-				IL_02a9: box [System.Runtime]System.Double
-				IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_02b3: stloc.3
+				IL_02b2: ldloc.3
+				IL_02b3: isinst [System.Runtime]System.String
+				IL_02b8: dup
+				IL_02b9: brtrue IL_02d0
 
-				IL_02b4: ldarg.0
-				IL_02b5: ldloc.3
-				IL_02b6: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_02bb: ldloc.0
-				IL_02bc: ldc.r8 1
-				IL_02c5: add
-				IL_02c6: stloc.0
-				IL_02c7: br IL_000a
+				IL_02be: pop
+				IL_02bf: ldloc.3
+				IL_02c0: ldstr "substr"
+				IL_02c5: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_02ca: dup
+				IL_02cb: brfalse IL_02f7
+
+				IL_02d0: ldc.r8 12000
+				IL_02d9: box [System.Runtime]System.Double
+				IL_02de: ldc.r8 5
+				IL_02e7: box [System.Runtime]System.Double
+				IL_02ec: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object, object)
+				IL_02f1: stloc.3
+				IL_02f2: br IL_0320
+
+				IL_02f7: pop
+
+				IL_02f8: ldloc.3
+				IL_02f9: ldstr "substr"
+				IL_02fe: ldc.r8 12000
+				IL_0307: box [System.Runtime]System.Double
+				IL_030c: ldc.r8 5
+				IL_0315: box [System.Runtime]System.Double
+				IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_031f: stloc.3
+
+				IL_0320: ldarg.0
+				IL_0321: ldloc.3
+				IL_0322: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0327: ldloc.0
+				IL_0328: ldc.r8 1
+				IL_0331: add
+				IL_0332: stloc.0
+				IL_0333: br IL_000a
 			// end loop
 
-			IL_02cc: ldnull
-			IL_02cd: ret
+			IL_0338: ldnull
+			IL_0339: ret
 		} // end of method FunctionExpression_L146C15::__js_call__
 
 	} // end of class FunctionExpression_L146C15
@@ -4839,7 +5053,7 @@
 				74 61 54 6f 6b 65 6e 1c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 708 (0x2c4)
+			// Code size: 816 (0x330)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -4862,7 +5076,7 @@
 				IL_0018: ldloc.1
 				IL_0019: ldloc.2
 				IL_001a: clt
-				IL_001c: brfalse IL_02c2
+				IL_001c: brfalse IL_032e
 
 				IL_0021: ldarg.0
 				IL_0022: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
@@ -4870,227 +5084,269 @@
 				IL_002c: stloc.3
 				IL_002d: ldc.i4.0
 				IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0033: brfalse IL_005e
+				IL_0033: brfalse IL_0070
 
 				IL_0038: ldloc.3
 				IL_0039: isinst [System.Runtime]System.String
 				IL_003e: dup
-				IL_003f: brfalse IL_005d
+				IL_003f: brtrue IL_0056
 
-				IL_0044: ldc.r8 0.0
-				IL_004d: box [System.Runtime]System.Double
-				IL_0052: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-				IL_0057: stloc.3
-				IL_0058: br IL_0078
+				IL_0044: pop
+				IL_0045: ldloc.3
+				IL_0046: ldstr "substring"
+				IL_004b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0050: dup
+				IL_0051: brfalse IL_006f
 
-				IL_005d: pop
+				IL_0056: ldc.r8 0.0
+				IL_005f: box [System.Runtime]System.Double
+				IL_0064: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+				IL_0069: stloc.3
+				IL_006a: br IL_008a
 
-				IL_005e: ldloc.3
-				IL_005f: ldstr "substring"
-				IL_0064: ldc.r8 0.0
-				IL_006d: box [System.Runtime]System.Double
-				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0077: stloc.3
+				IL_006f: pop
 
-				IL_0078: ldarg.0
-				IL_0079: ldloc.3
-				IL_007a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_007f: ldarg.0
-				IL_0080: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_008a: stloc.3
-				IL_008b: ldc.i4.0
-				IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0091: brfalse IL_00ca
+				IL_0070: ldloc.3
+				IL_0071: ldstr "substring"
+				IL_0076: ldc.r8 0.0
+				IL_007f: box [System.Runtime]System.Double
+				IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0089: stloc.3
 
-				IL_0096: ldloc.3
-				IL_0097: isinst [System.Runtime]System.String
-				IL_009c: dup
-				IL_009d: brfalse IL_00c9
+				IL_008a: ldarg.0
+				IL_008b: ldloc.3
+				IL_008c: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0091: ldarg.0
+				IL_0092: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_009c: stloc.3
+				IL_009d: ldc.i4.0
+				IL_009e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_00a3: brfalse IL_00ee
 
-				IL_00a2: ldc.r8 0.0
-				IL_00ab: box [System.Runtime]System.Double
-				IL_00b0: ldc.r8 5
-				IL_00b9: box [System.Runtime]System.Double
-				IL_00be: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-				IL_00c3: stloc.3
-				IL_00c4: br IL_00f2
+				IL_00a8: ldloc.3
+				IL_00a9: isinst [System.Runtime]System.String
+				IL_00ae: dup
+				IL_00af: brtrue IL_00c6
 
-				IL_00c9: pop
+				IL_00b4: pop
+				IL_00b5: ldloc.3
+				IL_00b6: ldstr "substring"
+				IL_00bb: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_00c0: dup
+				IL_00c1: brfalse IL_00ed
 
-				IL_00ca: ldloc.3
-				IL_00cb: ldstr "substring"
-				IL_00d0: ldc.r8 0.0
-				IL_00d9: box [System.Runtime]System.Double
-				IL_00de: ldc.r8 5
-				IL_00e7: box [System.Runtime]System.Double
-				IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_00f1: stloc.3
+				IL_00c6: ldc.r8 0.0
+				IL_00cf: box [System.Runtime]System.Double
+				IL_00d4: ldc.r8 5
+				IL_00dd: box [System.Runtime]System.Double
+				IL_00e2: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+				IL_00e7: stloc.3
+				IL_00e8: br IL_0116
 
-				IL_00f2: ldarg.0
-				IL_00f3: ldloc.3
-				IL_00f4: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_00f9: ldarg.0
-				IL_00fa: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0104: stloc.3
-				IL_0105: ldc.r8 1
-				IL_010e: neg
-				IL_010f: stloc.2
-				IL_0110: ldloc.2
-				IL_0111: box [System.Runtime]System.Double
-				IL_0116: stloc.s 4
-				IL_0118: ldc.i4.0
-				IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_011e: brfalse IL_013d
+				IL_00ed: pop
 
-				IL_0123: ldloc.3
-				IL_0124: isinst [System.Runtime]System.String
-				IL_0129: dup
-				IL_012a: brfalse IL_013c
+				IL_00ee: ldloc.3
+				IL_00ef: ldstr "substring"
+				IL_00f4: ldc.r8 0.0
+				IL_00fd: box [System.Runtime]System.Double
+				IL_0102: ldc.r8 5
+				IL_010b: box [System.Runtime]System.Double
+				IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0115: stloc.3
 
-				IL_012f: ldloc.s 4
-				IL_0131: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-				IL_0136: stloc.3
-				IL_0137: br IL_014b
+				IL_0116: ldarg.0
+				IL_0117: ldloc.3
+				IL_0118: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_011d: ldarg.0
+				IL_011e: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0128: stloc.3
+				IL_0129: ldc.r8 1
+				IL_0132: neg
+				IL_0133: stloc.2
+				IL_0134: ldloc.2
+				IL_0135: box [System.Runtime]System.Double
+				IL_013a: stloc.s 4
+				IL_013c: ldc.i4.0
+				IL_013d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0142: brfalse IL_0173
 
-				IL_013c: pop
+				IL_0147: ldloc.3
+				IL_0148: isinst [System.Runtime]System.String
+				IL_014d: dup
+				IL_014e: brtrue IL_0165
 
-				IL_013d: ldloc.3
-				IL_013e: ldstr "substring"
-				IL_0143: ldloc.s 4
-				IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_014a: stloc.3
+				IL_0153: pop
+				IL_0154: ldloc.3
+				IL_0155: ldstr "substring"
+				IL_015a: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_015f: dup
+				IL_0160: brfalse IL_0172
 
-				IL_014b: ldarg.0
-				IL_014c: ldloc.3
-				IL_014d: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_0152: ldarg.0
-				IL_0153: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_015d: stloc.3
-				IL_015e: ldc.r8 6
-				IL_0167: neg
-				IL_0168: stloc.2
-				IL_0169: ldloc.2
-				IL_016a: box [System.Runtime]System.Double
-				IL_016f: stloc.s 4
-				IL_0171: ldc.r8 1
-				IL_017a: neg
-				IL_017b: stloc.2
-				IL_017c: ldloc.2
-				IL_017d: box [System.Runtime]System.Double
-				IL_0182: stloc.s 5
-				IL_0184: ldc.i4.0
-				IL_0185: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_018a: brfalse IL_01ab
+				IL_0165: ldloc.s 4
+				IL_0167: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+				IL_016c: stloc.3
+				IL_016d: br IL_0181
 
-				IL_018f: ldloc.3
-				IL_0190: isinst [System.Runtime]System.String
-				IL_0195: dup
-				IL_0196: brfalse IL_01aa
+				IL_0172: pop
 
-				IL_019b: ldloc.s 4
-				IL_019d: ldloc.s 5
-				IL_019f: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-				IL_01a4: stloc.3
-				IL_01a5: br IL_01bb
+				IL_0173: ldloc.3
+				IL_0174: ldstr "substring"
+				IL_0179: ldloc.s 4
+				IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0180: stloc.3
 
-				IL_01aa: pop
+				IL_0181: ldarg.0
+				IL_0182: ldloc.3
+				IL_0183: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0188: ldarg.0
+				IL_0189: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_018e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0193: stloc.3
+				IL_0194: ldc.r8 6
+				IL_019d: neg
+				IL_019e: stloc.2
+				IL_019f: ldloc.2
+				IL_01a0: box [System.Runtime]System.Double
+				IL_01a5: stloc.s 4
+				IL_01a7: ldc.r8 1
+				IL_01b0: neg
+				IL_01b1: stloc.2
+				IL_01b2: ldloc.2
+				IL_01b3: box [System.Runtime]System.Double
+				IL_01b8: stloc.s 5
+				IL_01ba: ldc.i4.0
+				IL_01bb: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_01c0: brfalse IL_01f3
 
-				IL_01ab: ldloc.3
-				IL_01ac: ldstr "substring"
-				IL_01b1: ldloc.s 4
-				IL_01b3: ldloc.s 5
-				IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_01ba: stloc.3
+				IL_01c5: ldloc.3
+				IL_01c6: isinst [System.Runtime]System.String
+				IL_01cb: dup
+				IL_01cc: brtrue IL_01e3
 
-				IL_01bb: ldarg.0
-				IL_01bc: ldloc.3
-				IL_01bd: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_01c2: ldarg.0
-				IL_01c3: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_01cd: stloc.3
-				IL_01ce: ldc.i4.0
-				IL_01cf: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_01d4: brfalse IL_020d
+				IL_01d1: pop
+				IL_01d2: ldloc.3
+				IL_01d3: ldstr "substring"
+				IL_01d8: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_01dd: dup
+				IL_01de: brfalse IL_01f2
 
-				IL_01d9: ldloc.3
-				IL_01da: isinst [System.Runtime]System.String
-				IL_01df: dup
-				IL_01e0: brfalse IL_020c
+				IL_01e3: ldloc.s 4
+				IL_01e5: ldloc.s 5
+				IL_01e7: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+				IL_01ec: stloc.3
+				IL_01ed: br IL_0203
 
-				IL_01e5: ldc.r8 15000
-				IL_01ee: box [System.Runtime]System.Double
-				IL_01f3: ldc.r8 15005
-				IL_01fc: box [System.Runtime]System.Double
-				IL_0201: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-				IL_0206: stloc.3
-				IL_0207: br IL_0235
+				IL_01f2: pop
 
-				IL_020c: pop
+				IL_01f3: ldloc.3
+				IL_01f4: ldstr "substring"
+				IL_01f9: ldloc.s 4
+				IL_01fb: ldloc.s 5
+				IL_01fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0202: stloc.3
 
-				IL_020d: ldloc.3
-				IL_020e: ldstr "substring"
-				IL_0213: ldc.r8 15000
-				IL_021c: box [System.Runtime]System.Double
-				IL_0221: ldc.r8 15005
-				IL_022a: box [System.Runtime]System.Double
-				IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_0234: stloc.3
+				IL_0203: ldarg.0
+				IL_0204: ldloc.3
+				IL_0205: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_020a: ldarg.0
+				IL_020b: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0215: stloc.3
+				IL_0216: ldc.i4.0
+				IL_0217: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_021c: brfalse IL_0267
 
-				IL_0235: ldarg.0
-				IL_0236: ldloc.3
-				IL_0237: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_023c: ldarg.0
-				IL_023d: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
-				IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0247: stloc.3
-				IL_0248: ldc.r8 1
-				IL_0251: neg
-				IL_0252: stloc.2
-				IL_0253: ldloc.2
-				IL_0254: box [System.Runtime]System.Double
-				IL_0259: stloc.s 5
-				IL_025b: ldc.i4.0
-				IL_025c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0261: brfalse IL_028e
+				IL_0221: ldloc.3
+				IL_0222: isinst [System.Runtime]System.String
+				IL_0227: dup
+				IL_0228: brtrue IL_023f
 
-				IL_0266: ldloc.3
-				IL_0267: isinst [System.Runtime]System.String
-				IL_026c: dup
-				IL_026d: brfalse IL_028d
+				IL_022d: pop
+				IL_022e: ldloc.3
+				IL_022f: ldstr "substring"
+				IL_0234: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0239: dup
+				IL_023a: brfalse IL_0266
 
-				IL_0272: ldc.r8 12000
-				IL_027b: box [System.Runtime]System.Double
-				IL_0280: ldloc.s 5
-				IL_0282: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-				IL_0287: stloc.3
-				IL_0288: br IL_02aa
+				IL_023f: ldc.r8 15000
+				IL_0248: box [System.Runtime]System.Double
+				IL_024d: ldc.r8 15005
+				IL_0256: box [System.Runtime]System.Double
+				IL_025b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+				IL_0260: stloc.3
+				IL_0261: br IL_028f
 
-				IL_028d: pop
+				IL_0266: pop
 
-				IL_028e: ldloc.3
-				IL_028f: ldstr "substring"
-				IL_0294: ldc.r8 12000
-				IL_029d: box [System.Runtime]System.Double
-				IL_02a2: ldloc.s 5
-				IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_02a9: stloc.3
+				IL_0267: ldloc.3
+				IL_0268: ldstr "substring"
+				IL_026d: ldc.r8 15000
+				IL_0276: box [System.Runtime]System.Double
+				IL_027b: ldc.r8 15005
+				IL_0284: box [System.Runtime]System.Double
+				IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_028e: stloc.3
 
-				IL_02aa: ldarg.0
-				IL_02ab: ldloc.3
-				IL_02ac: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_02b1: ldloc.0
-				IL_02b2: ldc.r8 1
-				IL_02bb: add
-				IL_02bc: stloc.0
-				IL_02bd: br IL_000a
+				IL_028f: ldarg.0
+				IL_0290: ldloc.3
+				IL_0291: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0296: ldarg.0
+				IL_0297: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_029c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02a1: stloc.3
+				IL_02a2: ldc.r8 1
+				IL_02ab: neg
+				IL_02ac: stloc.2
+				IL_02ad: ldloc.2
+				IL_02ae: box [System.Runtime]System.Double
+				IL_02b3: stloc.s 5
+				IL_02b5: ldc.i4.0
+				IL_02b6: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_02bb: brfalse IL_02fa
+
+				IL_02c0: ldloc.3
+				IL_02c1: isinst [System.Runtime]System.String
+				IL_02c6: dup
+				IL_02c7: brtrue IL_02de
+
+				IL_02cc: pop
+				IL_02cd: ldloc.3
+				IL_02ce: ldstr "substring"
+				IL_02d3: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_02d8: dup
+				IL_02d9: brfalse IL_02f9
+
+				IL_02de: ldc.r8 12000
+				IL_02e7: box [System.Runtime]System.Double
+				IL_02ec: ldloc.s 5
+				IL_02ee: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+				IL_02f3: stloc.3
+				IL_02f4: br IL_0316
+
+				IL_02f9: pop
+
+				IL_02fa: ldloc.3
+				IL_02fb: ldstr "substring"
+				IL_0300: ldc.r8 12000
+				IL_0309: box [System.Runtime]System.Double
+				IL_030e: ldloc.s 5
+				IL_0310: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0315: stloc.3
+
+				IL_0316: ldarg.0
+				IL_0317: ldloc.3
+				IL_0318: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_031d: ldloc.0
+				IL_031e: ldc.r8 1
+				IL_0327: add
+				IL_0328: stloc.0
+				IL_0329: br IL_000a
 			// end loop
 
-			IL_02c2: ldnull
-			IL_02c3: ret
+			IL_032e: ldnull
+			IL_032f: ret
 		} // end of method FunctionExpression_L159C18::__js_call__
 
 	} // end of class FunctionExpression_L159C18
@@ -5254,7 +5510,7 @@
 				74 61 54 6f 6b 65 6e 1c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 128 (0x80)
+			// Code size: 146 (0x92)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -5277,7 +5533,7 @@
 				IL_0022: ldloc.1
 				IL_0023: ldloc.2
 				IL_0024: clt
-				IL_0026: brfalse IL_007e
+				IL_0026: brfalse IL_0090
 
 				IL_002b: ldarg.0
 				IL_002c: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
@@ -5285,36 +5541,43 @@
 				IL_0036: stloc.3
 				IL_0037: ldc.i4.0
 				IL_0038: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_003d: brfalse IL_005a
+				IL_003d: brfalse IL_006c
 
 				IL_0042: ldloc.3
 				IL_0043: isinst [System.Runtime]System.String
 				IL_0048: dup
-				IL_0049: brfalse IL_0059
+				IL_0049: brtrue IL_0060
 
-				IL_004e: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
-				IL_0053: stloc.3
-				IL_0054: br IL_0066
+				IL_004e: pop
+				IL_004f: ldloc.3
+				IL_0050: ldstr "toLowerCase"
+				IL_0055: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_005a: dup
+				IL_005b: brfalse IL_006b
 
-				IL_0059: pop
-
-				IL_005a: ldloc.3
-				IL_005b: ldstr "toLowerCase"
-				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0060: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
 				IL_0065: stloc.3
+				IL_0066: br IL_0078
 
-				IL_0066: ldarg.0
-				IL_0067: ldloc.3
-				IL_0068: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_006d: ldloc.0
-				IL_006e: ldc.r8 1
-				IL_0077: add
-				IL_0078: stloc.0
-				IL_0079: br IL_000a
+				IL_006b: pop
+
+				IL_006c: ldloc.3
+				IL_006d: ldstr "toLowerCase"
+				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0077: stloc.3
+
+				IL_0078: ldarg.0
+				IL_0079: ldloc.3
+				IL_007a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_007f: ldloc.0
+				IL_0080: ldc.r8 1
+				IL_0089: add
+				IL_008a: stloc.0
+				IL_008b: br IL_000a
 			// end loop
 
-			IL_007e: ldnull
-			IL_007f: ret
+			IL_0090: ldnull
+			IL_0091: ret
 		} // end of method FunctionExpression_L172C20::__js_call__
 
 	} // end of class FunctionExpression_L172C20
@@ -5478,7 +5741,7 @@
 				74 61 54 6f 6b 65 6e 1c 00 00 02
 			)
 			// Header size: 12
-			// Code size: 128 (0x80)
+			// Code size: 146 (0x92)
 			.maxstack 8
 			.locals init (
 				[0] float64,
@@ -5501,7 +5764,7 @@
 				IL_0022: ldloc.1
 				IL_0023: ldloc.2
 				IL_0024: clt
-				IL_0026: brfalse IL_007e
+				IL_0026: brfalse IL_0090
 
 				IL_002b: ldarg.0
 				IL_002c: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
@@ -5509,36 +5772,43 @@
 				IL_0036: stloc.3
 				IL_0037: ldc.i4.0
 				IL_0038: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_003d: brfalse IL_005a
+				IL_003d: brfalse IL_006c
 
 				IL_0042: ldloc.3
 				IL_0043: isinst [System.Runtime]System.String
 				IL_0048: dup
-				IL_0049: brfalse IL_0059
+				IL_0049: brtrue IL_0060
 
-				IL_004e: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
-				IL_0053: stloc.3
-				IL_0054: br IL_0066
+				IL_004e: pop
+				IL_004f: ldloc.3
+				IL_0050: ldstr "toUpperCase"
+				IL_0055: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_005a: dup
+				IL_005b: brfalse IL_006b
 
-				IL_0059: pop
-
-				IL_005a: ldloc.3
-				IL_005b: ldstr "toUpperCase"
-				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0060: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
 				IL_0065: stloc.3
+				IL_0066: br IL_0078
 
-				IL_0066: ldarg.0
-				IL_0067: ldloc.3
-				IL_0068: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
-				IL_006d: ldloc.0
-				IL_006e: ldc.r8 1
-				IL_0077: add
-				IL_0078: stloc.0
-				IL_0079: br IL_000a
+				IL_006b: pop
+
+				IL_006c: ldloc.3
+				IL_006d: ldstr "toUpperCase"
+				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0077: stloc.3
+
+				IL_0078: ldarg.0
+				IL_0079: ldloc.3
+				IL_007a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_007f: ldloc.0
+				IL_0080: ldc.r8 1
+				IL_0089: add
+				IL_008a: stloc.0
+				IL_008b: br IL_000a
 			// end loop
 
-			IL_007e: ldnull
-			IL_007f: ret
+			IL_0090: ldnull
+			IL_0091: ret
 		} // end of method FunctionExpression_L178C20::__js_call__
 
 	} // end of class FunctionExpression_L178C20

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_String.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_String.verified.txt
@@ -1,0 +1,6850 @@
+﻿// IL code: Compile_Performance_Dromaeo_Object_String
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Compile_Performance_Dromaeo_Object_String
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit startTest
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0019: call object Modules.Compile_Performance_Dromaeo_Object_String/startTest::__js_call__(object, string, string)
+				IL_001e: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0019: call object Modules.Compile_Performance_Dromaeo_Object_String/startTest::__js_call__(object, string, string)
+				IL_001e: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				string _name,
+				string _id
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 2 (0x2)
+			.maxstack 8
+
+			IL_0000: ldnull
+			IL_0001: ret
+		} // end of method startTest::__js_call__
+
+	} // end of class startTest
+
+	.class nested public auto ansi abstract sealed beforefieldinit endTest
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: call object Modules.Compile_Performance_Dromaeo_Object_String/endTest::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Compile_Performance_Dromaeo_Object_String/endTest::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 2 (0x2)
+			.maxstack 8
+
+			IL_0000: ldnull
+			IL_0001: ret
+		} // end of method endTest::__js_call__
+
+	} // end of class endTest
+
+	.class nested public auto ansi abstract sealed beforefieldinit prep
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L5C50
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L5C50::.ctor
+
+			} // end of class Block_L5C50
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Compile_Performance_Dromaeo_Object_String/prep::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Compile_Performance_Dromaeo_Object_String/prep::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object fn
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 39 (0x27)
+			.maxstack 8
+			.locals init (
+				[0] string,
+				[1] bool
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "function"
+			IL_000d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0012: stloc.1
+			IL_0013: ldloc.1
+			IL_0014: brfalse IL_0025
+
+			IL_0019: ldarg.1
+			IL_001a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0024: pop
+
+			IL_0025: ldnull
+			IL_0026: ret
+		} // end of method prep::__js_call__
+
+	} // end of class prep
+
+	.class nested public auto ansi abstract sealed beforefieldinit test
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L6C57
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L6C57::.ctor
+
+			} // end of class Block_L6C57
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+				IL_0019: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call object Modules.Compile_Performance_Dromaeo_Object_String/test::__js_call__(object, string, object)
+				IL_0019: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				string _name,
+				object fn
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 39 (0x27)
+			.maxstack 8
+			.locals init (
+				[0] string,
+				[1] bool
+			)
+
+			IL_0000: ldarg.2
+			IL_0001: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+			IL_0006: stloc.0
+			IL_0007: ldloc.0
+			IL_0008: ldstr "function"
+			IL_000d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0012: stloc.1
+			IL_0013: ldloc.1
+			IL_0014: brfalse IL_0025
+
+			IL_0019: ldarg.2
+			IL_001a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+			IL_001f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+			IL_0024: pop
+
+			IL_0025: ldnull
+			IL_0026: ret
+		} // end of method test::__js_call__
+
+	} // end of class test
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L15C22
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L15C22/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L15C22/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L15C22::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L15C22/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L15C22::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 90 (0x5a)
+			.maxstack 8
+			.locals init (
+				[0] class [System.Runtime]System.Text.StringBuilder,
+				[1] float64,
+				[2] float64,
+				[3] float64,
+				[4] string
+			)
+
+			IL_0000: ldstr ""
+			IL_0005: call class [System.Runtime]System.Text.StringBuilder [JavaScriptRuntime]JavaScriptRuntime.String::CreateConcatBuilder(string)
+			IL_000a: stloc.0
+			IL_000b: ldc.r8 0.0
+			IL_0014: stloc.1
+			// loop start (head: IL_0015)
+				IL_0015: ldloc.1
+				IL_0016: stloc.2
+				IL_0017: ldarg.0
+				IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+				IL_001d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0022: stloc.3
+				IL_0023: ldloc.2
+				IL_0024: ldloc.3
+				IL_0025: clt
+				IL_0027: brfalse IL_0048
+
+				IL_002c: ldloc.0
+				IL_002d: ldstr "a"
+				IL_0032: call void [JavaScriptRuntime]JavaScriptRuntime.String::AppendConcatBuilder(class [System.Runtime]System.Text.StringBuilder, string)
+				IL_0037: ldloc.1
+				IL_0038: ldc.r8 1
+				IL_0041: add
+				IL_0042: stloc.1
+				IL_0043: br IL_0015
+			// end loop
+
+			IL_0048: ldloc.0
+			IL_0049: call string [JavaScriptRuntime]JavaScriptRuntime.String::MaterializeConcatBuilder(class [System.Runtime]System.Text.StringBuilder)
+			IL_004e: stloc.s 4
+			IL_0050: ldarg.0
+			IL_0051: ldloc.s 4
+			IL_0053: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+			IL_0058: ldnull
+			IL_0059: ret
+		} // end of method FunctionExpression_L15C22::__js_call__
+
+	} // end of class FunctionExpression_L15C22
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L22C29
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L22C29/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L22C29/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L22C29::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L22C29/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L22C29::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 96 (0x60)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] float64,
+				[2] object,
+				[3] float64,
+				[4] float64,
+				[5] object
+			)
+
+			IL_0000: ldstr "String"
+			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_000a: stloc.2
+			IL_000b: ldloc.2
+			IL_000c: dup
+			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct0(object, object)
+			IL_0012: stloc.0
+			IL_0013: ldc.r8 0.0
+			IL_001c: stloc.1
+			// loop start (head: IL_001d)
+				IL_001d: ldloc.1
+				IL_001e: stloc.3
+				IL_001f: ldarg.0
+				IL_0020: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+				IL_0025: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_002a: stloc.s 4
+				IL_002c: ldloc.3
+				IL_002d: ldloc.s 4
+				IL_002f: clt
+				IL_0031: brfalse IL_0057
+
+				IL_0036: ldloc.0
+				IL_0037: ldstr "a"
+				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_0041: stloc.s 5
+				IL_0043: ldloc.s 5
+				IL_0045: stloc.0
+				IL_0046: ldloc.1
+				IL_0047: ldc.r8 1
+				IL_0050: add
+				IL_0051: stloc.1
+				IL_0052: br IL_001d
+			// end loop
+
+			IL_0057: ldarg.0
+			IL_0058: ldloc.0
+			IL_0059: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+			IL_005e: ldnull
+			IL_005f: ret
+		} // end of method FunctionExpression_L22C29::__js_call__
+
+	} // end of class FunctionExpression_L22C29
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L29C36
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L29C36/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L29C36/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L29C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L29C36/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L29C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 118 (0x76)
+			.maxstack 8
+			.locals init (
+				[0] class [System.Runtime]System.Text.StringBuilder,
+				[1] float64,
+				[2] float64,
+				[3] float64,
+				[4] string
+			)
+
+			IL_0000: ldstr ""
+			IL_0005: call class [System.Runtime]System.Text.StringBuilder [JavaScriptRuntime]JavaScriptRuntime.String::CreateConcatBuilder(string)
+			IL_000a: stloc.0
+			IL_000b: ldc.r8 0.0
+			IL_0014: stloc.1
+			// loop start (head: IL_0015)
+				IL_0015: ldloc.1
+				IL_0016: stloc.2
+				IL_0017: ldarg.0
+				IL_0018: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+				IL_001d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0022: ldc.r8 2
+				IL_002b: div
+				IL_002c: stloc.3
+				IL_002d: ldloc.2
+				IL_002e: ldloc.3
+				IL_002f: clt
+				IL_0031: brfalse IL_0064
+
+				IL_0036: ldc.r8 97
+				IL_003f: box [System.Runtime]System.Double
+				IL_0044: call string [JavaScriptRuntime]JavaScriptRuntime.String::FromCharCode(object)
+				IL_0049: stloc.s 4
+				IL_004b: ldloc.0
+				IL_004c: ldloc.s 4
+				IL_004e: call void [JavaScriptRuntime]JavaScriptRuntime.String::AppendConcatBuilder(class [System.Runtime]System.Text.StringBuilder, string)
+				IL_0053: ldloc.1
+				IL_0054: ldc.r8 1
+				IL_005d: add
+				IL_005e: stloc.1
+				IL_005f: br IL_0015
+			// end loop
+
+			IL_0064: ldloc.0
+			IL_0065: call string [JavaScriptRuntime]JavaScriptRuntime.String::MaterializeConcatBuilder(class [System.Runtime]System.Text.StringBuilder)
+			IL_006a: stloc.s 4
+			IL_006c: ldarg.0
+			IL_006d: ldloc.s 4
+			IL_006f: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+			IL_0074: ldnull
+			IL_0075: ret
+		} // end of method FunctionExpression_L29C36::__js_call__
+
+	} // end of class FunctionExpression_L29C36
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L36C26
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L36C26/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L36C26/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L36C26::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L36C26/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L36C26::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 111 (0x6f)
+			.maxstack 8
+			.locals init (
+				[0] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+				[1] float64,
+				[2] float64,
+				[3] float64,
+				[4] string
+			)
+
+			IL_0000: ldc.i4.0
+			IL_0001: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0006: stloc.0
+			IL_0007: ldc.r8 0.0
+			IL_0010: stloc.1
+			// loop start (head: IL_0011)
+				IL_0011: ldloc.1
+				IL_0012: stloc.2
+				IL_0013: ldarg.0
+				IL_0014: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+				IL_0019: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001e: ldc.r8 2
+				IL_0027: div
+				IL_0028: stloc.3
+				IL_0029: ldloc.2
+				IL_002a: ldloc.3
+				IL_002b: clt
+				IL_002d: brfalse IL_004f
+
+				IL_0032: ldloc.0
+				IL_0033: ldstr "a"
+				IL_0038: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Array::push(object)
+				IL_003d: pop
+				IL_003e: ldloc.1
+				IL_003f: ldc.r8 1
+				IL_0048: add
+				IL_0049: stloc.1
+				IL_004a: br IL_0011
+			// end loop
+
+			IL_004f: ldloc.0
+			IL_0050: ldc.i4.1
+			IL_0051: newarr [System.Runtime]System.Object
+			IL_0056: dup
+			IL_0057: ldc.i4.0
+			IL_0058: ldstr ""
+			IL_005d: stelem.ref
+			IL_005e: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Array::join(object[])
+			IL_0063: stloc.s 4
+			IL_0065: ldarg.0
+			IL_0066: ldloc.s 4
+			IL_0068: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+			IL_006d: ldnull
+			IL_006e: ret
+		} // end of method FunctionExpression_L36C26::__js_call__
+
+	} // end of class FunctionExpression_L36C26
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L55C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 36 (0x24)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object
+			)
+
+			IL_0000: ldstr "String"
+			IL_0005: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_000a: stloc.0
+			IL_000b: ldarg.0
+			IL_000c: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+			IL_0011: stloc.1
+			IL_0012: ldloc.0
+			IL_0013: dup
+			IL_0014: ldloc.1
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+			IL_001a: stloc.1
+			IL_001b: ldarg.0
+			IL_001c: ldloc.1
+			IL_001d: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+			IL_0022: ldnull
+			IL_0023: ret
+		} // end of method FunctionExpression_L55C5::__js_call__
+
+	} // end of class FunctionExpression_L55C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L60C21
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 36 (0x24)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: ldstr "split"
+			IL_0010: ldstr ""
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+			IL_0022: ldnull
+			IL_0023: ret
+		} // end of method FunctionExpression_L60C21::__js_call__
+
+	} // end of class FunctionExpression_L60C21
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L64C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 132 (0x84)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldloc.0
+			IL_0009: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
+			IL_000e: ldarg.0
+			IL_000f: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
+			IL_0014: stloc.0
+			IL_0015: ldarg.0
+			IL_0016: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
+			IL_001b: stloc.1
+			IL_001c: ldloc.0
+			IL_001d: ldloc.1
+			IL_001e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0023: stloc.2
+			IL_0024: ldarg.0
+			IL_0025: ldloc.2
+			IL_0026: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
+			IL_002b: ldarg.0
+			IL_002c: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
+			IL_0031: stloc.1
+			IL_0032: ldarg.0
+			IL_0033: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
+			IL_0038: stloc.0
+			IL_0039: ldloc.1
+			IL_003a: ldloc.0
+			IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0040: stloc.2
+			IL_0041: ldarg.0
+			IL_0042: ldloc.2
+			IL_0043: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
+			IL_0048: ldarg.0
+			IL_0049: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
+			IL_004e: stloc.0
+			IL_004f: ldarg.0
+			IL_0050: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
+			IL_0055: stloc.1
+			IL_0056: ldloc.0
+			IL_0057: ldloc.1
+			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_005d: stloc.2
+			IL_005e: ldarg.0
+			IL_005f: ldloc.2
+			IL_0060: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
+			IL_0065: ldarg.0
+			IL_0066: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
+			IL_006b: stloc.1
+			IL_006c: ldarg.0
+			IL_006d: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
+			IL_0072: stloc.0
+			IL_0073: ldloc.1
+			IL_0074: ldloc.0
+			IL_0075: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_007a: stloc.2
+			IL_007b: ldarg.0
+			IL_007c: ldloc.2
+			IL_007d: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
+			IL_0082: ldnull
+			IL_0083: ret
+		} // end of method FunctionExpression_L64C5::__js_call__
+
+	} // end of class FunctionExpression_L64C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L72C29
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 36 (0x24)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
+			IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_000b: ldstr "split"
+			IL_0010: ldstr "a"
+			IL_0015: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_001a: stloc.0
+			IL_001b: ldarg.0
+			IL_001c: ldloc.0
+			IL_001d: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+			IL_0022: ldnull
+			IL_0023: ret
+		} // end of method FunctionExpression_L72C29::__js_call__
+
+	} // end of class FunctionExpression_L72C29
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L76C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 31 (0x1f)
+			.maxstack 8
+			.locals init (
+				[0] object,
+				[1] object,
+				[2] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+			IL_000d: stloc.1
+			IL_000e: ldloc.0
+			IL_000f: ldloc.1
+			IL_0010: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0015: stloc.2
+			IL_0016: ldarg.0
+			IL_0017: ldloc.2
+			IL_0018: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+			IL_001d: ldnull
+			IL_001e: ret
+		} // end of method FunctionExpression_L76C5::__js_call__
+
+	} // end of class FunctionExpression_L76C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L82C15
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L83C34
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L83C34::.ctor
+
+			} // end of class Block_L83C34
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 448 (0x1c0)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] float64,
+				[2] float64,
+				[3] object,
+				[4] object,
+				[5] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldarg.0
+				IL_000d: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: stloc.2
+				IL_0018: ldloc.1
+				IL_0019: ldloc.2
+				IL_001a: clt
+				IL_001c: brfalse IL_01be
+
+				IL_0021: ldarg.0
+				IL_0022: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_002c: stloc.3
+				IL_002d: ldc.i4.0
+				IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0033: brfalse IL_005e
+
+				IL_0038: ldloc.3
+				IL_0039: isinst [System.Runtime]System.String
+				IL_003e: dup
+				IL_003f: brfalse IL_005d
+
+				IL_0044: ldc.r8 0.0
+				IL_004d: box [System.Runtime]System.Double
+				IL_0052: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+				IL_0057: stloc.3
+				IL_0058: br IL_0078
+
+				IL_005d: pop
+
+				IL_005e: ldloc.3
+				IL_005f: ldstr "charAt"
+				IL_0064: ldc.r8 0.0
+				IL_006d: box [System.Runtime]System.Double
+				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0077: stloc.3
+
+				IL_0078: ldarg.0
+				IL_0079: ldloc.3
+				IL_007a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_007f: ldarg.0
+				IL_0080: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_008a: stloc.3
+				IL_008b: ldarg.0
+				IL_008c: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0091: ldstr "length"
+				IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_009b: stloc.s 4
+				IL_009d: ldloc.s 4
+				IL_009f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00a4: ldc.r8 1
+				IL_00ad: sub
+				IL_00ae: stloc.2
+				IL_00af: ldloc.2
+				IL_00b0: box [System.Runtime]System.Double
+				IL_00b5: stloc.s 5
+				IL_00b7: ldc.i4.0
+				IL_00b8: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_00bd: brfalse IL_00dc
+
+				IL_00c2: ldloc.3
+				IL_00c3: isinst [System.Runtime]System.String
+				IL_00c8: dup
+				IL_00c9: brfalse IL_00db
+
+				IL_00ce: ldloc.s 5
+				IL_00d0: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+				IL_00d5: stloc.3
+				IL_00d6: br IL_00ea
+
+				IL_00db: pop
+
+				IL_00dc: ldloc.3
+				IL_00dd: ldstr "charAt"
+				IL_00e2: ldloc.s 5
+				IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00e9: stloc.3
+
+				IL_00ea: ldarg.0
+				IL_00eb: ldloc.3
+				IL_00ec: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_00f1: ldarg.0
+				IL_00f2: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00fc: stloc.3
+				IL_00fd: ldc.i4.0
+				IL_00fe: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0103: brfalse IL_012e
+
+				IL_0108: ldloc.3
+				IL_0109: isinst [System.Runtime]System.String
+				IL_010e: dup
+				IL_010f: brfalse IL_012d
+
+				IL_0114: ldc.r8 15000
+				IL_011d: box [System.Runtime]System.Double
+				IL_0122: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+				IL_0127: stloc.3
+				IL_0128: br IL_0148
+
+				IL_012d: pop
+
+				IL_012e: ldloc.3
+				IL_012f: ldstr "charAt"
+				IL_0134: ldc.r8 15000
+				IL_013d: box [System.Runtime]System.Double
+				IL_0142: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0147: stloc.3
+
+				IL_0148: ldarg.0
+				IL_0149: ldloc.3
+				IL_014a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_014f: ldarg.0
+				IL_0150: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0155: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_015a: stloc.3
+				IL_015b: ldc.i4.0
+				IL_015c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0161: brfalse IL_018c
+
+				IL_0166: ldloc.3
+				IL_0167: isinst [System.Runtime]System.String
+				IL_016c: dup
+				IL_016d: brfalse IL_018b
+
+				IL_0172: ldc.r8 12000
+				IL_017b: box [System.Runtime]System.Double
+				IL_0180: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+				IL_0185: stloc.3
+				IL_0186: br IL_01a6
+
+				IL_018b: pop
+
+				IL_018c: ldloc.3
+				IL_018d: ldstr "charAt"
+				IL_0192: ldc.r8 12000
+				IL_019b: box [System.Runtime]System.Double
+				IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01a5: stloc.3
+
+				IL_01a6: ldarg.0
+				IL_01a7: ldloc.3
+				IL_01a8: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_01ad: ldloc.0
+				IL_01ae: ldc.r8 1
+				IL_01b7: add
+				IL_01b8: stloc.0
+				IL_01b9: br IL_000a
+			// end loop
+
+			IL_01be: ldnull
+			IL_01bf: ret
+		} // end of method FunctionExpression_L82C15::__js_call__
+
+	} // end of class FunctionExpression_L82C15
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L91C17
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L92C34
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L92C34::.ctor
+
+			} // end of class Block_L92C34
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 218 (0xda)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] float64,
+				[2] float64,
+				[3] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldarg.0
+				IL_000d: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: stloc.2
+				IL_0018: ldloc.1
+				IL_0019: ldloc.2
+				IL_001a: clt
+				IL_001c: brfalse IL_00d8
+
+				IL_0021: ldarg.0
+				IL_0022: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0027: ldc.r8 0.0
+				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0035: stloc.3
+				IL_0036: ldarg.0
+				IL_0037: ldloc.3
+				IL_0038: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_003d: ldarg.0
+				IL_003e: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0043: ldarg.0
+				IL_0044: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0049: ldstr "length"
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0053: stloc.3
+				IL_0054: ldloc.3
+				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005a: ldc.r8 1
+				IL_0063: sub
+				IL_0064: stloc.2
+				IL_0065: ldloc.2
+				IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_006b: stloc.3
+				IL_006c: ldarg.0
+				IL_006d: ldloc.3
+				IL_006e: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0073: ldarg.0
+				IL_0074: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0079: ldc.r8 15000
+				IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0087: stloc.3
+				IL_0088: ldarg.0
+				IL_0089: ldloc.3
+				IL_008a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_008f: ldarg.0
+				IL_0090: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0095: ldc.r8 10000
+				IL_009e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00a3: stloc.3
+				IL_00a4: ldarg.0
+				IL_00a5: ldloc.3
+				IL_00a6: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_00ab: ldarg.0
+				IL_00ac: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_00b1: ldc.r8 5000
+				IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_00bf: stloc.3
+				IL_00c0: ldarg.0
+				IL_00c1: ldloc.3
+				IL_00c2: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_00c7: ldloc.0
+				IL_00c8: ldc.r8 1
+				IL_00d1: add
+				IL_00d2: stloc.0
+				IL_00d3: br IL_000a
+			// end loop
+
+			IL_00d8: ldnull
+			IL_00d9: ret
+		} // end of method FunctionExpression_L91C17::__js_call__
+
+	} // end of class FunctionExpression_L91C17
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L101C19
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L102C34
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L102C34::.ctor
+
+			} // end of class Block_L102C34
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 567 (0x237)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] float64,
+				[2] float64,
+				[3] object,
+				[4] object,
+				[5] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldarg.0
+				IL_000d: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: stloc.2
+				IL_0018: ldloc.1
+				IL_0019: ldloc.2
+				IL_001a: clt
+				IL_001c: brfalse IL_0235
+
+				IL_0021: ldarg.0
+				IL_0022: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_002c: stloc.3
+				IL_002d: ldc.i4.0
+				IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0033: brfalse IL_0063
+
+				IL_0038: ldloc.3
+				IL_0039: isinst [System.Runtime]System.String
+				IL_003e: dup
+				IL_003f: brfalse IL_0062
+
+				IL_0044: ldc.r8 0.0
+				IL_004d: box [System.Runtime]System.Double
+				IL_0052: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+				IL_0057: box [System.Runtime]System.Double
+				IL_005c: stloc.3
+				IL_005d: br IL_007d
+
+				IL_0062: pop
+
+				IL_0063: ldloc.3
+				IL_0064: ldstr "charCodeAt"
+				IL_0069: ldc.r8 0.0
+				IL_0072: box [System.Runtime]System.Double
+				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_007c: stloc.3
+
+				IL_007d: ldarg.0
+				IL_007e: ldloc.3
+				IL_007f: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0084: ldarg.0
+				IL_0085: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_008f: stloc.3
+				IL_0090: ldarg.0
+				IL_0091: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0096: ldstr "length"
+				IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_00a0: stloc.s 4
+				IL_00a2: ldloc.s 4
+				IL_00a4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00a9: ldc.r8 1
+				IL_00b2: sub
+				IL_00b3: stloc.2
+				IL_00b4: ldloc.2
+				IL_00b5: box [System.Runtime]System.Double
+				IL_00ba: stloc.s 5
+				IL_00bc: ldc.i4.0
+				IL_00bd: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_00c2: brfalse IL_00e6
+
+				IL_00c7: ldloc.3
+				IL_00c8: isinst [System.Runtime]System.String
+				IL_00cd: dup
+				IL_00ce: brfalse IL_00e5
+
+				IL_00d3: ldloc.s 5
+				IL_00d5: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+				IL_00da: box [System.Runtime]System.Double
+				IL_00df: stloc.3
+				IL_00e0: br IL_00f4
+
+				IL_00e5: pop
+
+				IL_00e6: ldloc.3
+				IL_00e7: ldstr "charCodeAt"
+				IL_00ec: ldloc.s 5
+				IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00f3: stloc.3
+
+				IL_00f4: ldarg.0
+				IL_00f5: ldloc.3
+				IL_00f6: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_00fb: ldarg.0
+				IL_00fc: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0106: stloc.3
+				IL_0107: ldc.i4.0
+				IL_0108: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_010d: brfalse IL_013d
+
+				IL_0112: ldloc.3
+				IL_0113: isinst [System.Runtime]System.String
+				IL_0118: dup
+				IL_0119: brfalse IL_013c
+
+				IL_011e: ldc.r8 15000
+				IL_0127: box [System.Runtime]System.Double
+				IL_012c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+				IL_0131: box [System.Runtime]System.Double
+				IL_0136: stloc.3
+				IL_0137: br IL_0157
+
+				IL_013c: pop
+
+				IL_013d: ldloc.3
+				IL_013e: ldstr "charCodeAt"
+				IL_0143: ldc.r8 15000
+				IL_014c: box [System.Runtime]System.Double
+				IL_0151: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0156: stloc.3
+
+				IL_0157: ldarg.0
+				IL_0158: ldloc.3
+				IL_0159: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_015e: ldarg.0
+				IL_015f: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0164: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0169: stloc.3
+				IL_016a: ldc.i4.0
+				IL_016b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0170: brfalse IL_01a0
+
+				IL_0175: ldloc.3
+				IL_0176: isinst [System.Runtime]System.String
+				IL_017b: dup
+				IL_017c: brfalse IL_019f
+
+				IL_0181: ldc.r8 10000
+				IL_018a: box [System.Runtime]System.Double
+				IL_018f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+				IL_0194: box [System.Runtime]System.Double
+				IL_0199: stloc.3
+				IL_019a: br IL_01ba
+
+				IL_019f: pop
+
+				IL_01a0: ldloc.3
+				IL_01a1: ldstr "charCodeAt"
+				IL_01a6: ldc.r8 10000
+				IL_01af: box [System.Runtime]System.Double
+				IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01b9: stloc.3
+
+				IL_01ba: ldarg.0
+				IL_01bb: ldloc.3
+				IL_01bc: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_01c1: ldarg.0
+				IL_01c2: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01cc: stloc.3
+				IL_01cd: ldc.i4.0
+				IL_01ce: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_01d3: brfalse IL_0203
+
+				IL_01d8: ldloc.3
+				IL_01d9: isinst [System.Runtime]System.String
+				IL_01de: dup
+				IL_01df: brfalse IL_0202
+
+				IL_01e4: ldc.r8 5000
+				IL_01ed: box [System.Runtime]System.Double
+				IL_01f2: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+				IL_01f7: box [System.Runtime]System.Double
+				IL_01fc: stloc.3
+				IL_01fd: br IL_021d
+
+				IL_0202: pop
+
+				IL_0203: ldloc.3
+				IL_0204: ldstr "charCodeAt"
+				IL_0209: ldc.r8 5000
+				IL_0212: box [System.Runtime]System.Double
+				IL_0217: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_021c: stloc.3
+
+				IL_021d: ldarg.0
+				IL_021e: ldloc.3
+				IL_021f: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0224: ldloc.0
+				IL_0225: ldc.r8 1
+				IL_022e: add
+				IL_022f: stloc.0
+				IL_0230: br IL_000a
+			// end loop
+
+			IL_0235: ldnull
+			IL_0236: ret
+		} // end of method FunctionExpression_L101C19::__js_call__
+
+	} // end of class FunctionExpression_L101C19
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L113C16
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L114C34
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L114C34::.ctor
+
+			} // end of class Block_L114C34
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 376 (0x178)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] float64,
+				[2] float64,
+				[3] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldarg.0
+				IL_000d: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: stloc.2
+				IL_0018: ldloc.1
+				IL_0019: ldloc.2
+				IL_001a: clt
+				IL_001c: brfalse IL_0176
+
+				IL_0021: ldarg.0
+				IL_0022: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_002c: stloc.3
+				IL_002d: ldc.i4.0
+				IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0033: brfalse IL_005a
+
+				IL_0038: ldloc.3
+				IL_0039: isinst [System.Runtime]System.String
+				IL_003e: dup
+				IL_003f: brfalse IL_0059
+
+				IL_0044: ldstr "a"
+				IL_0049: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+				IL_004e: box [System.Runtime]System.Double
+				IL_0053: stloc.3
+				IL_0054: br IL_006b
+
+				IL_0059: pop
+
+				IL_005a: ldloc.3
+				IL_005b: ldstr "indexOf"
+				IL_0060: ldstr "a"
+				IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_006a: stloc.3
+
+				IL_006b: ldarg.0
+				IL_006c: ldloc.3
+				IL_006d: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0072: ldarg.0
+				IL_0073: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_007d: stloc.3
+				IL_007e: ldc.i4.0
+				IL_007f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0084: brfalse IL_00ab
+
+				IL_0089: ldloc.3
+				IL_008a: isinst [System.Runtime]System.String
+				IL_008f: dup
+				IL_0090: brfalse IL_00aa
+
+				IL_0095: ldstr "b"
+				IL_009a: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+				IL_009f: box [System.Runtime]System.Double
+				IL_00a4: stloc.3
+				IL_00a5: br IL_00bc
+
+				IL_00aa: pop
+
+				IL_00ab: ldloc.3
+				IL_00ac: ldstr "indexOf"
+				IL_00b1: ldstr "b"
+				IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00bb: stloc.3
+
+				IL_00bc: ldarg.0
+				IL_00bd: ldloc.3
+				IL_00be: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_00c3: ldarg.0
+				IL_00c4: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00ce: stloc.3
+				IL_00cf: ldc.i4.0
+				IL_00d0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_00d5: brfalse IL_00fc
+
+				IL_00da: ldloc.3
+				IL_00db: isinst [System.Runtime]System.String
+				IL_00e0: dup
+				IL_00e1: brfalse IL_00fb
+
+				IL_00e6: ldstr "c"
+				IL_00eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+				IL_00f0: box [System.Runtime]System.Double
+				IL_00f5: stloc.3
+				IL_00f6: br IL_010d
+
+				IL_00fb: pop
+
+				IL_00fc: ldloc.3
+				IL_00fd: ldstr "indexOf"
+				IL_0102: ldstr "c"
+				IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_010c: stloc.3
+
+				IL_010d: ldarg.0
+				IL_010e: ldloc.3
+				IL_010f: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0114: ldarg.0
+				IL_0115: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_011f: stloc.3
+				IL_0120: ldc.i4.0
+				IL_0121: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0126: brfalse IL_014d
+
+				IL_012b: ldloc.3
+				IL_012c: isinst [System.Runtime]System.String
+				IL_0131: dup
+				IL_0132: brfalse IL_014c
+
+				IL_0137: ldstr "d"
+				IL_013c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+				IL_0141: box [System.Runtime]System.Double
+				IL_0146: stloc.3
+				IL_0147: br IL_015e
+
+				IL_014c: pop
+
+				IL_014d: ldloc.3
+				IL_014e: ldstr "indexOf"
+				IL_0153: ldstr "d"
+				IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_015d: stloc.3
+
+				IL_015e: ldarg.0
+				IL_015f: ldloc.3
+				IL_0160: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0165: ldloc.0
+				IL_0166: ldc.r8 1
+				IL_016f: add
+				IL_0170: stloc.0
+				IL_0171: br IL_000a
+			// end loop
+
+			IL_0176: ldnull
+			IL_0177: ret
+		} // end of method FunctionExpression_L113C16::__js_call__
+
+	} // end of class FunctionExpression_L113C16
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L122C20
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L123C34
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L123C34::.ctor
+
+			} // end of class Block_L123C34
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 376 (0x178)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] float64,
+				[2] float64,
+				[3] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldarg.0
+				IL_000d: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: stloc.2
+				IL_0018: ldloc.1
+				IL_0019: ldloc.2
+				IL_001a: clt
+				IL_001c: brfalse IL_0176
+
+				IL_0021: ldarg.0
+				IL_0022: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_002c: stloc.3
+				IL_002d: ldc.i4.0
+				IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0033: brfalse IL_005a
+
+				IL_0038: ldloc.3
+				IL_0039: isinst [System.Runtime]System.String
+				IL_003e: dup
+				IL_003f: brfalse IL_0059
+
+				IL_0044: ldstr "a"
+				IL_0049: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+				IL_004e: box [System.Runtime]System.Double
+				IL_0053: stloc.3
+				IL_0054: br IL_006b
+
+				IL_0059: pop
+
+				IL_005a: ldloc.3
+				IL_005b: ldstr "lastIndexOf"
+				IL_0060: ldstr "a"
+				IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_006a: stloc.3
+
+				IL_006b: ldarg.0
+				IL_006c: ldloc.3
+				IL_006d: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0072: ldarg.0
+				IL_0073: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_007d: stloc.3
+				IL_007e: ldc.i4.0
+				IL_007f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0084: brfalse IL_00ab
+
+				IL_0089: ldloc.3
+				IL_008a: isinst [System.Runtime]System.String
+				IL_008f: dup
+				IL_0090: brfalse IL_00aa
+
+				IL_0095: ldstr "b"
+				IL_009a: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+				IL_009f: box [System.Runtime]System.Double
+				IL_00a4: stloc.3
+				IL_00a5: br IL_00bc
+
+				IL_00aa: pop
+
+				IL_00ab: ldloc.3
+				IL_00ac: ldstr "lastIndexOf"
+				IL_00b1: ldstr "b"
+				IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00bb: stloc.3
+
+				IL_00bc: ldarg.0
+				IL_00bd: ldloc.3
+				IL_00be: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_00c3: ldarg.0
+				IL_00c4: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00ce: stloc.3
+				IL_00cf: ldc.i4.0
+				IL_00d0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_00d5: brfalse IL_00fc
+
+				IL_00da: ldloc.3
+				IL_00db: isinst [System.Runtime]System.String
+				IL_00e0: dup
+				IL_00e1: brfalse IL_00fb
+
+				IL_00e6: ldstr "c"
+				IL_00eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+				IL_00f0: box [System.Runtime]System.Double
+				IL_00f5: stloc.3
+				IL_00f6: br IL_010d
+
+				IL_00fb: pop
+
+				IL_00fc: ldloc.3
+				IL_00fd: ldstr "lastIndexOf"
+				IL_0102: ldstr "c"
+				IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_010c: stloc.3
+
+				IL_010d: ldarg.0
+				IL_010e: ldloc.3
+				IL_010f: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0114: ldarg.0
+				IL_0115: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_011f: stloc.3
+				IL_0120: ldc.i4.0
+				IL_0121: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0126: brfalse IL_014d
+
+				IL_012b: ldloc.3
+				IL_012c: isinst [System.Runtime]System.String
+				IL_0131: dup
+				IL_0132: brfalse IL_014c
+
+				IL_0137: ldstr "d"
+				IL_013c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string)
+				IL_0141: box [System.Runtime]System.Double
+				IL_0146: stloc.3
+				IL_0147: br IL_015e
+
+				IL_014c: pop
+
+				IL_014d: ldloc.3
+				IL_014e: ldstr "lastIndexOf"
+				IL_0153: ldstr "d"
+				IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_015d: stloc.3
+
+				IL_015e: ldarg.0
+				IL_015f: ldloc.3
+				IL_0160: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0165: ldloc.0
+				IL_0166: ldc.r8 1
+				IL_016f: add
+				IL_0170: stloc.0
+				IL_0171: br IL_000a
+			// end loop
+
+			IL_0176: ldnull
+			IL_0177: ret
+		} // end of method FunctionExpression_L122C20::__js_call__
+
+	} // end of class FunctionExpression_L122C20
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L133C14
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L134C34
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L134C34::.ctor
+
+			} // end of class Block_L134C34
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 708 (0x2c4)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] float64,
+				[2] float64,
+				[3] object,
+				[4] object,
+				[5] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldarg.0
+				IL_000d: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: stloc.2
+				IL_0018: ldloc.1
+				IL_0019: ldloc.2
+				IL_001a: clt
+				IL_001c: brfalse IL_02c2
+
+				IL_0021: ldarg.0
+				IL_0022: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_002c: stloc.3
+				IL_002d: ldc.i4.0
+				IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0033: brfalse IL_005e
+
+				IL_0038: ldloc.3
+				IL_0039: isinst [System.Runtime]System.String
+				IL_003e: dup
+				IL_003f: brfalse IL_005d
+
+				IL_0044: ldc.r8 0.0
+				IL_004d: box [System.Runtime]System.Double
+				IL_0052: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
+				IL_0057: stloc.3
+				IL_0058: br IL_0078
+
+				IL_005d: pop
+
+				IL_005e: ldloc.3
+				IL_005f: ldstr "slice"
+				IL_0064: ldc.r8 0.0
+				IL_006d: box [System.Runtime]System.Double
+				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0077: stloc.3
+
+				IL_0078: ldarg.0
+				IL_0079: ldloc.3
+				IL_007a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_007f: ldarg.0
+				IL_0080: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_008a: stloc.3
+				IL_008b: ldc.i4.0
+				IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0091: brfalse IL_00ca
+
+				IL_0096: ldloc.3
+				IL_0097: isinst [System.Runtime]System.String
+				IL_009c: dup
+				IL_009d: brfalse IL_00c9
+
+				IL_00a2: ldc.r8 0.0
+				IL_00ab: box [System.Runtime]System.Double
+				IL_00b0: ldc.r8 5
+				IL_00b9: box [System.Runtime]System.Double
+				IL_00be: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+				IL_00c3: stloc.3
+				IL_00c4: br IL_00f2
+
+				IL_00c9: pop
+
+				IL_00ca: ldloc.3
+				IL_00cb: ldstr "slice"
+				IL_00d0: ldc.r8 0.0
+				IL_00d9: box [System.Runtime]System.Double
+				IL_00de: ldc.r8 5
+				IL_00e7: box [System.Runtime]System.Double
+				IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_00f1: stloc.3
+
+				IL_00f2: ldarg.0
+				IL_00f3: ldloc.3
+				IL_00f4: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_00f9: ldarg.0
+				IL_00fa: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0104: stloc.3
+				IL_0105: ldc.r8 1
+				IL_010e: neg
+				IL_010f: stloc.2
+				IL_0110: ldloc.2
+				IL_0111: box [System.Runtime]System.Double
+				IL_0116: stloc.s 4
+				IL_0118: ldc.i4.0
+				IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_011e: brfalse IL_013d
+
+				IL_0123: ldloc.3
+				IL_0124: isinst [System.Runtime]System.String
+				IL_0129: dup
+				IL_012a: brfalse IL_013c
+
+				IL_012f: ldloc.s 4
+				IL_0131: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
+				IL_0136: stloc.3
+				IL_0137: br IL_014b
+
+				IL_013c: pop
+
+				IL_013d: ldloc.3
+				IL_013e: ldstr "slice"
+				IL_0143: ldloc.s 4
+				IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_014a: stloc.3
+
+				IL_014b: ldarg.0
+				IL_014c: ldloc.3
+				IL_014d: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0152: ldarg.0
+				IL_0153: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_015d: stloc.3
+				IL_015e: ldc.r8 6
+				IL_0167: neg
+				IL_0168: stloc.2
+				IL_0169: ldloc.2
+				IL_016a: box [System.Runtime]System.Double
+				IL_016f: stloc.s 4
+				IL_0171: ldc.r8 1
+				IL_017a: neg
+				IL_017b: stloc.2
+				IL_017c: ldloc.2
+				IL_017d: box [System.Runtime]System.Double
+				IL_0182: stloc.s 5
+				IL_0184: ldc.i4.0
+				IL_0185: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_018a: brfalse IL_01ab
+
+				IL_018f: ldloc.3
+				IL_0190: isinst [System.Runtime]System.String
+				IL_0195: dup
+				IL_0196: brfalse IL_01aa
+
+				IL_019b: ldloc.s 4
+				IL_019d: ldloc.s 5
+				IL_019f: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+				IL_01a4: stloc.3
+				IL_01a5: br IL_01bb
+
+				IL_01aa: pop
+
+				IL_01ab: ldloc.3
+				IL_01ac: ldstr "slice"
+				IL_01b1: ldloc.s 4
+				IL_01b3: ldloc.s 5
+				IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_01ba: stloc.3
+
+				IL_01bb: ldarg.0
+				IL_01bc: ldloc.3
+				IL_01bd: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_01c2: ldarg.0
+				IL_01c3: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01cd: stloc.3
+				IL_01ce: ldc.i4.0
+				IL_01cf: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_01d4: brfalse IL_020d
+
+				IL_01d9: ldloc.3
+				IL_01da: isinst [System.Runtime]System.String
+				IL_01df: dup
+				IL_01e0: brfalse IL_020c
+
+				IL_01e5: ldc.r8 15000
+				IL_01ee: box [System.Runtime]System.Double
+				IL_01f3: ldc.r8 15005
+				IL_01fc: box [System.Runtime]System.Double
+				IL_0201: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+				IL_0206: stloc.3
+				IL_0207: br IL_0235
+
+				IL_020c: pop
+
+				IL_020d: ldloc.3
+				IL_020e: ldstr "slice"
+				IL_0213: ldc.r8 15000
+				IL_021c: box [System.Runtime]System.Double
+				IL_0221: ldc.r8 15005
+				IL_022a: box [System.Runtime]System.Double
+				IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0234: stloc.3
+
+				IL_0235: ldarg.0
+				IL_0236: ldloc.3
+				IL_0237: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_023c: ldarg.0
+				IL_023d: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0247: stloc.3
+				IL_0248: ldc.r8 1
+				IL_0251: neg
+				IL_0252: stloc.2
+				IL_0253: ldloc.2
+				IL_0254: box [System.Runtime]System.Double
+				IL_0259: stloc.s 5
+				IL_025b: ldc.i4.0
+				IL_025c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0261: brfalse IL_028e
+
+				IL_0266: ldloc.3
+				IL_0267: isinst [System.Runtime]System.String
+				IL_026c: dup
+				IL_026d: brfalse IL_028d
+
+				IL_0272: ldc.r8 12000
+				IL_027b: box [System.Runtime]System.Double
+				IL_0280: ldloc.s 5
+				IL_0282: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+				IL_0287: stloc.3
+				IL_0288: br IL_02aa
+
+				IL_028d: pop
+
+				IL_028e: ldloc.3
+				IL_028f: ldstr "slice"
+				IL_0294: ldc.r8 12000
+				IL_029d: box [System.Runtime]System.Double
+				IL_02a2: ldloc.s 5
+				IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_02a9: stloc.3
+
+				IL_02aa: ldarg.0
+				IL_02ab: ldloc.3
+				IL_02ac: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_02b1: ldloc.0
+				IL_02b2: ldc.r8 1
+				IL_02bb: add
+				IL_02bc: stloc.0
+				IL_02bd: br IL_000a
+			// end loop
+
+			IL_02c2: ldnull
+			IL_02c3: ret
+		} // end of method FunctionExpression_L133C14::__js_call__
+
+	} // end of class FunctionExpression_L133C14
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L146C15
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L147C34
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L147C34::.ctor
+
+			} // end of class Block_L147C34
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 718 (0x2ce)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] float64,
+				[2] float64,
+				[3] object,
+				[4] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldarg.0
+				IL_000d: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: stloc.2
+				IL_0018: ldloc.1
+				IL_0019: ldloc.2
+				IL_001a: clt
+				IL_001c: brfalse IL_02cc
+
+				IL_0021: ldarg.0
+				IL_0022: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_002c: stloc.3
+				IL_002d: ldc.i4.0
+				IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0033: brfalse IL_005e
+
+				IL_0038: ldloc.3
+				IL_0039: isinst [System.Runtime]System.String
+				IL_003e: dup
+				IL_003f: brfalse IL_005d
+
+				IL_0044: ldc.r8 0.0
+				IL_004d: box [System.Runtime]System.Double
+				IL_0052: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object)
+				IL_0057: stloc.3
+				IL_0058: br IL_0078
+
+				IL_005d: pop
+
+				IL_005e: ldloc.3
+				IL_005f: ldstr "substr"
+				IL_0064: ldc.r8 0.0
+				IL_006d: box [System.Runtime]System.Double
+				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0077: stloc.3
+
+				IL_0078: ldarg.0
+				IL_0079: ldloc.3
+				IL_007a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_007f: ldarg.0
+				IL_0080: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_008a: stloc.3
+				IL_008b: ldc.i4.0
+				IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0091: brfalse IL_00ca
+
+				IL_0096: ldloc.3
+				IL_0097: isinst [System.Runtime]System.String
+				IL_009c: dup
+				IL_009d: brfalse IL_00c9
+
+				IL_00a2: ldc.r8 0.0
+				IL_00ab: box [System.Runtime]System.Double
+				IL_00b0: ldc.r8 5
+				IL_00b9: box [System.Runtime]System.Double
+				IL_00be: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object, object)
+				IL_00c3: stloc.3
+				IL_00c4: br IL_00f2
+
+				IL_00c9: pop
+
+				IL_00ca: ldloc.3
+				IL_00cb: ldstr "substr"
+				IL_00d0: ldc.r8 0.0
+				IL_00d9: box [System.Runtime]System.Double
+				IL_00de: ldc.r8 5
+				IL_00e7: box [System.Runtime]System.Double
+				IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_00f1: stloc.3
+
+				IL_00f2: ldarg.0
+				IL_00f3: ldloc.3
+				IL_00f4: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_00f9: ldarg.0
+				IL_00fa: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0104: stloc.3
+				IL_0105: ldc.r8 1
+				IL_010e: neg
+				IL_010f: stloc.2
+				IL_0110: ldloc.2
+				IL_0111: box [System.Runtime]System.Double
+				IL_0116: stloc.s 4
+				IL_0118: ldc.i4.0
+				IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_011e: brfalse IL_013d
+
+				IL_0123: ldloc.3
+				IL_0124: isinst [System.Runtime]System.String
+				IL_0129: dup
+				IL_012a: brfalse IL_013c
+
+				IL_012f: ldloc.s 4
+				IL_0131: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object)
+				IL_0136: stloc.3
+				IL_0137: br IL_014b
+
+				IL_013c: pop
+
+				IL_013d: ldloc.3
+				IL_013e: ldstr "substr"
+				IL_0143: ldloc.s 4
+				IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_014a: stloc.3
+
+				IL_014b: ldarg.0
+				IL_014c: ldloc.3
+				IL_014d: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0152: ldarg.0
+				IL_0153: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_015d: stloc.3
+				IL_015e: ldc.r8 6
+				IL_0167: neg
+				IL_0168: stloc.2
+				IL_0169: ldloc.2
+				IL_016a: box [System.Runtime]System.Double
+				IL_016f: stloc.s 4
+				IL_0171: ldc.i4.0
+				IL_0172: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0177: brfalse IL_01a4
+
+				IL_017c: ldloc.3
+				IL_017d: isinst [System.Runtime]System.String
+				IL_0182: dup
+				IL_0183: brfalse IL_01a3
+
+				IL_0188: ldloc.s 4
+				IL_018a: ldc.r8 1
+				IL_0193: box [System.Runtime]System.Double
+				IL_0198: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object, object)
+				IL_019d: stloc.3
+				IL_019e: br IL_01c0
+
+				IL_01a3: pop
+
+				IL_01a4: ldloc.3
+				IL_01a5: ldstr "substr"
+				IL_01aa: ldloc.s 4
+				IL_01ac: ldc.r8 1
+				IL_01b5: box [System.Runtime]System.Double
+				IL_01ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_01bf: stloc.3
+
+				IL_01c0: ldarg.0
+				IL_01c1: ldloc.3
+				IL_01c2: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_01c7: ldarg.0
+				IL_01c8: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01d2: stloc.3
+				IL_01d3: ldc.i4.0
+				IL_01d4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_01d9: brfalse IL_0212
+
+				IL_01de: ldloc.3
+				IL_01df: isinst [System.Runtime]System.String
+				IL_01e4: dup
+				IL_01e5: brfalse IL_0211
+
+				IL_01ea: ldc.r8 15000
+				IL_01f3: box [System.Runtime]System.Double
+				IL_01f8: ldc.r8 5
+				IL_0201: box [System.Runtime]System.Double
+				IL_0206: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object, object)
+				IL_020b: stloc.3
+				IL_020c: br IL_023a
+
+				IL_0211: pop
+
+				IL_0212: ldloc.3
+				IL_0213: ldstr "substr"
+				IL_0218: ldc.r8 15000
+				IL_0221: box [System.Runtime]System.Double
+				IL_0226: ldc.r8 5
+				IL_022f: box [System.Runtime]System.Double
+				IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0239: stloc.3
+
+				IL_023a: ldarg.0
+				IL_023b: ldloc.3
+				IL_023c: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0241: ldarg.0
+				IL_0242: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_024c: stloc.3
+				IL_024d: ldc.i4.0
+				IL_024e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0253: brfalse IL_028c
+
+				IL_0258: ldloc.3
+				IL_0259: isinst [System.Runtime]System.String
+				IL_025e: dup
+				IL_025f: brfalse IL_028b
+
+				IL_0264: ldc.r8 12000
+				IL_026d: box [System.Runtime]System.Double
+				IL_0272: ldc.r8 5
+				IL_027b: box [System.Runtime]System.Double
+				IL_0280: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substr(string, object, object)
+				IL_0285: stloc.3
+				IL_0286: br IL_02b4
+
+				IL_028b: pop
+
+				IL_028c: ldloc.3
+				IL_028d: ldstr "substr"
+				IL_0292: ldc.r8 12000
+				IL_029b: box [System.Runtime]System.Double
+				IL_02a0: ldc.r8 5
+				IL_02a9: box [System.Runtime]System.Double
+				IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_02b3: stloc.3
+
+				IL_02b4: ldarg.0
+				IL_02b5: ldloc.3
+				IL_02b6: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_02bb: ldloc.0
+				IL_02bc: ldc.r8 1
+				IL_02c5: add
+				IL_02c6: stloc.0
+				IL_02c7: br IL_000a
+			// end loop
+
+			IL_02cc: ldnull
+			IL_02cd: ret
+		} // end of method FunctionExpression_L146C15::__js_call__
+
+	} // end of class FunctionExpression_L146C15
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L159C18
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L160C34
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L160C34::.ctor
+
+			} // end of class Block_L160C34
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 708 (0x2c4)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] float64,
+				[2] float64,
+				[3] object,
+				[4] object,
+				[5] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldarg.0
+				IL_000d: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: stloc.2
+				IL_0018: ldloc.1
+				IL_0019: ldloc.2
+				IL_001a: clt
+				IL_001c: brfalse IL_02c2
+
+				IL_0021: ldarg.0
+				IL_0022: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_002c: stloc.3
+				IL_002d: ldc.i4.0
+				IL_002e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0033: brfalse IL_005e
+
+				IL_0038: ldloc.3
+				IL_0039: isinst [System.Runtime]System.String
+				IL_003e: dup
+				IL_003f: brfalse IL_005d
+
+				IL_0044: ldc.r8 0.0
+				IL_004d: box [System.Runtime]System.Double
+				IL_0052: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+				IL_0057: stloc.3
+				IL_0058: br IL_0078
+
+				IL_005d: pop
+
+				IL_005e: ldloc.3
+				IL_005f: ldstr "substring"
+				IL_0064: ldc.r8 0.0
+				IL_006d: box [System.Runtime]System.Double
+				IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0077: stloc.3
+
+				IL_0078: ldarg.0
+				IL_0079: ldloc.3
+				IL_007a: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_007f: ldarg.0
+				IL_0080: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_008a: stloc.3
+				IL_008b: ldc.i4.0
+				IL_008c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0091: brfalse IL_00ca
+
+				IL_0096: ldloc.3
+				IL_0097: isinst [System.Runtime]System.String
+				IL_009c: dup
+				IL_009d: brfalse IL_00c9
+
+				IL_00a2: ldc.r8 0.0
+				IL_00ab: box [System.Runtime]System.Double
+				IL_00b0: ldc.r8 5
+				IL_00b9: box [System.Runtime]System.Double
+				IL_00be: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+				IL_00c3: stloc.3
+				IL_00c4: br IL_00f2
+
+				IL_00c9: pop
+
+				IL_00ca: ldloc.3
+				IL_00cb: ldstr "substring"
+				IL_00d0: ldc.r8 0.0
+				IL_00d9: box [System.Runtime]System.Double
+				IL_00de: ldc.r8 5
+				IL_00e7: box [System.Runtime]System.Double
+				IL_00ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_00f1: stloc.3
+
+				IL_00f2: ldarg.0
+				IL_00f3: ldloc.3
+				IL_00f4: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_00f9: ldarg.0
+				IL_00fa: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0104: stloc.3
+				IL_0105: ldc.r8 1
+				IL_010e: neg
+				IL_010f: stloc.2
+				IL_0110: ldloc.2
+				IL_0111: box [System.Runtime]System.Double
+				IL_0116: stloc.s 4
+				IL_0118: ldc.i4.0
+				IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_011e: brfalse IL_013d
+
+				IL_0123: ldloc.3
+				IL_0124: isinst [System.Runtime]System.String
+				IL_0129: dup
+				IL_012a: brfalse IL_013c
+
+				IL_012f: ldloc.s 4
+				IL_0131: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+				IL_0136: stloc.3
+				IL_0137: br IL_014b
+
+				IL_013c: pop
+
+				IL_013d: ldloc.3
+				IL_013e: ldstr "substring"
+				IL_0143: ldloc.s 4
+				IL_0145: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_014a: stloc.3
+
+				IL_014b: ldarg.0
+				IL_014c: ldloc.3
+				IL_014d: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0152: ldarg.0
+				IL_0153: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_015d: stloc.3
+				IL_015e: ldc.r8 6
+				IL_0167: neg
+				IL_0168: stloc.2
+				IL_0169: ldloc.2
+				IL_016a: box [System.Runtime]System.Double
+				IL_016f: stloc.s 4
+				IL_0171: ldc.r8 1
+				IL_017a: neg
+				IL_017b: stloc.2
+				IL_017c: ldloc.2
+				IL_017d: box [System.Runtime]System.Double
+				IL_0182: stloc.s 5
+				IL_0184: ldc.i4.0
+				IL_0185: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_018a: brfalse IL_01ab
+
+				IL_018f: ldloc.3
+				IL_0190: isinst [System.Runtime]System.String
+				IL_0195: dup
+				IL_0196: brfalse IL_01aa
+
+				IL_019b: ldloc.s 4
+				IL_019d: ldloc.s 5
+				IL_019f: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+				IL_01a4: stloc.3
+				IL_01a5: br IL_01bb
+
+				IL_01aa: pop
+
+				IL_01ab: ldloc.3
+				IL_01ac: ldstr "substring"
+				IL_01b1: ldloc.s 4
+				IL_01b3: ldloc.s 5
+				IL_01b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_01ba: stloc.3
+
+				IL_01bb: ldarg.0
+				IL_01bc: ldloc.3
+				IL_01bd: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_01c2: ldarg.0
+				IL_01c3: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_01c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_01cd: stloc.3
+				IL_01ce: ldc.i4.0
+				IL_01cf: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_01d4: brfalse IL_020d
+
+				IL_01d9: ldloc.3
+				IL_01da: isinst [System.Runtime]System.String
+				IL_01df: dup
+				IL_01e0: brfalse IL_020c
+
+				IL_01e5: ldc.r8 15000
+				IL_01ee: box [System.Runtime]System.Double
+				IL_01f3: ldc.r8 15005
+				IL_01fc: box [System.Runtime]System.Double
+				IL_0201: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+				IL_0206: stloc.3
+				IL_0207: br IL_0235
+
+				IL_020c: pop
+
+				IL_020d: ldloc.3
+				IL_020e: ldstr "substring"
+				IL_0213: ldc.r8 15000
+				IL_021c: box [System.Runtime]System.Double
+				IL_0221: ldc.r8 15005
+				IL_022a: box [System.Runtime]System.Double
+				IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0234: stloc.3
+
+				IL_0235: ldarg.0
+				IL_0236: ldloc.3
+				IL_0237: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_023c: ldarg.0
+				IL_023d: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0242: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0247: stloc.3
+				IL_0248: ldc.r8 1
+				IL_0251: neg
+				IL_0252: stloc.2
+				IL_0253: ldloc.2
+				IL_0254: box [System.Runtime]System.Double
+				IL_0259: stloc.s 5
+				IL_025b: ldc.i4.0
+				IL_025c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0261: brfalse IL_028e
+
+				IL_0266: ldloc.3
+				IL_0267: isinst [System.Runtime]System.String
+				IL_026c: dup
+				IL_026d: brfalse IL_028d
+
+				IL_0272: ldc.r8 12000
+				IL_027b: box [System.Runtime]System.Double
+				IL_0280: ldloc.s 5
+				IL_0282: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+				IL_0287: stloc.3
+				IL_0288: br IL_02aa
+
+				IL_028d: pop
+
+				IL_028e: ldloc.3
+				IL_028f: ldstr "substring"
+				IL_0294: ldc.r8 12000
+				IL_029d: box [System.Runtime]System.Double
+				IL_02a2: ldloc.s 5
+				IL_02a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_02a9: stloc.3
+
+				IL_02aa: ldarg.0
+				IL_02ab: ldloc.3
+				IL_02ac: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_02b1: ldloc.0
+				IL_02b2: ldc.r8 1
+				IL_02bb: add
+				IL_02bc: stloc.0
+				IL_02bd: br IL_000a
+			// end loop
+
+			IL_02c2: ldnull
+			IL_02c3: ret
+		} // end of method FunctionExpression_L159C18::__js_call__
+
+	} // end of class FunctionExpression_L159C18
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L172C20
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L173C41
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L173C41::.ctor
+
+			} // end of class Block_L173C41
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 128 (0x80)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] float64,
+				[2] float64,
+				[3] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldarg.0
+				IL_000d: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: ldc.r8 1000
+				IL_0020: div
+				IL_0021: stloc.2
+				IL_0022: ldloc.1
+				IL_0023: ldloc.2
+				IL_0024: clt
+				IL_0026: brfalse IL_007e
+
+				IL_002b: ldarg.0
+				IL_002c: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0036: stloc.3
+				IL_0037: ldc.i4.0
+				IL_0038: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_003d: brfalse IL_005a
+
+				IL_0042: ldloc.3
+				IL_0043: isinst [System.Runtime]System.String
+				IL_0048: dup
+				IL_0049: brfalse IL_0059
+
+				IL_004e: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToLowerCase(string)
+				IL_0053: stloc.3
+				IL_0054: br IL_0066
+
+				IL_0059: pop
+
+				IL_005a: ldloc.3
+				IL_005b: ldstr "toLowerCase"
+				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0065: stloc.3
+
+				IL_0066: ldarg.0
+				IL_0067: ldloc.3
+				IL_0068: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_006d: ldloc.0
+				IL_006e: ldc.r8 1
+				IL_0077: add
+				IL_0078: stloc.0
+				IL_0079: br IL_000a
+			// end loop
+
+			IL_007e: ldnull
+			IL_007f: ret
+		} // end of method FunctionExpression_L172C20::__js_call__
+
+	} // end of class FunctionExpression_L172C20
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L178C20
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L179C41
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L179C41::.ctor
+
+			} // end of class Block_L179C41
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 128 (0x80)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] float64,
+				[2] float64,
+				[3] object
+			)
+
+			IL_0000: ldc.r8 0.0
+			IL_0009: stloc.0
+			// loop start (head: IL_000a)
+				IL_000a: ldloc.0
+				IL_000b: stloc.1
+				IL_000c: ldarg.0
+				IL_000d: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: ldc.r8 1000
+				IL_0020: div
+				IL_0021: stloc.2
+				IL_0022: ldloc.1
+				IL_0023: ldloc.2
+				IL_0024: clt
+				IL_0026: brfalse IL_007e
+
+				IL_002b: ldarg.0
+				IL_002c: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+				IL_0031: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0036: stloc.3
+				IL_0037: ldc.i4.0
+				IL_0038: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_003d: brfalse IL_005a
+
+				IL_0042: ldloc.3
+				IL_0043: isinst [System.Runtime]System.String
+				IL_0048: dup
+				IL_0049: brfalse IL_0059
+
+				IL_004e: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+				IL_0053: stloc.3
+				IL_0054: br IL_0066
+
+				IL_0059: pop
+
+				IL_005a: ldloc.3
+				IL_005b: ldstr "toUpperCase"
+				IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0065: stloc.3
+
+				IL_0066: ldarg.0
+				IL_0067: ldloc.3
+				IL_0068: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_006d: ldloc.0
+				IL_006e: ldc.r8 1
+				IL_0077: add
+				IL_0078: stloc.0
+				IL_0079: br IL_000a
+			// end loop
+
+			IL_007e: ldnull
+			IL_007f: ret
+		} // end of method FunctionExpression_L178C20::__js_call__
+
+	} // end of class FunctionExpression_L178C20
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L185C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 30 (0x1e)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+			IL_0006: stloc.0
+			IL_0007: ldarg.0
+			IL_0008: ldloc.0
+			IL_0009: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp
+			IL_000e: ldarg.0
+			IL_000f: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+			IL_0014: stloc.0
+			IL_0015: ldarg.0
+			IL_0016: ldloc.0
+			IL_0017: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp2
+			IL_001c: ldnull
+			IL_001d: ret
+		} // end of method FunctionExpression_L185C5::__js_call__
+
+	} // end of class FunctionExpression_L185C5
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L190C18
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L193C41
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L193C41::.ctor
+
+			} // end of class Block_L193C41
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_String/Scope _environment0_Compile_Performance_Dromaeo_Object_String
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_String/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldnull
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_String/Scope Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_String
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_String/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Compile_Performance_Dromaeo_Object_String/Scope scope,
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 1c 00 00 02
+			)
+			// Header size: 12
+			// Code size: 280 (0x118)
+			.maxstack 8
+			.locals init (
+				[0] float64,
+				[1] object,
+				[2] object,
+				[3] float64,
+				[4] float64,
+				[5] object,
+				[6] bool,
+				[7] object
+			)
+
+			IL_0000: ldarg.0
+			IL_0001: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp
+			IL_0006: stloc.1
+			IL_0007: ldstr "a"
+			IL_000c: ldloc.1
+			IL_000d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0012: stloc.2
+			IL_0013: ldloc.2
+			IL_0014: ldstr "a"
+			IL_0019: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_001e: stloc.2
+			IL_001f: ldarg.0
+			IL_0020: ldloc.2
+			IL_0021: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp
+			IL_0026: ldarg.0
+			IL_0027: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp2
+			IL_002c: stloc.1
+			IL_002d: ldstr "a"
+			IL_0032: ldloc.1
+			IL_0033: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0038: stloc.2
+			IL_0039: ldloc.2
+			IL_003a: ldstr "a"
+			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0044: stloc.2
+			IL_0045: ldarg.0
+			IL_0046: ldloc.2
+			IL_0047: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp2
+			IL_004c: ldc.r8 0.0
+			IL_0055: stloc.0
+			// loop start (head: IL_0056)
+				IL_0056: ldloc.0
+				IL_0057: stloc.3
+				IL_0058: ldarg.0
+				IL_0059: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+				IL_005e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0063: ldc.r8 1000
+				IL_006c: div
+				IL_006d: stloc.s 4
+				IL_006f: ldloc.3
+				IL_0070: ldloc.s 4
+				IL_0072: clt
+				IL_0074: brfalse IL_0116
+
+				IL_0079: ldarg.0
+				IL_007a: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp
+				IL_007f: stloc.1
+				IL_0080: ldarg.0
+				IL_0081: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp2
+				IL_0086: stloc.s 5
+				IL_0088: ldloc.1
+				IL_0089: ldloc.s 5
+				IL_008b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::Equal(object, object)
+				IL_0090: stloc.s 6
+				IL_0092: ldloc.s 6
+				IL_0094: box [System.Runtime]System.Boolean
+				IL_0099: stloc.s 7
+				IL_009b: ldarg.0
+				IL_009c: ldloc.s 7
+				IL_009e: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_00a3: ldarg.0
+				IL_00a4: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp
+				IL_00a9: stloc.s 5
+				IL_00ab: ldarg.0
+				IL_00ac: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp2
+				IL_00b1: stloc.1
+				IL_00b2: ldloc.s 5
+				IL_00b4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00b9: ldloc.1
+				IL_00ba: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00bf: clt
+				IL_00c1: stloc.s 6
+				IL_00c3: ldloc.s 6
+				IL_00c5: box [System.Runtime]System.Boolean
+				IL_00ca: stloc.s 7
+				IL_00cc: ldarg.0
+				IL_00cd: ldloc.s 7
+				IL_00cf: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_00d4: ldarg.0
+				IL_00d5: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp
+				IL_00da: stloc.1
+				IL_00db: ldarg.0
+				IL_00dc: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp2
+				IL_00e1: stloc.s 5
+				IL_00e3: ldloc.1
+				IL_00e4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00e9: ldloc.s 5
+				IL_00eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_00f0: cgt
+				IL_00f2: stloc.s 6
+				IL_00f4: ldloc.s 6
+				IL_00f6: box [System.Runtime]System.Boolean
+				IL_00fb: stloc.s 7
+				IL_00fd: ldarg.0
+				IL_00fe: ldloc.s 7
+				IL_0100: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+				IL_0105: ldloc.0
+				IL_0106: ldc.r8 1
+				IL_010f: add
+				IL_0110: stloc.0
+				IL_0111: br IL_0056
+			// end loop
+
+			IL_0116: ldnull
+			IL_0117: ret
+		} // end of method FunctionExpression_L190C18::__js_call__
+
+	} // end of class FunctionExpression_L190C18
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		.custom instance void [System.Runtime]System.Diagnostics.DebuggerDisplayAttribute::.ctor(string) = (
+			01 00 7b 53 63 6f 70 65 20 73 74 61 72 74 54 65
+			73 74 3d 7b 73 74 61 72 74 54 65 73 74 7d 2c 20
+			65 6e 64 54 65 73 74 3d 7b 65 6e 64 54 65 73 74
+			7d 2c 20 70 72 65 70 3d 7b 70 72 65 70 7d 2c 20
+			74 65 73 74 3d 7b 74 65 73 74 7d 2c 20 72 65 74
+			3d 7b 72 65 74 7d 2c 20 6e 75 6d 3d 7b 6e 75 6d
+			7d 2c 20 6f 73 74 72 3d 7b 6f 73 74 72 7d 2c 20
+			74 6d 70 3d 7b 74 6d 70 7d 2c 20 e2 80 a6 00 00
+		)
+		// Fields
+		.field public object startTest
+		.field public object endTest
+		.field public object prep
+		.field public object test
+		.field public object 'ret'
+		.field public object num
+		.field public object ostr
+		.field public object tmp
+		.field public object tmp2
+		.field public object tmpstr
+		.field public object str
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Header size: 12
+		// Code size: 1862 (0x746)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Compile_Performance_Dromaeo_Object_String/Scope,
+			[1] class Modules.Compile_Performance_Dromaeo_Object_String/startTest/FunctionObject,
+			[2] class Modules.Compile_Performance_Dromaeo_Object_String/endTest/FunctionObject,
+			[3] class Modules.Compile_Performance_Dromaeo_Object_String/prep/FunctionObject,
+			[4] class Modules.Compile_Performance_Dromaeo_Object_String/test/FunctionObject,
+			[5] float64,
+			[6] object[],
+			[7] object[],
+			[8] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L15C22/FunctionObject,
+			[9] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L22C29/FunctionObject,
+			[10] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L29C36/FunctionObject,
+			[11] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L36C26/FunctionObject,
+			[12] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[13] float64,
+			[14] string,
+			[15] object,
+			[16] object,
+			[17] object,
+			[18] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5/FunctionObject,
+			[19] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21/FunctionObject,
+			[20] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5/FunctionObject,
+			[21] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29/FunctionObject,
+			[22] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5/FunctionObject,
+			[23] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15/FunctionObject,
+			[24] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17/FunctionObject,
+			[25] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19/FunctionObject,
+			[26] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16/FunctionObject,
+			[27] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20/FunctionObject,
+			[28] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14/FunctionObject,
+			[29] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15/FunctionObject,
+			[30] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18/FunctionObject,
+			[31] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20/FunctionObject,
+			[32] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20/FunctionObject,
+			[33] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5/FunctionObject,
+			[34] class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18/FunctionObject
+		)
+
+		IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: ldc.i4.1
+		IL_0007: newarr [System.Runtime]System.Object
+		IL_000c: dup
+		IL_000d: ldc.i4.0
+		IL_000e: ldloc.0
+		IL_000f: stelem.ref
+		IL_0010: stloc.s 6
+		IL_0012: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/startTest/FunctionObject::.ctor()
+		IL_0017: ldc.i4.2
+		IL_0018: conv.r8
+		IL_0019: ldstr "startTest"
+		IL_001e: ldc.i4.0
+		IL_001f: ldc.i4.1
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/startTest/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: stloc.1
+		IL_0026: ldc.i4.1
+		IL_0027: newarr [System.Runtime]System.Object
+		IL_002c: dup
+		IL_002d: ldc.i4.0
+		IL_002e: ldloc.0
+		IL_002f: stelem.ref
+		IL_0030: stloc.s 6
+		IL_0032: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/endTest/FunctionObject::.ctor()
+		IL_0037: ldc.i4.0
+		IL_0038: conv.r8
+		IL_0039: ldstr "endTest"
+		IL_003e: ldc.i4.0
+		IL_003f: ldc.i4.1
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/endTest/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0045: stloc.2
+		IL_0046: ldc.i4.1
+		IL_0047: newarr [System.Runtime]System.Object
+		IL_004c: dup
+		IL_004d: ldc.i4.0
+		IL_004e: ldloc.0
+		IL_004f: stelem.ref
+		IL_0050: stloc.s 6
+		IL_0052: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/prep/FunctionObject::.ctor()
+		IL_0057: ldc.i4.1
+		IL_0058: conv.r8
+		IL_0059: ldstr "prep"
+		IL_005e: ldc.i4.0
+		IL_005f: ldc.i4.1
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/prep/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0065: stloc.3
+		IL_0066: ldc.i4.1
+		IL_0067: newarr [System.Runtime]System.Object
+		IL_006c: dup
+		IL_006d: ldc.i4.0
+		IL_006e: ldloc.0
+		IL_006f: stelem.ref
+		IL_0070: stloc.s 6
+		IL_0072: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/test/FunctionObject::.ctor()
+		IL_0077: ldc.i4.2
+		IL_0078: conv.r8
+		IL_0079: ldstr "test"
+		IL_007e: ldc.i4.0
+		IL_007f: ldc.i4.1
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/test/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0085: stloc.s 4
+		IL_0087: nop
+		IL_0088: nop
+		IL_0089: nop
+		IL_008a: nop
+		IL_008b: nop
+		IL_008c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0091: stloc.s 6
+		IL_0093: ldloc.1
+		IL_0094: ldloc.s 6
+		IL_0096: ldstr "dromaeo-object-string"
+		IL_009b: ldstr "ef8605c3"
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_00a5: pop
+		IL_00a6: ldloc.0
+		IL_00a7: ldnull
+		IL_00a8: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::'ret'
+		IL_00ad: ldloc.0
+		IL_00ae: ldc.r8 5000
+		IL_00b7: box [System.Runtime]System.Double
+		IL_00bc: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+		IL_00c1: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_00c6: stloc.s 6
+		IL_00c8: ldc.i4.1
+		IL_00c9: newarr [System.Runtime]System.Object
+		IL_00ce: dup
+		IL_00cf: ldc.i4.0
+		IL_00d0: ldloc.0
+		IL_00d1: stelem.ref
+		IL_00d2: stloc.s 7
+		IL_00d4: ldloc.s 7
+		IL_00d6: ldc.i4.0
+		IL_00d7: ldelem.ref
+		IL_00d8: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_00dd: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L15C22/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_00e2: ldc.i4.0
+		IL_00e3: conv.r8
+		IL_00e4: ldstr ""
+		IL_00e9: ldc.i4.0
+		IL_00ea: ldc.i4.1
+		IL_00eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L15C22/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00f0: stloc.s 8
+		IL_00f2: ldloc.s 4
+		IL_00f4: ldloc.s 6
+		IL_00f6: ldstr "Concat String"
+		IL_00fb: ldloc.s 8
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0102: pop
+		IL_0103: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0108: stloc.s 6
+		IL_010a: ldc.i4.1
+		IL_010b: newarr [System.Runtime]System.Object
+		IL_0110: dup
+		IL_0111: ldc.i4.0
+		IL_0112: ldloc.0
+		IL_0113: stelem.ref
+		IL_0114: stloc.s 7
+		IL_0116: ldloc.s 7
+		IL_0118: ldc.i4.0
+		IL_0119: ldelem.ref
+		IL_011a: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_011f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L22C29/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0124: ldc.i4.0
+		IL_0125: conv.r8
+		IL_0126: ldstr ""
+		IL_012b: ldc.i4.0
+		IL_012c: ldc.i4.1
+		IL_012d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L22C29/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0132: stloc.s 9
+		IL_0134: ldloc.s 4
+		IL_0136: ldloc.s 6
+		IL_0138: ldstr "Concat String Object"
+		IL_013d: ldloc.s 9
+		IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0144: pop
+		IL_0145: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_014a: stloc.s 6
+		IL_014c: ldc.i4.1
+		IL_014d: newarr [System.Runtime]System.Object
+		IL_0152: dup
+		IL_0153: ldc.i4.0
+		IL_0154: ldloc.0
+		IL_0155: stelem.ref
+		IL_0156: stloc.s 7
+		IL_0158: ldloc.s 7
+		IL_015a: ldc.i4.0
+		IL_015b: ldelem.ref
+		IL_015c: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0161: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L29C36/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0166: ldc.i4.0
+		IL_0167: conv.r8
+		IL_0168: ldstr ""
+		IL_016d: ldc.i4.0
+		IL_016e: ldc.i4.1
+		IL_016f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L29C36/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0174: stloc.s 10
+		IL_0176: ldloc.s 4
+		IL_0178: ldloc.s 6
+		IL_017a: ldstr "Concat String from charCode"
+		IL_017f: ldloc.s 10
+		IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0186: pop
+		IL_0187: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_018c: stloc.s 6
+		IL_018e: ldc.i4.1
+		IL_018f: newarr [System.Runtime]System.Object
+		IL_0194: dup
+		IL_0195: ldc.i4.0
+		IL_0196: ldloc.0
+		IL_0197: stelem.ref
+		IL_0198: stloc.s 7
+		IL_019a: ldloc.s 7
+		IL_019c: ldc.i4.0
+		IL_019d: ldelem.ref
+		IL_019e: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_01a3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L36C26/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_01a8: ldc.i4.0
+		IL_01a9: conv.r8
+		IL_01aa: ldstr ""
+		IL_01af: ldc.i4.0
+		IL_01b0: ldc.i4.1
+		IL_01b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L36C26/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01b6: stloc.s 11
+		IL_01b8: ldloc.s 4
+		IL_01ba: ldloc.s 6
+		IL_01bc: ldstr "Array String Join"
+		IL_01c1: ldloc.s 11
+		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_01c8: pop
+		IL_01c9: ldc.i4.0
+		IL_01ca: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01cf: stloc.s 12
+		IL_01d1: ldloc.0
+		IL_01d2: ldloc.s 12
+		IL_01d4: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_01d9: ldloc.0
+		IL_01da: ldnull
+		IL_01db: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp
+		IL_01e0: ldloc.0
+		IL_01e1: ldnull
+		IL_01e2: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmp2
+		IL_01e7: ldloc.0
+		IL_01e8: ldc.r8 5000
+		IL_01f1: box [System.Runtime]System.Double
+		IL_01f6: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::num
+		IL_01fb: ldloc.0
+		IL_01fc: ldnull
+		IL_01fd: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::tmpstr
+		IL_0202: ldc.r8 0.0
+		IL_020b: stloc.s 5
+		// loop start (head: IL_020d)
+			IL_020d: ldloc.s 5
+			IL_020f: stloc.s 13
+			IL_0211: ldloc.s 13
+			IL_0213: ldc.r8 16384
+			IL_021c: clt
+			IL_021e: brfalse IL_0273
+
+			IL_0223: ldloc.0
+			IL_0224: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+			IL_0229: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_022e: ldc.r8 25
+			IL_0237: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::random()
+			IL_023c: mul
+			IL_023d: ldc.r8 97
+			IL_0246: add
+			IL_0247: box [System.Runtime]System.Double
+			IL_024c: call string [JavaScriptRuntime]JavaScriptRuntime.String::FromCharCode(object)
+			IL_0251: stloc.s 14
+			IL_0253: ldstr "push"
+			IL_0258: ldloc.s 14
+			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_025f: pop
+			IL_0260: ldloc.s 5
+			IL_0262: ldc.r8 1
+			IL_026b: add
+			IL_026c: stloc.s 5
+			IL_026e: br IL_020d
+		// end loop
+
+		IL_0273: ldloc.0
+		IL_0274: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_027e: ldstr "join"
+		IL_0283: ldstr ""
+		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_028d: stloc.s 15
+		IL_028f: ldloc.0
+		IL_0290: ldloc.s 15
+		IL_0292: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_0297: ldloc.0
+		IL_0298: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_029d: stloc.s 15
+		IL_029f: ldloc.0
+		IL_02a0: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_02a5: stloc.s 16
+		IL_02a7: ldloc.s 15
+		IL_02a9: ldloc.s 16
+		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02b0: stloc.s 17
+		IL_02b2: ldloc.0
+		IL_02b3: ldloc.s 17
+		IL_02b5: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_02ba: ldloc.0
+		IL_02bb: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_02c0: stloc.s 16
+		IL_02c2: ldloc.0
+		IL_02c3: ldfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_02c8: stloc.s 15
+		IL_02ca: ldloc.s 16
+		IL_02cc: ldloc.s 15
+		IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+		IL_02d3: stloc.s 17
+		IL_02d5: ldloc.0
+		IL_02d6: ldloc.s 17
+		IL_02d8: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::ostr
+		IL_02dd: ldloc.0
+		IL_02de: ldnull
+		IL_02df: stfld object Modules.Compile_Performance_Dromaeo_Object_String/Scope::str
+		IL_02e4: ldc.r8 52288
+		IL_02ed: stloc.s 5
+		IL_02ef: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02f4: stloc.s 6
+		IL_02f6: ldc.i4.1
+		IL_02f7: newarr [System.Runtime]System.Object
+		IL_02fc: dup
+		IL_02fd: ldc.i4.0
+		IL_02fe: ldloc.0
+		IL_02ff: stelem.ref
+		IL_0300: stloc.s 7
+		IL_0302: ldloc.s 7
+		IL_0304: ldc.i4.0
+		IL_0305: ldelem.ref
+		IL_0306: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_030b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0310: ldc.i4.0
+		IL_0311: conv.r8
+		IL_0312: ldstr ""
+		IL_0317: ldc.i4.0
+		IL_0318: ldc.i4.1
+		IL_0319: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L55C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_031e: stloc.s 18
+		IL_0320: ldloc.3
+		IL_0321: ldloc.s 6
+		IL_0323: ldloc.s 18
+		IL_0325: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_032a: pop
+		IL_032b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0330: stloc.s 6
+		IL_0332: ldc.i4.1
+		IL_0333: newarr [System.Runtime]System.Object
+		IL_0338: dup
+		IL_0339: ldc.i4.0
+		IL_033a: ldloc.0
+		IL_033b: stelem.ref
+		IL_033c: stloc.s 7
+		IL_033e: ldloc.s 7
+		IL_0340: ldc.i4.0
+		IL_0341: ldelem.ref
+		IL_0342: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0347: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_034c: ldc.i4.0
+		IL_034d: conv.r8
+		IL_034e: ldstr ""
+		IL_0353: ldc.i4.0
+		IL_0354: ldc.i4.1
+		IL_0355: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L60C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_035a: stloc.s 19
+		IL_035c: ldloc.s 4
+		IL_035e: ldloc.s 6
+		IL_0360: ldstr "String Split"
+		IL_0365: ldloc.s 19
+		IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_036c: pop
+		IL_036d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0372: stloc.s 6
+		IL_0374: ldc.i4.1
+		IL_0375: newarr [System.Runtime]System.Object
+		IL_037a: dup
+		IL_037b: ldc.i4.0
+		IL_037c: ldloc.0
+		IL_037d: stelem.ref
+		IL_037e: stloc.s 7
+		IL_0380: ldloc.s 7
+		IL_0382: ldc.i4.0
+		IL_0383: ldelem.ref
+		IL_0384: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0389: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_038e: ldc.i4.0
+		IL_038f: conv.r8
+		IL_0390: ldstr ""
+		IL_0395: ldc.i4.0
+		IL_0396: ldc.i4.1
+		IL_0397: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L64C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_039c: stloc.s 20
+		IL_039e: ldloc.3
+		IL_039f: ldloc.s 6
+		IL_03a1: ldloc.s 20
+		IL_03a3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_03a8: pop
+		IL_03a9: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03ae: stloc.s 6
+		IL_03b0: ldc.i4.1
+		IL_03b1: newarr [System.Runtime]System.Object
+		IL_03b6: dup
+		IL_03b7: ldc.i4.0
+		IL_03b8: ldloc.0
+		IL_03b9: stelem.ref
+		IL_03ba: stloc.s 7
+		IL_03bc: ldloc.s 7
+		IL_03be: ldc.i4.0
+		IL_03bf: ldelem.ref
+		IL_03c0: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_03c5: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_03ca: ldc.i4.0
+		IL_03cb: conv.r8
+		IL_03cc: ldstr ""
+		IL_03d1: ldc.i4.0
+		IL_03d2: ldc.i4.1
+		IL_03d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L72C29/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03d8: stloc.s 21
+		IL_03da: ldloc.s 4
+		IL_03dc: ldloc.s 6
+		IL_03de: ldstr "String Split on Char"
+		IL_03e3: ldloc.s 21
+		IL_03e5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_03ea: pop
+		IL_03eb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_03f0: stloc.s 6
+		IL_03f2: ldc.i4.1
+		IL_03f3: newarr [System.Runtime]System.Object
+		IL_03f8: dup
+		IL_03f9: ldc.i4.0
+		IL_03fa: ldloc.0
+		IL_03fb: stelem.ref
+		IL_03fc: stloc.s 7
+		IL_03fe: ldloc.s 7
+		IL_0400: ldc.i4.0
+		IL_0401: ldelem.ref
+		IL_0402: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0407: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_040c: ldc.i4.0
+		IL_040d: conv.r8
+		IL_040e: ldstr ""
+		IL_0413: ldc.i4.0
+		IL_0414: ldc.i4.1
+		IL_0415: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L76C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_041a: stloc.s 22
+		IL_041c: ldloc.3
+		IL_041d: ldloc.s 6
+		IL_041f: ldloc.s 22
+		IL_0421: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0426: pop
+		IL_0427: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_042c: stloc.s 6
+		IL_042e: ldc.i4.1
+		IL_042f: newarr [System.Runtime]System.Object
+		IL_0434: dup
+		IL_0435: ldc.i4.0
+		IL_0436: ldloc.0
+		IL_0437: stelem.ref
+		IL_0438: stloc.s 7
+		IL_043a: ldloc.s 7
+		IL_043c: ldc.i4.0
+		IL_043d: ldelem.ref
+		IL_043e: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0443: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0448: ldc.i4.0
+		IL_0449: conv.r8
+		IL_044a: ldstr ""
+		IL_044f: ldc.i4.0
+		IL_0450: ldc.i4.1
+		IL_0451: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L82C15/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0456: stloc.s 23
+		IL_0458: ldloc.s 4
+		IL_045a: ldloc.s 6
+		IL_045c: ldstr "charAt"
+		IL_0461: ldloc.s 23
+		IL_0463: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0468: pop
+		IL_0469: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_046e: stloc.s 6
+		IL_0470: ldc.i4.1
+		IL_0471: newarr [System.Runtime]System.Object
+		IL_0476: dup
+		IL_0477: ldc.i4.0
+		IL_0478: ldloc.0
+		IL_0479: stelem.ref
+		IL_047a: stloc.s 7
+		IL_047c: ldloc.s 7
+		IL_047e: ldc.i4.0
+		IL_047f: ldelem.ref
+		IL_0480: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0485: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_048a: ldc.i4.0
+		IL_048b: conv.r8
+		IL_048c: ldstr ""
+		IL_0491: ldc.i4.0
+		IL_0492: ldc.i4.1
+		IL_0493: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L91C17/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0498: stloc.s 24
+		IL_049a: ldloc.s 4
+		IL_049c: ldloc.s 6
+		IL_049e: ldstr "[Number]"
+		IL_04a3: ldloc.s 24
+		IL_04a5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_04aa: pop
+		IL_04ab: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04b0: stloc.s 6
+		IL_04b2: ldc.i4.1
+		IL_04b3: newarr [System.Runtime]System.Object
+		IL_04b8: dup
+		IL_04b9: ldc.i4.0
+		IL_04ba: ldloc.0
+		IL_04bb: stelem.ref
+		IL_04bc: stloc.s 7
+		IL_04be: ldloc.s 7
+		IL_04c0: ldc.i4.0
+		IL_04c1: ldelem.ref
+		IL_04c2: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_04c7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_04cc: ldc.i4.0
+		IL_04cd: conv.r8
+		IL_04ce: ldstr ""
+		IL_04d3: ldc.i4.0
+		IL_04d4: ldc.i4.1
+		IL_04d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L101C19/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04da: stloc.s 25
+		IL_04dc: ldloc.s 4
+		IL_04de: ldloc.s 6
+		IL_04e0: ldstr "charCodeAt"
+		IL_04e5: ldloc.s 25
+		IL_04e7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_04ec: pop
+		IL_04ed: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_04f2: stloc.s 6
+		IL_04f4: ldc.i4.1
+		IL_04f5: newarr [System.Runtime]System.Object
+		IL_04fa: dup
+		IL_04fb: ldc.i4.0
+		IL_04fc: ldloc.0
+		IL_04fd: stelem.ref
+		IL_04fe: stloc.s 7
+		IL_0500: ldloc.s 7
+		IL_0502: ldc.i4.0
+		IL_0503: ldelem.ref
+		IL_0504: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0509: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_050e: ldc.i4.0
+		IL_050f: conv.r8
+		IL_0510: ldstr ""
+		IL_0515: ldc.i4.0
+		IL_0516: ldc.i4.1
+		IL_0517: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L113C16/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_051c: stloc.s 26
+		IL_051e: ldloc.s 4
+		IL_0520: ldloc.s 6
+		IL_0522: ldstr "indexOf"
+		IL_0527: ldloc.s 26
+		IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_052e: pop
+		IL_052f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0534: stloc.s 6
+		IL_0536: ldc.i4.1
+		IL_0537: newarr [System.Runtime]System.Object
+		IL_053c: dup
+		IL_053d: ldc.i4.0
+		IL_053e: ldloc.0
+		IL_053f: stelem.ref
+		IL_0540: stloc.s 7
+		IL_0542: ldloc.s 7
+		IL_0544: ldc.i4.0
+		IL_0545: ldelem.ref
+		IL_0546: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_054b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0550: ldc.i4.0
+		IL_0551: conv.r8
+		IL_0552: ldstr ""
+		IL_0557: ldc.i4.0
+		IL_0558: ldc.i4.1
+		IL_0559: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L122C20/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_055e: stloc.s 27
+		IL_0560: ldloc.s 4
+		IL_0562: ldloc.s 6
+		IL_0564: ldstr "lastIndexOf"
+		IL_0569: ldloc.s 27
+		IL_056b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0570: pop
+		IL_0571: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0576: stloc.s 6
+		IL_0578: ldc.i4.1
+		IL_0579: newarr [System.Runtime]System.Object
+		IL_057e: dup
+		IL_057f: ldc.i4.0
+		IL_0580: ldloc.0
+		IL_0581: stelem.ref
+		IL_0582: stloc.s 7
+		IL_0584: ldloc.s 7
+		IL_0586: ldc.i4.0
+		IL_0587: ldelem.ref
+		IL_0588: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_058d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0592: ldc.i4.0
+		IL_0593: conv.r8
+		IL_0594: ldstr ""
+		IL_0599: ldc.i4.0
+		IL_059a: ldc.i4.1
+		IL_059b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L133C14/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05a0: stloc.s 28
+		IL_05a2: ldloc.s 4
+		IL_05a4: ldloc.s 6
+		IL_05a6: ldstr "slice"
+		IL_05ab: ldloc.s 28
+		IL_05ad: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_05b2: pop
+		IL_05b3: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05b8: stloc.s 6
+		IL_05ba: ldc.i4.1
+		IL_05bb: newarr [System.Runtime]System.Object
+		IL_05c0: dup
+		IL_05c1: ldc.i4.0
+		IL_05c2: ldloc.0
+		IL_05c3: stelem.ref
+		IL_05c4: stloc.s 7
+		IL_05c6: ldloc.s 7
+		IL_05c8: ldc.i4.0
+		IL_05c9: ldelem.ref
+		IL_05ca: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_05cf: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_05d4: ldc.i4.0
+		IL_05d5: conv.r8
+		IL_05d6: ldstr ""
+		IL_05db: ldc.i4.0
+		IL_05dc: ldc.i4.1
+		IL_05dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L146C15/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05e2: stloc.s 29
+		IL_05e4: ldloc.s 4
+		IL_05e6: ldloc.s 6
+		IL_05e8: ldstr "substr"
+		IL_05ed: ldloc.s 29
+		IL_05ef: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_05f4: pop
+		IL_05f5: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_05fa: stloc.s 6
+		IL_05fc: ldc.i4.1
+		IL_05fd: newarr [System.Runtime]System.Object
+		IL_0602: dup
+		IL_0603: ldc.i4.0
+		IL_0604: ldloc.0
+		IL_0605: stelem.ref
+		IL_0606: stloc.s 7
+		IL_0608: ldloc.s 7
+		IL_060a: ldc.i4.0
+		IL_060b: ldelem.ref
+		IL_060c: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0611: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0616: ldc.i4.0
+		IL_0617: conv.r8
+		IL_0618: ldstr ""
+		IL_061d: ldc.i4.0
+		IL_061e: ldc.i4.1
+		IL_061f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L159C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0624: stloc.s 30
+		IL_0626: ldloc.s 4
+		IL_0628: ldloc.s 6
+		IL_062a: ldstr "substring"
+		IL_062f: ldloc.s 30
+		IL_0631: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0636: pop
+		IL_0637: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_063c: stloc.s 6
+		IL_063e: ldc.i4.1
+		IL_063f: newarr [System.Runtime]System.Object
+		IL_0644: dup
+		IL_0645: ldc.i4.0
+		IL_0646: ldloc.0
+		IL_0647: stelem.ref
+		IL_0648: stloc.s 7
+		IL_064a: ldloc.s 7
+		IL_064c: ldc.i4.0
+		IL_064d: ldelem.ref
+		IL_064e: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0653: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0658: ldc.i4.0
+		IL_0659: conv.r8
+		IL_065a: ldstr ""
+		IL_065f: ldc.i4.0
+		IL_0660: ldc.i4.1
+		IL_0661: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L172C20/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0666: stloc.s 31
+		IL_0668: ldloc.s 4
+		IL_066a: ldloc.s 6
+		IL_066c: ldstr "toLowerCase"
+		IL_0671: ldloc.s 31
+		IL_0673: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0678: pop
+		IL_0679: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_067e: stloc.s 6
+		IL_0680: ldc.i4.1
+		IL_0681: newarr [System.Runtime]System.Object
+		IL_0686: dup
+		IL_0687: ldc.i4.0
+		IL_0688: ldloc.0
+		IL_0689: stelem.ref
+		IL_068a: stloc.s 7
+		IL_068c: ldloc.s 7
+		IL_068e: ldc.i4.0
+		IL_068f: ldelem.ref
+		IL_0690: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0695: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_069a: ldc.i4.0
+		IL_069b: conv.r8
+		IL_069c: ldstr ""
+		IL_06a1: ldc.i4.0
+		IL_06a2: ldc.i4.1
+		IL_06a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L178C20/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_06a8: stloc.s 32
+		IL_06aa: ldloc.s 4
+		IL_06ac: ldloc.s 6
+		IL_06ae: ldstr "toUpperCase"
+		IL_06b3: ldloc.s 32
+		IL_06b5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_06ba: pop
+		IL_06bb: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_06c0: stloc.s 6
+		IL_06c2: ldc.i4.1
+		IL_06c3: newarr [System.Runtime]System.Object
+		IL_06c8: dup
+		IL_06c9: ldc.i4.0
+		IL_06ca: ldloc.0
+		IL_06cb: stelem.ref
+		IL_06cc: stloc.s 7
+		IL_06ce: ldloc.s 7
+		IL_06d0: ldc.i4.0
+		IL_06d1: ldelem.ref
+		IL_06d2: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_06d7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_06dc: ldc.i4.0
+		IL_06dd: conv.r8
+		IL_06de: ldstr ""
+		IL_06e3: ldc.i4.0
+		IL_06e4: ldc.i4.1
+		IL_06e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L185C5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_06ea: stloc.s 33
+		IL_06ec: ldloc.3
+		IL_06ed: ldloc.s 6
+		IL_06ef: ldloc.s 33
+		IL_06f1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_06f6: pop
+		IL_06f7: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_06fc: stloc.s 6
+		IL_06fe: ldc.i4.1
+		IL_06ff: newarr [System.Runtime]System.Object
+		IL_0704: dup
+		IL_0705: ldc.i4.0
+		IL_0706: ldloc.0
+		IL_0707: stelem.ref
+		IL_0708: stloc.s 7
+		IL_070a: ldloc.s 7
+		IL_070c: ldc.i4.0
+		IL_070d: ldelem.ref
+		IL_070e: castclass Modules.Compile_Performance_Dromaeo_Object_String/Scope
+		IL_0713: newobj instance void Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_String/Scope)
+		IL_0718: ldc.i4.0
+		IL_0719: conv.r8
+		IL_071a: ldstr ""
+		IL_071f: ldc.i4.0
+		IL_0720: ldc.i4.1
+		IL_0721: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_String/FunctionExpression_L190C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0726: stloc.s 34
+		IL_0728: ldloc.s 4
+		IL_072a: ldloc.s 6
+		IL_072c: ldstr "comparing"
+		IL_0731: ldloc.s 34
+		IL_0733: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+		IL_0738: pop
+		IL_0739: ldloc.2
+		IL_073a: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_073f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+		IL_0744: pop
+		IL_0745: ret
+	} // end of method Compile_Performance_Dromaeo_Object_String::__js_module_init__
+
+} // end of class Modules.Compile_Performance_Dromaeo_Object_String
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Compile_Performance_Dromaeo_Object_String::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -3144,7 +3144,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 724 (0x2d4)
+		// Code size: 743 (0x2e7)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_PrimeJavaScript/Scope,
@@ -3249,158 +3249,165 @@
 		IL_0124: stloc.s 5
 		IL_0126: ldc.i4.0
 		IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_012c: brfalse IL_0155
+		IL_012c: brfalse IL_0168
 
 		IL_0131: ldloc.s 5
 		IL_0133: isinst [System.Runtime]System.String
 		IL_0138: dup
-		IL_0139: brfalse IL_0154
+		IL_0139: brtrue IL_0151
 
-		IL_013e: ldstr "verbose"
-		IL_0143: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-		IL_0148: box [System.Runtime]System.Boolean
-		IL_014d: stloc.s 5
-		IL_014f: br IL_0168
+		IL_013e: pop
+		IL_013f: ldloc.s 5
+		IL_0141: ldstr "includes"
+		IL_0146: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_014b: dup
+		IL_014c: brfalse IL_0167
 
-		IL_0154: pop
+		IL_0151: ldstr "verbose"
+		IL_0156: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_015b: box [System.Runtime]System.Boolean
+		IL_0160: stloc.s 5
+		IL_0162: br IL_017b
 
-		IL_0155: ldloc.s 5
-		IL_0157: ldstr "includes"
-		IL_015c: ldstr "verbose"
-		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0166: stloc.s 5
+		IL_0167: pop
 
-		IL_0168: ldloc.1
-		IL_0169: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
-		IL_016e: ldloc.s 5
-		IL_0170: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_verbose(object)
-		IL_0175: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_017a: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_017f: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_0184: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0189: stloc.s 8
-		IL_018b: ldloc.s 8
-		IL_018d: ldstr "prototype"
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0197: stloc.s 5
-		IL_0199: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_019e: stloc.s 9
-		IL_01a0: ldloc.s 5
-		IL_01a2: ldstr "setBitTrue"
-		IL_01a7: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject::.ctor()
-		IL_01ac: ldc.i4.1
-		IL_01ad: conv.r8
-		IL_01ae: ldstr "setBitTrue"
-		IL_01b3: ldc.i4.1
-		IL_01b4: ldc.i4.1
-		IL_01b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject>(!!0)
-		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01c4: pop
-		IL_01c5: ldc.i4.1
-		IL_01c6: newarr [System.Runtime]System.Object
-		IL_01cb: dup
-		IL_01cc: ldc.i4.0
-		IL_01cd: ldloc.0
-		IL_01ce: stelem.ref
-		IL_01cf: stloc.s 9
-		IL_01d1: ldloc.s 5
-		IL_01d3: ldstr "setBitsTrue"
-		IL_01d8: ldloc.s 9
-		IL_01da: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject::.ctor(object[])
-		IL_01df: ldc.i4.3
-		IL_01e0: conv.r8
-		IL_01e1: ldstr "setBitsTrue"
-		IL_01e6: ldc.i4.1
-		IL_01e7: ldc.i4.1
-		IL_01e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject>(!!0)
-		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01f7: pop
-		IL_01f8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01fd: stloc.s 9
-		IL_01ff: ldloc.s 5
-		IL_0201: ldstr "testBitTrue"
-		IL_0206: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject::.ctor()
-		IL_020b: ldc.i4.1
-		IL_020c: conv.r8
-		IL_020d: ldstr "testBitTrue"
-		IL_0212: ldc.i4.1
-		IL_0213: ldc.i4.1
-		IL_0214: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0219: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject>(!!0)
-		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0223: pop
-		IL_0224: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0229: stloc.s 9
-		IL_022b: ldloc.s 5
-		IL_022d: ldstr "searchBitFalse"
-		IL_0232: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject::.ctor()
-		IL_0237: ldc.i4.1
-		IL_0238: conv.r8
-		IL_0239: ldstr "searchBitFalse"
-		IL_023e: ldc.i4.1
-		IL_023f: ldc.i4.1
-		IL_0240: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0245: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject>(!!0)
-		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_024f: pop
-		IL_0250: ldc.i4.1
-		IL_0251: newarr [System.Runtime]System.Object
-		IL_0256: dup
-		IL_0257: ldc.i4.0
-		IL_0258: ldloc.0
-		IL_0259: stelem.ref
-		IL_025a: stloc.s 9
-		IL_025c: ldloc.s 9
-		IL_025e: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
-		IL_0263: ldloc.s 8
-		IL_0265: ldloc.s 9
-		IL_0267: ldc.i4.1
-		IL_0268: conv.r8
-		IL_0269: ldc.i4.0
-		IL_026a: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_026f: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_ctor/FunctionObject
-		IL_0274: stloc.s 10
-		IL_0276: ldloc.0
-		IL_0277: ldloc.s 10
-		IL_0279: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
-		IL_027e: nop
-		IL_027f: ldc.i4.1
-		IL_0280: newarr [System.Runtime]System.Object
-		IL_0285: dup
-		IL_0286: ldc.i4.0
-		IL_0287: ldloc.0
-		IL_0288: stelem.ref
-		IL_0289: stloc.s 9
-		IL_028b: ldloc.s 9
-		IL_028d: ldc.i4.0
-		IL_028e: ldelem.ref
-		IL_028f: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_0294: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
-		IL_0299: ldc.i4.1
-		IL_029a: conv.r8
-		IL_029b: ldstr ""
+		IL_0168: ldloc.s 5
+		IL_016a: ldstr "includes"
+		IL_016f: ldstr "verbose"
+		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0179: stloc.s 5
+
+		IL_017b: ldloc.1
+		IL_017c: castclass Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config
+		IL_0181: ldloc.s 5
+		IL_0183: callvirt instance void Modules.Compile_Performance_PrimeJavaScript/ObjectLiterals/L23C14_config::set_verbose(object)
+		IL_0188: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+		IL_018d: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0192: ldtoken Modules.Compile_Performance_PrimeJavaScript/BitArray
+		IL_0197: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_019c: stloc.s 8
+		IL_019e: ldloc.s 8
+		IL_01a0: ldstr "prototype"
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01aa: stloc.s 5
+		IL_01ac: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01b1: stloc.s 9
+		IL_01b3: ldloc.s 5
+		IL_01b5: ldstr "setBitTrue"
+		IL_01ba: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject::.ctor()
+		IL_01bf: ldc.i4.1
+		IL_01c0: conv.r8
+		IL_01c1: ldstr "setBitTrue"
+		IL_01c6: ldc.i4.1
+		IL_01c7: ldc.i4.1
+		IL_01c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitTrue/FunctionObject>(!!0)
+		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01d7: pop
+		IL_01d8: ldc.i4.1
+		IL_01d9: newarr [System.Runtime]System.Object
+		IL_01de: dup
+		IL_01df: ldc.i4.0
+		IL_01e0: ldloc.0
+		IL_01e1: stelem.ref
+		IL_01e2: stloc.s 9
+		IL_01e4: ldloc.s 5
+		IL_01e6: ldstr "setBitsTrue"
+		IL_01eb: ldloc.s 9
+		IL_01ed: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject::.ctor(object[])
+		IL_01f2: ldc.i4.3
+		IL_01f3: conv.r8
+		IL_01f4: ldstr "setBitsTrue"
+		IL_01f9: ldc.i4.1
+		IL_01fa: ldc.i4.1
+		IL_01fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0200: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_setBitsTrue/FunctionObject>(!!0)
+		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_020a: pop
+		IL_020b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0210: stloc.s 9
+		IL_0212: ldloc.s 5
+		IL_0214: ldstr "testBitTrue"
+		IL_0219: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject::.ctor()
+		IL_021e: ldc.i4.1
+		IL_021f: conv.r8
+		IL_0220: ldstr "testBitTrue"
+		IL_0225: ldc.i4.1
+		IL_0226: ldc.i4.1
+		IL_0227: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_022c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_testBitTrue/FunctionObject>(!!0)
+		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0236: pop
+		IL_0237: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_023c: stloc.s 9
+		IL_023e: ldloc.s 5
+		IL_0240: ldstr "searchBitFalse"
+		IL_0245: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject::.ctor()
+		IL_024a: ldc.i4.1
+		IL_024b: conv.r8
+		IL_024c: ldstr "searchBitFalse"
+		IL_0251: ldc.i4.1
+		IL_0252: ldc.i4.1
+		IL_0253: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0258: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_searchBitFalse/FunctionObject>(!!0)
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0262: pop
+		IL_0263: ldc.i4.1
+		IL_0264: newarr [System.Runtime]System.Object
+		IL_0269: dup
+		IL_026a: ldc.i4.0
+		IL_026b: ldloc.0
+		IL_026c: stelem.ref
+		IL_026d: stloc.s 9
+		IL_026f: ldloc.s 9
+		IL_0271: newobj instance void Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
+		IL_0276: ldloc.s 8
+		IL_0278: ldloc.s 9
+		IL_027a: ldc.i4.1
+		IL_027b: conv.r8
+		IL_027c: ldc.i4.0
+		IL_027d: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_0282: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray/Scope_ctor/FunctionObject
+		IL_0287: stloc.s 10
+		IL_0289: ldloc.0
+		IL_028a: ldloc.s 10
+		IL_028c: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::BitArray
+		IL_0291: nop
+		IL_0292: ldc.i4.1
+		IL_0293: newarr [System.Runtime]System.Object
+		IL_0298: dup
+		IL_0299: ldc.i4.0
+		IL_029a: ldloc.0
+		IL_029b: stelem.ref
+		IL_029c: stloc.s 9
+		IL_029e: ldloc.s 9
 		IL_02a0: ldc.i4.0
-		IL_02a1: ldc.i4.0
-		IL_02a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0)
-		IL_02ac: stloc.s 11
-		IL_02ae: ldloc.s 11
-		IL_02b0: ldstr "runSieveBatch"
-		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
-		IL_02ba: stloc.s 5
-		IL_02bc: ldloc.0
-		IL_02bd: ldloc.s 5
-		IL_02bf: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
-		IL_02c4: nop
-		IL_02c5: ldloc.0
-		IL_02c6: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
-		IL_02cb: ldnull
-		IL_02cc: ldloc.1
-		IL_02cd: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
-		IL_02d2: pop
-		IL_02d3: ret
+		IL_02a1: ldelem.ref
+		IL_02a2: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_02a7: newobj instance void Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject::.ctor(class Modules.Compile_Performance_PrimeJavaScript/Scope)
+		IL_02ac: ldc.i4.1
+		IL_02ad: conv.r8
+		IL_02ae: ldstr ""
+		IL_02b3: ldc.i4.0
+		IL_02b4: ldc.i4.0
+		IL_02b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L210C23/FunctionObject>(!!0)
+		IL_02bf: stloc.s 11
+		IL_02c1: ldloc.s 11
+		IL_02c3: ldstr "runSieveBatch"
+		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetFunctionInferredName(object, object)
+		IL_02cd: stloc.s 5
+		IL_02cf: ldloc.0
+		IL_02d0: ldloc.s 5
+		IL_02d2: stfld object Modules.Compile_Performance_PrimeJavaScript/Scope::runSieveBatch
+		IL_02d7: nop
+		IL_02d8: ldloc.0
+		IL_02d9: castclass Modules.Compile_Performance_PrimeJavaScript/Scope
+		IL_02de: ldnull
+		IL_02df: ldloc.1
+		IL_02e0: call object Modules.Compile_Performance_PrimeJavaScript/ArrowFunction_L229C14::__js_call__(class Modules.Compile_Performance_PrimeJavaScript/Scope, object, object)
+		IL_02e5: pop
+		IL_02e6: ret
 	} // end of method Compile_Performance_PrimeJavaScript::__js_module_init__
 
 } // end of class Modules.Compile_Performance_PrimeJavaScript

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -475,7 +475,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 158 (0x9e)
+			// Code size: 176 (0xb0)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -529,26 +529,33 @@
 			IL_006c: stloc.2
 			IL_006d: ldc.i4.0
 			IL_006e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0073: brfalse IL_0090
+			IL_0073: brfalse IL_00a2
 
 			IL_0078: ldloc.2
 			IL_0079: isinst [System.Runtime]System.String
 			IL_007e: dup
-			IL_007f: brfalse IL_008f
+			IL_007f: brtrue IL_0096
 
-			IL_0084: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0089: stloc.2
-			IL_008a: br IL_009c
+			IL_0084: pop
+			IL_0085: ldloc.2
+			IL_0086: ldstr "trim"
+			IL_008b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0090: dup
+			IL_0091: brfalse IL_00a1
 
-			IL_008f: pop
-
-			IL_0090: ldloc.2
-			IL_0091: ldstr "trim"
-			IL_0096: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0096: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
 			IL_009b: stloc.2
+			IL_009c: br IL_00ae
 
-			IL_009c: ldloc.2
-			IL_009d: ret
+			IL_00a1: pop
+
+			IL_00a2: ldloc.2
+			IL_00a3: ldstr "trim"
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_00ad: stloc.2
+
+			IL_00ae: ldloc.2
+			IL_00af: ret
 		} // end of method parseCurrentVersion::__js_call__
 
 	} // end of class parseCurrentVersion
@@ -1710,7 +1717,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 218 (0xda)
+			// Code size: 236 (0xec)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -1724,82 +1731,89 @@
 			IL_0006: stloc.0
 			IL_0007: ldc.i4.0
 			IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_000d: brfalse IL_0034
+			IL_000d: brfalse IL_0046
 
 			IL_0012: ldloc.0
 			IL_0013: isinst [System.Runtime]System.String
 			IL_0018: dup
-			IL_0019: brfalse IL_0033
+			IL_0019: brtrue IL_0030
 
-			IL_001e: ldstr "<Version>"
-			IL_0023: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-			IL_0028: box [System.Runtime]System.Boolean
-			IL_002d: stloc.0
-			IL_002e: br IL_0045
+			IL_001e: pop
+			IL_001f: ldloc.0
+			IL_0020: ldstr "includes"
+			IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_002a: dup
+			IL_002b: brfalse IL_0045
 
-			IL_0033: pop
+			IL_0030: ldstr "<Version>"
+			IL_0035: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_003a: box [System.Runtime]System.Boolean
+			IL_003f: stloc.0
+			IL_0040: br IL_0057
 
-			IL_0034: ldloc.0
-			IL_0035: ldstr "includes"
-			IL_003a: ldstr "<Version>"
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0044: stloc.0
+			IL_0045: pop
 
-			IL_0045: ldloc.0
-			IL_0046: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_004b: stloc.1
-			IL_004c: ldloc.1
-			IL_004d: brfalse IL_0096
+			IL_0046: ldloc.0
+			IL_0047: ldstr "includes"
+			IL_004c: ldstr "<Version>"
+			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0056: stloc.0
 
-			IL_0052: ldarg.1
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0058: stloc.0
-			IL_0059: ldstr "<Version>[^<]+<\\/Version>"
-			IL_005e: ldstr ""
-			IL_0063: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0068: stloc.2
-			IL_0069: ldarg.2
-			IL_006a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_006f: stloc.3
-			IL_0070: ldstr "<Version>"
-			IL_0075: ldloc.3
-			IL_0076: call string [System.Runtime]System.String::Concat(string, string)
-			IL_007b: ldstr "</Version>"
-			IL_0080: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0085: stloc.3
-			IL_0086: ldloc.0
-			IL_0087: ldstr "replace"
-			IL_008c: ldloc.2
-			IL_008d: ldloc.3
-			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0093: stloc.0
-			IL_0094: ldloc.0
-			IL_0095: ret
+			IL_0057: ldloc.0
+			IL_0058: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_005d: stloc.1
+			IL_005e: ldloc.1
+			IL_005f: brfalse IL_00a8
 
-			IL_0096: ldarg.1
-			IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_009c: stloc.0
-			IL_009d: ldstr "(<PropertyGroup>\\s*\\n)"
-			IL_00a2: ldstr ""
-			IL_00a7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_00ac: stloc.2
-			IL_00ad: ldarg.2
-			IL_00ae: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00b3: stloc.3
-			IL_00b4: ldstr "$1    <Version>"
-			IL_00b9: ldloc.3
-			IL_00ba: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00bf: ldstr "</Version>\n"
-			IL_00c4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_00c9: stloc.3
-			IL_00ca: ldloc.0
-			IL_00cb: ldstr "replace"
-			IL_00d0: ldloc.2
-			IL_00d1: ldloc.3
-			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00d7: stloc.0
-			IL_00d8: ldloc.0
-			IL_00d9: ret
+			IL_0064: ldarg.1
+			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006a: stloc.0
+			IL_006b: ldstr "<Version>[^<]+<\\/Version>"
+			IL_0070: ldstr ""
+			IL_0075: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_007a: stloc.2
+			IL_007b: ldarg.2
+			IL_007c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0081: stloc.3
+			IL_0082: ldstr "<Version>"
+			IL_0087: ldloc.3
+			IL_0088: call string [System.Runtime]System.String::Concat(string, string)
+			IL_008d: ldstr "</Version>"
+			IL_0092: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0097: stloc.3
+			IL_0098: ldloc.0
+			IL_0099: ldstr "replace"
+			IL_009e: ldloc.2
+			IL_009f: ldloc.3
+			IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00a5: stloc.0
+			IL_00a6: ldloc.0
+			IL_00a7: ret
+
+			IL_00a8: ldarg.1
+			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ae: stloc.0
+			IL_00af: ldstr "(<PropertyGroup>\\s*\\n)"
+			IL_00b4: ldstr ""
+			IL_00b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_00be: stloc.2
+			IL_00bf: ldarg.2
+			IL_00c0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_00c5: stloc.3
+			IL_00c6: ldstr "$1    <Version>"
+			IL_00cb: ldloc.3
+			IL_00cc: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00d1: ldstr "</Version>\n"
+			IL_00d6: call string [System.Runtime]System.String::Concat(string, string)
+			IL_00db: stloc.3
+			IL_00dc: ldloc.0
+			IL_00dd: ldstr "replace"
+			IL_00e2: ldloc.2
+			IL_00e3: ldloc.3
+			IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00e9: stloc.0
+			IL_00ea: ldloc.0
+			IL_00eb: ret
 		} // end of method updateCsprojVersion::__js_call__
 
 	} // end of class updateCsprojVersion
@@ -2193,7 +2207,7 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 751 (0x2ef)
+			// Code size: 846 (0x34e)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -2218,267 +2232,302 @@
 			IL_0006: stloc.s 8
 			IL_0008: ldc.i4.0
 			IL_0009: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_000e: brfalse IL_0036
+			IL_000e: brfalse IL_0049
 
 			IL_0013: ldloc.s 8
 			IL_0015: isinst [System.Runtime]System.String
 			IL_001a: dup
-			IL_001b: brfalse IL_0035
+			IL_001b: brtrue IL_0033
 
-			IL_0020: ldstr "## Unreleased"
-			IL_0025: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_002a: box [System.Runtime]System.Double
-			IL_002f: stloc.0
-			IL_0030: br IL_0048
+			IL_0020: pop
+			IL_0021: ldloc.s 8
+			IL_0023: ldstr "indexOf"
+			IL_0028: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_002d: dup
+			IL_002e: brfalse IL_0048
 
-			IL_0035: pop
+			IL_0033: ldstr "## Unreleased"
+			IL_0038: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_003d: box [System.Runtime]System.Double
+			IL_0042: stloc.0
+			IL_0043: br IL_005b
 
-			IL_0036: ldloc.s 8
-			IL_0038: ldstr "indexOf"
-			IL_003d: ldstr "## Unreleased"
-			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0047: stloc.0
+			IL_0048: pop
 
-			IL_0048: ldc.r8 1
-			IL_0051: neg
-			IL_0052: stloc.s 9
-			IL_0054: ldloc.s 9
-			IL_0056: box [System.Runtime]System.Double
-			IL_005b: stloc.s 10
-			IL_005d: ldloc.0
-			IL_005e: ldloc.s 10
-			IL_0060: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0065: stloc.s 11
-			IL_0067: ldloc.s 11
-			IL_0069: brfalse IL_008e
+			IL_0049: ldloc.s 8
+			IL_004b: ldstr "indexOf"
+			IL_0050: ldstr "## Unreleased"
+			IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_005a: stloc.0
 
-			IL_006e: ldstr "CHANGELOG.md missing \"## Unreleased\" section"
-			IL_0073: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0078: stloc.1
-			IL_0079: ldloc.1
-			IL_007a: isinst [System.Runtime]System.Exception
-			IL_007f: dup
-			IL_0080: brtrue IL_008d
+			IL_005b: ldc.r8 1
+			IL_0064: neg
+			IL_0065: stloc.s 9
+			IL_0067: ldloc.s 9
+			IL_0069: box [System.Runtime]System.Double
+			IL_006e: stloc.s 10
+			IL_0070: ldloc.0
+			IL_0071: ldloc.s 10
+			IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0078: stloc.s 11
+			IL_007a: ldloc.s 11
+			IL_007c: brfalse IL_00a1
 
-			IL_0085: pop
-			IL_0086: ldloc.1
-			IL_0087: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_008c: throw
+			IL_0081: ldstr "CHANGELOG.md missing \"## Unreleased\" section"
+			IL_0086: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_008b: stloc.1
+			IL_008c: ldloc.1
+			IL_008d: isinst [System.Runtime]System.Exception
+			IL_0092: dup
+			IL_0093: brtrue IL_00a0
 
-			IL_008d: throw
+			IL_0098: pop
+			IL_0099: ldloc.1
+			IL_009a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_009f: throw
 
-			IL_008e: ldarg.2
-			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0094: stloc.s 8
-			IL_0096: ldc.i4.0
-			IL_0097: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_009c: brfalse IL_00c5
+			IL_00a0: throw
 
-			IL_00a1: ldloc.s 8
-			IL_00a3: isinst [System.Runtime]System.String
-			IL_00a8: dup
-			IL_00a9: brfalse IL_00c4
+			IL_00a1: ldarg.2
+			IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a7: stloc.s 8
+			IL_00a9: ldc.i4.0
+			IL_00aa: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00af: brfalse IL_00eb
 
-			IL_00ae: ldstr "\n"
-			IL_00b3: ldloc.0
-			IL_00b4: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string, object)
-			IL_00b9: box [System.Runtime]System.Double
-			IL_00be: stloc.2
-			IL_00bf: br IL_00d8
+			IL_00b4: ldloc.s 8
+			IL_00b6: isinst [System.Runtime]System.String
+			IL_00bb: dup
+			IL_00bc: brtrue IL_00d4
 
-			IL_00c4: pop
+			IL_00c1: pop
+			IL_00c2: ldloc.s 8
+			IL_00c4: ldstr "indexOf"
+			IL_00c9: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_00ce: dup
+			IL_00cf: brfalse IL_00ea
 
-			IL_00c5: ldloc.s 8
-			IL_00c7: ldstr "indexOf"
-			IL_00cc: ldstr "\n"
-			IL_00d1: ldloc.0
-			IL_00d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00d7: stloc.2
+			IL_00d4: ldstr "\n"
+			IL_00d9: ldloc.0
+			IL_00da: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string, object)
+			IL_00df: box [System.Runtime]System.Double
+			IL_00e4: stloc.2
+			IL_00e5: br IL_00fe
 
-			IL_00d8: ldarg.2
-			IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00de: stloc.s 8
-			IL_00e0: ldloc.2
-			IL_00e1: ldc.r8 1
-			IL_00ea: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_00ef: stloc.s 12
-			IL_00f1: ldc.i4.0
-			IL_00f2: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_00f7: brfalse IL_0118
+			IL_00ea: pop
 
-			IL_00fc: ldloc.s 8
-			IL_00fe: isinst [System.Runtime]System.String
-			IL_0103: dup
-			IL_0104: brfalse IL_0117
+			IL_00eb: ldloc.s 8
+			IL_00ed: ldstr "indexOf"
+			IL_00f2: ldstr "\n"
+			IL_00f7: ldloc.0
+			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00fd: stloc.2
 
-			IL_0109: ldloc.s 12
-			IL_010b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
-			IL_0110: stloc.s 8
-			IL_0112: br IL_0128
+			IL_00fe: ldarg.2
+			IL_00ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0104: stloc.s 8
+			IL_0106: ldloc.2
+			IL_0107: ldc.r8 1
+			IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_0115: stloc.s 12
+			IL_0117: ldc.i4.0
+			IL_0118: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_011d: brfalse IL_0151
 
-			IL_0117: pop
+			IL_0122: ldloc.s 8
+			IL_0124: isinst [System.Runtime]System.String
+			IL_0129: dup
+			IL_012a: brtrue IL_0142
 
-			IL_0118: ldloc.s 8
-			IL_011a: ldstr "slice"
-			IL_011f: ldloc.s 12
-			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0126: stloc.s 8
+			IL_012f: pop
+			IL_0130: ldloc.s 8
+			IL_0132: ldstr "slice"
+			IL_0137: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_013c: dup
+			IL_013d: brfalse IL_0150
 
-			IL_0128: ldloc.s 8
-			IL_012a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_012f: stloc.s 8
-			IL_0131: ldstr "\\n## v?\\d+\\.\\d+\\.\\d+ "
-			IL_0136: ldstr ""
-			IL_013b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0140: stloc.s 13
-			IL_0142: ldloc.s 8
-			IL_0144: ldstr "match"
-			IL_0149: ldloc.s 13
-			IL_014b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0150: stloc.3
-			IL_0151: ldc.r8 1
-			IL_015a: neg
-			IL_015b: stloc.s 9
-			IL_015d: ldloc.s 9
-			IL_015f: box [System.Runtime]System.Double
-			IL_0164: stloc.s 4
-			IL_0166: ldloc.3
-			IL_0167: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_016c: stloc.s 11
-			IL_016e: ldloc.s 11
-			IL_0170: brfalse IL_01b4
+			IL_0142: ldloc.s 12
+			IL_0144: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
+			IL_0149: stloc.s 8
+			IL_014b: br IL_0161
 
-			IL_0175: ldloc.2
-			IL_0176: ldc.r8 1
-			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0184: stloc.s 12
-			IL_0186: ldloc.3
-			IL_0187: ldstr "index"
-			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0191: stloc.s 8
-			IL_0193: ldloc.s 12
-			IL_0195: ldloc.s 8
-			IL_0197: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_019c: stloc.s 12
-			IL_019e: ldloc.s 12
-			IL_01a0: ldc.r8 1
-			IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_01ae: stloc.s 12
-			IL_01b0: ldloc.s 12
-			IL_01b2: stloc.s 4
+			IL_0150: pop
 
-			IL_01b4: ldloc.s 4
-			IL_01b6: stloc.s 12
-			IL_01b8: ldc.r8 1
-			IL_01c1: neg
-			IL_01c2: stloc.s 9
-			IL_01c4: ldloc.s 9
-			IL_01c6: box [System.Runtime]System.Double
-			IL_01cb: stloc.s 10
-			IL_01cd: ldloc.s 12
-			IL_01cf: ldloc.s 10
-			IL_01d1: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01d6: stloc.s 11
-			IL_01d8: ldloc.s 11
-			IL_01da: brfalse IL_01f5
+			IL_0151: ldloc.s 8
+			IL_0153: ldstr "slice"
+			IL_0158: ldloc.s 12
+			IL_015a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_015f: stloc.s 8
 
-			IL_01df: ldarg.2
-			IL_01e0: ldstr "length"
-			IL_01e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ea: stloc.s 8
-			IL_01ec: ldloc.s 8
-			IL_01ee: stloc.s 5
-			IL_01f0: br IL_0219
+			IL_0161: ldloc.s 8
+			IL_0163: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0168: stloc.s 8
+			IL_016a: ldstr "\\n## v?\\d+\\.\\d+\\.\\d+ "
+			IL_016f: ldstr ""
+			IL_0174: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_0179: stloc.s 13
+			IL_017b: ldloc.s 8
+			IL_017d: ldstr "match"
+			IL_0182: ldloc.s 13
+			IL_0184: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0189: stloc.3
+			IL_018a: ldc.r8 1
+			IL_0193: neg
+			IL_0194: stloc.s 9
+			IL_0196: ldloc.s 9
+			IL_0198: box [System.Runtime]System.Double
+			IL_019d: stloc.s 4
+			IL_019f: ldloc.3
+			IL_01a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01a5: stloc.s 11
+			IL_01a7: ldloc.s 11
+			IL_01a9: brfalse IL_01ed
 
-			IL_01f5: ldloc.s 4
-			IL_01f7: stloc.s 12
-			IL_01f9: ldloc.s 12
-			IL_01fb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0200: ldc.r8 1
-			IL_0209: sub
-			IL_020a: stloc.s 9
-			IL_020c: ldloc.s 9
-			IL_020e: box [System.Runtime]System.Double
-			IL_0213: stloc.s 10
-			IL_0215: ldloc.s 10
-			IL_0217: stloc.s 5
+			IL_01ae: ldloc.2
+			IL_01af: ldc.r8 1
+			IL_01b8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01bd: stloc.s 12
+			IL_01bf: ldloc.3
+			IL_01c0: ldstr "index"
+			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01ca: stloc.s 8
+			IL_01cc: ldloc.s 12
+			IL_01ce: ldloc.s 8
+			IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_01d5: stloc.s 12
+			IL_01d7: ldloc.s 12
+			IL_01d9: ldc.r8 1
+			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_01e7: stloc.s 12
+			IL_01e9: ldloc.s 12
+			IL_01eb: stloc.s 4
 
-			IL_0219: ldloc.s 5
-			IL_021b: stloc.s 6
-			IL_021d: ldarg.2
-			IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01ed: ldloc.s 4
+			IL_01ef: stloc.s 12
+			IL_01f1: ldc.r8 1
+			IL_01fa: neg
+			IL_01fb: stloc.s 9
+			IL_01fd: ldloc.s 9
+			IL_01ff: box [System.Runtime]System.Double
+			IL_0204: stloc.s 10
+			IL_0206: ldloc.s 12
+			IL_0208: ldloc.s 10
+			IL_020a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_020f: stloc.s 11
+			IL_0211: ldloc.s 11
+			IL_0213: brfalse IL_022e
+
+			IL_0218: ldarg.2
+			IL_0219: ldstr "length"
+			IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0223: stloc.s 8
-			IL_0225: ldloc.2
-			IL_0226: ldc.r8 1
-			IL_022f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_0234: stloc.s 12
-			IL_0236: ldc.i4.0
-			IL_0237: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_023c: brfalse IL_025f
+			IL_0225: ldloc.s 8
+			IL_0227: stloc.s 5
+			IL_0229: br IL_0252
 
-			IL_0241: ldloc.s 8
-			IL_0243: isinst [System.Runtime]System.String
-			IL_0248: dup
-			IL_0249: brfalse IL_025e
+			IL_022e: ldloc.s 4
+			IL_0230: stloc.s 12
+			IL_0232: ldloc.s 12
+			IL_0234: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0239: ldc.r8 1
+			IL_0242: sub
+			IL_0243: stloc.s 9
+			IL_0245: ldloc.s 9
+			IL_0247: box [System.Runtime]System.Double
+			IL_024c: stloc.s 10
+			IL_024e: ldloc.s 10
+			IL_0250: stloc.s 5
 
-			IL_024e: ldloc.s 12
-			IL_0250: ldloc.s 6
-			IL_0252: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
-			IL_0257: stloc.s 8
-			IL_0259: br IL_0271
+			IL_0252: ldloc.s 5
+			IL_0254: stloc.s 6
+			IL_0256: ldarg.2
+			IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_025c: stloc.s 8
+			IL_025e: ldloc.2
+			IL_025f: ldc.r8 1
+			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_026d: stloc.s 12
+			IL_026f: ldc.i4.0
+			IL_0270: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0275: brfalse IL_02ab
 
-			IL_025e: pop
+			IL_027a: ldloc.s 8
+			IL_027c: isinst [System.Runtime]System.String
+			IL_0281: dup
+			IL_0282: brtrue IL_029a
 
-			IL_025f: ldloc.s 8
-			IL_0261: ldstr "slice"
-			IL_0266: ldloc.s 12
-			IL_0268: ldloc.s 6
-			IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_026f: stloc.s 8
+			IL_0287: pop
+			IL_0288: ldloc.s 8
+			IL_028a: ldstr "slice"
+			IL_028f: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0294: dup
+			IL_0295: brfalse IL_02aa
 
-			IL_0271: ldloc.s 8
-			IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0278: stloc.s 8
-			IL_027a: ldc.i4.0
-			IL_027b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0280: brfalse IL_029f
+			IL_029a: ldloc.s 12
+			IL_029c: ldloc.s 6
+			IL_029e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+			IL_02a3: stloc.s 8
+			IL_02a5: br IL_02bd
 
-			IL_0285: ldloc.s 8
-			IL_0287: isinst [System.Runtime]System.String
-			IL_028c: dup
-			IL_028d: brfalse IL_029e
+			IL_02aa: pop
 
-			IL_0292: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0297: stloc.s 7
-			IL_0299: br IL_02ad
+			IL_02ab: ldloc.s 8
+			IL_02ad: ldstr "slice"
+			IL_02b2: ldloc.s 12
+			IL_02b4: ldloc.s 6
+			IL_02b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_02bb: stloc.s 8
 
-			IL_029e: pop
+			IL_02bd: ldloc.s 8
+			IL_02bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02c4: stloc.s 8
+			IL_02c6: ldc.i4.0
+			IL_02c7: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_02cc: brfalse IL_02fe
 
-			IL_029f: ldloc.s 8
-			IL_02a1: ldstr "trim"
-			IL_02a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_02ab: stloc.s 7
+			IL_02d1: ldloc.s 8
+			IL_02d3: isinst [System.Runtime]System.String
+			IL_02d8: dup
+			IL_02d9: brtrue IL_02f1
 
-			IL_02ad: ldloc.2
-			IL_02ae: ldc.r8 1
-			IL_02b7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_02bc: stloc.s 12
-			IL_02be: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02c3: dup
-			IL_02c4: ldstr "body"
-			IL_02c9: ldloc.s 7
-			IL_02cb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_02d0: dup
-			IL_02d1: ldstr "start"
-			IL_02d6: ldloc.s 12
-			IL_02d8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_02dd: dup
-			IL_02de: ldstr "end"
-			IL_02e3: ldloc.s 6
-			IL_02e5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_02ea: stloc.s 14
-			IL_02ec: ldloc.s 14
-			IL_02ee: ret
+			IL_02de: pop
+			IL_02df: ldloc.s 8
+			IL_02e1: ldstr "trim"
+			IL_02e6: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_02eb: dup
+			IL_02ec: brfalse IL_02fd
+
+			IL_02f1: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_02f6: stloc.s 7
+			IL_02f8: br IL_030c
+
+			IL_02fd: pop
+
+			IL_02fe: ldloc.s 8
+			IL_0300: ldstr "trim"
+			IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_030a: stloc.s 7
+
+			IL_030c: ldloc.2
+			IL_030d: ldc.r8 1
+			IL_0316: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_031b: stloc.s 12
+			IL_031d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0322: dup
+			IL_0323: ldstr "body"
+			IL_0328: ldloc.s 7
+			IL_032a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_032f: dup
+			IL_0330: ldstr "start"
+			IL_0335: ldloc.s 12
+			IL_0337: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_033c: dup
+			IL_033d: ldstr "end"
+			IL_0342: ldloc.s 6
+			IL_0344: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0349: stloc.s 14
+			IL_034b: ldloc.s 14
+			IL_034d: ret
 		} // end of method extractUnreleased::__js_call__
 
 	} // end of class extractUnreleased
@@ -2613,7 +2662,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 80 (0x50)
+			// Code size: 98 (0x62)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
@@ -2629,30 +2678,37 @@
 			IL_0016: stloc.1
 			IL_0017: ldc.i4.0
 			IL_0018: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_001d: brfalse IL_003a
+			IL_001d: brfalse IL_004c
 
 			IL_0022: ldloc.1
 			IL_0023: isinst [System.Runtime]System.String
 			IL_0028: dup
-			IL_0029: brfalse IL_0039
+			IL_0029: brtrue IL_0040
 
-			IL_002e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0033: stloc.1
-			IL_0034: br IL_0046
+			IL_002e: pop
+			IL_002f: ldloc.1
+			IL_0030: ldstr "trim"
+			IL_0035: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_003a: dup
+			IL_003b: brfalse IL_004b
 
-			IL_0039: pop
-
-			IL_003a: ldloc.1
-			IL_003b: ldstr "trim"
-			IL_0040: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0040: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
 			IL_0045: stloc.1
+			IL_0046: br IL_0058
 
-			IL_0046: ldloc.0
-			IL_0047: ldloc.1
-			IL_0048: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
-			IL_004d: stloc.1
-			IL_004e: ldloc.1
-			IL_004f: ret
+			IL_004b: pop
+
+			IL_004c: ldloc.1
+			IL_004d: ldstr "trim"
+			IL_0052: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0057: stloc.1
+
+			IL_0058: ldloc.0
+			IL_0059: ldloc.1
+			IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.RegExp::test(object)
+			IL_005f: stloc.1
+			IL_0060: ldloc.1
+			IL_0061: ret
 		} // end of method isPlaceholder::__js_call__
 
 	} // end of class isPlaceholder
@@ -2776,7 +2832,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 163 (0xa3)
+				// Code size: 181 (0xb5)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -2790,77 +2846,84 @@
 				IL_0006: stloc.0
 				IL_0007: ldc.i4.0
 				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_000d: brfalse IL_002a
+				IL_000d: brfalse IL_003c
 
 				IL_0012: ldloc.0
 				IL_0013: isinst [System.Runtime]System.String
 				IL_0018: dup
-				IL_0019: brfalse IL_0029
+				IL_0019: brtrue IL_0030
 
-				IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-				IL_0023: stloc.0
-				IL_0024: br IL_0036
+				IL_001e: pop
+				IL_001f: ldloc.0
+				IL_0020: ldstr "trim"
+				IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_002a: dup
+				IL_002b: brfalse IL_003b
 
-				IL_0029: pop
-
-				IL_002a: ldloc.0
-				IL_002b: ldstr "trim"
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0030: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
 				IL_0035: stloc.0
+				IL_0036: br IL_0048
 
-				IL_0036: ldloc.0
-				IL_0037: ldstr "length"
-				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0041: stloc.0
-				IL_0042: ldloc.0
-				IL_0043: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0048: ldc.r8 0.0
-				IL_0051: cgt
-				IL_0053: stloc.1
-				IL_0054: ldloc.1
-				IL_0055: box [System.Runtime]System.Boolean
-				IL_005a: stloc.2
-				IL_005b: ldloc.2
-				IL_005c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0061: stloc.1
-				IL_0062: ldloc.1
-				IL_0063: brfalse IL_00a1
+				IL_003b: pop
 
-				IL_0068: ldarg.0
-				IL_0069: ldc.i4.0
-				IL_006a: ldelem.ref
-				IL_006b: castclass Modules.Compile_Scripts_BumpVersion/Scope
-				IL_0070: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
-				IL_0075: ldc.i4.2
-				IL_0076: newarr [System.Runtime]System.Object
-				IL_007b: dup
-				IL_007c: ldc.i4.0
-				IL_007d: ldarg.0
-				IL_007e: ldc.i4.0
-				IL_007f: ldelem.ref
-				IL_0080: stelem.ref
-				IL_0081: dup
-				IL_0082: ldc.i4.1
-				IL_0083: ldarg.0
-				IL_0084: ldc.i4.1
-				IL_0085: ldelem.ref
-				IL_0086: stelem.ref
-				IL_0087: stloc.3
-				IL_0088: ldloc.3
-				IL_0089: ldarg.2
-				IL_008a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_008f: stloc.0
-				IL_0090: ldloc.0
-				IL_0091: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_0096: ldc.i4.0
-				IL_0097: ceq
-				IL_0099: stloc.1
-				IL_009a: ldloc.1
-				IL_009b: box [System.Runtime]System.Boolean
-				IL_00a0: ret
+				IL_003c: ldloc.0
+				IL_003d: ldstr "trim"
+				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0047: stloc.0
 
-				IL_00a1: ldloc.2
-				IL_00a2: ret
+				IL_0048: ldloc.0
+				IL_0049: ldstr "length"
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0053: stloc.0
+				IL_0054: ldloc.0
+				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005a: ldc.r8 0.0
+				IL_0063: cgt
+				IL_0065: stloc.1
+				IL_0066: ldloc.1
+				IL_0067: box [System.Runtime]System.Boolean
+				IL_006c: stloc.2
+				IL_006d: ldloc.2
+				IL_006e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0073: stloc.1
+				IL_0074: ldloc.1
+				IL_0075: brfalse IL_00b3
+
+				IL_007a: ldarg.0
+				IL_007b: ldc.i4.0
+				IL_007c: ldelem.ref
+				IL_007d: castclass Modules.Compile_Scripts_BumpVersion/Scope
+				IL_0082: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
+				IL_0087: ldc.i4.2
+				IL_0088: newarr [System.Runtime]System.Object
+				IL_008d: dup
+				IL_008e: ldc.i4.0
+				IL_008f: ldarg.0
+				IL_0090: ldc.i4.0
+				IL_0091: ldelem.ref
+				IL_0092: stelem.ref
+				IL_0093: dup
+				IL_0094: ldc.i4.1
+				IL_0095: ldarg.0
+				IL_0096: ldc.i4.1
+				IL_0097: ldelem.ref
+				IL_0098: stelem.ref
+				IL_0099: stloc.3
+				IL_009a: ldloc.3
+				IL_009b: ldarg.2
+				IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_00a1: stloc.0
+				IL_00a2: ldloc.0
+				IL_00a3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_00a8: ldc.i4.0
+				IL_00a9: ceq
+				IL_00ab: stloc.1
+				IL_00ac: ldloc.1
+				IL_00ad: box [System.Runtime]System.Boolean
+				IL_00b2: ret
+
+				IL_00b3: ldloc.2
+				IL_00b4: ret
 			} // end of method ArrowFunction_L113C44::__js_call__
 
 		} // end of class ArrowFunction_L113C44
@@ -3013,7 +3076,7 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 397 (0x18d)
+			// Code size: 416 (0x1a0)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/Scope,
@@ -3044,119 +3107,126 @@
 			IL_0027: stloc.s 4
 			IL_0029: ldc.i4.0
 			IL_002a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_002f: brfalse IL_0069
+			IL_002f: brfalse IL_007c
 
 			IL_0034: ldloc.s 4
 			IL_0036: isinst [System.Runtime]System.String
 			IL_003b: dup
-			IL_003c: brfalse IL_0068
+			IL_003c: brtrue IL_0054
 
-			IL_0041: ldc.r8 0.0
-			IL_004a: box [System.Runtime]System.Double
-			IL_004f: ldc.r8 10
-			IL_0058: box [System.Runtime]System.Double
-			IL_005d: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
-			IL_0062: stloc.1
-			IL_0063: br IL_0092
+			IL_0041: pop
+			IL_0042: ldloc.s 4
+			IL_0044: ldstr "slice"
+			IL_0049: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_004e: dup
+			IL_004f: brfalse IL_007b
 
-			IL_0068: pop
+			IL_0054: ldc.r8 0.0
+			IL_005d: box [System.Runtime]System.Double
+			IL_0062: ldc.r8 10
+			IL_006b: box [System.Runtime]System.Double
+			IL_0070: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+			IL_0075: stloc.1
+			IL_0076: br IL_00a5
 
-			IL_0069: ldloc.s 4
-			IL_006b: ldstr "slice"
-			IL_0070: ldc.r8 0.0
-			IL_0079: box [System.Runtime]System.Double
-			IL_007e: ldc.r8 10
-			IL_0087: box [System.Runtime]System.Double
-			IL_008c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0091: stloc.1
+			IL_007b: pop
 
-			IL_0092: ldarg.3
-			IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0098: stloc.s 4
-			IL_009a: ldstr "\\r?\\n"
-			IL_009f: ldstr ""
-			IL_00a4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_00a9: stloc.s 5
-			IL_00ab: ldloc.s 4
-			IL_00ad: ldstr "split"
-			IL_00b2: ldloc.s 5
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00b9: stloc.s 4
-			IL_00bb: ldloc.s 4
-			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00c2: stloc.s 4
-			IL_00c4: ldc.i4.2
-			IL_00c5: newarr [System.Runtime]System.Object
-			IL_00ca: dup
-			IL_00cb: ldc.i4.0
-			IL_00cc: ldarg.0
-			IL_00cd: stelem.ref
-			IL_00ce: dup
-			IL_00cf: ldc.i4.1
-			IL_00d0: ldloc.0
-			IL_00d1: stelem.ref
-			IL_00d2: stloc.s 6
-			IL_00d4: ldloc.s 6
-			IL_00d6: ldc.i4.0
-			IL_00d7: ldelem.ref
-			IL_00d8: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_00dd: ldloc.s 6
-			IL_00df: newobj instance void Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope, object[])
-			IL_00e4: ldc.i4.1
-			IL_00e5: conv.r8
-			IL_00e6: ldstr ""
-			IL_00eb: ldc.i4.0
-			IL_00ec: ldc.i4.0
-			IL_00ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_00f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject>(!!0)
-			IL_00f7: stloc.s 7
-			IL_00f9: ldloc.s 4
-			IL_00fb: ldstr "filter"
-			IL_0100: ldloc.s 7
-			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0107: stloc.s 4
-			IL_0109: ldloc.s 4
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0110: ldstr "join"
-			IL_0115: ldstr "\n"
-			IL_011a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_011f: stloc.2
-			IL_0120: ldloc.2
-			IL_0121: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_0126: ldc.i4.0
-			IL_0127: ceq
-			IL_0129: stloc.s 8
-			IL_012b: ldloc.s 8
-			IL_012d: brfalse IL_013c
+			IL_007c: ldloc.s 4
+			IL_007e: ldstr "slice"
+			IL_0083: ldc.r8 0.0
+			IL_008c: box [System.Runtime]System.Double
+			IL_0091: ldc.r8 10
+			IL_009a: box [System.Runtime]System.Double
+			IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_00a4: stloc.1
 
-			IL_0132: ldstr "\n"
-			IL_0137: stloc.s 9
-			IL_0139: ldloc.s 9
-			IL_013b: stloc.2
+			IL_00a5: ldarg.3
+			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00ab: stloc.s 4
+			IL_00ad: ldstr "\\r?\\n"
+			IL_00b2: ldstr ""
+			IL_00b7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_00bc: stloc.s 5
+			IL_00be: ldloc.s 4
+			IL_00c0: ldstr "split"
+			IL_00c5: ldloc.s 5
+			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00cc: stloc.s 4
+			IL_00ce: ldloc.s 4
+			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d5: stloc.s 4
+			IL_00d7: ldc.i4.2
+			IL_00d8: newarr [System.Runtime]System.Object
+			IL_00dd: dup
+			IL_00de: ldc.i4.0
+			IL_00df: ldarg.0
+			IL_00e0: stelem.ref
+			IL_00e1: dup
+			IL_00e2: ldc.i4.1
+			IL_00e3: ldloc.0
+			IL_00e4: stelem.ref
+			IL_00e5: stloc.s 6
+			IL_00e7: ldloc.s 6
+			IL_00e9: ldc.i4.0
+			IL_00ea: ldelem.ref
+			IL_00eb: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_00f0: ldloc.s 6
+			IL_00f2: newobj instance void Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope, object[])
+			IL_00f7: ldc.i4.1
+			IL_00f8: conv.r8
+			IL_00f9: ldstr ""
+			IL_00fe: ldc.i4.0
+			IL_00ff: ldc.i4.0
+			IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/ArrowFunction_L113C44/FunctionObject>(!!0)
+			IL_010a: stloc.s 7
+			IL_010c: ldloc.s 4
+			IL_010e: ldstr "filter"
+			IL_0113: ldloc.s 7
+			IL_0115: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_011a: stloc.s 4
+			IL_011c: ldloc.s 4
+			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0123: ldstr "join"
+			IL_0128: ldstr "\n"
+			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0132: stloc.2
+			IL_0133: ldloc.2
+			IL_0134: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0139: ldc.i4.0
+			IL_013a: ceq
+			IL_013c: stloc.s 8
+			IL_013e: ldloc.s 8
+			IL_0140: brfalse IL_014f
 
-			IL_013c: ldarg.2
-			IL_013d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0142: stloc.s 9
-			IL_0144: ldstr "## v"
-			IL_0149: ldloc.s 9
-			IL_014b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0150: ldstr " - "
-			IL_0155: call string [System.Runtime]System.String::Concat(string, string)
-			IL_015a: ldloc.1
-			IL_015b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0160: stloc.s 9
-			IL_0162: ldloc.s 9
-			IL_0164: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0169: ldstr "\n\n"
-			IL_016e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0173: ldloc.2
-			IL_0174: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0179: stloc.s 9
-			IL_017b: ldloc.s 9
-			IL_017d: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0182: ldstr "\n"
-			IL_0187: call string [System.Runtime]System.String::Concat(string, string)
-			IL_018c: ret
+			IL_0145: ldstr "\n"
+			IL_014a: stloc.s 9
+			IL_014c: ldloc.s 9
+			IL_014e: stloc.2
+
+			IL_014f: ldarg.2
+			IL_0150: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0155: stloc.s 9
+			IL_0157: ldstr "## v"
+			IL_015c: ldloc.s 9
+			IL_015e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0163: ldstr " - "
+			IL_0168: call string [System.Runtime]System.String::Concat(string, string)
+			IL_016d: ldloc.1
+			IL_016e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0173: stloc.s 9
+			IL_0175: ldloc.s 9
+			IL_0177: call string [System.Runtime]System.String::Concat(string, string)
+			IL_017c: ldstr "\n\n"
+			IL_0181: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0186: ldloc.2
+			IL_0187: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_018c: stloc.s 9
+			IL_018e: ldloc.s 9
+			IL_0190: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0195: ldstr "\n"
+			IL_019a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_019f: ret
 		} // end of method generateReleaseSection::__js_call__
 
 	} // end of class generateReleaseSection
@@ -3280,7 +3350,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 138 (0x8a)
+				// Code size: 156 (0x9c)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -3294,69 +3364,76 @@
 				IL_0006: stloc.0
 				IL_0007: ldc.i4.0
 				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_000d: brfalse IL_002a
+				IL_000d: brfalse IL_003c
 
 				IL_0012: ldloc.0
 				IL_0013: isinst [System.Runtime]System.String
 				IL_0018: dup
-				IL_0019: brfalse IL_0029
+				IL_0019: brtrue IL_0030
 
-				IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-				IL_0023: stloc.0
-				IL_0024: br IL_0036
+				IL_001e: pop
+				IL_001f: ldloc.0
+				IL_0020: ldstr "trim"
+				IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_002a: dup
+				IL_002b: brfalse IL_003b
 
-				IL_0029: pop
-
-				IL_002a: ldloc.0
-				IL_002b: ldstr "trim"
-				IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0030: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
 				IL_0035: stloc.0
+				IL_0036: br IL_0048
 
-				IL_0036: ldloc.0
-				IL_0037: ldstr "length"
-				IL_003c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0041: stloc.0
-				IL_0042: ldloc.0
-				IL_0043: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0048: stloc.1
-				IL_0049: ldloc.1
-				IL_004a: brfalse IL_0088
+				IL_003b: pop
 
-				IL_004f: ldarg.0
-				IL_0050: ldc.i4.0
-				IL_0051: ldelem.ref
-				IL_0052: castclass Modules.Compile_Scripts_BumpVersion/Scope
-				IL_0057: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
-				IL_005c: ldc.i4.2
-				IL_005d: newarr [System.Runtime]System.Object
-				IL_0062: dup
-				IL_0063: ldc.i4.0
-				IL_0064: ldarg.0
-				IL_0065: ldc.i4.0
-				IL_0066: ldelem.ref
-				IL_0067: stelem.ref
-				IL_0068: dup
-				IL_0069: ldc.i4.1
-				IL_006a: ldarg.0
-				IL_006b: ldc.i4.1
-				IL_006c: ldelem.ref
-				IL_006d: stelem.ref
-				IL_006e: stloc.2
-				IL_006f: ldloc.2
-				IL_0070: ldarg.2
-				IL_0071: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_0076: stloc.3
-				IL_0077: ldloc.3
-				IL_0078: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_007d: ldc.i4.0
-				IL_007e: ceq
-				IL_0080: stloc.1
-				IL_0081: ldloc.1
-				IL_0082: box [System.Runtime]System.Boolean
-				IL_0087: ret
+				IL_003c: ldloc.0
+				IL_003d: ldstr "trim"
+				IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0047: stloc.0
 
-				IL_0088: ldloc.0
-				IL_0089: ret
+				IL_0048: ldloc.0
+				IL_0049: ldstr "length"
+				IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0053: stloc.0
+				IL_0054: ldloc.0
+				IL_0055: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_005a: stloc.1
+				IL_005b: ldloc.1
+				IL_005c: brfalse IL_009a
+
+				IL_0061: ldarg.0
+				IL_0062: ldc.i4.0
+				IL_0063: ldelem.ref
+				IL_0064: castclass Modules.Compile_Scripts_BumpVersion/Scope
+				IL_0069: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::isPlaceholder
+				IL_006e: ldc.i4.2
+				IL_006f: newarr [System.Runtime]System.Object
+				IL_0074: dup
+				IL_0075: ldc.i4.0
+				IL_0076: ldarg.0
+				IL_0077: ldc.i4.0
+				IL_0078: ldelem.ref
+				IL_0079: stelem.ref
+				IL_007a: dup
+				IL_007b: ldc.i4.1
+				IL_007c: ldarg.0
+				IL_007d: ldc.i4.1
+				IL_007e: ldelem.ref
+				IL_007f: stelem.ref
+				IL_0080: stloc.2
+				IL_0081: ldloc.2
+				IL_0082: ldarg.2
+				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_0088: stloc.3
+				IL_0089: ldloc.3
+				IL_008a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_008f: ldc.i4.0
+				IL_0090: ceq
+				IL_0092: stloc.1
+				IL_0093: ldloc.1
+				IL_0094: box [System.Runtime]System.Boolean
+				IL_0099: ret
+
+				IL_009a: ldloc.0
+				IL_009b: ret
 			} // end of method ArrowFunction_L136C51::__js_call__
 
 		} // end of class ArrowFunction_L136C51
@@ -3535,7 +3612,7 @@
 				74 61 54 6f 6b 65 6e 12 00 00 02
 			)
 			// Header size: 12
-			// Code size: 2071 (0x817)
+			// Code size: 2128 (0x850)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_BumpVersion/perform/Scope,
@@ -3602,788 +3679,809 @@
 			IL_004a: stloc.s 30
 			IL_004c: ldc.i4.0
 			IL_004d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0052: brfalse IL_007a
+			IL_0052: brfalse IL_008d
 
 			IL_0057: ldloc.s 30
 			IL_0059: isinst [System.Runtime]System.String
 			IL_005e: dup
-			IL_005f: brfalse IL_0079
+			IL_005f: brtrue IL_0077
 
-			IL_0064: ldstr "--skip-empty"
-			IL_0069: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-			IL_006e: box [System.Runtime]System.Boolean
-			IL_0073: stloc.2
-			IL_0074: br IL_008c
+			IL_0064: pop
+			IL_0065: ldloc.s 30
+			IL_0067: ldstr "includes"
+			IL_006c: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0071: dup
+			IL_0072: brfalse IL_008c
 
-			IL_0079: pop
+			IL_0077: ldstr "--skip-empty"
+			IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_0081: box [System.Runtime]System.Boolean
+			IL_0086: stloc.2
+			IL_0087: br IL_009f
 
-			IL_007a: ldloc.s 30
-			IL_007c: ldstr "includes"
-			IL_0081: ldstr "--skip-empty"
-			IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_008b: stloc.2
+			IL_008c: pop
 
-			IL_008c: ldarg.0
-			IL_008d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_0092: ldc.i4.1
-			IL_0093: newarr [System.Runtime]System.Object
-			IL_0098: dup
-			IL_0099: ldc.i4.0
-			IL_009a: ldarg.0
-			IL_009b: stelem.ref
-			IL_009c: stloc.s 31
-			IL_009e: ldarg.0
-			IL_009f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_00a4: stloc.s 30
-			IL_00a6: ldloc.s 31
-			IL_00a8: ldloc.s 30
-			IL_00aa: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00af: stloc.3
-			IL_00b0: ldarg.0
-			IL_00b1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_00b6: ldc.i4.1
-			IL_00b7: newarr [System.Runtime]System.Object
-			IL_00bc: dup
-			IL_00bd: ldc.i4.0
-			IL_00be: ldarg.0
-			IL_00bf: stelem.ref
-			IL_00c0: stloc.s 31
-			IL_00c2: ldarg.0
-			IL_00c3: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_00c8: stloc.s 30
-			IL_00ca: ldloc.s 31
-			IL_00cc: ldloc.s 30
-			IL_00ce: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00d3: stloc.s 4
+			IL_008d: ldloc.s 30
+			IL_008f: ldstr "includes"
+			IL_0094: ldstr "--skip-empty"
+			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_009e: stloc.2
+
+			IL_009f: ldarg.0
+			IL_00a0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_00a5: ldc.i4.1
+			IL_00a6: newarr [System.Runtime]System.Object
+			IL_00ab: dup
+			IL_00ac: ldc.i4.0
+			IL_00ad: ldarg.0
+			IL_00ae: stelem.ref
+			IL_00af: stloc.s 31
+			IL_00b1: ldarg.0
+			IL_00b2: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_00b7: stloc.s 30
+			IL_00b9: ldloc.s 31
+			IL_00bb: ldloc.s 30
+			IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00c2: stloc.3
+			IL_00c3: ldarg.0
+			IL_00c4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_00c9: ldc.i4.1
+			IL_00ca: newarr [System.Runtime]System.Object
+			IL_00cf: dup
+			IL_00d0: ldc.i4.0
+			IL_00d1: ldarg.0
+			IL_00d2: stelem.ref
+			IL_00d3: stloc.s 31
 			IL_00d5: ldarg.0
-			IL_00d6: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_00db: ldc.i4.1
-			IL_00dc: newarr [System.Runtime]System.Object
-			IL_00e1: dup
-			IL_00e2: ldc.i4.0
-			IL_00e3: ldarg.0
-			IL_00e4: stelem.ref
-			IL_00e5: stloc.s 31
-			IL_00e7: ldarg.0
-			IL_00e8: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_00ed: stloc.s 30
-			IL_00ef: ldloc.s 31
-			IL_00f1: ldloc.s 30
-			IL_00f3: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_00f8: stloc.s 5
+			IL_00d6: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_00db: stloc.s 30
+			IL_00dd: ldloc.s 31
+			IL_00df: ldloc.s 30
+			IL_00e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_00e6: stloc.s 4
+			IL_00e8: ldarg.0
+			IL_00e9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_00ee: ldc.i4.1
+			IL_00ef: newarr [System.Runtime]System.Object
+			IL_00f4: dup
+			IL_00f5: ldc.i4.0
+			IL_00f6: ldarg.0
+			IL_00f7: stelem.ref
+			IL_00f8: stloc.s 31
 			IL_00fa: ldarg.0
-			IL_00fb: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_0100: ldc.i4.1
-			IL_0101: newarr [System.Runtime]System.Object
-			IL_0106: dup
-			IL_0107: ldc.i4.0
-			IL_0108: ldarg.0
-			IL_0109: stelem.ref
-			IL_010a: stloc.s 31
-			IL_010c: ldarg.0
-			IL_010d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_0112: stloc.s 30
-			IL_0114: ldloc.s 31
-			IL_0116: ldloc.s 30
-			IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_011d: stloc.s 6
+			IL_00fb: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_0100: stloc.s 30
+			IL_0102: ldloc.s 31
+			IL_0104: ldloc.s 30
+			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_010b: stloc.s 5
+			IL_010d: ldarg.0
+			IL_010e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_0113: ldc.i4.1
+			IL_0114: newarr [System.Runtime]System.Object
+			IL_0119: dup
+			IL_011a: ldc.i4.0
+			IL_011b: ldarg.0
+			IL_011c: stelem.ref
+			IL_011d: stloc.s 31
 			IL_011f: ldarg.0
-			IL_0120: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_0125: ldc.i4.1
-			IL_0126: newarr [System.Runtime]System.Object
-			IL_012b: dup
-			IL_012c: ldc.i4.0
-			IL_012d: ldarg.0
-			IL_012e: stelem.ref
-			IL_012f: stloc.s 31
-			IL_0131: ldarg.0
-			IL_0132: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_0137: stloc.s 30
-			IL_0139: ldloc.s 31
-			IL_013b: ldloc.s 30
-			IL_013d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0142: stloc.s 7
+			IL_0120: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_0125: stloc.s 30
+			IL_0127: ldloc.s 31
+			IL_0129: ldloc.s 30
+			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0130: stloc.s 6
+			IL_0132: ldarg.0
+			IL_0133: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_0138: ldc.i4.1
+			IL_0139: newarr [System.Runtime]System.Object
+			IL_013e: dup
+			IL_013f: ldc.i4.0
+			IL_0140: ldarg.0
+			IL_0141: stelem.ref
+			IL_0142: stloc.s 31
 			IL_0144: ldarg.0
-			IL_0145: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
-			IL_014a: ldc.i4.1
-			IL_014b: newarr [System.Runtime]System.Object
-			IL_0150: dup
-			IL_0151: ldc.i4.0
-			IL_0152: ldarg.0
-			IL_0153: stelem.ref
-			IL_0154: stloc.s 31
-			IL_0156: ldarg.0
-			IL_0157: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_015c: stloc.s 30
-			IL_015e: ldloc.s 31
-			IL_0160: ldloc.s 30
-			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0167: stloc.s 8
+			IL_0145: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_014a: stloc.s 30
+			IL_014c: ldloc.s 31
+			IL_014e: ldloc.s 30
+			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0155: stloc.s 7
+			IL_0157: ldarg.0
+			IL_0158: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::readFile
+			IL_015d: ldc.i4.1
+			IL_015e: newarr [System.Runtime]System.Object
+			IL_0163: dup
+			IL_0164: ldc.i4.0
+			IL_0165: ldarg.0
+			IL_0166: stelem.ref
+			IL_0167: stloc.s 31
 			IL_0169: ldarg.0
-			IL_016a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::parseCurrentVersion
-			IL_016f: ldc.i4.1
-			IL_0170: newarr [System.Runtime]System.Object
-			IL_0175: dup
-			IL_0176: ldc.i4.0
-			IL_0177: ldarg.0
-			IL_0178: stelem.ref
-			IL_0179: ldloc.3
-			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_017f: stloc.s 9
-			IL_0181: ldarg.0
-			IL_0182: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::resolveTargetVersion
-			IL_0187: ldc.i4.1
-			IL_0188: newarr [System.Runtime]System.Object
-			IL_018d: dup
-			IL_018e: ldc.i4.0
-			IL_018f: ldarg.0
-			IL_0190: stelem.ref
-			IL_0191: ldloc.1
-			IL_0192: ldloc.s 9
-			IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0199: stloc.s 10
-			IL_019b: ldloc.s 9
-			IL_019d: ldloc.s 10
-			IL_019f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_01a4: stloc.s 32
-			IL_01a6: ldloc.s 32
-			IL_01a8: brfalse IL_0216
+			IL_016a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
+			IL_016f: stloc.s 30
+			IL_0171: ldloc.s 31
+			IL_0173: ldloc.s 30
+			IL_0175: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_017a: stloc.s 8
+			IL_017c: ldarg.0
+			IL_017d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::parseCurrentVersion
+			IL_0182: ldc.i4.1
+			IL_0183: newarr [System.Runtime]System.Object
+			IL_0188: dup
+			IL_0189: ldc.i4.0
+			IL_018a: ldarg.0
+			IL_018b: stelem.ref
+			IL_018c: ldloc.3
+			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0192: stloc.s 9
+			IL_0194: ldarg.0
+			IL_0195: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::resolveTargetVersion
+			IL_019a: ldc.i4.1
+			IL_019b: newarr [System.Runtime]System.Object
+			IL_01a0: dup
+			IL_01a1: ldc.i4.0
+			IL_01a2: ldarg.0
+			IL_01a3: stelem.ref
+			IL_01a4: ldloc.1
+			IL_01a5: ldloc.s 9
+			IL_01a7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01ac: stloc.s 10
+			IL_01ae: ldloc.s 9
+			IL_01b0: ldloc.s 10
+			IL_01b2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_01b7: stloc.s 32
+			IL_01b9: ldloc.s 32
+			IL_01bb: brfalse IL_0229
 
-			IL_01ad: ldstr "console"
-			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01bc: stloc.s 30
-			IL_01be: ldloc.s 9
-			IL_01c0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01c5: stloc.s 33
-			IL_01c7: ldstr "Version unchanged ("
-			IL_01cc: ldloc.s 33
-			IL_01ce: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01d3: ldstr "); aborting."
-			IL_01d8: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01dd: stloc.s 33
-			IL_01df: ldloc.s 30
-			IL_01e1: ldstr "error"
-			IL_01e6: ldloc.s 33
-			IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01ed: pop
-			IL_01ee: ldstr "process"
-			IL_01f3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01fd: ldstr "exit"
-			IL_0202: ldc.r8 1
-			IL_020b: box [System.Runtime]System.Double
-			IL_0210: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0215: pop
+			IL_01c0: ldstr "console"
+			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_01ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01cf: stloc.s 30
+			IL_01d1: ldloc.s 9
+			IL_01d3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01d8: stloc.s 33
+			IL_01da: ldstr "Version unchanged ("
+			IL_01df: ldloc.s 33
+			IL_01e1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01e6: ldstr "); aborting."
+			IL_01eb: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01f0: stloc.s 33
+			IL_01f2: ldloc.s 30
+			IL_01f4: ldstr "error"
+			IL_01f9: ldloc.s 33
+			IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0200: pop
+			IL_0201: ldstr "process"
+			IL_0206: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_020b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0210: ldstr "exit"
+			IL_0215: ldc.r8 1
+			IL_021e: box [System.Runtime]System.Double
+			IL_0223: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0228: pop
 
-			IL_0216: ldarg.0
-			IL_0217: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::extractUnreleased
-			IL_021c: ldc.i4.1
-			IL_021d: newarr [System.Runtime]System.Object
-			IL_0222: dup
-			IL_0223: ldc.i4.0
-			IL_0224: ldarg.0
-			IL_0225: stelem.ref
-			IL_0226: ldloc.s 8
-			IL_0228: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_022d: stloc.s 30
-			IL_022f: ldloc.s 30
-			IL_0231: brfalse IL_0242
-
-			IL_0236: ldloc.s 30
-			IL_0238: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_023d: brfalse IL_0253
-
+			IL_0229: ldarg.0
+			IL_022a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::extractUnreleased
+			IL_022f: ldc.i4.1
+			IL_0230: newarr [System.Runtime]System.Object
+			IL_0235: dup
+			IL_0236: ldc.i4.0
+			IL_0237: ldarg.0
+			IL_0238: stelem.ref
+			IL_0239: ldloc.s 8
+			IL_023b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0240: stloc.s 30
 			IL_0242: ldloc.s 30
-			IL_0244: ldstr ""
-			IL_0249: ldstr "body"
-			IL_024e: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
+			IL_0244: brfalse IL_0255
 
-			IL_0253: ldloc.s 30
-			IL_0255: ldstr "body"
-			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_025f: stloc.s 11
-			IL_0261: ldloc.s 30
-			IL_0263: ldstr "start"
-			IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_026d: stloc.s 12
-			IL_026f: ldloc.s 30
-			IL_0271: ldstr "end"
-			IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_027b: stloc.s 13
-			IL_027d: ldloc.s 11
-			IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0284: stloc.s 30
-			IL_0286: ldstr "\\r?\\n"
-			IL_028b: ldstr ""
-			IL_0290: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0295: stloc.s 34
-			IL_0297: ldloc.s 30
-			IL_0299: ldstr "split"
-			IL_029e: ldloc.s 34
-			IL_02a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02a5: stloc.s 30
-			IL_02a7: ldloc.s 30
-			IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_02ae: stloc.s 30
-			IL_02b0: ldc.i4.2
-			IL_02b1: newarr [System.Runtime]System.Object
-			IL_02b6: dup
-			IL_02b7: ldc.i4.0
-			IL_02b8: ldarg.0
-			IL_02b9: stelem.ref
-			IL_02ba: dup
-			IL_02bb: ldc.i4.1
-			IL_02bc: ldloc.0
-			IL_02bd: stelem.ref
-			IL_02be: stloc.s 31
-			IL_02c0: ldloc.s 31
-			IL_02c2: ldc.i4.0
-			IL_02c3: ldelem.ref
-			IL_02c4: castclass Modules.Compile_Scripts_BumpVersion/Scope
-			IL_02c9: ldloc.s 31
-			IL_02cb: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope, object[])
-			IL_02d0: ldc.i4.1
-			IL_02d1: conv.r8
-			IL_02d2: ldstr ""
-			IL_02d7: ldc.i4.0
-			IL_02d8: ldc.i4.0
-			IL_02d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject>(!!0, float64, string, bool, bool)
-			IL_02de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject>(!!0)
-			IL_02e3: stloc.s 35
-			IL_02e5: ldloc.s 30
-			IL_02e7: ldstr "some"
-			IL_02ec: ldloc.s 35
-			IL_02ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02f3: stloc.s 14
-			IL_02f5: ldloc.s 14
-			IL_02f7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_02fc: ldc.i4.0
-			IL_02fd: ceq
-			IL_02ff: stloc.s 32
-			IL_0301: ldloc.s 32
-			IL_0303: box [System.Runtime]System.Boolean
-			IL_0308: stloc.s 36
-			IL_030a: ldloc.s 36
-			IL_030c: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0311: stloc.s 32
-			IL_0313: ldloc.s 32
-			IL_0315: brfalse IL_0322
+			IL_0249: ldloc.s 30
+			IL_024b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0250: brfalse IL_0266
 
-			IL_031a: ldloc.2
-			IL_031b: stloc.s 38
-			IL_031d: br IL_0326
+			IL_0255: ldloc.s 30
+			IL_0257: ldstr ""
+			IL_025c: ldstr "body"
+			IL_0261: call void [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::ThrowDestructuringNullOrUndefined(object, string, string)
 
-			IL_0322: ldloc.s 36
-			IL_0324: stloc.s 38
+			IL_0266: ldloc.s 30
+			IL_0268: ldstr "body"
+			IL_026d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0272: stloc.s 11
+			IL_0274: ldloc.s 30
+			IL_0276: ldstr "start"
+			IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0280: stloc.s 12
+			IL_0282: ldloc.s 30
+			IL_0284: ldstr "end"
+			IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_028e: stloc.s 13
+			IL_0290: ldloc.s 11
+			IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0297: stloc.s 30
+			IL_0299: ldstr "\\r?\\n"
+			IL_029e: ldstr ""
+			IL_02a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_02a8: stloc.s 34
+			IL_02aa: ldloc.s 30
+			IL_02ac: ldstr "split"
+			IL_02b1: ldloc.s 34
+			IL_02b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02b8: stloc.s 30
+			IL_02ba: ldloc.s 30
+			IL_02bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02c1: stloc.s 30
+			IL_02c3: ldc.i4.2
+			IL_02c4: newarr [System.Runtime]System.Object
+			IL_02c9: dup
+			IL_02ca: ldc.i4.0
+			IL_02cb: ldarg.0
+			IL_02cc: stelem.ref
+			IL_02cd: dup
+			IL_02ce: ldc.i4.1
+			IL_02cf: ldloc.0
+			IL_02d0: stelem.ref
+			IL_02d1: stloc.s 31
+			IL_02d3: ldloc.s 31
+			IL_02d5: ldc.i4.0
+			IL_02d6: ldelem.ref
+			IL_02d7: castclass Modules.Compile_Scripts_BumpVersion/Scope
+			IL_02dc: ldloc.s 31
+			IL_02de: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope, object[])
+			IL_02e3: ldc.i4.1
+			IL_02e4: conv.r8
+			IL_02e5: ldstr ""
+			IL_02ea: ldc.i4.0
+			IL_02eb: ldc.i4.0
+			IL_02ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_02f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_BumpVersion/perform/ArrowFunction_L136C51/FunctionObject>(!!0)
+			IL_02f6: stloc.s 35
+			IL_02f8: ldloc.s 30
+			IL_02fa: ldstr "some"
+			IL_02ff: ldloc.s 35
+			IL_0301: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0306: stloc.s 14
+			IL_0308: ldloc.s 14
+			IL_030a: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_030f: ldc.i4.0
+			IL_0310: ceq
+			IL_0312: stloc.s 32
+			IL_0314: ldloc.s 32
+			IL_0316: box [System.Runtime]System.Boolean
+			IL_031b: stloc.s 36
+			IL_031d: ldloc.s 36
+			IL_031f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0324: stloc.s 32
+			IL_0326: ldloc.s 32
+			IL_0328: brfalse IL_0335
 
-			IL_0326: ldloc.s 38
-			IL_0328: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_032d: stloc.s 32
-			IL_032f: ldloc.s 32
-			IL_0331: brfalse IL_04a4
+			IL_032d: ldloc.2
+			IL_032e: stloc.s 38
+			IL_0330: br IL_0339
 
-			IL_0336: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_033b: stloc.s 39
-			IL_033d: ldloc.s 39
-			IL_033f: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
-			IL_0344: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0349: pop
-			IL_034a: ldarg.0
-			IL_034b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0350: ldc.i4.1
-			IL_0351: newarr [System.Runtime]System.Object
-			IL_0356: dup
-			IL_0357: ldc.i4.0
-			IL_0358: ldarg.0
-			IL_0359: stelem.ref
-			IL_035a: ldloc.3
-			IL_035b: ldloc.s 10
-			IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0362: stloc.s 15
-			IL_0364: ldarg.0
-			IL_0365: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_036a: ldc.i4.1
-			IL_036b: newarr [System.Runtime]System.Object
-			IL_0370: dup
-			IL_0371: ldc.i4.0
-			IL_0372: ldarg.0
-			IL_0373: stelem.ref
-			IL_0374: ldloc.s 4
-			IL_0376: ldloc.s 10
-			IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_037d: stloc.s 16
-			IL_037f: ldarg.0
-			IL_0380: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0385: ldc.i4.1
-			IL_0386: newarr [System.Runtime]System.Object
-			IL_038b: dup
-			IL_038c: ldc.i4.0
-			IL_038d: ldarg.0
-			IL_038e: stelem.ref
-			IL_038f: ldloc.s 5
-			IL_0391: ldloc.s 10
-			IL_0393: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0398: stloc.s 17
-			IL_039a: ldarg.0
-			IL_039b: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_03a0: ldc.i4.1
-			IL_03a1: newarr [System.Runtime]System.Object
-			IL_03a6: dup
-			IL_03a7: ldc.i4.0
-			IL_03a8: ldarg.0
-			IL_03a9: stelem.ref
-			IL_03aa: ldloc.s 6
-			IL_03ac: ldloc.s 10
-			IL_03ae: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03b3: stloc.s 18
-			IL_03b5: ldarg.0
-			IL_03b6: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
-			IL_03bb: ldc.i4.1
-			IL_03bc: newarr [System.Runtime]System.Object
-			IL_03c1: dup
-			IL_03c2: ldc.i4.0
-			IL_03c3: ldarg.0
-			IL_03c4: stelem.ref
-			IL_03c5: ldloc.s 7
-			IL_03c7: ldloc.s 10
-			IL_03c9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03ce: stloc.s 19
-			IL_03d0: ldarg.0
-			IL_03d1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_03d6: stloc.s 30
-			IL_03d8: ldc.i4.1
-			IL_03d9: newarr [System.Runtime]System.Object
-			IL_03de: dup
-			IL_03df: ldc.i4.0
-			IL_03e0: ldarg.0
-			IL_03e1: stelem.ref
-			IL_03e2: stloc.s 31
-			IL_03e4: ldarg.0
-			IL_03e5: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_03ea: stloc.s 40
-			IL_03ec: ldloc.s 30
-			IL_03ee: ldloc.s 31
-			IL_03f0: ldloc.s 40
-			IL_03f2: ldloc.s 15
-			IL_03f4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_03f9: pop
-			IL_03fa: ldarg.0
-			IL_03fb: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0400: stloc.s 40
-			IL_0402: ldc.i4.1
-			IL_0403: newarr [System.Runtime]System.Object
-			IL_0408: dup
-			IL_0409: ldc.i4.0
-			IL_040a: ldarg.0
-			IL_040b: stelem.ref
-			IL_040c: stloc.s 31
-			IL_040e: ldarg.0
-			IL_040f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_0414: stloc.s 30
-			IL_0416: ldloc.s 40
-			IL_0418: ldloc.s 31
-			IL_041a: ldloc.s 30
-			IL_041c: ldloc.s 16
-			IL_041e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0423: pop
-			IL_0424: ldarg.0
-			IL_0425: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_042a: stloc.s 30
-			IL_042c: ldc.i4.1
-			IL_042d: newarr [System.Runtime]System.Object
-			IL_0432: dup
-			IL_0433: ldc.i4.0
-			IL_0434: ldarg.0
-			IL_0435: stelem.ref
-			IL_0436: stloc.s 31
-			IL_0438: ldarg.0
-			IL_0439: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_043e: stloc.s 40
-			IL_0440: ldloc.s 30
-			IL_0442: ldloc.s 31
-			IL_0444: ldloc.s 40
-			IL_0446: ldloc.s 17
-			IL_0448: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_044d: pop
-			IL_044e: ldarg.0
-			IL_044f: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0454: stloc.s 40
-			IL_0456: ldc.i4.1
-			IL_0457: newarr [System.Runtime]System.Object
-			IL_045c: dup
-			IL_045d: ldc.i4.0
-			IL_045e: ldarg.0
-			IL_045f: stelem.ref
-			IL_0460: stloc.s 31
-			IL_0462: ldarg.0
-			IL_0463: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_0468: stloc.s 30
-			IL_046a: ldloc.s 40
-			IL_046c: ldloc.s 31
-			IL_046e: ldloc.s 30
-			IL_0470: ldloc.s 18
-			IL_0472: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0477: pop
-			IL_0478: ldarg.0
-			IL_0479: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_047e: stloc.s 30
-			IL_0480: ldc.i4.1
-			IL_0481: newarr [System.Runtime]System.Object
-			IL_0486: dup
-			IL_0487: ldc.i4.0
-			IL_0488: ldarg.0
-			IL_0489: stelem.ref
-			IL_048a: stloc.s 31
-			IL_048c: ldarg.0
-			IL_048d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_0492: stloc.s 40
-			IL_0494: ldloc.s 30
-			IL_0496: ldloc.s 31
-			IL_0498: ldloc.s 40
-			IL_049a: ldloc.s 19
-			IL_049c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04a1: pop
-			IL_04a2: ldnull
-			IL_04a3: ret
+			IL_0335: ldloc.s 36
+			IL_0337: stloc.s 38
 
-			IL_04a4: ldarg.0
-			IL_04a5: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::generateReleaseSection
-			IL_04aa: ldc.i4.1
-			IL_04ab: newarr [System.Runtime]System.Object
-			IL_04b0: dup
-			IL_04b1: ldc.i4.0
-			IL_04b2: ldarg.0
-			IL_04b3: stelem.ref
-			IL_04b4: ldloc.s 10
-			IL_04b6: ldloc.s 11
-			IL_04b8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_04bd: stloc.s 20
-			IL_04bf: ldloc.s 8
-			IL_04c1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_04c6: stloc.s 40
-			IL_04c8: ldc.i4.0
-			IL_04c9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_04ce: brfalse IL_04fd
+			IL_0339: ldloc.s 38
+			IL_033b: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0340: stloc.s 32
+			IL_0342: ldloc.s 32
+			IL_0344: brfalse IL_04b7
 
-			IL_04d3: ldloc.s 40
-			IL_04d5: isinst [System.Runtime]System.String
-			IL_04da: dup
-			IL_04db: brfalse IL_04fc
+			IL_0349: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_034e: stloc.s 39
+			IL_0350: ldloc.s 39
+			IL_0352: ldstr "Unreleased is empty and --skip-empty specified; only bumping csproj versions and samples/Directory.Build.props."
+			IL_0357: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_035c: pop
+			IL_035d: ldarg.0
+			IL_035e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0363: ldc.i4.1
+			IL_0364: newarr [System.Runtime]System.Object
+			IL_0369: dup
+			IL_036a: ldc.i4.0
+			IL_036b: ldarg.0
+			IL_036c: stelem.ref
+			IL_036d: ldloc.3
+			IL_036e: ldloc.s 10
+			IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0375: stloc.s 15
+			IL_0377: ldarg.0
+			IL_0378: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_037d: ldc.i4.1
+			IL_037e: newarr [System.Runtime]System.Object
+			IL_0383: dup
+			IL_0384: ldc.i4.0
+			IL_0385: ldarg.0
+			IL_0386: stelem.ref
+			IL_0387: ldloc.s 4
+			IL_0389: ldloc.s 10
+			IL_038b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0390: stloc.s 16
+			IL_0392: ldarg.0
+			IL_0393: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0398: ldc.i4.1
+			IL_0399: newarr [System.Runtime]System.Object
+			IL_039e: dup
+			IL_039f: ldc.i4.0
+			IL_03a0: ldarg.0
+			IL_03a1: stelem.ref
+			IL_03a2: ldloc.s 5
+			IL_03a4: ldloc.s 10
+			IL_03a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03ab: stloc.s 17
+			IL_03ad: ldarg.0
+			IL_03ae: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_03b3: ldc.i4.1
+			IL_03b4: newarr [System.Runtime]System.Object
+			IL_03b9: dup
+			IL_03ba: ldc.i4.0
+			IL_03bb: ldarg.0
+			IL_03bc: stelem.ref
+			IL_03bd: ldloc.s 6
+			IL_03bf: ldloc.s 10
+			IL_03c1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03c6: stloc.s 18
+			IL_03c8: ldarg.0
+			IL_03c9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
+			IL_03ce: ldc.i4.1
+			IL_03cf: newarr [System.Runtime]System.Object
+			IL_03d4: dup
+			IL_03d5: ldc.i4.0
+			IL_03d6: ldarg.0
+			IL_03d7: stelem.ref
+			IL_03d8: ldloc.s 7
+			IL_03da: ldloc.s 10
+			IL_03dc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_03e1: stloc.s 19
+			IL_03e3: ldarg.0
+			IL_03e4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_03e9: stloc.s 30
+			IL_03eb: ldc.i4.1
+			IL_03ec: newarr [System.Runtime]System.Object
+			IL_03f1: dup
+			IL_03f2: ldc.i4.0
+			IL_03f3: ldarg.0
+			IL_03f4: stelem.ref
+			IL_03f5: stloc.s 31
+			IL_03f7: ldarg.0
+			IL_03f8: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_03fd: stloc.s 40
+			IL_03ff: ldloc.s 30
+			IL_0401: ldloc.s 31
+			IL_0403: ldloc.s 40
+			IL_0405: ldloc.s 15
+			IL_0407: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_040c: pop
+			IL_040d: ldarg.0
+			IL_040e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0413: stloc.s 40
+			IL_0415: ldc.i4.1
+			IL_0416: newarr [System.Runtime]System.Object
+			IL_041b: dup
+			IL_041c: ldc.i4.0
+			IL_041d: ldarg.0
+			IL_041e: stelem.ref
+			IL_041f: stloc.s 31
+			IL_0421: ldarg.0
+			IL_0422: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_0427: stloc.s 30
+			IL_0429: ldloc.s 40
+			IL_042b: ldloc.s 31
+			IL_042d: ldloc.s 30
+			IL_042f: ldloc.s 16
+			IL_0431: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0436: pop
+			IL_0437: ldarg.0
+			IL_0438: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_043d: stloc.s 30
+			IL_043f: ldc.i4.1
+			IL_0440: newarr [System.Runtime]System.Object
+			IL_0445: dup
+			IL_0446: ldc.i4.0
+			IL_0447: ldarg.0
+			IL_0448: stelem.ref
+			IL_0449: stloc.s 31
+			IL_044b: ldarg.0
+			IL_044c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_0451: stloc.s 40
+			IL_0453: ldloc.s 30
+			IL_0455: ldloc.s 31
+			IL_0457: ldloc.s 40
+			IL_0459: ldloc.s 17
+			IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0460: pop
+			IL_0461: ldarg.0
+			IL_0462: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0467: stloc.s 40
+			IL_0469: ldc.i4.1
+			IL_046a: newarr [System.Runtime]System.Object
+			IL_046f: dup
+			IL_0470: ldc.i4.0
+			IL_0471: ldarg.0
+			IL_0472: stelem.ref
+			IL_0473: stloc.s 31
+			IL_0475: ldarg.0
+			IL_0476: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_047b: stloc.s 30
+			IL_047d: ldloc.s 40
+			IL_047f: ldloc.s 31
+			IL_0481: ldloc.s 30
+			IL_0483: ldloc.s 18
+			IL_0485: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_048a: pop
+			IL_048b: ldarg.0
+			IL_048c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0491: stloc.s 30
+			IL_0493: ldc.i4.1
+			IL_0494: newarr [System.Runtime]System.Object
+			IL_0499: dup
+			IL_049a: ldc.i4.0
+			IL_049b: ldarg.0
+			IL_049c: stelem.ref
+			IL_049d: stloc.s 31
+			IL_049f: ldarg.0
+			IL_04a0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_04a5: stloc.s 40
+			IL_04a7: ldloc.s 30
+			IL_04a9: ldloc.s 31
+			IL_04ab: ldloc.s 40
+			IL_04ad: ldloc.s 19
+			IL_04af: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04b4: pop
+			IL_04b5: ldnull
+			IL_04b6: ret
 
-			IL_04e0: ldc.r8 0.0
-			IL_04e9: box [System.Runtime]System.Double
-			IL_04ee: ldloc.s 12
-			IL_04f0: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
-			IL_04f5: stloc.s 21
-			IL_04f7: br IL_051b
+			IL_04b7: ldarg.0
+			IL_04b8: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::generateReleaseSection
+			IL_04bd: ldc.i4.1
+			IL_04be: newarr [System.Runtime]System.Object
+			IL_04c3: dup
+			IL_04c4: ldc.i4.0
+			IL_04c5: ldarg.0
+			IL_04c6: stelem.ref
+			IL_04c7: ldloc.s 10
+			IL_04c9: ldloc.s 11
+			IL_04cb: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_04d0: stloc.s 20
+			IL_04d2: ldloc.s 8
+			IL_04d4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_04d9: stloc.s 40
+			IL_04db: ldc.i4.0
+			IL_04dc: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_04e1: brfalse IL_0523
 
-			IL_04fc: pop
+			IL_04e6: ldloc.s 40
+			IL_04e8: isinst [System.Runtime]System.String
+			IL_04ed: dup
+			IL_04ee: brtrue IL_0506
 
-			IL_04fd: ldloc.s 40
-			IL_04ff: ldstr "slice"
-			IL_0504: ldc.r8 0.0
-			IL_050d: box [System.Runtime]System.Double
-			IL_0512: ldloc.s 12
-			IL_0514: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0519: stloc.s 21
+			IL_04f3: pop
+			IL_04f4: ldloc.s 40
+			IL_04f6: ldstr "slice"
+			IL_04fb: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0500: dup
+			IL_0501: brfalse IL_0522
 
-			IL_051b: ldloc.s 8
-			IL_051d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0522: stloc.s 40
-			IL_0524: ldc.i4.0
-			IL_0525: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_052a: brfalse IL_054b
+			IL_0506: ldc.r8 0.0
+			IL_050f: box [System.Runtime]System.Double
+			IL_0514: ldloc.s 12
+			IL_0516: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object, object)
+			IL_051b: stloc.s 21
+			IL_051d: br IL_0541
 
-			IL_052f: ldloc.s 40
-			IL_0531: isinst [System.Runtime]System.String
-			IL_0536: dup
-			IL_0537: brfalse IL_054a
+			IL_0522: pop
 
-			IL_053c: ldloc.s 13
-			IL_053e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
-			IL_0543: stloc.s 22
-			IL_0545: br IL_055b
+			IL_0523: ldloc.s 40
+			IL_0525: ldstr "slice"
+			IL_052a: ldc.r8 0.0
+			IL_0533: box [System.Runtime]System.Double
+			IL_0538: ldloc.s 12
+			IL_053a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_053f: stloc.s 21
 
-			IL_054a: pop
+			IL_0541: ldloc.s 8
+			IL_0543: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0548: stloc.s 40
+			IL_054a: ldc.i4.0
+			IL_054b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0550: brfalse IL_0584
 
-			IL_054b: ldloc.s 40
-			IL_054d: ldstr "slice"
-			IL_0552: ldloc.s 13
-			IL_0554: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0559: stloc.s 22
+			IL_0555: ldloc.s 40
+			IL_0557: isinst [System.Runtime]System.String
+			IL_055c: dup
+			IL_055d: brtrue IL_0575
 
-			IL_055b: ldstr "\n_Nothing yet._\n\n"
-			IL_0560: stloc.s 23
-			IL_0562: ldloc.s 21
-			IL_0564: ldloc.s 23
-			IL_0566: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_056b: stloc.s 38
-			IL_056d: ldloc.s 38
-			IL_056f: ldloc.s 20
-			IL_0571: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0576: stloc.s 38
-			IL_0578: ldloc.s 38
-			IL_057a: ldloc.s 22
-			IL_057c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0581: stloc.s 24
-			IL_0583: ldarg.0
-			IL_0584: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_0589: ldc.i4.1
-			IL_058a: newarr [System.Runtime]System.Object
-			IL_058f: dup
-			IL_0590: ldc.i4.0
-			IL_0591: ldarg.0
-			IL_0592: stelem.ref
-			IL_0593: ldloc.3
-			IL_0594: ldloc.s 10
-			IL_0596: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_059b: stloc.s 25
-			IL_059d: ldarg.0
-			IL_059e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_05a3: ldc.i4.1
-			IL_05a4: newarr [System.Runtime]System.Object
-			IL_05a9: dup
-			IL_05aa: ldc.i4.0
-			IL_05ab: ldarg.0
-			IL_05ac: stelem.ref
-			IL_05ad: ldloc.s 4
-			IL_05af: ldloc.s 10
-			IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05b6: stloc.s 26
-			IL_05b8: ldarg.0
-			IL_05b9: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_05be: ldc.i4.1
-			IL_05bf: newarr [System.Runtime]System.Object
-			IL_05c4: dup
-			IL_05c5: ldc.i4.0
-			IL_05c6: ldarg.0
-			IL_05c7: stelem.ref
-			IL_05c8: ldloc.s 5
-			IL_05ca: ldloc.s 10
-			IL_05cc: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05d1: stloc.s 27
-			IL_05d3: ldarg.0
-			IL_05d4: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
-			IL_05d9: ldc.i4.1
-			IL_05da: newarr [System.Runtime]System.Object
-			IL_05df: dup
-			IL_05e0: ldc.i4.0
-			IL_05e1: ldarg.0
-			IL_05e2: stelem.ref
-			IL_05e3: ldloc.s 6
-			IL_05e5: ldloc.s 10
-			IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05ec: stloc.s 28
-			IL_05ee: ldarg.0
-			IL_05ef: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
-			IL_05f4: ldc.i4.1
-			IL_05f5: newarr [System.Runtime]System.Object
-			IL_05fa: dup
-			IL_05fb: ldc.i4.0
-			IL_05fc: ldarg.0
-			IL_05fd: stelem.ref
-			IL_05fe: ldloc.s 7
-			IL_0600: ldloc.s 10
-			IL_0602: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0607: stloc.s 29
-			IL_0609: ldarg.0
-			IL_060a: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_060f: stloc.s 40
-			IL_0611: ldc.i4.1
-			IL_0612: newarr [System.Runtime]System.Object
-			IL_0617: dup
-			IL_0618: ldc.i4.0
-			IL_0619: ldarg.0
-			IL_061a: stelem.ref
-			IL_061b: stloc.s 31
-			IL_061d: ldarg.0
-			IL_061e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
-			IL_0623: stloc.s 30
-			IL_0625: ldloc.s 40
-			IL_0627: ldloc.s 31
-			IL_0629: ldloc.s 30
-			IL_062b: ldloc.s 24
-			IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0632: pop
-			IL_0633: ldarg.0
-			IL_0634: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0639: stloc.s 30
-			IL_063b: ldc.i4.1
-			IL_063c: newarr [System.Runtime]System.Object
-			IL_0641: dup
-			IL_0642: ldc.i4.0
-			IL_0643: ldarg.0
-			IL_0644: stelem.ref
-			IL_0645: stloc.s 31
-			IL_0647: ldarg.0
-			IL_0648: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
-			IL_064d: stloc.s 40
-			IL_064f: ldloc.s 30
-			IL_0651: ldloc.s 31
-			IL_0653: ldloc.s 40
-			IL_0655: ldloc.s 25
-			IL_0657: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_065c: pop
-			IL_065d: ldarg.0
-			IL_065e: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_0663: stloc.s 40
-			IL_0665: ldc.i4.1
-			IL_0666: newarr [System.Runtime]System.Object
-			IL_066b: dup
-			IL_066c: ldc.i4.0
-			IL_066d: ldarg.0
-			IL_066e: stelem.ref
-			IL_066f: stloc.s 31
-			IL_0671: ldarg.0
-			IL_0672: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
-			IL_0677: stloc.s 30
-			IL_0679: ldloc.s 40
-			IL_067b: ldloc.s 31
-			IL_067d: ldloc.s 30
-			IL_067f: ldloc.s 26
-			IL_0681: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0686: pop
-			IL_0687: ldarg.0
-			IL_0688: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_068d: stloc.s 30
-			IL_068f: ldc.i4.1
-			IL_0690: newarr [System.Runtime]System.Object
-			IL_0695: dup
-			IL_0696: ldc.i4.0
-			IL_0697: ldarg.0
-			IL_0698: stelem.ref
-			IL_0699: stloc.s 31
-			IL_069b: ldarg.0
-			IL_069c: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
-			IL_06a1: stloc.s 40
-			IL_06a3: ldloc.s 30
-			IL_06a5: ldloc.s 31
-			IL_06a7: ldloc.s 40
-			IL_06a9: ldloc.s 27
-			IL_06ab: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_06b0: pop
-			IL_06b1: ldarg.0
-			IL_06b2: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_06b7: stloc.s 40
-			IL_06b9: ldc.i4.1
-			IL_06ba: newarr [System.Runtime]System.Object
-			IL_06bf: dup
-			IL_06c0: ldc.i4.0
-			IL_06c1: ldarg.0
-			IL_06c2: stelem.ref
-			IL_06c3: stloc.s 31
-			IL_06c5: ldarg.0
-			IL_06c6: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
-			IL_06cb: stloc.s 30
-			IL_06cd: ldloc.s 40
-			IL_06cf: ldloc.s 31
-			IL_06d1: ldloc.s 30
-			IL_06d3: ldloc.s 28
-			IL_06d5: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_06da: pop
-			IL_06db: ldarg.0
-			IL_06dc: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
-			IL_06e1: stloc.s 30
-			IL_06e3: ldc.i4.1
-			IL_06e4: newarr [System.Runtime]System.Object
-			IL_06e9: dup
-			IL_06ea: ldc.i4.0
-			IL_06eb: ldarg.0
-			IL_06ec: stelem.ref
-			IL_06ed: stloc.s 31
-			IL_06ef: ldarg.0
-			IL_06f0: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
-			IL_06f5: stloc.s 40
-			IL_06f7: ldloc.s 30
-			IL_06f9: ldloc.s 31
-			IL_06fb: ldloc.s 40
-			IL_06fd: ldloc.s 29
-			IL_06ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0704: pop
-			IL_0705: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_070a: stloc.s 39
-			IL_070c: ldloc.s 9
-			IL_070e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0713: stloc.s 33
-			IL_0715: ldstr "Bumped version: "
-			IL_071a: ldloc.s 33
-			IL_071c: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0721: ldstr " -> "
-			IL_0726: call string [System.Runtime]System.String::Concat(string, string)
-			IL_072b: ldloc.s 10
-			IL_072d: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0732: stloc.s 33
-			IL_0734: ldloc.s 33
-			IL_0736: call string [System.Runtime]System.String::Concat(string, string)
-			IL_073b: stloc.s 33
-			IL_073d: ldloc.s 39
-			IL_073f: ldloc.s 33
-			IL_0741: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0746: pop
-			IL_0747: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_074c: stloc.s 39
-			IL_074e: ldloc.s 39
-			IL_0750: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_0755: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_075a: pop
-			IL_075b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0760: stloc.s 39
-			IL_0762: ldloc.s 39
-			IL_0764: ldstr "\nNext steps:"
-			IL_0769: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_076e: pop
-			IL_076f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0774: stloc.s 39
+			IL_0562: pop
+			IL_0563: ldloc.s 40
+			IL_0565: ldstr "slice"
+			IL_056a: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_056f: dup
+			IL_0570: brfalse IL_0583
+
+			IL_0575: ldloc.s 13
+			IL_0577: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
+			IL_057c: stloc.s 22
+			IL_057e: br IL_0594
+
+			IL_0583: pop
+
+			IL_0584: ldloc.s 40
+			IL_0586: ldstr "slice"
+			IL_058b: ldloc.s 13
+			IL_058d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0592: stloc.s 22
+
+			IL_0594: ldstr "\n_Nothing yet._\n\n"
+			IL_0599: stloc.s 23
+			IL_059b: ldloc.s 21
+			IL_059d: ldloc.s 23
+			IL_059f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_05a4: stloc.s 38
+			IL_05a6: ldloc.s 38
+			IL_05a8: ldloc.s 20
+			IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_05af: stloc.s 38
+			IL_05b1: ldloc.s 38
+			IL_05b3: ldloc.s 22
+			IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_05ba: stloc.s 24
+			IL_05bc: ldarg.0
+			IL_05bd: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_05c2: ldc.i4.1
+			IL_05c3: newarr [System.Runtime]System.Object
+			IL_05c8: dup
+			IL_05c9: ldc.i4.0
+			IL_05ca: ldarg.0
+			IL_05cb: stelem.ref
+			IL_05cc: ldloc.3
+			IL_05cd: ldloc.s 10
+			IL_05cf: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05d4: stloc.s 25
+			IL_05d6: ldarg.0
+			IL_05d7: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_05dc: ldc.i4.1
+			IL_05dd: newarr [System.Runtime]System.Object
+			IL_05e2: dup
+			IL_05e3: ldc.i4.0
+			IL_05e4: ldarg.0
+			IL_05e5: stelem.ref
+			IL_05e6: ldloc.s 4
+			IL_05e8: ldloc.s 10
+			IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05ef: stloc.s 26
+			IL_05f1: ldarg.0
+			IL_05f2: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_05f7: ldc.i4.1
+			IL_05f8: newarr [System.Runtime]System.Object
+			IL_05fd: dup
+			IL_05fe: ldc.i4.0
+			IL_05ff: ldarg.0
+			IL_0600: stelem.ref
+			IL_0601: ldloc.s 5
+			IL_0603: ldloc.s 10
+			IL_0605: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_060a: stloc.s 27
+			IL_060c: ldarg.0
+			IL_060d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateCsprojVersion
+			IL_0612: ldc.i4.1
+			IL_0613: newarr [System.Runtime]System.Object
+			IL_0618: dup
+			IL_0619: ldc.i4.0
+			IL_061a: ldarg.0
+			IL_061b: stelem.ref
+			IL_061c: ldloc.s 6
+			IL_061e: ldloc.s 10
+			IL_0620: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0625: stloc.s 28
+			IL_0627: ldarg.0
+			IL_0628: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::updateSamplesPropsVersion
+			IL_062d: ldc.i4.1
+			IL_062e: newarr [System.Runtime]System.Object
+			IL_0633: dup
+			IL_0634: ldc.i4.0
+			IL_0635: ldarg.0
+			IL_0636: stelem.ref
+			IL_0637: ldloc.s 7
+			IL_0639: ldloc.s 10
+			IL_063b: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0640: stloc.s 29
+			IL_0642: ldarg.0
+			IL_0643: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0648: stloc.s 40
+			IL_064a: ldc.i4.1
+			IL_064b: newarr [System.Runtime]System.Object
+			IL_0650: dup
+			IL_0651: ldc.i4.0
+			IL_0652: ldarg.0
+			IL_0653: stelem.ref
+			IL_0654: stloc.s 31
+			IL_0656: ldarg.0
+			IL_0657: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CHANGELOG_PATH
+			IL_065c: stloc.s 30
+			IL_065e: ldloc.s 40
+			IL_0660: ldloc.s 31
+			IL_0662: ldloc.s 30
+			IL_0664: ldloc.s 24
+			IL_0666: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_066b: pop
+			IL_066c: ldarg.0
+			IL_066d: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_0672: stloc.s 30
+			IL_0674: ldc.i4.1
+			IL_0675: newarr [System.Runtime]System.Object
+			IL_067a: dup
+			IL_067b: ldc.i4.0
+			IL_067c: ldarg.0
+			IL_067d: stelem.ref
+			IL_067e: stloc.s 31
+			IL_0680: ldarg.0
+			IL_0681: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CSPROJ_PATH
+			IL_0686: stloc.s 40
+			IL_0688: ldloc.s 30
+			IL_068a: ldloc.s 31
+			IL_068c: ldloc.s 40
+			IL_068e: ldloc.s 25
+			IL_0690: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0695: pop
+			IL_0696: ldarg.0
+			IL_0697: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_069c: stloc.s 40
+			IL_069e: ldc.i4.1
+			IL_069f: newarr [System.Runtime]System.Object
+			IL_06a4: dup
+			IL_06a5: ldc.i4.0
+			IL_06a6: ldarg.0
+			IL_06a7: stelem.ref
+			IL_06a8: stloc.s 31
+			IL_06aa: ldarg.0
+			IL_06ab: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::CORE_CSPROJ_PATH
+			IL_06b0: stloc.s 30
+			IL_06b2: ldloc.s 40
+			IL_06b4: ldloc.s 31
+			IL_06b6: ldloc.s 30
+			IL_06b8: ldloc.s 26
+			IL_06ba: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_06bf: pop
+			IL_06c0: ldarg.0
+			IL_06c1: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_06c6: stloc.s 30
+			IL_06c8: ldc.i4.1
+			IL_06c9: newarr [System.Runtime]System.Object
+			IL_06ce: dup
+			IL_06cf: ldc.i4.0
+			IL_06d0: ldarg.0
+			IL_06d1: stelem.ref
+			IL_06d2: stloc.s 31
+			IL_06d4: ldarg.0
+			IL_06d5: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SDK_CSPROJ_PATH
+			IL_06da: stloc.s 40
+			IL_06dc: ldloc.s 30
+			IL_06de: ldloc.s 31
+			IL_06e0: ldloc.s 40
+			IL_06e2: ldloc.s 27
+			IL_06e4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_06e9: pop
+			IL_06ea: ldarg.0
+			IL_06eb: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_06f0: stloc.s 40
+			IL_06f2: ldc.i4.1
+			IL_06f3: newarr [System.Runtime]System.Object
+			IL_06f8: dup
+			IL_06f9: ldc.i4.0
+			IL_06fa: ldarg.0
+			IL_06fb: stelem.ref
+			IL_06fc: stloc.s 31
+			IL_06fe: ldarg.0
+			IL_06ff: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::RUNTIME_CSPROJ_PATH
+			IL_0704: stloc.s 30
+			IL_0706: ldloc.s 40
+			IL_0708: ldloc.s 31
+			IL_070a: ldloc.s 30
+			IL_070c: ldloc.s 28
+			IL_070e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0713: pop
+			IL_0714: ldarg.0
+			IL_0715: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::writeFile
+			IL_071a: stloc.s 30
+			IL_071c: ldc.i4.1
+			IL_071d: newarr [System.Runtime]System.Object
+			IL_0722: dup
+			IL_0723: ldc.i4.0
+			IL_0724: ldarg.0
+			IL_0725: stelem.ref
+			IL_0726: stloc.s 31
+			IL_0728: ldarg.0
+			IL_0729: ldfld object Modules.Compile_Scripts_BumpVersion/Scope::SAMPLES_PROPS_PATH
+			IL_072e: stloc.s 40
+			IL_0730: ldloc.s 30
+			IL_0732: ldloc.s 31
+			IL_0734: ldloc.s 40
+			IL_0736: ldloc.s 29
+			IL_0738: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_073d: pop
+			IL_073e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0743: stloc.s 39
+			IL_0745: ldloc.s 9
+			IL_0747: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_074c: stloc.s 33
+			IL_074e: ldstr "Bumped version: "
+			IL_0753: ldloc.s 33
+			IL_0755: call string [System.Runtime]System.String::Concat(string, string)
+			IL_075a: ldstr " -> "
+			IL_075f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0764: ldloc.s 10
+			IL_0766: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_076b: stloc.s 33
+			IL_076d: ldloc.s 33
+			IL_076f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0774: stloc.s 33
 			IL_0776: ldloc.s 39
-			IL_0778: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
-			IL_077d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0782: pop
-			IL_0783: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0788: stloc.s 39
-			IL_078a: ldloc.s 10
-			IL_078c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0791: stloc.s 33
-			IL_0793: ldstr "  git commit -m \"chore(release): cut "
-			IL_0798: ldloc.s 33
-			IL_079a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_079f: ldstr "\""
-			IL_07a4: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07a9: stloc.s 33
-			IL_07ab: ldloc.s 39
-			IL_07ad: ldloc.s 33
-			IL_07af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_07b4: pop
-			IL_07b5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_07ba: stloc.s 39
-			IL_07bc: ldloc.s 10
-			IL_07be: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_07c3: stloc.s 33
-			IL_07c5: ldstr "  git tag -a v"
-			IL_07ca: ldloc.s 33
-			IL_07cc: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07d1: ldstr " -m \"Release "
-			IL_07d6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07db: ldloc.s 10
-			IL_07dd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0778: ldloc.s 33
+			IL_077a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_077f: pop
+			IL_0780: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0785: stloc.s 39
+			IL_0787: ldloc.s 39
+			IL_0789: ldstr "Updated CHANGELOG.md, samples/Directory.Build.props, src/Cli/Jroc.csproj, src/Jroc.Core/Jroc.Core.csproj, src/Jroc.SDK/Jroc.SDK.csproj, and src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_078e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0793: pop
+			IL_0794: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0799: stloc.s 39
+			IL_079b: ldloc.s 39
+			IL_079d: ldstr "\nNext steps:"
+			IL_07a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_07a7: pop
+			IL_07a8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07ad: stloc.s 39
+			IL_07af: ldloc.s 39
+			IL_07b1: ldstr "  git add CHANGELOG.md samples/Directory.Build.props src/Cli/Jroc.csproj src/Jroc.Core/Jroc.Core.csproj src/Jroc.SDK/Jroc.SDK.csproj src/JavaScriptRuntime/JavaScriptRuntime.csproj"
+			IL_07b6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_07bb: pop
+			IL_07bc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07c1: stloc.s 39
+			IL_07c3: ldloc.s 10
+			IL_07c5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_07ca: stloc.s 33
+			IL_07cc: ldstr "  git commit -m \"chore(release): cut "
+			IL_07d1: ldloc.s 33
+			IL_07d3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_07d8: ldstr "\""
+			IL_07dd: call string [System.Runtime]System.String::Concat(string, string)
 			IL_07e2: stloc.s 33
-			IL_07e4: ldloc.s 33
-			IL_07e6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07eb: ldstr "\""
-			IL_07f0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_07f5: stloc.s 33
-			IL_07f7: ldloc.s 39
-			IL_07f9: ldloc.s 33
-			IL_07fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0800: pop
-			IL_0801: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0806: stloc.s 39
-			IL_0808: ldloc.s 39
-			IL_080a: ldstr "  git push && git push --tags"
-			IL_080f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0814: pop
-			IL_0815: ldnull
-			IL_0816: ret
+			IL_07e4: ldloc.s 39
+			IL_07e6: ldloc.s 33
+			IL_07e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_07ed: pop
+			IL_07ee: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_07f3: stloc.s 39
+			IL_07f5: ldloc.s 10
+			IL_07f7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_07fc: stloc.s 33
+			IL_07fe: ldstr "  git tag -a v"
+			IL_0803: ldloc.s 33
+			IL_0805: call string [System.Runtime]System.String::Concat(string, string)
+			IL_080a: ldstr " -m \"Release "
+			IL_080f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0814: ldloc.s 10
+			IL_0816: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_081b: stloc.s 33
+			IL_081d: ldloc.s 33
+			IL_081f: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0824: ldstr "\""
+			IL_0829: call string [System.Runtime]System.String::Concat(string, string)
+			IL_082e: stloc.s 33
+			IL_0830: ldloc.s 39
+			IL_0832: ldloc.s 33
+			IL_0834: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0839: pop
+			IL_083a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_083f: stloc.s 39
+			IL_0841: ldloc.s 39
+			IL_0843: ldstr "  git push && git push --tags"
+			IL_0848: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_084d: pop
+			IL_084e: ldnull
+			IL_084f: ret
 		} // end of method perform::__js_call__
 
 	} // end of class perform

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -270,7 +270,7 @@
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 842 (0x34a)
+			// Code size: 918 (0x396)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -312,7 +312,7 @@
 				IL_003f: ldloc.3
 				IL_0040: ldloc.s 4
 				IL_0042: clt
-				IL_0044: brfalse IL_0348
+				IL_0044: brfalse IL_0394
 
 				IL_0049: ldarg.2
 				IL_004a: ldloc.1
@@ -384,225 +384,253 @@
 				IL_00f5: ldc.r8 1
 				IL_00fe: add
 				IL_00ff: stloc.1
-				IL_0100: br IL_0337
+				IL_0100: br IL_0383
 
 				IL_0105: ldloc.2
 				IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
 				IL_010b: stloc.s 10
 				IL_010d: ldc.i4.0
 				IL_010e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0113: brfalse IL_013c
+				IL_0113: brfalse IL_014f
 
 				IL_0118: ldloc.s 10
 				IL_011a: isinst [System.Runtime]System.String
 				IL_011f: dup
-				IL_0120: brfalse IL_013b
+				IL_0120: brtrue IL_0138
 
-				IL_0125: ldstr "--in="
-				IL_012a: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-				IL_012f: box [System.Runtime]System.Boolean
-				IL_0134: stloc.s 10
-				IL_0136: br IL_014f
+				IL_0125: pop
+				IL_0126: ldloc.s 10
+				IL_0128: ldstr "startsWith"
+				IL_012d: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0132: dup
+				IL_0133: brfalse IL_014e
 
-				IL_013b: pop
+				IL_0138: ldstr "--in="
+				IL_013d: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+				IL_0142: box [System.Runtime]System.Boolean
+				IL_0147: stloc.s 10
+				IL_0149: br IL_0162
 
-				IL_013c: ldloc.s 10
-				IL_013e: ldstr "startsWith"
-				IL_0143: ldstr "--in="
-				IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_014d: stloc.s 10
+				IL_014e: pop
 
 				IL_014f: ldloc.s 10
-				IL_0151: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0156: stloc.s 5
-				IL_0158: ldloc.s 5
-				IL_015a: brfalse IL_01c4
+				IL_0151: ldstr "startsWith"
+				IL_0156: ldstr "--in="
+				IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0160: stloc.s 10
 
-				IL_015f: ldloc.2
-				IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0165: stloc.s 10
-				IL_0167: ldstr "--in="
-				IL_016c: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_0171: conv.r8
-				IL_0172: box [System.Runtime]System.Double
-				IL_0177: stloc.s 12
-				IL_0179: ldc.i4.0
-				IL_017a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_017f: brfalse IL_01a0
+				IL_0162: ldloc.s 10
+				IL_0164: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0169: stloc.s 5
+				IL_016b: ldloc.s 5
+				IL_016d: brfalse IL_01ea
 
-				IL_0184: ldloc.s 10
-				IL_0186: isinst [System.Runtime]System.String
-				IL_018b: dup
-				IL_018c: brfalse IL_019f
+				IL_0172: ldloc.2
+				IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0178: stloc.s 10
+				IL_017a: ldstr "--in="
+				IL_017f: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_0184: conv.r8
+				IL_0185: box [System.Runtime]System.Double
+				IL_018a: stloc.s 12
+				IL_018c: ldc.i4.0
+				IL_018d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0192: brfalse IL_01c6
 
-				IL_0191: ldloc.s 12
-				IL_0193: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-				IL_0198: stloc.s 10
-				IL_019a: br IL_01b0
+				IL_0197: ldloc.s 10
+				IL_0199: isinst [System.Runtime]System.String
+				IL_019e: dup
+				IL_019f: brtrue IL_01b7
 
-				IL_019f: pop
+				IL_01a4: pop
+				IL_01a5: ldloc.s 10
+				IL_01a7: ldstr "substring"
+				IL_01ac: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_01b1: dup
+				IL_01b2: brfalse IL_01c5
 
-				IL_01a0: ldloc.s 10
-				IL_01a2: ldstr "substring"
-				IL_01a7: ldloc.s 12
-				IL_01a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_01ae: stloc.s 10
+				IL_01b7: ldloc.s 12
+				IL_01b9: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+				IL_01be: stloc.s 10
+				IL_01c0: br IL_01d6
 
-				IL_01b0: ldloc.0
-				IL_01b1: ldstr "inFile"
-				IL_01b6: ldloc.s 10
-				IL_01b8: ldc.i4.1
-				IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_01be: pop
-				IL_01bf: br IL_0337
+				IL_01c5: pop
 
-				IL_01c4: ldloc.2
-				IL_01c5: ldstr "--out"
-				IL_01ca: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-				IL_01cf: stloc.s 5
-				IL_01d1: ldloc.s 5
-				IL_01d3: box [System.Runtime]System.Boolean
-				IL_01d8: stloc.s 6
-				IL_01da: ldloc.s 6
-				IL_01dc: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_01e1: stloc.s 5
-				IL_01e3: ldloc.s 5
-				IL_01e5: brtrue IL_0209
+				IL_01c6: ldloc.s 10
+				IL_01c8: ldstr "substring"
+				IL_01cd: ldloc.s 12
+				IL_01cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01d4: stloc.s 10
+
+				IL_01d6: ldloc.0
+				IL_01d7: ldstr "inFile"
+				IL_01dc: ldloc.s 10
+				IL_01de: ldc.i4.1
+				IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_01e4: pop
+				IL_01e5: br IL_0383
 
 				IL_01ea: ldloc.2
-				IL_01eb: ldstr "-o"
+				IL_01eb: ldstr "--out"
 				IL_01f0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
 				IL_01f5: stloc.s 5
 				IL_01f7: ldloc.s 5
 				IL_01f9: box [System.Runtime]System.Boolean
-				IL_01fe: stloc.s 7
-				IL_0200: ldloc.s 7
-				IL_0202: stloc.s 13
-				IL_0204: br IL_020d
+				IL_01fe: stloc.s 6
+				IL_0200: ldloc.s 6
+				IL_0202: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0207: stloc.s 5
+				IL_0209: ldloc.s 5
+				IL_020b: brtrue IL_022f
 
-				IL_0209: ldloc.s 6
-				IL_020b: stloc.s 13
+				IL_0210: ldloc.2
+				IL_0211: ldstr "-o"
+				IL_0216: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+				IL_021b: stloc.s 5
+				IL_021d: ldloc.s 5
+				IL_021f: box [System.Runtime]System.Boolean
+				IL_0224: stloc.s 7
+				IL_0226: ldloc.s 7
+				IL_0228: stloc.s 13
+				IL_022a: br IL_0233
 
-				IL_020d: ldloc.s 13
-				IL_020f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0214: stloc.s 5
-				IL_0216: ldloc.s 5
-				IL_0218: brfalse IL_0278
+				IL_022f: ldloc.s 6
+				IL_0231: stloc.s 13
 
-				IL_021d: ldloc.1
-				IL_021e: stloc.s 4
-				IL_0220: ldloc.s 4
-				IL_0222: ldc.r8 1
-				IL_022b: add
-				IL_022c: stloc.s 4
-				IL_022e: ldarg.2
-				IL_022f: ldloc.s 4
-				IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_0236: stloc.s 10
-				IL_0238: ldloc.s 10
-				IL_023a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_023f: stloc.s 5
-				IL_0241: ldloc.s 5
-				IL_0243: brtrue IL_0254
+				IL_0233: ldloc.s 13
+				IL_0235: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_023a: stloc.s 5
+				IL_023c: ldloc.s 5
+				IL_023e: brfalse IL_029e
 
-				IL_0248: ldstr ""
-				IL_024d: stloc.s 14
-				IL_024f: br IL_0258
+				IL_0243: ldloc.1
+				IL_0244: stloc.s 4
+				IL_0246: ldloc.s 4
+				IL_0248: ldc.r8 1
+				IL_0251: add
+				IL_0252: stloc.s 4
+				IL_0254: ldarg.2
+				IL_0255: ldloc.s 4
+				IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_025c: stloc.s 10
+				IL_025e: ldloc.s 10
+				IL_0260: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0265: stloc.s 5
+				IL_0267: ldloc.s 5
+				IL_0269: brtrue IL_027a
 
-				IL_0254: ldloc.s 10
-				IL_0256: stloc.s 14
+				IL_026e: ldstr ""
+				IL_0273: stloc.s 14
+				IL_0275: br IL_027e
 
-				IL_0258: ldloc.0
-				IL_0259: ldstr "outFile"
-				IL_025e: ldloc.s 14
-				IL_0260: ldc.i4.1
-				IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0266: pop
-				IL_0267: ldloc.1
-				IL_0268: ldc.r8 1
-				IL_0271: add
-				IL_0272: stloc.1
-				IL_0273: br IL_0337
+				IL_027a: ldloc.s 10
+				IL_027c: stloc.s 14
 
-				IL_0278: ldloc.2
-				IL_0279: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_027e: stloc.s 10
-				IL_0280: ldc.i4.0
-				IL_0281: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0286: brfalse IL_02af
+				IL_027e: ldloc.0
+				IL_027f: ldstr "outFile"
+				IL_0284: ldloc.s 14
+				IL_0286: ldc.i4.1
+				IL_0287: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_028c: pop
+				IL_028d: ldloc.1
+				IL_028e: ldc.r8 1
+				IL_0297: add
+				IL_0298: stloc.1
+				IL_0299: br IL_0383
 
-				IL_028b: ldloc.s 10
-				IL_028d: isinst [System.Runtime]System.String
-				IL_0292: dup
-				IL_0293: brfalse IL_02ae
+				IL_029e: ldloc.2
+				IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02a4: stloc.s 10
+				IL_02a6: ldc.i4.0
+				IL_02a7: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_02ac: brfalse IL_02e8
 
-				IL_0298: ldstr "--out="
-				IL_029d: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-				IL_02a2: box [System.Runtime]System.Boolean
-				IL_02a7: stloc.s 10
-				IL_02a9: br IL_02c2
+				IL_02b1: ldloc.s 10
+				IL_02b3: isinst [System.Runtime]System.String
+				IL_02b8: dup
+				IL_02b9: brtrue IL_02d1
 
-				IL_02ae: pop
+				IL_02be: pop
+				IL_02bf: ldloc.s 10
+				IL_02c1: ldstr "startsWith"
+				IL_02c6: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_02cb: dup
+				IL_02cc: brfalse IL_02e7
 
-				IL_02af: ldloc.s 10
-				IL_02b1: ldstr "startsWith"
-				IL_02b6: ldstr "--out="
-				IL_02bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_02c0: stloc.s 10
+				IL_02d1: ldstr "--out="
+				IL_02d6: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+				IL_02db: box [System.Runtime]System.Boolean
+				IL_02e0: stloc.s 10
+				IL_02e2: br IL_02fb
 
-				IL_02c2: ldloc.s 10
-				IL_02c4: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_02c9: stloc.s 5
-				IL_02cb: ldloc.s 5
-				IL_02cd: brfalse IL_0337
+				IL_02e7: pop
 
-				IL_02d2: ldloc.2
-				IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_02d8: stloc.s 10
-				IL_02da: ldstr "--out="
-				IL_02df: callvirt instance int32 [System.Runtime]System.String::get_Length()
-				IL_02e4: conv.r8
-				IL_02e5: box [System.Runtime]System.Double
-				IL_02ea: stloc.s 12
-				IL_02ec: ldc.i4.0
-				IL_02ed: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_02f2: brfalse IL_0313
+				IL_02e8: ldloc.s 10
+				IL_02ea: ldstr "startsWith"
+				IL_02ef: ldstr "--out="
+				IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_02f9: stloc.s 10
 
-				IL_02f7: ldloc.s 10
-				IL_02f9: isinst [System.Runtime]System.String
-				IL_02fe: dup
-				IL_02ff: brfalse IL_0312
+				IL_02fb: ldloc.s 10
+				IL_02fd: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_0302: stloc.s 5
+				IL_0304: ldloc.s 5
+				IL_0306: brfalse IL_0383
 
-				IL_0304: ldloc.s 12
-				IL_0306: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
-				IL_030b: stloc.s 10
-				IL_030d: br IL_0323
+				IL_030b: ldloc.2
+				IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0311: stloc.s 10
+				IL_0313: ldstr "--out="
+				IL_0318: callvirt instance int32 [System.Runtime]System.String::get_Length()
+				IL_031d: conv.r8
+				IL_031e: box [System.Runtime]System.Double
+				IL_0323: stloc.s 12
+				IL_0325: ldc.i4.0
+				IL_0326: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_032b: brfalse IL_035f
 
-				IL_0312: pop
+				IL_0330: ldloc.s 10
+				IL_0332: isinst [System.Runtime]System.String
+				IL_0337: dup
+				IL_0338: brtrue IL_0350
 
-				IL_0313: ldloc.s 10
-				IL_0315: ldstr "substring"
-				IL_031a: ldloc.s 12
-				IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0321: stloc.s 10
+				IL_033d: pop
+				IL_033e: ldloc.s 10
+				IL_0340: ldstr "substring"
+				IL_0345: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_034a: dup
+				IL_034b: brfalse IL_035e
 
-				IL_0323: ldloc.0
-				IL_0324: ldstr "outFile"
-				IL_0329: ldloc.s 10
-				IL_032b: ldc.i4.1
-				IL_032c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-				IL_0331: pop
-				IL_0332: br IL_0337
+				IL_0350: ldloc.s 12
+				IL_0352: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object)
+				IL_0357: stloc.s 10
+				IL_0359: br IL_036f
 
-				IL_0337: ldloc.1
-				IL_0338: ldc.r8 1
-				IL_0341: add
-				IL_0342: stloc.1
-				IL_0343: br IL_0030
+				IL_035e: pop
+
+				IL_035f: ldloc.s 10
+				IL_0361: ldstr "substring"
+				IL_0366: ldloc.s 12
+				IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_036d: stloc.s 10
+
+				IL_036f: ldloc.0
+				IL_0370: ldstr "outFile"
+				IL_0375: ldloc.s 10
+				IL_0377: ldc.i4.1
+				IL_0378: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+				IL_037d: pop
+				IL_037e: br IL_0383
+
+				IL_0383: ldloc.1
+				IL_0384: ldc.r8 1
+				IL_038d: add
+				IL_038e: stloc.1
+				IL_038f: br IL_0030
 			// end loop
 
-			IL_0348: ldloc.0
-			IL_0349: ret
+			IL_0394: ldloc.0
+			IL_0395: ret
 		} // end of method parseArgs::__js_call__
 
 	} // end of class parseArgs
@@ -708,7 +736,7 @@
 					01 00 00 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 470 (0x1d6)
+				// Code size: 489 (0x1e9)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -852,40 +880,47 @@
 				IL_0167: stloc.s 7
 				IL_0169: ldc.i4.0
 				IL_016a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_016f: brfalse IL_018e
+				IL_016f: brfalse IL_01a1
 
 				IL_0174: ldloc.s 7
 				IL_0176: isinst [System.Runtime]System.String
 				IL_017b: dup
-				IL_017c: brfalse IL_018d
+				IL_017c: brtrue IL_0194
 
-				IL_0181: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-				IL_0186: stloc.s 6
-				IL_0188: br IL_019c
+				IL_0181: pop
+				IL_0182: ldloc.s 7
+				IL_0184: ldstr "trim"
+				IL_0189: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_018e: dup
+				IL_018f: brfalse IL_01a0
 
-				IL_018d: pop
+				IL_0194: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+				IL_0199: stloc.s 6
+				IL_019b: br IL_01af
 
-				IL_018e: ldloc.s 7
-				IL_0190: ldstr "trim"
-				IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_019a: stloc.s 6
+				IL_01a0: pop
 
-				IL_019c: ldloc.s 5
-				IL_019e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01a3: stloc.s 14
-				IL_01a5: ldstr "\n\n"
-				IL_01aa: ldloc.s 14
-				IL_01ac: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01b1: ldstr " "
-				IL_01b6: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01bb: ldloc.s 6
-				IL_01bd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_01c2: stloc.s 14
-				IL_01c4: ldloc.s 14
-				IL_01c6: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01cb: ldstr "\n\n"
-				IL_01d0: call string [System.Runtime]System.String::Concat(string, string)
-				IL_01d5: ret
+				IL_01a1: ldloc.s 7
+				IL_01a3: ldstr "trim"
+				IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_01ad: stloc.s 6
+
+				IL_01af: ldloc.s 5
+				IL_01b1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01b6: stloc.s 14
+				IL_01b8: ldstr "\n\n"
+				IL_01bd: ldloc.s 14
+				IL_01bf: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01c4: ldstr " "
+				IL_01c9: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01ce: ldloc.s 6
+				IL_01d0: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_01d5: stloc.s 14
+				IL_01d7: ldloc.s 14
+				IL_01d9: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01de: ldstr "\n\n"
+				IL_01e3: call string [System.Runtime]System.String::Concat(string, string)
+				IL_01e8: ret
 			} // end of method FunctionExpression_L61C15::__js_call__
 
 		} // end of class FunctionExpression_L61C15
@@ -983,7 +1018,7 @@
 					01 00 00 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 180 (0xb4)
+				// Code size: 199 (0xc7)
 				.maxstack 8
 				.locals init (
 					[0] object,
@@ -1026,42 +1061,49 @@
 				IL_004f: stloc.s 4
 				IL_0051: ldc.i4.0
 				IL_0052: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0057: brfalse IL_0075
+				IL_0057: brfalse IL_0088
 
 				IL_005c: ldloc.s 4
 				IL_005e: isinst [System.Runtime]System.String
 				IL_0063: dup
-				IL_0064: brfalse IL_0074
+				IL_0064: brtrue IL_007c
 
-				IL_0069: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-				IL_006e: stloc.0
-				IL_006f: br IL_0082
+				IL_0069: pop
+				IL_006a: ldloc.s 4
+				IL_006c: ldstr "trim"
+				IL_0071: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0076: dup
+				IL_0077: brfalse IL_0087
 
-				IL_0074: pop
-
-				IL_0075: ldloc.s 4
-				IL_0077: ldstr "trim"
-				IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_007c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
 				IL_0081: stloc.0
+				IL_0082: br IL_0095
 
-				IL_0082: ldloc.0
-				IL_0083: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_0088: stloc.1
-				IL_0089: ldloc.1
-				IL_008a: brfalse IL_00ae
+				IL_0087: pop
 
-				IL_008f: ldloc.0
-				IL_0090: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_0095: stloc.s 6
-				IL_0097: ldstr "`"
-				IL_009c: ldloc.s 6
-				IL_009e: call string [System.Runtime]System.String::Concat(string, string)
-				IL_00a3: ldstr "`"
-				IL_00a8: call string [System.Runtime]System.String::Concat(string, string)
-				IL_00ad: ret
+				IL_0088: ldloc.s 4
+				IL_008a: ldstr "trim"
+				IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0094: stloc.0
 
-				IL_00ae: ldstr ""
-				IL_00b3: ret
+				IL_0095: ldloc.0
+				IL_0096: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_009b: stloc.1
+				IL_009c: ldloc.1
+				IL_009d: brfalse IL_00c1
+
+				IL_00a2: ldloc.0
+				IL_00a3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_00a8: stloc.s 6
+				IL_00aa: ldstr "`"
+				IL_00af: ldloc.s 6
+				IL_00b1: call string [System.Runtime]System.String::Concat(string, string)
+				IL_00b6: ldstr "`"
+				IL_00bb: call string [System.Runtime]System.String::Concat(string, string)
+				IL_00c0: ret
+
+				IL_00c1: ldstr ""
+				IL_00c6: ret
 			} // end of method FunctionExpression_L74C15::__js_call__
 
 		} // end of class FunctionExpression_L74C15
@@ -1832,7 +1874,7 @@
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 663 (0x297)
+			// Code size: 681 (0x2a9)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/Scope,
@@ -2062,30 +2104,37 @@
 			IL_0257: stloc.3
 			IL_0258: ldc.i4.0
 			IL_0259: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_025e: brfalse IL_027b
+			IL_025e: brfalse IL_028d
 
 			IL_0263: ldloc.3
 			IL_0264: isinst [System.Runtime]System.String
 			IL_0269: dup
-			IL_026a: brfalse IL_027a
+			IL_026a: brtrue IL_0281
 
-			IL_026f: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0274: stloc.3
-			IL_0275: br IL_0287
+			IL_026f: pop
+			IL_0270: ldloc.3
+			IL_0271: ldstr "trim"
+			IL_0276: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_027b: dup
+			IL_027c: brfalse IL_028c
 
-			IL_027a: pop
-
-			IL_027b: ldloc.3
-			IL_027c: ldstr "trim"
-			IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0281: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
 			IL_0286: stloc.3
+			IL_0287: br IL_0299
 
-			IL_0287: ldloc.3
-			IL_0288: ldstr "\n"
-			IL_028d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0292: stloc.s 12
-			IL_0294: ldloc.s 12
-			IL_0296: ret
+			IL_028c: pop
+
+			IL_028d: ldloc.3
+			IL_028e: ldstr "trim"
+			IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0298: stloc.3
+
+			IL_0299: ldloc.3
+			IL_029a: ldstr "\n"
+			IL_029f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_02a4: stloc.s 12
+			IL_02a6: ldloc.s 12
+			IL_02a8: ret
 		} // end of method convertHtmlToMarkdown::__js_call__
 
 	} // end of class convertHtmlToMarkdown

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -3182,7 +3182,7 @@
 				74 61 54 6f 6b 65 6e 0f 00 00 02
 			)
 			// Header size: 12
-			// Code size: 2149 (0x865)
+			// Code size: 2168 (0x878)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3228,675 +3228,682 @@
 			IL_001d: stloc.s 18
 			IL_001f: ldc.i4.0
 			IL_0020: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0025: brfalse IL_0051
+			IL_0025: brfalse IL_0064
 
 			IL_002a: ldloc.s 18
 			IL_002c: isinst [System.Runtime]System.String
 			IL_0031: dup
-			IL_0032: brfalse IL_0050
+			IL_0032: brtrue IL_004a
 
-			IL_0037: ldc.r8 2
-			IL_0040: box [System.Runtime]System.Double
-			IL_0045: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
-			IL_004a: stloc.0
-			IL_004b: br IL_006c
+			IL_0037: pop
+			IL_0038: ldloc.s 18
+			IL_003a: ldstr "slice"
+			IL_003f: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0044: dup
+			IL_0045: brfalse IL_0063
 
-			IL_0050: pop
+			IL_004a: ldc.r8 2
+			IL_0053: box [System.Runtime]System.Double
+			IL_0058: call string [JavaScriptRuntime]JavaScriptRuntime.String::Slice(string, object)
+			IL_005d: stloc.0
+			IL_005e: br IL_007f
 
-			IL_0051: ldloc.s 18
-			IL_0053: ldstr "slice"
-			IL_0058: ldc.r8 2
-			IL_0061: box [System.Runtime]System.Double
-			IL_0066: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_006b: stloc.0
+			IL_0063: pop
 
-			IL_006c: ldloc.0
-			IL_006d: ldstr "length"
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0077: stloc.s 18
-			IL_0079: ldloc.s 18
-			IL_007b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0080: ldc.r8 2
-			IL_0089: clt
-			IL_008b: brfalse IL_0153
+			IL_0064: ldloc.s 18
+			IL_0066: ldstr "slice"
+			IL_006b: ldc.r8 2
+			IL_0074: box [System.Runtime]System.Double
+			IL_0079: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_007e: stloc.0
 
-			IL_0090: ldstr "console"
-			IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_009f: ldstr "error"
-			IL_00a4: ldstr "Usage: node scripts/decompileGeneratorTest.js <Category> <TestName>"
-			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00ae: pop
-			IL_00af: ldstr "console"
-			IL_00b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00be: ldstr "error"
-			IL_00c3: ldstr ""
-			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00cd: pop
-			IL_00ce: ldstr "console"
-			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00dd: ldstr "error"
-			IL_00e2: ldstr "Examples:"
-			IL_00e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00ec: pop
-			IL_00ed: ldstr "console"
-			IL_00f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00fc: ldstr "error"
-			IL_0101: ldstr "  node scripts/decompileGeneratorTest.js Async Async_HelloWorld"
-			IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_010b: pop
-			IL_010c: ldstr "console"
-			IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0116: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_011b: ldstr "error"
-			IL_0120: ldstr "  node scripts/decompileGeneratorTest.js Function Function_ReturnsStaticValueAndLogs"
-			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_012a: pop
-			IL_012b: ldstr "process"
-			IL_0130: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_013a: ldstr "exit"
-			IL_013f: ldc.r8 1
-			IL_0148: box [System.Runtime]System.Double
-			IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0152: pop
+			IL_007f: ldloc.0
+			IL_0080: ldstr "length"
+			IL_0085: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_008a: stloc.s 18
+			IL_008c: ldloc.s 18
+			IL_008e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0093: ldc.r8 2
+			IL_009c: clt
+			IL_009e: brfalse IL_0166
 
-			IL_0153: ldarg.0
-			IL_0154: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::normalizeCategory
-			IL_0159: ldc.i4.1
-			IL_015a: newarr [System.Runtime]System.Object
-			IL_015f: dup
-			IL_0160: ldc.i4.0
-			IL_0161: ldarg.0
-			IL_0162: stelem.ref
-			IL_0163: stloc.s 19
-			IL_0165: ldloc.0
-			IL_0166: ldc.r8 0.0
-			IL_016f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_0174: stloc.s 18
-			IL_0176: ldloc.s 19
-			IL_0178: ldloc.s 18
-			IL_017a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_017f: stloc.1
-			IL_0180: ldloc.0
-			IL_0181: ldc.r8 1
-			IL_018a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-			IL_018f: stloc.2
-			IL_0190: ldarg.0
-			IL_0191: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getGeneratorTestSnapshotPath
-			IL_0196: ldc.i4.1
-			IL_0197: newarr [System.Runtime]System.Object
-			IL_019c: dup
-			IL_019d: ldc.i4.0
-			IL_019e: ldarg.0
-			IL_019f: stelem.ref
-			IL_01a0: stloc.s 19
-			IL_01a2: ldloc.1
-			IL_01a3: ldstr "path"
-			IL_01a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_01ad: stloc.s 18
-			IL_01af: ldloc.s 19
-			IL_01b1: ldloc.s 18
-			IL_01b3: ldloc.2
-			IL_01b4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01b9: stloc.3
-			IL_01ba: ldarg.0
-			IL_01bb: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
-			IL_01c0: stloc.s 20
-			IL_01c2: ldloc.s 20
-			IL_01c4: ldloc.3
-			IL_01c5: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
-			IL_01ca: box [System.Runtime]System.Boolean
-			IL_01cf: stloc.s 18
-			IL_01d1: ldloc.s 18
-			IL_01d3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01d8: ldc.i4.0
-			IL_01d9: ceq
-			IL_01db: stloc.s 21
-			IL_01dd: ldloc.s 21
-			IL_01df: brfalse IL_0261
+			IL_00a3: ldstr "console"
+			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b2: ldstr "error"
+			IL_00b7: ldstr "Usage: node scripts/decompileGeneratorTest.js <Category> <TestName>"
+			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00c1: pop
+			IL_00c2: ldstr "console"
+			IL_00c7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00d1: ldstr "error"
+			IL_00d6: ldstr ""
+			IL_00db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00e0: pop
+			IL_00e1: ldstr "console"
+			IL_00e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_00eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00f0: ldstr "error"
+			IL_00f5: ldstr "Examples:"
+			IL_00fa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00ff: pop
+			IL_0100: ldstr "console"
+			IL_0105: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_010f: ldstr "error"
+			IL_0114: ldstr "  node scripts/decompileGeneratorTest.js Async Async_HelloWorld"
+			IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_011e: pop
+			IL_011f: ldstr "console"
+			IL_0124: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0129: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_012e: ldstr "error"
+			IL_0133: ldstr "  node scripts/decompileGeneratorTest.js Function Function_ReturnsStaticValueAndLogs"
+			IL_0138: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_013d: pop
+			IL_013e: ldstr "process"
+			IL_0143: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014d: ldstr "exit"
+			IL_0152: ldc.r8 1
+			IL_015b: box [System.Runtime]System.Double
+			IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0165: pop
 
-			IL_01e4: ldstr "console"
-			IL_01e9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_01f3: stloc.s 18
-			IL_01f5: ldloc.3
-			IL_01f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_01fb: stloc.s 22
-			IL_01fd: ldstr "Generator test snapshot not found: "
-			IL_0202: ldloc.s 22
-			IL_0204: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0209: stloc.s 22
-			IL_020b: ldloc.s 18
-			IL_020d: ldstr "error"
-			IL_0212: ldloc.s 22
-			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0219: pop
-			IL_021a: ldstr "console"
-			IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0224: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0229: ldstr "error"
-			IL_022e: ldstr "Check the category and test name before running the helper."
-			IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0238: pop
-			IL_0239: ldstr "process"
-			IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0243: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0248: ldstr "exit"
-			IL_024d: ldc.r8 1
-			IL_0256: box [System.Runtime]System.Double
-			IL_025b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0260: pop
+			IL_0166: ldarg.0
+			IL_0167: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::normalizeCategory
+			IL_016c: ldc.i4.1
+			IL_016d: newarr [System.Runtime]System.Object
+			IL_0172: dup
+			IL_0173: ldc.i4.0
+			IL_0174: ldarg.0
+			IL_0175: stelem.ref
+			IL_0176: stloc.s 19
+			IL_0178: ldloc.0
+			IL_0179: ldc.r8 0.0
+			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_0187: stloc.s 18
+			IL_0189: ldloc.s 19
+			IL_018b: ldloc.s 18
+			IL_018d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0192: stloc.1
+			IL_0193: ldloc.0
+			IL_0194: ldc.r8 1
+			IL_019d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+			IL_01a2: stloc.2
+			IL_01a3: ldarg.0
+			IL_01a4: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getGeneratorTestSnapshotPath
+			IL_01a9: ldc.i4.1
+			IL_01aa: newarr [System.Runtime]System.Object
+			IL_01af: dup
+			IL_01b0: ldc.i4.0
+			IL_01b1: ldarg.0
+			IL_01b2: stelem.ref
+			IL_01b3: stloc.s 19
+			IL_01b5: ldloc.1
+			IL_01b6: ldstr "path"
+			IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_01c0: stloc.s 18
+			IL_01c2: ldloc.s 19
+			IL_01c4: ldloc.s 18
+			IL_01c6: ldloc.2
+			IL_01c7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_01cc: stloc.3
+			IL_01cd: ldarg.0
+			IL_01ce: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::fs
+			IL_01d3: stloc.s 20
+			IL_01d5: ldloc.s 20
+			IL_01d7: ldloc.3
+			IL_01d8: callvirt instance bool [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::existsSync(object)
+			IL_01dd: box [System.Runtime]System.Boolean
+			IL_01e2: stloc.s 18
+			IL_01e4: ldloc.s 18
+			IL_01e6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_01eb: ldc.i4.0
+			IL_01ec: ceq
+			IL_01ee: stloc.s 21
+			IL_01f0: ldloc.s 21
+			IL_01f2: brfalse IL_0274
 
-			IL_0261: ldloc.1
-			IL_0262: ldstr "namespace"
-			IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_026c: stloc.s 18
-			IL_026e: ldloc.s 18
-			IL_0270: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0275: stloc.s 22
-			IL_0277: ldstr "Jroc.Tests."
-			IL_027c: ldloc.s 22
-			IL_027e: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0283: ldstr ".GeneratorTests."
-			IL_0288: call string [System.Runtime]System.String::Concat(string, string)
-			IL_028d: ldloc.2
-			IL_028e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0293: stloc.s 22
-			IL_0295: ldloc.s 22
-			IL_0297: call string [System.Runtime]System.String::Concat(string, string)
-			IL_029c: stloc.s 4
-			IL_029e: ldarg.0
-			IL_029f: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
-			IL_02a4: stloc.s 23
-			IL_02a6: ldarg.0
-			IL_02a7: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_02ac: stloc.s 18
-			IL_02ae: ldloc.s 23
-			IL_02b0: ldc.i4.4
-			IL_02b1: newarr [System.Runtime]System.Object
-			IL_02b6: dup
-			IL_02b7: ldc.i4.0
-			IL_02b8: ldloc.s 18
-			IL_02ba: stelem.ref
-			IL_02bb: dup
-			IL_02bc: ldc.i4.1
-			IL_02bd: ldstr "tests"
-			IL_02c2: stelem.ref
-			IL_02c3: dup
-			IL_02c4: ldc.i4.2
-			IL_02c5: ldstr "Jroc.Tests"
-			IL_02ca: stelem.ref
-			IL_02cb: dup
-			IL_02cc: ldc.i4.3
-			IL_02cd: ldstr "Jroc.Tests.csproj"
-			IL_02d2: stelem.ref
-			IL_02d3: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_02d8: stloc.s 5
-			IL_02da: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_02df: stloc.s 24
-			IL_02e1: ldloc.s 4
-			IL_02e3: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_02e8: stloc.s 22
-			IL_02ea: ldstr "Running test: "
-			IL_02ef: ldloc.s 22
-			IL_02f1: call string [System.Runtime]System.String::Concat(string, string)
-			IL_02f6: stloc.s 22
-			IL_02f8: ldloc.s 24
-			IL_02fa: ldloc.s 22
-			IL_02fc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0301: pop
-			IL_0302: ldstr "process"
-			IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_030c: ldstr "env"
-			IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0316: stloc.s 18
-			IL_0318: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_031d: stloc.s 25
-			IL_031f: ldloc.s 25
-			IL_0321: ldloc.s 18
-			IL_0323: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
-			IL_0328: pop
-			IL_0329: ldloc.s 25
-			IL_032b: ldstr "JROC_WRITE_TEST_ARTIFACTS"
-			IL_0330: ldstr "1"
-			IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-			IL_033a: pop
-			IL_033b: ldloc.s 25
-			IL_033d: stloc.s 6
-			IL_033f: ldarg.0
-			IL_0340: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_0345: stloc.s 26
-			IL_0347: ldloc.s 4
-			IL_0349: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_034e: stloc.s 22
-			IL_0350: ldstr "FullyQualifiedName="
-			IL_0355: ldloc.s 22
-			IL_0357: call string [System.Runtime]System.String::Concat(string, string)
-			IL_035c: stloc.s 22
-			IL_035e: ldc.i4.5
-			IL_035f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0364: dup
-			IL_0365: ldstr "test"
-			IL_036a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_036f: dup
-			IL_0370: ldloc.s 5
-			IL_0372: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01f7: ldstr "console"
+			IL_01fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0201: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0206: stloc.s 18
+			IL_0208: ldloc.3
+			IL_0209: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_020e: stloc.s 22
+			IL_0210: ldstr "Generator test snapshot not found: "
+			IL_0215: ldloc.s 22
+			IL_0217: call string [System.Runtime]System.String::Concat(string, string)
+			IL_021c: stloc.s 22
+			IL_021e: ldloc.s 18
+			IL_0220: ldstr "error"
+			IL_0225: ldloc.s 22
+			IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_022c: pop
+			IL_022d: ldstr "console"
+			IL_0232: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0237: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_023c: ldstr "error"
+			IL_0241: ldstr "Check the category and test name before running the helper."
+			IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_024b: pop
+			IL_024c: ldstr "process"
+			IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0256: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_025b: ldstr "exit"
+			IL_0260: ldc.r8 1
+			IL_0269: box [System.Runtime]System.Double
+			IL_026e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0273: pop
+
+			IL_0274: ldloc.1
+			IL_0275: ldstr "namespace"
+			IL_027a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_027f: stloc.s 18
+			IL_0281: ldloc.s 18
+			IL_0283: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0288: stloc.s 22
+			IL_028a: ldstr "Jroc.Tests."
+			IL_028f: ldloc.s 22
+			IL_0291: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0296: ldstr ".GeneratorTests."
+			IL_029b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02a0: ldloc.2
+			IL_02a1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02a6: stloc.s 22
+			IL_02a8: ldloc.s 22
+			IL_02aa: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02af: stloc.s 4
+			IL_02b1: ldarg.0
+			IL_02b2: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::path
+			IL_02b7: stloc.s 23
+			IL_02b9: ldarg.0
+			IL_02ba: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_02bf: stloc.s 18
+			IL_02c1: ldloc.s 23
+			IL_02c3: ldc.i4.4
+			IL_02c4: newarr [System.Runtime]System.Object
+			IL_02c9: dup
+			IL_02ca: ldc.i4.0
+			IL_02cb: ldloc.s 18
+			IL_02cd: stelem.ref
+			IL_02ce: dup
+			IL_02cf: ldc.i4.1
+			IL_02d0: ldstr "tests"
+			IL_02d5: stelem.ref
+			IL_02d6: dup
+			IL_02d7: ldc.i4.2
+			IL_02d8: ldstr "Jroc.Tests"
+			IL_02dd: stelem.ref
+			IL_02de: dup
+			IL_02df: ldc.i4.3
+			IL_02e0: ldstr "Jroc.Tests.csproj"
+			IL_02e5: stelem.ref
+			IL_02e6: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_02eb: stloc.s 5
+			IL_02ed: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_02f2: stloc.s 24
+			IL_02f4: ldloc.s 4
+			IL_02f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02fb: stloc.s 22
+			IL_02fd: ldstr "Running test: "
+			IL_0302: ldloc.s 22
+			IL_0304: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0309: stloc.s 22
+			IL_030b: ldloc.s 24
+			IL_030d: ldloc.s 22
+			IL_030f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0314: pop
+			IL_0315: ldstr "process"
+			IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_031f: ldstr "env"
+			IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0329: stloc.s 18
+			IL_032b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0330: stloc.s 25
+			IL_0332: ldloc.s 25
+			IL_0334: ldloc.s 18
+			IL_0336: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SpreadIntoObjectLiteral(object, object)
+			IL_033b: pop
+			IL_033c: ldloc.s 25
+			IL_033e: ldstr "JROC_WRITE_TEST_ARTIFACTS"
+			IL_0343: ldstr "1"
+			IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_034d: pop
+			IL_034e: ldloc.s 25
+			IL_0350: stloc.s 6
+			IL_0352: ldarg.0
+			IL_0353: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_0358: stloc.s 26
+			IL_035a: ldloc.s 4
+			IL_035c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0361: stloc.s 22
+			IL_0363: ldstr "FullyQualifiedName="
+			IL_0368: ldloc.s 22
+			IL_036a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_036f: stloc.s 22
+			IL_0371: ldc.i4.5
+			IL_0372: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_0377: dup
-			IL_0378: ldstr "--filter"
+			IL_0378: ldstr "test"
 			IL_037d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_0382: dup
-			IL_0383: ldloc.s 22
+			IL_0383: ldloc.s 5
 			IL_0385: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_038a: dup
-			IL_038b: ldstr "--no-build"
+			IL_038b: ldstr "--filter"
 			IL_0390: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0395: stloc.s 27
-			IL_0397: ldarg.0
-			IL_0398: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_039d: stloc.s 18
-			IL_039f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_03a4: dup
-			IL_03a5: ldstr "stdio"
-			IL_03aa: ldstr "inherit"
-			IL_03af: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_03b4: dup
-			IL_03b5: ldstr "shell"
-			IL_03ba: ldc.i4.1
-			IL_03bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_03c0: dup
-			IL_03c1: ldstr "cwd"
-			IL_03c6: ldloc.s 18
-			IL_03c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_03cd: dup
-			IL_03ce: ldstr "env"
-			IL_03d3: ldloc.s 6
-			IL_03d5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_03da: stloc.s 25
-			IL_03dc: ldloc.s 26
-			IL_03de: ldstr "dotnet"
-			IL_03e3: ldloc.s 27
-			IL_03e5: ldloc.s 25
-			IL_03e7: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
-			IL_03ec: stloc.s 7
-			IL_03ee: ldarg.0
-			IL_03ef: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
-			IL_03f4: ldc.i4.1
-			IL_03f5: newarr [System.Runtime]System.Object
-			IL_03fa: dup
-			IL_03fb: ldc.i4.0
-			IL_03fc: ldarg.0
-			IL_03fd: stelem.ref
-			IL_03fe: ldloc.2
-			IL_03ff: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0404: stloc.s 8
-			IL_0406: ldloc.s 7
-			IL_0408: ldstr "status"
-			IL_040d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0412: stloc.s 18
-			IL_0414: ldloc.s 18
-			IL_0416: ldc.r8 0.0
-			IL_041f: box [System.Runtime]System.Double
-			IL_0424: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0429: stloc.s 21
-			IL_042b: ldloc.s 21
-			IL_042d: brfalse IL_0455
+			IL_0395: dup
+			IL_0396: ldloc.s 22
+			IL_0398: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_039d: dup
+			IL_039e: ldstr "--no-build"
+			IL_03a3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03a8: stloc.s 27
+			IL_03aa: ldarg.0
+			IL_03ab: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_03b0: stloc.s 18
+			IL_03b2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_03b7: dup
+			IL_03b8: ldstr "stdio"
+			IL_03bd: ldstr "inherit"
+			IL_03c2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03c7: dup
+			IL_03c8: ldstr "shell"
+			IL_03cd: ldc.i4.1
+			IL_03ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_03d3: dup
+			IL_03d4: ldstr "cwd"
+			IL_03d9: ldloc.s 18
+			IL_03db: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03e0: dup
+			IL_03e1: ldstr "env"
+			IL_03e6: ldloc.s 6
+			IL_03e8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_03ed: stloc.s 25
+			IL_03ef: ldloc.s 26
+			IL_03f1: ldstr "dotnet"
+			IL_03f6: ldloc.s 27
+			IL_03f8: ldloc.s 25
+			IL_03fa: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
+			IL_03ff: stloc.s 7
+			IL_0401: ldarg.0
+			IL_0402: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getAssemblyFileBaseName
+			IL_0407: ldc.i4.1
+			IL_0408: newarr [System.Runtime]System.Object
+			IL_040d: dup
+			IL_040e: ldc.i4.0
+			IL_040f: ldarg.0
+			IL_0410: stelem.ref
+			IL_0411: ldloc.2
+			IL_0412: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0417: stloc.s 8
+			IL_0419: ldloc.s 7
+			IL_041b: ldstr "status"
+			IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0425: stloc.s 18
+			IL_0427: ldloc.s 18
+			IL_0429: ldc.r8 0.0
+			IL_0432: box [System.Runtime]System.Double
+			IL_0437: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_043c: stloc.s 21
+			IL_043e: ldloc.s 21
+			IL_0440: brfalse IL_0468
 
-			IL_0432: ldarg.0
-			IL_0433: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
-			IL_0438: ldc.i4.1
-			IL_0439: newarr [System.Runtime]System.Object
-			IL_043e: dup
-			IL_043f: ldc.i4.0
-			IL_0440: ldarg.0
-			IL_0441: stelem.ref
-			IL_0442: ldloc.1
-			IL_0443: ldloc.s 8
-			IL_0445: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_044a: stloc.s 18
-			IL_044c: ldloc.s 18
-			IL_044e: stloc.s 9
-			IL_0450: br IL_045d
+			IL_0445: ldarg.0
+			IL_0446: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
+			IL_044b: ldc.i4.1
+			IL_044c: newarr [System.Runtime]System.Object
+			IL_0451: dup
+			IL_0452: ldc.i4.0
+			IL_0453: ldarg.0
+			IL_0454: stelem.ref
+			IL_0455: ldloc.1
+			IL_0456: ldloc.s 8
+			IL_0458: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_045d: stloc.s 18
+			IL_045f: ldloc.s 18
+			IL_0461: stloc.s 9
+			IL_0463: br IL_0470
 
-			IL_0455: ldc.i4.0
-			IL_0456: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
-			IL_045b: stloc.s 9
-
-			IL_045d: ldloc.s 9
-			IL_045f: stloc.s 10
-			IL_0461: ldloc.s 10
-			IL_0463: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 			IL_0468: ldc.i4.0
-			IL_0469: ceq
-			IL_046b: stloc.s 21
-			IL_046d: ldloc.s 21
-			IL_046f: brfalse IL_05df
+			IL_0469: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_046e: stloc.s 9
 
-			IL_0474: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0479: stloc.s 24
-			IL_047b: ldloc.s 24
-			IL_047d: ldstr "Test did not produce an assembly, retrying with build..."
-			IL_0482: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0487: pop
-			IL_0488: ldarg.0
-			IL_0489: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
-			IL_048e: stloc.s 26
-			IL_0490: ldloc.s 4
-			IL_0492: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0497: stloc.s 22
-			IL_0499: ldstr "FullyQualifiedName="
-			IL_049e: ldloc.s 22
-			IL_04a0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_04a5: stloc.s 22
-			IL_04a7: ldc.i4.4
-			IL_04a8: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_04ad: dup
-			IL_04ae: ldstr "test"
-			IL_04b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_04b8: dup
-			IL_04b9: ldloc.s 5
-			IL_04bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0470: ldloc.s 9
+			IL_0472: stloc.s 10
+			IL_0474: ldloc.s 10
+			IL_0476: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_047b: ldc.i4.0
+			IL_047c: ceq
+			IL_047e: stloc.s 21
+			IL_0480: ldloc.s 21
+			IL_0482: brfalse IL_05f2
+
+			IL_0487: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_048c: stloc.s 24
+			IL_048e: ldloc.s 24
+			IL_0490: ldstr "Test did not produce an assembly, retrying with build..."
+			IL_0495: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_049a: pop
+			IL_049b: ldarg.0
+			IL_049c: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule Modules.Compile_Scripts_DecompileGeneratorTest/Scope::childProcess
+			IL_04a1: stloc.s 26
+			IL_04a3: ldloc.s 4
+			IL_04a5: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_04aa: stloc.s 22
+			IL_04ac: ldstr "FullyQualifiedName="
+			IL_04b1: ldloc.s 22
+			IL_04b3: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04b8: stloc.s 22
+			IL_04ba: ldc.i4.4
+			IL_04bb: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
 			IL_04c0: dup
-			IL_04c1: ldstr "--filter"
+			IL_04c1: ldstr "test"
 			IL_04c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
 			IL_04cb: dup
-			IL_04cc: ldloc.s 22
+			IL_04cc: ldloc.s 5
 			IL_04ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_04d3: stloc.s 27
-			IL_04d5: ldarg.0
-			IL_04d6: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
-			IL_04db: stloc.s 18
-			IL_04dd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_04e2: dup
-			IL_04e3: ldstr "stdio"
-			IL_04e8: ldstr "inherit"
-			IL_04ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_04f2: dup
-			IL_04f3: ldstr "shell"
-			IL_04f8: ldc.i4.1
-			IL_04f9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_04fe: dup
-			IL_04ff: ldstr "cwd"
-			IL_0504: ldloc.s 18
-			IL_0506: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_050b: dup
-			IL_050c: ldstr "env"
-			IL_0511: ldloc.s 6
-			IL_0513: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0518: stloc.s 25
-			IL_051a: ldloc.s 26
-			IL_051c: ldstr "dotnet"
-			IL_0521: ldloc.s 27
-			IL_0523: ldloc.s 25
-			IL_0525: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
-			IL_052a: stloc.s 11
-			IL_052c: ldloc.s 11
-			IL_052e: ldstr "status"
-			IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0538: stloc.s 18
-			IL_053a: ldloc.s 18
-			IL_053c: ldc.r8 0.0
-			IL_0545: box [System.Runtime]System.Double
-			IL_054a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
-			IL_054f: stloc.s 21
-			IL_0551: ldloc.s 21
-			IL_0553: brfalse IL_05c1
+			IL_04d3: dup
+			IL_04d4: ldstr "--filter"
+			IL_04d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_04de: dup
+			IL_04df: ldloc.s 22
+			IL_04e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_04e6: stloc.s 27
+			IL_04e8: ldarg.0
+			IL_04e9: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::projectRoot
+			IL_04ee: stloc.s 18
+			IL_04f0: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_04f5: dup
+			IL_04f6: ldstr "stdio"
+			IL_04fb: ldstr "inherit"
+			IL_0500: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0505: dup
+			IL_0506: ldstr "shell"
+			IL_050b: ldc.i4.1
+			IL_050c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0511: dup
+			IL_0512: ldstr "cwd"
+			IL_0517: ldloc.s 18
+			IL_0519: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_051e: dup
+			IL_051f: ldstr "env"
+			IL_0524: ldloc.s 6
+			IL_0526: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_052b: stloc.s 25
+			IL_052d: ldloc.s 26
+			IL_052f: ldstr "dotnet"
+			IL_0534: ldloc.s 27
+			IL_0536: ldloc.s 25
+			IL_0538: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::spawnSync(string, object, object)
+			IL_053d: stloc.s 11
+			IL_053f: ldloc.s 11
+			IL_0541: ldstr "status"
+			IL_0546: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_054b: stloc.s 18
+			IL_054d: ldloc.s 18
+			IL_054f: ldc.r8 0.0
+			IL_0558: box [System.Runtime]System.Double
+			IL_055d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictNotEqual(object, object)
+			IL_0562: stloc.s 21
+			IL_0564: ldloc.s 21
+			IL_0566: brfalse IL_05d4
 
-			IL_0558: ldstr "console"
-			IL_055d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0562: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0567: stloc.s 18
-			IL_0569: ldloc.s 4
-			IL_056b: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0570: stloc.s 22
-			IL_0572: ldstr "Test "
-			IL_0577: ldloc.s 22
-			IL_0579: call string [System.Runtime]System.String::Concat(string, string)
-			IL_057e: ldstr " failed or not found."
-			IL_0583: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0588: stloc.s 22
-			IL_058a: ldloc.s 18
-			IL_058c: ldstr "error"
-			IL_0591: ldloc.s 22
-			IL_0593: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0598: pop
-			IL_0599: ldstr "process"
-			IL_059e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_05a8: ldstr "exit"
-			IL_05ad: ldc.r8 1
-			IL_05b6: box [System.Runtime]System.Double
-			IL_05bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_05c0: pop
+			IL_056b: ldstr "console"
+			IL_0570: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0575: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_057a: stloc.s 18
+			IL_057c: ldloc.s 4
+			IL_057e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0583: stloc.s 22
+			IL_0585: ldstr "Test "
+			IL_058a: ldloc.s 22
+			IL_058c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0591: ldstr " failed or not found."
+			IL_0596: call string [System.Runtime]System.String::Concat(string, string)
+			IL_059b: stloc.s 22
+			IL_059d: ldloc.s 18
+			IL_059f: ldstr "error"
+			IL_05a4: ldloc.s 22
+			IL_05a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_05ab: pop
+			IL_05ac: ldstr "process"
+			IL_05b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_05b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_05bb: ldstr "exit"
+			IL_05c0: ldc.r8 1
+			IL_05c9: box [System.Runtime]System.Double
+			IL_05ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_05d3: pop
 
-			IL_05c1: ldarg.0
-			IL_05c2: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
-			IL_05c7: ldc.i4.1
-			IL_05c8: newarr [System.Runtime]System.Object
-			IL_05cd: dup
-			IL_05ce: ldc.i4.0
-			IL_05cf: ldarg.0
-			IL_05d0: stelem.ref
-			IL_05d1: ldloc.1
-			IL_05d2: ldloc.s 8
-			IL_05d4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05d9: stloc.s 18
-			IL_05db: ldloc.s 18
-			IL_05dd: stloc.s 10
+			IL_05d4: ldarg.0
+			IL_05d5: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::tryFindLatestGeneratedAssembly
+			IL_05da: ldc.i4.1
+			IL_05db: newarr [System.Runtime]System.Object
+			IL_05e0: dup
+			IL_05e1: ldc.i4.0
+			IL_05e2: ldarg.0
+			IL_05e3: stelem.ref
+			IL_05e4: ldloc.1
+			IL_05e5: ldloc.s 8
+			IL_05e7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05ec: stloc.s 18
+			IL_05ee: ldloc.s 18
+			IL_05f0: stloc.s 10
 
-			IL_05df: ldloc.s 10
-			IL_05e1: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_05e6: ldc.i4.0
-			IL_05e7: ceq
-			IL_05e9: stloc.s 21
-			IL_05eb: ldloc.s 21
-			IL_05ed: brfalse IL_0753
+			IL_05f2: ldloc.s 10
+			IL_05f4: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_05f9: ldc.i4.0
+			IL_05fa: ceq
+			IL_05fc: stloc.s 21
+			IL_05fe: ldloc.s 21
+			IL_0600: brfalse IL_0766
 
-			IL_05f2: ldstr "console"
-			IL_05f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_05fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0601: stloc.s 18
-			IL_0603: ldloc.1
-			IL_0604: ldstr "path"
-			IL_0609: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_060e: stloc.s 28
-			IL_0610: ldloc.s 28
-			IL_0612: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0617: stloc.s 22
-			IL_0619: ldstr "Assembly not found for category '"
-			IL_061e: ldloc.s 22
-			IL_0620: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0625: ldstr "' and test '"
-			IL_062a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_062f: ldloc.2
-			IL_0630: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0635: stloc.s 22
-			IL_0637: ldloc.s 22
-			IL_0639: call string [System.Runtime]System.String::Concat(string, string)
-			IL_063e: ldstr "'."
-			IL_0643: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0605: ldstr "console"
+			IL_060a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_060f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0614: stloc.s 18
+			IL_0616: ldloc.1
+			IL_0617: ldstr "path"
+			IL_061c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0621: stloc.s 28
+			IL_0623: ldloc.s 28
+			IL_0625: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_062a: stloc.s 22
+			IL_062c: ldstr "Assembly not found for category '"
+			IL_0631: ldloc.s 22
+			IL_0633: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0638: ldstr "' and test '"
+			IL_063d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0642: ldloc.2
+			IL_0643: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 			IL_0648: stloc.s 22
-			IL_064a: ldloc.s 18
-			IL_064c: ldstr "error"
-			IL_0651: ldloc.s 22
-			IL_0653: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0658: pop
-			IL_0659: ldstr "console"
-			IL_065e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0663: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0668: ldstr "error"
-			IL_066d: ldstr "Looked under:"
-			IL_0672: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0677: pop
-			IL_0678: ldarg.0
-			IL_0679: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
-			IL_067e: ldc.i4.1
-			IL_067f: newarr [System.Runtime]System.Object
-			IL_0684: dup
-			IL_0685: ldc.i4.0
-			IL_0686: ldarg.0
-			IL_0687: stelem.ref
-			IL_0688: ldloc.1
-			IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_068e: stloc.s 12
-			IL_0690: ldc.r8 0.0
-			IL_0699: stloc.s 13
-			// loop start (head: IL_069b)
-				IL_069b: ldloc.s 13
-				IL_069d: stloc.s 29
-				IL_069f: ldloc.s 12
-				IL_06a1: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
-				IL_06a6: stloc.s 30
-				IL_06a8: ldloc.s 29
-				IL_06aa: ldloc.s 30
-				IL_06ac: clt
-				IL_06ae: brfalse IL_070c
+			IL_064a: ldloc.s 22
+			IL_064c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0651: ldstr "'."
+			IL_0656: call string [System.Runtime]System.String::Concat(string, string)
+			IL_065b: stloc.s 22
+			IL_065d: ldloc.s 18
+			IL_065f: ldstr "error"
+			IL_0664: ldloc.s 22
+			IL_0666: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_066b: pop
+			IL_066c: ldstr "console"
+			IL_0671: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0676: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_067b: ldstr "error"
+			IL_0680: ldstr "Looked under:"
+			IL_0685: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_068a: pop
+			IL_068b: ldarg.0
+			IL_068c: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::getCandidateCategoryRoots
+			IL_0691: ldc.i4.1
+			IL_0692: newarr [System.Runtime]System.Object
+			IL_0697: dup
+			IL_0698: ldc.i4.0
+			IL_0699: ldarg.0
+			IL_069a: stelem.ref
+			IL_069b: ldloc.1
+			IL_069c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_06a1: stloc.s 12
+			IL_06a3: ldc.r8 0.0
+			IL_06ac: stloc.s 13
+			// loop start (head: IL_06ae)
+				IL_06ae: ldloc.s 13
+				IL_06b0: stloc.s 29
+				IL_06b2: ldloc.s 12
+				IL_06b4: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetLength(object)
+				IL_06b9: stloc.s 30
+				IL_06bb: ldloc.s 29
+				IL_06bd: ldloc.s 30
+				IL_06bf: clt
+				IL_06c1: brfalse IL_071f
 
-				IL_06b3: ldstr "console"
-				IL_06b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_06c2: stloc.s 18
-				IL_06c4: ldloc.s 12
-				IL_06c6: ldloc.s 13
-				IL_06c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_06cd: stloc.s 28
-				IL_06cf: ldloc.s 28
-				IL_06d1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-				IL_06d6: stloc.s 22
-				IL_06d8: ldstr "  - "
-				IL_06dd: ldloc.s 22
-				IL_06df: call string [System.Runtime]System.String::Concat(string, string)
-				IL_06e4: stloc.s 22
-				IL_06e6: ldloc.s 18
-				IL_06e8: ldstr "error"
-				IL_06ed: ldloc.s 22
-				IL_06ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_06f4: pop
-				IL_06f5: ldloc.s 13
-				IL_06f7: ldc.r8 1
-				IL_0700: add
-				IL_0701: stloc.s 30
-				IL_0703: ldloc.s 30
-				IL_0705: stloc.s 13
-				IL_0707: br IL_069b
+				IL_06c6: ldstr "console"
+				IL_06cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_06d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_06d5: stloc.s 18
+				IL_06d7: ldloc.s 12
+				IL_06d9: ldloc.s 13
+				IL_06db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_06e0: stloc.s 28
+				IL_06e2: ldloc.s 28
+				IL_06e4: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_06e9: stloc.s 22
+				IL_06eb: ldstr "  - "
+				IL_06f0: ldloc.s 22
+				IL_06f2: call string [System.Runtime]System.String::Concat(string, string)
+				IL_06f7: stloc.s 22
+				IL_06f9: ldloc.s 18
+				IL_06fb: ldstr "error"
+				IL_0700: ldloc.s 22
+				IL_0702: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0707: pop
+				IL_0708: ldloc.s 13
+				IL_070a: ldc.r8 1
+				IL_0713: add
+				IL_0714: stloc.s 30
+				IL_0716: ldloc.s 30
+				IL_0718: stloc.s 13
+				IL_071a: br IL_06ae
 			// end loop
 
-			IL_070c: ldstr "console"
-			IL_0711: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0716: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_071b: ldstr "error"
-			IL_0720: ldstr "Make sure the test ran successfully and generated the assembly."
-			IL_0725: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_072a: pop
-			IL_072b: ldstr "process"
-			IL_0730: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0735: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_073a: ldstr "exit"
-			IL_073f: ldc.r8 1
-			IL_0748: box [System.Runtime]System.Double
-			IL_074d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0752: pop
+			IL_071f: ldstr "console"
+			IL_0724: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0729: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_072e: ldstr "error"
+			IL_0733: ldstr "Make sure the test ran successfully and generated the assembly."
+			IL_0738: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_073d: pop
+			IL_073e: ldstr "process"
+			IL_0743: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0748: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_074d: ldstr "exit"
+			IL_0752: ldc.r8 1
+			IL_075b: box [System.Runtime]System.Double
+			IL_0760: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0765: pop
 
-			IL_0753: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0758: stloc.s 24
-			IL_075a: ldloc.s 10
-			IL_075c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0761: stloc.s 22
-			IL_0763: ldstr "Found assembly: "
-			IL_0768: ldloc.s 22
-			IL_076a: call string [System.Runtime]System.String::Concat(string, string)
-			IL_076f: stloc.s 22
-			IL_0771: ldloc.s 24
-			IL_0773: ldloc.s 22
-			IL_0775: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_077a: pop
+			IL_0766: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_076b: stloc.s 24
+			IL_076d: ldloc.s 10
+			IL_076f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0774: stloc.s 22
+			IL_0776: ldstr "Found assembly: "
+			IL_077b: ldloc.s 22
+			IL_077d: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0782: stloc.s 22
+			IL_0784: ldloc.s 24
+			IL_0786: ldloc.s 22
+			IL_0788: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_078d: pop
 			.try
 			{
-				IL_077b: nop
-				IL_077c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0781: stloc.s 24
-				IL_0783: ldloc.s 24
-				IL_0785: ldstr "Opening in ILSpy..."
-				IL_078a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-				IL_078f: pop
-				IL_0790: ldarg.0
-				IL_0791: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
-				IL_0796: stloc.s 18
-				IL_0798: ldloc.s 18
-				IL_079a: ldc.i4.1
-				IL_079b: newarr [System.Runtime]System.Object
-				IL_07a0: dup
-				IL_07a1: ldc.i4.0
-				IL_07a2: ldarg.0
-				IL_07a3: stelem.ref
-				IL_07a4: ldloc.s 10
-				IL_07a6: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-				IL_07ab: pop
-				IL_07ac: leave IL_084b
+				IL_078e: nop
+				IL_078f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_0794: stloc.s 24
+				IL_0796: ldloc.s 24
+				IL_0798: ldstr "Opening in ILSpy..."
+				IL_079d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+				IL_07a2: pop
+				IL_07a3: ldarg.0
+				IL_07a4: ldfld object Modules.Compile_Scripts_DecompileGeneratorTest/Scope::openInIlSpy
+				IL_07a9: stloc.s 18
+				IL_07ab: ldloc.s 18
+				IL_07ad: ldc.i4.1
+				IL_07ae: newarr [System.Runtime]System.Object
+				IL_07b3: dup
+				IL_07b4: ldc.i4.0
+				IL_07b5: ldarg.0
+				IL_07b6: stelem.ref
+				IL_07b7: ldloc.s 10
+				IL_07b9: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+				IL_07be: pop
+				IL_07bf: leave IL_085e
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
-				IL_07b1: stloc.s 14
-				IL_07b3: ldloc.s 14
-				IL_07b5: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-				IL_07ba: dup
-				IL_07bb: brtrue IL_07d1
+				IL_07c4: stloc.s 14
+				IL_07c6: ldloc.s 14
+				IL_07c8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+				IL_07cd: dup
+				IL_07ce: brtrue IL_07e4
 
-				IL_07c0: pop
-				IL_07c1: ldloc.s 14
-				IL_07c3: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-				IL_07c8: dup
-				IL_07c9: brtrue IL_07dd
+				IL_07d3: pop
+				IL_07d4: ldloc.s 14
+				IL_07d6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+				IL_07db: dup
+				IL_07dc: brtrue IL_07f0
 
-				IL_07ce: pop
-				IL_07cf: rethrow
+				IL_07e1: pop
+				IL_07e2: rethrow
 
-				IL_07d1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-				IL_07d6: stloc.s 15
-				IL_07d8: br IL_07df
+				IL_07e4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+				IL_07e9: stloc.s 15
+				IL_07eb: br IL_07f2
 
-				IL_07dd: stloc.s 15
+				IL_07f0: stloc.s 15
 
-				IL_07df: ldloc.s 15
-				IL_07e1: stloc.s 16
-				IL_07e3: ldstr "console"
-				IL_07e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_07ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_07f2: ldstr "error"
-				IL_07f7: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
-				IL_07fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0801: pop
-				IL_0802: ldstr "console"
-				IL_0807: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_080c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0811: ldstr "error"
-				IL_0816: ldloc.s 16
-				IL_0818: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_081d: pop
-				IL_081e: ldstr "process"
-				IL_0823: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-				IL_0828: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_082d: ldstr "exit"
-				IL_0832: ldc.r8 1
-				IL_083b: box [System.Runtime]System.Double
-				IL_0840: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0845: pop
-				IL_0846: leave IL_084b
+				IL_07f2: ldloc.s 15
+				IL_07f4: stloc.s 16
+				IL_07f6: ldstr "console"
+				IL_07fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_0800: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0805: ldstr "error"
+				IL_080a: ldstr "Failed to launch ILSpy (is `ilspy` on PATH?)."
+				IL_080f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0814: pop
+				IL_0815: ldstr "console"
+				IL_081a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_081f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0824: ldstr "error"
+				IL_0829: ldloc.s 16
+				IL_082b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0830: pop
+				IL_0831: ldstr "process"
+				IL_0836: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+				IL_083b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_0840: ldstr "exit"
+				IL_0845: ldc.r8 1
+				IL_084e: box [System.Runtime]System.Double
+				IL_0853: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0858: pop
+				IL_0859: leave IL_085e
 			} // end handler
 
-			IL_084b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0850: stloc.s 24
-			IL_0852: ldloc.s 24
-			IL_0854: ldstr "Done!"
-			IL_0859: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_085e: pop
-			IL_085f: ldnull
-			IL_0860: stloc.s 17
-			IL_0862: ldloc.s 17
-			IL_0864: ret
+			IL_085e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0863: stloc.s 24
+			IL_0865: ldloc.s 24
+			IL_0867: ldstr "Done!"
+			IL_086c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0871: pop
+			IL_0872: ldnull
+			IL_0873: stloc.s 17
+			IL_0875: ldloc.s 17
+			IL_0877: ret
 		} // end of method main::__js_call__
 
 	} // end of class main

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -740,7 +740,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 436 (0x1b4)
+			// Code size: 490 (0x1ea)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -755,153 +755,174 @@
 			IL_0006: stloc.0
 			IL_0007: ldc.i4.0
 			IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_000d: brfalse IL_0034
+			IL_000d: brfalse IL_0046
 
 			IL_0012: ldloc.0
 			IL_0013: isinst [System.Runtime]System.String
 			IL_0018: dup
-			IL_0019: brfalse IL_0033
+			IL_0019: brtrue IL_0030
 
-			IL_001e: ldstr " -> "
-			IL_0023: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-			IL_0028: box [System.Runtime]System.Boolean
-			IL_002d: stloc.0
-			IL_002e: br IL_0045
+			IL_001e: pop
+			IL_001f: ldloc.0
+			IL_0020: ldstr "includes"
+			IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_002a: dup
+			IL_002b: brfalse IL_0045
 
-			IL_0033: pop
+			IL_0030: ldstr " -> "
+			IL_0035: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_003a: box [System.Runtime]System.Boolean
+			IL_003f: stloc.0
+			IL_0040: br IL_0057
 
-			IL_0034: ldloc.0
-			IL_0035: ldstr "includes"
-			IL_003a: ldstr " -> "
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0044: stloc.0
+			IL_0045: pop
 
-			IL_0045: ldloc.0
-			IL_0046: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_004b: stloc.1
-			IL_004c: ldloc.1
-			IL_004d: brfalse IL_010a
+			IL_0046: ldloc.0
+			IL_0047: ldstr "includes"
+			IL_004c: ldstr " -> "
+			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0056: stloc.0
 
-			IL_0052: ldarg.1
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0058: stloc.0
-			IL_0059: ldarg.1
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_005f: stloc.2
-			IL_0060: ldc.i4.0
-			IL_0061: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0066: brfalse IL_008d
+			IL_0057: ldloc.0
+			IL_0058: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_005d: stloc.1
+			IL_005e: ldloc.1
+			IL_005f: brfalse IL_0140
 
-			IL_006b: ldloc.2
-			IL_006c: isinst [System.Runtime]System.String
-			IL_0071: dup
-			IL_0072: brfalse IL_008c
+			IL_0064: ldarg.1
+			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006a: stloc.0
+			IL_006b: ldarg.1
+			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0071: stloc.2
+			IL_0072: ldc.i4.0
+			IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0078: brfalse IL_00b1
 
-			IL_0077: ldstr " -> "
-			IL_007c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_0081: box [System.Runtime]System.Double
-			IL_0086: stloc.2
-			IL_0087: br IL_009e
+			IL_007d: ldloc.2
+			IL_007e: isinst [System.Runtime]System.String
+			IL_0083: dup
+			IL_0084: brtrue IL_009b
 
-			IL_008c: pop
+			IL_0089: pop
+			IL_008a: ldloc.2
+			IL_008b: ldstr "indexOf"
+			IL_0090: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0095: dup
+			IL_0096: brfalse IL_00b0
 
-			IL_008d: ldloc.2
-			IL_008e: ldstr "indexOf"
-			IL_0093: ldstr " -> "
-			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_009d: stloc.2
+			IL_009b: ldstr " -> "
+			IL_00a0: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_00a5: box [System.Runtime]System.Double
+			IL_00aa: stloc.2
+			IL_00ab: br IL_00c2
 
-			IL_009e: ldloc.2
-			IL_009f: ldc.r8 4
-			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_00ad: stloc.3
-			IL_00ae: ldc.i4.0
-			IL_00af: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_00b4: brfalse IL_00e0
+			IL_00b0: pop
 
-			IL_00b9: ldloc.0
-			IL_00ba: isinst [System.Runtime]System.String
-			IL_00bf: dup
-			IL_00c0: brfalse IL_00df
+			IL_00b1: ldloc.2
+			IL_00b2: ldstr "indexOf"
+			IL_00b7: ldstr " -> "
+			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00c1: stloc.2
 
-			IL_00c5: ldc.r8 0.0
-			IL_00ce: box [System.Runtime]System.Double
-			IL_00d3: ldloc.3
-			IL_00d4: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_00d9: stloc.0
-			IL_00da: br IL_00fb
+			IL_00c2: ldloc.2
+			IL_00c3: ldc.r8 4
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_00d1: stloc.3
+			IL_00d2: ldc.i4.0
+			IL_00d3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00d8: brfalse IL_0116
 
-			IL_00df: pop
+			IL_00dd: ldloc.0
+			IL_00de: isinst [System.Runtime]System.String
+			IL_00e3: dup
+			IL_00e4: brtrue IL_00fb
 
-			IL_00e0: ldloc.0
-			IL_00e1: ldstr "substring"
-			IL_00e6: ldc.r8 0.0
-			IL_00ef: box [System.Runtime]System.Double
-			IL_00f4: ldloc.3
-			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00fa: stloc.0
+			IL_00e9: pop
+			IL_00ea: ldloc.0
+			IL_00eb: ldstr "substring"
+			IL_00f0: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_00f5: dup
+			IL_00f6: brfalse IL_0115
 
-			IL_00fb: ldloc.0
-			IL_00fc: ldstr "<outFile>"
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0106: stloc.3
-			IL_0107: ldloc.3
-			IL_0108: starg.s text
+			IL_00fb: ldc.r8 0.0
+			IL_0104: box [System.Runtime]System.Double
+			IL_0109: ldloc.3
+			IL_010a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_010f: stloc.0
+			IL_0110: br IL_0131
 
-			IL_010a: ldarg.1
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0110: stloc.0
-			IL_0111: ldarg.2
-			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0117: stloc.2
-			IL_0118: ldstr "[.*+?^${}()|[\\]\\\\]"
-			IL_011d: ldstr "g"
-			IL_0122: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0127: stloc.s 4
-			IL_0129: ldloc.2
-			IL_012a: ldstr "replace"
-			IL_012f: ldloc.s 4
-			IL_0131: ldstr "\\$&"
-			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_013b: stloc.2
-			IL_013c: ldloc.2
-			IL_013d: ldstr "g"
-			IL_0142: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0147: stloc.s 4
-			IL_0149: ldloc.0
-			IL_014a: ldstr "replace"
-			IL_014f: ldloc.s 4
-			IL_0151: ldstr "<outFile>"
-			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_015b: stloc.0
-			IL_015c: ldloc.0
-			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0162: stloc.0
-			IL_0163: ldstr "127\\.0\\.0\\.1:\\d+"
-			IL_0168: ldstr "g"
-			IL_016d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0172: stloc.s 4
-			IL_0174: ldloc.0
-			IL_0175: ldstr "replace"
-			IL_017a: ldloc.s 4
-			IL_017c: ldstr "127.0.0.1:<port>"
-			IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0186: stloc.0
-			IL_0187: ldloc.0
-			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018d: stloc.0
-			IL_018e: ldstr "\\r\\n"
-			IL_0193: ldstr "g"
-			IL_0198: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_019d: stloc.s 4
-			IL_019f: ldloc.0
-			IL_01a0: ldstr "replace"
-			IL_01a5: ldloc.s 4
-			IL_01a7: ldstr "\n"
-			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01b1: stloc.0
-			IL_01b2: ldloc.0
-			IL_01b3: ret
+			IL_0115: pop
+
+			IL_0116: ldloc.0
+			IL_0117: ldstr "substring"
+			IL_011c: ldc.r8 0.0
+			IL_0125: box [System.Runtime]System.Double
+			IL_012a: ldloc.3
+			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0130: stloc.0
+
+			IL_0131: ldloc.0
+			IL_0132: ldstr "<outFile>"
+			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_013c: stloc.3
+			IL_013d: ldloc.3
+			IL_013e: starg.s text
+
+			IL_0140: ldarg.1
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0146: stloc.0
+			IL_0147: ldarg.2
+			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014d: stloc.2
+			IL_014e: ldstr "[.*+?^${}()|[\\]\\\\]"
+			IL_0153: ldstr "g"
+			IL_0158: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_015d: stloc.s 4
+			IL_015f: ldloc.2
+			IL_0160: ldstr "replace"
+			IL_0165: ldloc.s 4
+			IL_0167: ldstr "\\$&"
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0171: stloc.2
+			IL_0172: ldloc.2
+			IL_0173: ldstr "g"
+			IL_0178: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_017d: stloc.s 4
+			IL_017f: ldloc.0
+			IL_0180: ldstr "replace"
+			IL_0185: ldloc.s 4
+			IL_0187: ldstr "<outFile>"
+			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0191: stloc.0
+			IL_0192: ldloc.0
+			IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0198: stloc.0
+			IL_0199: ldstr "127\\.0\\.0\\.1:\\d+"
+			IL_019e: ldstr "g"
+			IL_01a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_01a8: stloc.s 4
+			IL_01aa: ldloc.0
+			IL_01ab: ldstr "replace"
+			IL_01b0: ldloc.s 4
+			IL_01b2: ldstr "127.0.0.1:<port>"
+			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01bc: stloc.0
+			IL_01bd: ldloc.0
+			IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c3: stloc.0
+			IL_01c4: ldstr "\\r\\n"
+			IL_01c9: ldstr "g"
+			IL_01ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_01d3: stloc.s 4
+			IL_01d5: ldloc.0
+			IL_01d6: ldstr "replace"
+			IL_01db: ldloc.s 4
+			IL_01dd: ldstr "\n"
+			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01e7: stloc.0
+			IL_01e8: ldloc.0
+			IL_01e9: ret
 		} // end of method normalize::__js_call__
 
 	} // end of class normalize
@@ -3555,7 +3576,7 @@
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
-			// Code size: 542 (0x21e)
+			// Code size: 561 (0x231)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3765,30 +3786,37 @@
 			IL_01e0: stloc.s 9
 			IL_01e2: ldc.i4.0
 			IL_01e3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_01e8: brfalse IL_020a
+			IL_01e8: brfalse IL_021d
 
 			IL_01ed: ldloc.s 5
 			IL_01ef: isinst [System.Runtime]System.String
 			IL_01f4: dup
-			IL_01f5: brfalse IL_0209
+			IL_01f5: brtrue IL_020d
 
-			IL_01fa: ldloc.s 9
-			IL_01fc: ldloc.0
-			IL_01fd: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_0202: stloc.s 5
-			IL_0204: br IL_021b
+			IL_01fa: pop
+			IL_01fb: ldloc.s 5
+			IL_01fd: ldstr "substring"
+			IL_0202: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0207: dup
+			IL_0208: brfalse IL_021c
 
-			IL_0209: pop
+			IL_020d: ldloc.s 9
+			IL_020f: ldloc.0
+			IL_0210: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_0215: stloc.s 5
+			IL_0217: br IL_022e
 
-			IL_020a: ldloc.s 5
-			IL_020c: ldstr "substring"
-			IL_0211: ldloc.s 9
-			IL_0213: ldloc.0
-			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0219: stloc.s 5
+			IL_021c: pop
 
-			IL_021b: ldloc.s 5
-			IL_021d: ret
+			IL_021d: ldloc.s 5
+			IL_021f: ldstr "substring"
+			IL_0224: ldloc.s 9
+			IL_0226: ldloc.0
+			IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_022c: stloc.s 5
+
+			IL_022e: ldloc.s 5
+			IL_0230: ret
 		} // end of method findTagNameAt::__js_call__
 
 	} // end of class findTagNameAt
@@ -4141,7 +4169,7 @@
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1172 (0x494)
+			// Code size: 1267 (0x4f3)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -4191,406 +4219,441 @@
 			IL_0044: stloc.s 15
 			IL_0046: ldc.i4.0
 			IL_0047: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_004c: brfalse IL_0070
+			IL_004c: brfalse IL_0083
 
 			IL_0051: ldloc.s 15
 			IL_0053: isinst [System.Runtime]System.String
 			IL_0058: dup
-			IL_0059: brfalse IL_006f
+			IL_0059: brtrue IL_0071
 
-			IL_005e: ldloc.0
-			IL_005f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_0064: box [System.Runtime]System.Double
-			IL_0069: stloc.2
-			IL_006a: br IL_007e
+			IL_005e: pop
+			IL_005f: ldloc.s 15
+			IL_0061: ldstr "indexOf"
+			IL_0066: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_006b: dup
+			IL_006c: brfalse IL_0082
 
-			IL_006f: pop
+			IL_0071: ldloc.0
+			IL_0072: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0077: box [System.Runtime]System.Double
+			IL_007c: stloc.2
+			IL_007d: br IL_0091
 
-			IL_0070: ldloc.s 15
-			IL_0072: ldstr "indexOf"
-			IL_0077: ldloc.0
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_007d: stloc.2
+			IL_0082: pop
 
-			IL_007e: ldloc.2
-			IL_007f: stloc.s 15
-			IL_0081: ldloc.s 15
-			IL_0083: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0088: ldc.r8 0.0
-			IL_0091: clt
-			IL_0093: brfalse IL_00dd
+			IL_0083: ldloc.s 15
+			IL_0085: ldstr "indexOf"
+			IL_008a: ldloc.0
+			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0090: stloc.2
 
-			IL_0098: ldarg.2
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_009e: stloc.s 15
-			IL_00a0: ldc.i4.0
-			IL_00a1: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_00a6: brfalse IL_00cb
+			IL_0091: ldloc.2
+			IL_0092: stloc.s 15
+			IL_0094: ldloc.s 15
+			IL_0096: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_009b: ldc.r8 0.0
+			IL_00a4: clt
+			IL_00a6: brfalse IL_0103
 
-			IL_00ab: ldloc.s 15
-			IL_00ad: isinst [System.Runtime]System.String
-			IL_00b2: dup
-			IL_00b3: brfalse IL_00ca
+			IL_00ab: ldarg.2
+			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b1: stloc.s 15
+			IL_00b3: ldc.i4.0
+			IL_00b4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00b9: brfalse IL_00f1
 
-			IL_00b8: ldloc.1
-			IL_00b9: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_00be: box [System.Runtime]System.Double
-			IL_00c3: stloc.s 15
-			IL_00c5: br IL_00da
+			IL_00be: ldloc.s 15
+			IL_00c0: isinst [System.Runtime]System.String
+			IL_00c5: dup
+			IL_00c6: brtrue IL_00de
 
-			IL_00ca: pop
+			IL_00cb: pop
+			IL_00cc: ldloc.s 15
+			IL_00ce: ldstr "indexOf"
+			IL_00d3: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_00d8: dup
+			IL_00d9: brfalse IL_00f0
 
-			IL_00cb: ldloc.s 15
-			IL_00cd: ldstr "indexOf"
-			IL_00d2: ldloc.1
-			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00d8: stloc.s 15
+			IL_00de: ldloc.1
+			IL_00df: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_00e4: box [System.Runtime]System.Double
+			IL_00e9: stloc.s 15
+			IL_00eb: br IL_0100
 
-			IL_00da: ldloc.s 15
-			IL_00dc: stloc.2
+			IL_00f0: pop
 
-			IL_00dd: ldloc.2
-			IL_00de: stloc.s 15
-			IL_00e0: ldloc.s 15
-			IL_00e2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00e7: ldc.r8 0.0
-			IL_00f0: clt
-			IL_00f2: brfalse IL_0134
+			IL_00f1: ldloc.s 15
+			IL_00f3: ldstr "indexOf"
+			IL_00f8: ldloc.1
+			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00fe: stloc.s 15
 
-			IL_00f7: ldarg.3
-			IL_00f8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00fd: stloc.s 14
-			IL_00ff: ldstr "Could not find id '"
-			IL_0104: ldloc.s 14
-			IL_0106: call string [System.Runtime]System.String::Concat(string, string)
-			IL_010b: ldstr "' in input HTML."
-			IL_0110: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0115: stloc.s 14
-			IL_0117: ldloc.s 14
-			IL_0119: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_011e: stloc.3
-			IL_011f: ldloc.3
-			IL_0120: isinst [System.Runtime]System.Exception
-			IL_0125: dup
-			IL_0126: brtrue IL_0133
+			IL_0100: ldloc.s 15
+			IL_0102: stloc.2
 
-			IL_012b: pop
-			IL_012c: ldloc.3
-			IL_012d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0132: throw
+			IL_0103: ldloc.2
+			IL_0104: stloc.s 15
+			IL_0106: ldloc.s 15
+			IL_0108: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_010d: ldc.r8 0.0
+			IL_0116: clt
+			IL_0118: brfalse IL_015a
 
-			IL_0133: throw
+			IL_011d: ldarg.3
+			IL_011e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0123: stloc.s 14
+			IL_0125: ldstr "Could not find id '"
+			IL_012a: ldloc.s 14
+			IL_012c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0131: ldstr "' in input HTML."
+			IL_0136: call string [System.Runtime]System.String::Concat(string, string)
+			IL_013b: stloc.s 14
+			IL_013d: ldloc.s 14
+			IL_013f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0144: stloc.3
+			IL_0145: ldloc.3
+			IL_0146: isinst [System.Runtime]System.Exception
+			IL_014b: dup
+			IL_014c: brtrue IL_0159
 
-			IL_0134: ldarg.2
-			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_013a: stloc.s 15
-			IL_013c: ldc.i4.0
-			IL_013d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0142: brfalse IL_016c
+			IL_0151: pop
+			IL_0152: ldloc.3
+			IL_0153: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0158: throw
 
-			IL_0147: ldloc.s 15
-			IL_0149: isinst [System.Runtime]System.String
-			IL_014e: dup
-			IL_014f: brfalse IL_016b
+			IL_0159: throw
 
-			IL_0154: ldstr "<"
-			IL_0159: ldloc.2
-			IL_015a: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
-			IL_015f: box [System.Runtime]System.Double
-			IL_0164: stloc.s 4
-			IL_0166: br IL_0180
+			IL_015a: ldarg.2
+			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0160: stloc.s 15
+			IL_0162: ldc.i4.0
+			IL_0163: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0168: brfalse IL_01a5
 
-			IL_016b: pop
+			IL_016d: ldloc.s 15
+			IL_016f: isinst [System.Runtime]System.String
+			IL_0174: dup
+			IL_0175: brtrue IL_018d
 
-			IL_016c: ldloc.s 15
-			IL_016e: ldstr "lastIndexOf"
-			IL_0173: ldstr "<"
-			IL_0178: ldloc.2
-			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_017e: stloc.s 4
+			IL_017a: pop
+			IL_017b: ldloc.s 15
+			IL_017d: ldstr "lastIndexOf"
+			IL_0182: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0187: dup
+			IL_0188: brfalse IL_01a4
 
-			IL_0180: ldloc.s 4
-			IL_0182: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0187: ldc.r8 0.0
-			IL_0190: clt
-			IL_0192: brfalse IL_01d7
+			IL_018d: ldstr "<"
+			IL_0192: ldloc.2
+			IL_0193: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+			IL_0198: box [System.Runtime]System.Double
+			IL_019d: stloc.s 4
+			IL_019f: br IL_01b9
 
-			IL_0197: ldarg.3
-			IL_0198: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_019d: stloc.s 14
-			IL_019f: ldstr "Could not locate tag start for id '"
-			IL_01a4: ldloc.s 14
-			IL_01a6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01ab: ldstr "'."
-			IL_01b0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01b5: stloc.s 14
-			IL_01b7: ldloc.s 14
-			IL_01b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01be: stloc.s 5
-			IL_01c0: ldloc.s 5
-			IL_01c2: isinst [System.Runtime]System.Exception
-			IL_01c7: dup
-			IL_01c8: brtrue IL_01d6
+			IL_01a4: pop
 
-			IL_01cd: pop
-			IL_01ce: ldloc.s 5
-			IL_01d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_01d5: throw
+			IL_01a5: ldloc.s 15
+			IL_01a7: ldstr "lastIndexOf"
+			IL_01ac: ldstr "<"
+			IL_01b1: ldloc.2
+			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01b7: stloc.s 4
 
-			IL_01d6: throw
+			IL_01b9: ldloc.s 4
+			IL_01bb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_01c0: ldc.r8 0.0
+			IL_01c9: clt
+			IL_01cb: brfalse IL_0210
 
-			IL_01d7: ldarg.0
-			IL_01d8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
-			IL_01dd: ldc.i4.1
-			IL_01de: newarr [System.Runtime]System.Object
-			IL_01e3: dup
-			IL_01e4: ldc.i4.0
-			IL_01e5: ldarg.0
-			IL_01e6: stelem.ref
-			IL_01e7: stloc.s 16
-			IL_01e9: ldloc.s 16
-			IL_01eb: ldarg.2
-			IL_01ec: ldloc.s 4
-			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01f3: stloc.s 6
-			IL_01f5: ldloc.s 6
-			IL_01f7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01fc: ldc.i4.0
-			IL_01fd: ceq
-			IL_01ff: stloc.s 17
-			IL_0201: ldloc.s 17
-			IL_0203: brfalse IL_0248
+			IL_01d0: ldarg.3
+			IL_01d1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01d6: stloc.s 14
+			IL_01d8: ldstr "Could not locate tag start for id '"
+			IL_01dd: ldloc.s 14
+			IL_01df: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01e4: ldstr "'."
+			IL_01e9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ee: stloc.s 14
+			IL_01f0: ldloc.s 14
+			IL_01f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01f7: stloc.s 5
+			IL_01f9: ldloc.s 5
+			IL_01fb: isinst [System.Runtime]System.Exception
+			IL_0200: dup
+			IL_0201: brtrue IL_020f
 
-			IL_0208: ldarg.3
-			IL_0209: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_020e: stloc.s 14
-			IL_0210: ldstr "Could not determine tag name for id '"
-			IL_0215: ldloc.s 14
-			IL_0217: call string [System.Runtime]System.String::Concat(string, string)
-			IL_021c: ldstr "'."
-			IL_0221: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0226: stloc.s 14
-			IL_0228: ldloc.s 14
-			IL_022a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_022f: stloc.s 7
-			IL_0231: ldloc.s 7
-			IL_0233: isinst [System.Runtime]System.Exception
-			IL_0238: dup
-			IL_0239: brtrue IL_0247
+			IL_0206: pop
+			IL_0207: ldloc.s 5
+			IL_0209: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_020e: throw
 
-			IL_023e: pop
-			IL_023f: ldloc.s 7
-			IL_0241: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0246: throw
+			IL_020f: throw
 
-			IL_0247: throw
+			IL_0210: ldarg.0
+			IL_0211: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
+			IL_0216: ldc.i4.1
+			IL_0217: newarr [System.Runtime]System.Object
+			IL_021c: dup
+			IL_021d: ldc.i4.0
+			IL_021e: ldarg.0
+			IL_021f: stelem.ref
+			IL_0220: stloc.s 16
+			IL_0222: ldloc.s 16
+			IL_0224: ldarg.2
+			IL_0225: ldloc.s 4
+			IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_022c: stloc.s 6
+			IL_022e: ldloc.s 6
+			IL_0230: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0235: ldc.i4.0
+			IL_0236: ceq
+			IL_0238: stloc.s 17
+			IL_023a: ldloc.s 17
+			IL_023c: brfalse IL_0281
 
-			IL_0248: ldarg.0
-			IL_0249: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
-			IL_024e: ldc.i4.1
-			IL_024f: newarr [System.Runtime]System.Object
-			IL_0254: dup
-			IL_0255: ldc.i4.0
-			IL_0256: ldarg.0
-			IL_0257: stelem.ref
-			IL_0258: ldloc.s 6
-			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_025f: stloc.s 15
-			IL_0261: ldloc.s 15
-			IL_0263: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0268: stloc.s 14
-			IL_026a: ldstr "<\\/?"
-			IL_026f: ldloc.s 14
-			IL_0271: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0276: ldstr "\\b[^>]*>"
-			IL_027b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0280: stloc.s 14
-			IL_0282: ldloc.s 14
-			IL_0284: ldstr "gi"
-			IL_0289: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_028e: stloc.s 8
-			IL_0290: ldloc.s 8
-			IL_0292: ldstr "lastIndex"
-			IL_0297: ldloc.s 4
-			IL_0299: ldc.i4.1
-			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_029f: pop
-			IL_02a0: ldc.r8 0.0
-			IL_02a9: stloc.s 9
-			IL_02ab: ldc.r8 1
-			IL_02b4: neg
-			IL_02b5: stloc.s 18
-			IL_02b7: ldloc.s 18
-			IL_02b9: box [System.Runtime]System.Double
-			IL_02be: stloc.s 10
-			// loop start (head: IL_02c0)
-				IL_02c0: ldc.i4.1
-				IL_02c1: brfalse IL_0438
+			IL_0241: ldarg.3
+			IL_0242: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0247: stloc.s 14
+			IL_0249: ldstr "Could not determine tag name for id '"
+			IL_024e: ldloc.s 14
+			IL_0250: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0255: ldstr "'."
+			IL_025a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_025f: stloc.s 14
+			IL_0261: ldloc.s 14
+			IL_0263: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0268: stloc.s 7
+			IL_026a: ldloc.s 7
+			IL_026c: isinst [System.Runtime]System.Exception
+			IL_0271: dup
+			IL_0272: brtrue IL_0280
 
-				IL_02c6: ldloc.s 8
-				IL_02c8: ldstr "exec"
-				IL_02cd: ldarg.2
-				IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_02d3: stloc.s 11
-				IL_02d5: ldloc.s 11
-				IL_02d7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_02dc: ldc.i4.0
-				IL_02dd: ceq
-				IL_02df: stloc.s 17
-				IL_02e1: ldloc.s 17
-				IL_02e3: brfalse IL_02ed
+			IL_0277: pop
+			IL_0278: ldloc.s 7
+			IL_027a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_027f: throw
 
-				IL_02e8: br IL_0438
+			IL_0280: throw
 
-				IL_02ed: ldloc.s 11
-				IL_02ef: ldc.r8 0.0
-				IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_02fd: stloc.s 12
-				IL_02ff: ldloc.s 10
-				IL_0301: stloc.s 19
-				IL_0303: ldloc.s 19
-				IL_0305: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_030a: ldc.r8 0.0
-				IL_0313: clt
-				IL_0315: brfalse IL_032c
+			IL_0281: ldarg.0
+			IL_0282: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
+			IL_0287: ldc.i4.1
+			IL_0288: newarr [System.Runtime]System.Object
+			IL_028d: dup
+			IL_028e: ldc.i4.0
+			IL_028f: ldarg.0
+			IL_0290: stelem.ref
+			IL_0291: ldloc.s 6
+			IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0298: stloc.s 15
+			IL_029a: ldloc.s 15
+			IL_029c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02a1: stloc.s 14
+			IL_02a3: ldstr "<\\/?"
+			IL_02a8: ldloc.s 14
+			IL_02aa: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02af: ldstr "\\b[^>]*>"
+			IL_02b4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02b9: stloc.s 14
+			IL_02bb: ldloc.s 14
+			IL_02bd: ldstr "gi"
+			IL_02c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_02c7: stloc.s 8
+			IL_02c9: ldloc.s 8
+			IL_02cb: ldstr "lastIndex"
+			IL_02d0: ldloc.s 4
+			IL_02d2: ldc.i4.1
+			IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_02d8: pop
+			IL_02d9: ldc.r8 0.0
+			IL_02e2: stloc.s 9
+			IL_02e4: ldc.r8 1
+			IL_02ed: neg
+			IL_02ee: stloc.s 18
+			IL_02f0: ldloc.s 18
+			IL_02f2: box [System.Runtime]System.Double
+			IL_02f7: stloc.s 10
+			// loop start (head: IL_02f9)
+				IL_02f9: ldc.i4.1
+				IL_02fa: brfalse IL_0497
 
-				IL_031a: ldloc.s 11
-				IL_031c: ldstr "index"
-				IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0326: stloc.s 15
-				IL_0328: ldloc.s 15
-				IL_032a: stloc.s 10
+				IL_02ff: ldloc.s 8
+				IL_0301: ldstr "exec"
+				IL_0306: ldarg.2
+				IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_030c: stloc.s 11
+				IL_030e: ldloc.s 11
+				IL_0310: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0315: ldc.i4.0
+				IL_0316: ceq
+				IL_0318: stloc.s 17
+				IL_031a: ldloc.s 17
+				IL_031c: brfalse IL_0326
 
-				IL_032c: ldloc.s 12
-				IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0333: stloc.s 15
-				IL_0335: ldc.i4.0
-				IL_0336: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_033b: brfalse IL_0364
+				IL_0321: br IL_0497
 
-				IL_0340: ldloc.s 15
-				IL_0342: isinst [System.Runtime]System.String
-				IL_0347: dup
-				IL_0348: brfalse IL_0363
+				IL_0326: ldloc.s 11
+				IL_0328: ldc.r8 0.0
+				IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0336: stloc.s 12
+				IL_0338: ldloc.s 10
+				IL_033a: stloc.s 19
+				IL_033c: ldloc.s 19
+				IL_033e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0343: ldc.r8 0.0
+				IL_034c: clt
+				IL_034e: brfalse IL_0365
 
-				IL_034d: ldstr "</"
-				IL_0352: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-				IL_0357: box [System.Runtime]System.Boolean
-				IL_035c: stloc.s 15
-				IL_035e: br IL_0377
+				IL_0353: ldloc.s 11
+				IL_0355: ldstr "index"
+				IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_035f: stloc.s 15
+				IL_0361: ldloc.s 15
+				IL_0363: stloc.s 10
 
-				IL_0363: pop
+				IL_0365: ldloc.s 12
+				IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_036c: stloc.s 15
+				IL_036e: ldc.i4.0
+				IL_036f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0374: brfalse IL_03b0
 
-				IL_0364: ldloc.s 15
-				IL_0366: ldstr "startsWith"
-				IL_036b: ldstr "</"
-				IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0375: stloc.s 15
+				IL_0379: ldloc.s 15
+				IL_037b: isinst [System.Runtime]System.String
+				IL_0380: dup
+				IL_0381: brtrue IL_0399
 
-				IL_0377: ldloc.s 15
-				IL_0379: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_037e: stloc.s 17
-				IL_0380: ldloc.s 17
-				IL_0382: brfalse IL_0425
+				IL_0386: pop
+				IL_0387: ldloc.s 15
+				IL_0389: ldstr "startsWith"
+				IL_038e: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0393: dup
+				IL_0394: brfalse IL_03af
 
-				IL_0387: ldloc.s 9
-				IL_0389: ldc.r8 1
-				IL_0392: sub
-				IL_0393: stloc.s 9
-				IL_0395: ldloc.s 9
-				IL_0397: stloc.s 18
-				IL_0399: ldloc.s 18
-				IL_039b: ldc.r8 0.0
-				IL_03a4: ceq
-				IL_03a6: brfalse IL_0420
+				IL_0399: ldstr "</"
+				IL_039e: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+				IL_03a3: box [System.Runtime]System.Boolean
+				IL_03a8: stloc.s 15
+				IL_03aa: br IL_03c3
 
-				IL_03ab: ldarg.2
-				IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_03b1: stloc.s 15
-				IL_03b3: ldloc.s 8
-				IL_03b5: ldstr "lastIndex"
-				IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_03bf: stloc.s 20
-				IL_03c1: ldc.i4.0
-				IL_03c2: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_03c7: brfalse IL_03ea
+				IL_03af: pop
 
-				IL_03cc: ldloc.s 15
-				IL_03ce: isinst [System.Runtime]System.String
-				IL_03d3: dup
-				IL_03d4: brfalse IL_03e9
+				IL_03b0: ldloc.s 15
+				IL_03b2: ldstr "startsWith"
+				IL_03b7: ldstr "</"
+				IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_03c1: stloc.s 15
 
-				IL_03d9: ldloc.s 10
-				IL_03db: ldloc.s 20
-				IL_03dd: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-				IL_03e2: stloc.s 20
-				IL_03e4: br IL_03fc
+				IL_03c3: ldloc.s 15
+				IL_03c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_03ca: stloc.s 17
+				IL_03cc: ldloc.s 17
+				IL_03ce: brfalse IL_0484
 
-				IL_03e9: pop
+				IL_03d3: ldloc.s 9
+				IL_03d5: ldc.r8 1
+				IL_03de: sub
+				IL_03df: stloc.s 9
+				IL_03e1: ldloc.s 9
+				IL_03e3: stloc.s 18
+				IL_03e5: ldloc.s 18
+				IL_03e7: ldc.r8 0.0
+				IL_03f0: ceq
+				IL_03f2: brfalse IL_047f
 
-				IL_03ea: ldloc.s 15
-				IL_03ec: ldstr "substring"
-				IL_03f1: ldloc.s 10
-				IL_03f3: ldloc.s 20
-				IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_03fa: stloc.s 20
+				IL_03f7: ldarg.2
+				IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_03fd: stloc.s 15
+				IL_03ff: ldloc.s 8
+				IL_0401: ldstr "lastIndex"
+				IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_040b: stloc.s 20
+				IL_040d: ldc.i4.0
+				IL_040e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0413: brfalse IL_0449
 
-				IL_03fc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0401: dup
-				IL_0402: ldstr "tagName"
-				IL_0407: ldloc.s 6
-				IL_0409: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_040e: dup
-				IL_040f: ldstr "html"
-				IL_0414: ldloc.s 20
-				IL_0416: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_041b: stloc.s 21
-				IL_041d: ldloc.s 21
-				IL_041f: ret
+				IL_0418: ldloc.s 15
+				IL_041a: isinst [System.Runtime]System.String
+				IL_041f: dup
+				IL_0420: brtrue IL_0438
 
-				IL_0420: br IL_0433
+				IL_0425: pop
+				IL_0426: ldloc.s 15
+				IL_0428: ldstr "substring"
+				IL_042d: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0432: dup
+				IL_0433: brfalse IL_0448
 
-				IL_0425: ldloc.s 9
-				IL_0427: ldc.r8 1
-				IL_0430: add
-				IL_0431: stloc.s 9
+				IL_0438: ldloc.s 10
+				IL_043a: ldloc.s 20
+				IL_043c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+				IL_0441: stloc.s 20
+				IL_0443: br IL_045b
 
-				IL_0433: br IL_02c0
+				IL_0448: pop
+
+				IL_0449: ldloc.s 15
+				IL_044b: ldstr "substring"
+				IL_0450: ldloc.s 10
+				IL_0452: ldloc.s 20
+				IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0459: stloc.s 20
+
+				IL_045b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0460: dup
+				IL_0461: ldstr "tagName"
+				IL_0466: ldloc.s 6
+				IL_0468: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_046d: dup
+				IL_046e: ldstr "html"
+				IL_0473: ldloc.s 20
+				IL_0475: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_047a: stloc.s 21
+				IL_047c: ldloc.s 21
+				IL_047e: ret
+
+				IL_047f: br IL_0492
+
+				IL_0484: ldloc.s 9
+				IL_0486: ldc.r8 1
+				IL_048f: add
+				IL_0490: stloc.s 9
+
+				IL_0492: br IL_02f9
 			// end loop
 
-			IL_0438: ldloc.s 6
-			IL_043a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_043f: stloc.s 14
-			IL_0441: ldstr "Could not find a matching closing </"
-			IL_0446: ldloc.s 14
-			IL_0448: call string [System.Runtime]System.String::Concat(string, string)
-			IL_044d: ldstr "> for id '"
-			IL_0452: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0457: ldarg.3
-			IL_0458: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_045d: stloc.s 14
-			IL_045f: ldloc.s 14
-			IL_0461: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0466: ldstr "'."
-			IL_046b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0470: stloc.s 14
-			IL_0472: ldloc.s 14
-			IL_0474: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0479: stloc.s 13
-			IL_047b: ldloc.s 13
-			IL_047d: isinst [System.Runtime]System.Exception
-			IL_0482: dup
-			IL_0483: brtrue IL_0491
+			IL_0497: ldloc.s 6
+			IL_0499: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_049e: stloc.s 14
+			IL_04a0: ldstr "Could not find a matching closing </"
+			IL_04a5: ldloc.s 14
+			IL_04a7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04ac: ldstr "> for id '"
+			IL_04b1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04b6: ldarg.3
+			IL_04b7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_04bc: stloc.s 14
+			IL_04be: ldloc.s 14
+			IL_04c0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04c5: ldstr "'."
+			IL_04ca: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04cf: stloc.s 14
+			IL_04d1: ldloc.s 14
+			IL_04d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_04d8: stloc.s 13
+			IL_04da: ldloc.s 13
+			IL_04dc: isinst [System.Runtime]System.Exception
+			IL_04e1: dup
+			IL_04e2: brtrue IL_04f0
 
-			IL_0488: pop
-			IL_0489: ldloc.s 13
-			IL_048b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0490: throw
+			IL_04e7: pop
+			IL_04e8: ldloc.s 13
+			IL_04ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_04ef: throw
 
-			IL_0491: throw
+			IL_04f0: throw
 
-			IL_0492: ldnull
-			IL_0493: ret
+			IL_04f1: ldnull
+			IL_04f2: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -5476,7 +5539,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 3152 (0xc50)
+			// Code size: 3209 (0xc89)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -5709,7 +5772,7 @@
 
 			IL_0172: ldloc.0
 			IL_0173: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0178: switch (IL_018d, IL_054e, IL_07d1, IL_0987)
+			IL_0178: switch (IL_018d, IL_0561, IL_07f7, IL_09c0)
 
 			IL_018d: ldarg.0
 			IL_018e: ldc.i4.1
@@ -5928,7 +5991,7 @@
 			IL_03e8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_03ed: stloc.s 23
 			IL_03ef: ldloc.s 23
-			IL_03f1: brfalse IL_082f
+			IL_03f1: brfalse IL_0855
 
 			IL_03f6: ldloc.1
 			IL_03f7: ldstr "indexUrl"
@@ -5939,1003 +6002,1024 @@
 			IL_040a: stloc.s 22
 			IL_040c: ldc.i4.0
 			IL_040d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0412: brfalse IL_0431
+			IL_0412: brfalse IL_0444
 
 			IL_0417: ldloc.s 22
 			IL_0419: isinst [System.Runtime]System.String
 			IL_041e: dup
-			IL_041f: brfalse IL_0430
+			IL_041f: brtrue IL_0437
 
-			IL_0424: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0429: stloc.s 11
-			IL_042b: br IL_043f
+			IL_0424: pop
+			IL_0425: ldloc.s 22
+			IL_0427: ldstr "trim"
+			IL_042c: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0431: dup
+			IL_0432: brfalse IL_0443
 
-			IL_0430: pop
+			IL_0437: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_043c: stloc.s 11
+			IL_043e: br IL_0452
 
-			IL_0431: ldloc.s 22
-			IL_0433: ldstr "trim"
-			IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_043d: stloc.s 11
+			IL_0443: pop
 
-			IL_043f: ldarg.0
-			IL_0440: ldc.i4.1
-			IL_0441: ldelem.ref
-			IL_0442: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0447: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_044c: ldc.i4.1
-			IL_044d: newarr [System.Runtime]System.Object
-			IL_0452: dup
-			IL_0453: ldc.i4.0
-			IL_0454: ldarg.0
-			IL_0455: ldc.i4.1
-			IL_0456: ldelem.ref
-			IL_0457: stelem.ref
-			IL_0458: stloc.s 21
-			IL_045a: ldloc.s 21
-			IL_045c: ldloc.s 11
-			IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0463: stloc.s 22
-			IL_0465: ldloc.0
-			IL_0466: ldc.i4.1
-			IL_0467: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_046c: ldloc.0
-			IL_046d: ldloc.s 22
-			IL_046f: ldarg.0
-			IL_0470: ldc.i4.1
-			IL_0471: ldloc.0
-			IL_0472: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0477: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_047c: ldloc.0
-			IL_047d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0482: dup
-			IL_0483: ldc.i4.0
-			IL_0484: ldloc.1
-			IL_0485: stelem.ref
-			IL_0486: dup
-			IL_0487: ldc.i4.1
-			IL_0488: ldloc.2
-			IL_0489: stelem.ref
-			IL_048a: dup
-			IL_048b: ldc.i4.2
-			IL_048c: ldloc.3
-			IL_048d: stelem.ref
-			IL_048e: dup
-			IL_048f: ldc.i4.3
-			IL_0490: ldloc.s 4
-			IL_0492: stelem.ref
-			IL_0493: dup
-			IL_0494: ldc.i4.4
-			IL_0495: ldloc.s 5
-			IL_0497: stelem.ref
-			IL_0498: dup
-			IL_0499: ldc.i4.5
-			IL_049a: ldloc.s 6
+			IL_0444: ldloc.s 22
+			IL_0446: ldstr "trim"
+			IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0450: stloc.s 11
+
+			IL_0452: ldarg.0
+			IL_0453: ldc.i4.1
+			IL_0454: ldelem.ref
+			IL_0455: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_045a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_045f: ldc.i4.1
+			IL_0460: newarr [System.Runtime]System.Object
+			IL_0465: dup
+			IL_0466: ldc.i4.0
+			IL_0467: ldarg.0
+			IL_0468: ldc.i4.1
+			IL_0469: ldelem.ref
+			IL_046a: stelem.ref
+			IL_046b: stloc.s 21
+			IL_046d: ldloc.s 21
+			IL_046f: ldloc.s 11
+			IL_0471: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0476: stloc.s 22
+			IL_0478: ldloc.0
+			IL_0479: ldc.i4.1
+			IL_047a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_047f: ldloc.0
+			IL_0480: ldloc.s 22
+			IL_0482: ldarg.0
+			IL_0483: ldc.i4.1
+			IL_0484: ldloc.0
+			IL_0485: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_048a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_048f: ldloc.0
+			IL_0490: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0495: dup
+			IL_0496: ldc.i4.0
+			IL_0497: ldloc.1
+			IL_0498: stelem.ref
+			IL_0499: dup
+			IL_049a: ldc.i4.1
+			IL_049b: ldloc.2
 			IL_049c: stelem.ref
 			IL_049d: dup
-			IL_049e: ldc.i4.6
-			IL_049f: ldloc.s 7
-			IL_04a1: stelem.ref
-			IL_04a2: dup
-			IL_04a3: ldc.i4.7
-			IL_04a4: ldloc.s 8
-			IL_04a6: stelem.ref
-			IL_04a7: dup
-			IL_04a8: ldc.i4.8
-			IL_04a9: ldloc.s 9
-			IL_04ab: stelem.ref
-			IL_04ac: dup
-			IL_04ad: ldc.i4.s 9
-			IL_04af: ldloc.s 10
-			IL_04b1: stelem.ref
-			IL_04b2: dup
-			IL_04b3: ldc.i4.s 10
-			IL_04b5: ldloc.s 11
-			IL_04b7: stelem.ref
-			IL_04b8: dup
-			IL_04b9: ldc.i4.s 11
-			IL_04bb: ldloc.s 12
-			IL_04bd: stelem.ref
-			IL_04be: dup
-			IL_04bf: ldc.i4.s 12
-			IL_04c1: ldloc.s 13
-			IL_04c3: stelem.ref
-			IL_04c4: dup
-			IL_04c5: ldc.i4.s 13
-			IL_04c7: ldloc.s 14
-			IL_04c9: stelem.ref
-			IL_04ca: dup
-			IL_04cb: ldc.i4.s 14
-			IL_04cd: ldloc.s 15
-			IL_04cf: stelem.ref
-			IL_04d0: dup
-			IL_04d1: ldc.i4.s 15
-			IL_04d3: ldloc.s 16
-			IL_04d5: stelem.ref
-			IL_04d6: dup
-			IL_04d7: ldc.i4.s 16
-			IL_04d9: ldloc.s 17
-			IL_04db: stelem.ref
-			IL_04dc: dup
-			IL_04dd: ldc.i4.s 17
-			IL_04df: ldloc.s 18
-			IL_04e1: stelem.ref
-			IL_04e2: dup
-			IL_04e3: ldc.i4.s 18
-			IL_04e5: ldloc.s 19
-			IL_04e7: stelem.ref
-			IL_04e8: dup
-			IL_04e9: ldc.i4.s 19
-			IL_04eb: ldloc.s 20
-			IL_04ed: stelem.ref
-			IL_04ee: dup
-			IL_04ef: ldc.i4.s 20
-			IL_04f1: ldloc.s 21
-			IL_04f3: stelem.ref
-			IL_04f4: dup
-			IL_04f5: ldc.i4.s 21
-			IL_04f7: ldloc.s 22
-			IL_04f9: stelem.ref
-			IL_04fa: dup
-			IL_04fb: ldc.i4.s 22
-			IL_04fd: ldloc.s 23
-			IL_04ff: box [System.Runtime]System.Boolean
-			IL_0504: stelem.ref
-			IL_0505: dup
-			IL_0506: ldc.i4.s 23
-			IL_0508: ldloc.s 24
-			IL_050a: stelem.ref
-			IL_050b: dup
-			IL_050c: ldc.i4.s 24
-			IL_050e: ldloc.s 25
-			IL_0510: stelem.ref
-			IL_0511: dup
-			IL_0512: ldc.i4.s 25
-			IL_0514: ldloc.s 26
-			IL_0516: stelem.ref
-			IL_0517: dup
-			IL_0518: ldc.i4.s 26
-			IL_051a: ldloc.s 27
-			IL_051c: stelem.ref
-			IL_051d: dup
-			IL_051e: ldc.i4.s 27
-			IL_0520: ldloc.s 28
-			IL_0522: stelem.ref
-			IL_0523: dup
-			IL_0524: ldc.i4.s 28
-			IL_0526: ldloc.s 29
-			IL_0528: stelem.ref
-			IL_0529: dup
-			IL_052a: ldc.i4.s 29
-			IL_052c: ldloc.s 30
-			IL_052e: stelem.ref
-			IL_052f: dup
-			IL_0530: ldc.i4.s 30
-			IL_0532: ldloc.s 31
-			IL_0534: stelem.ref
-			IL_0535: dup
-			IL_0536: ldc.i4.s 31
-			IL_0538: ldloc.s 32
-			IL_053a: stelem.ref
-			IL_053b: dup
-			IL_053c: ldc.i4.s 32
-			IL_053e: ldloc.s 33
-			IL_0540: stelem.ref
-			IL_0541: pop
-			IL_0542: ldloc.0
-			IL_0543: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0548: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_054d: ret
+			IL_049e: ldc.i4.2
+			IL_049f: ldloc.3
+			IL_04a0: stelem.ref
+			IL_04a1: dup
+			IL_04a2: ldc.i4.3
+			IL_04a3: ldloc.s 4
+			IL_04a5: stelem.ref
+			IL_04a6: dup
+			IL_04a7: ldc.i4.4
+			IL_04a8: ldloc.s 5
+			IL_04aa: stelem.ref
+			IL_04ab: dup
+			IL_04ac: ldc.i4.5
+			IL_04ad: ldloc.s 6
+			IL_04af: stelem.ref
+			IL_04b0: dup
+			IL_04b1: ldc.i4.6
+			IL_04b2: ldloc.s 7
+			IL_04b4: stelem.ref
+			IL_04b5: dup
+			IL_04b6: ldc.i4.7
+			IL_04b7: ldloc.s 8
+			IL_04b9: stelem.ref
+			IL_04ba: dup
+			IL_04bb: ldc.i4.8
+			IL_04bc: ldloc.s 9
+			IL_04be: stelem.ref
+			IL_04bf: dup
+			IL_04c0: ldc.i4.s 9
+			IL_04c2: ldloc.s 10
+			IL_04c4: stelem.ref
+			IL_04c5: dup
+			IL_04c6: ldc.i4.s 10
+			IL_04c8: ldloc.s 11
+			IL_04ca: stelem.ref
+			IL_04cb: dup
+			IL_04cc: ldc.i4.s 11
+			IL_04ce: ldloc.s 12
+			IL_04d0: stelem.ref
+			IL_04d1: dup
+			IL_04d2: ldc.i4.s 12
+			IL_04d4: ldloc.s 13
+			IL_04d6: stelem.ref
+			IL_04d7: dup
+			IL_04d8: ldc.i4.s 13
+			IL_04da: ldloc.s 14
+			IL_04dc: stelem.ref
+			IL_04dd: dup
+			IL_04de: ldc.i4.s 14
+			IL_04e0: ldloc.s 15
+			IL_04e2: stelem.ref
+			IL_04e3: dup
+			IL_04e4: ldc.i4.s 15
+			IL_04e6: ldloc.s 16
+			IL_04e8: stelem.ref
+			IL_04e9: dup
+			IL_04ea: ldc.i4.s 16
+			IL_04ec: ldloc.s 17
+			IL_04ee: stelem.ref
+			IL_04ef: dup
+			IL_04f0: ldc.i4.s 17
+			IL_04f2: ldloc.s 18
+			IL_04f4: stelem.ref
+			IL_04f5: dup
+			IL_04f6: ldc.i4.s 18
+			IL_04f8: ldloc.s 19
+			IL_04fa: stelem.ref
+			IL_04fb: dup
+			IL_04fc: ldc.i4.s 19
+			IL_04fe: ldloc.s 20
+			IL_0500: stelem.ref
+			IL_0501: dup
+			IL_0502: ldc.i4.s 20
+			IL_0504: ldloc.s 21
+			IL_0506: stelem.ref
+			IL_0507: dup
+			IL_0508: ldc.i4.s 21
+			IL_050a: ldloc.s 22
+			IL_050c: stelem.ref
+			IL_050d: dup
+			IL_050e: ldc.i4.s 22
+			IL_0510: ldloc.s 23
+			IL_0512: box [System.Runtime]System.Boolean
+			IL_0517: stelem.ref
+			IL_0518: dup
+			IL_0519: ldc.i4.s 23
+			IL_051b: ldloc.s 24
+			IL_051d: stelem.ref
+			IL_051e: dup
+			IL_051f: ldc.i4.s 24
+			IL_0521: ldloc.s 25
+			IL_0523: stelem.ref
+			IL_0524: dup
+			IL_0525: ldc.i4.s 25
+			IL_0527: ldloc.s 26
+			IL_0529: stelem.ref
+			IL_052a: dup
+			IL_052b: ldc.i4.s 26
+			IL_052d: ldloc.s 27
+			IL_052f: stelem.ref
+			IL_0530: dup
+			IL_0531: ldc.i4.s 27
+			IL_0533: ldloc.s 28
+			IL_0535: stelem.ref
+			IL_0536: dup
+			IL_0537: ldc.i4.s 28
+			IL_0539: ldloc.s 29
+			IL_053b: stelem.ref
+			IL_053c: dup
+			IL_053d: ldc.i4.s 29
+			IL_053f: ldloc.s 30
+			IL_0541: stelem.ref
+			IL_0542: dup
+			IL_0543: ldc.i4.s 30
+			IL_0545: ldloc.s 31
+			IL_0547: stelem.ref
+			IL_0548: dup
+			IL_0549: ldc.i4.s 31
+			IL_054b: ldloc.s 32
+			IL_054d: stelem.ref
+			IL_054e: dup
+			IL_054f: ldc.i4.s 32
+			IL_0551: ldloc.s 33
+			IL_0553: stelem.ref
+			IL_0554: pop
+			IL_0555: ldloc.0
+			IL_0556: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_055b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0560: ret
 
-			IL_054e: ldloc.0
-			IL_054f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
-			IL_0554: stloc.s 12
-			IL_0556: ldarg.0
-			IL_0557: ldc.i4.1
-			IL_0558: ldelem.ref
-			IL_0559: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_055e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
-			IL_0563: stloc.s 22
-			IL_0565: ldc.i4.1
-			IL_0566: newarr [System.Runtime]System.Object
-			IL_056b: dup
-			IL_056c: ldc.i4.0
-			IL_056d: ldarg.0
-			IL_056e: ldc.i4.1
-			IL_056f: ldelem.ref
-			IL_0570: stelem.ref
-			IL_0571: stloc.s 21
-			IL_0573: ldloc.1
-			IL_0574: ldstr "section"
-			IL_0579: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_057e: stloc.s 26
-			IL_0580: ldloc.s 26
-			IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0587: stloc.s 26
-			IL_0589: ldc.i4.0
-			IL_058a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_058f: brfalse IL_05ae
+			IL_0561: ldloc.0
+			IL_0562: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_0567: stloc.s 12
+			IL_0569: ldarg.0
+			IL_056a: ldc.i4.1
+			IL_056b: ldelem.ref
+			IL_056c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0571: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
+			IL_0576: stloc.s 22
+			IL_0578: ldc.i4.1
+			IL_0579: newarr [System.Runtime]System.Object
+			IL_057e: dup
+			IL_057f: ldc.i4.0
+			IL_0580: ldarg.0
+			IL_0581: ldc.i4.1
+			IL_0582: ldelem.ref
+			IL_0583: stelem.ref
+			IL_0584: stloc.s 21
+			IL_0586: ldloc.1
+			IL_0587: ldstr "section"
+			IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0591: stloc.s 26
+			IL_0593: ldloc.s 26
+			IL_0595: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_059a: stloc.s 26
+			IL_059c: ldc.i4.0
+			IL_059d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_05a2: brfalse IL_05d4
 
-			IL_0594: ldloc.s 26
-			IL_0596: isinst [System.Runtime]System.String
-			IL_059b: dup
-			IL_059c: brfalse IL_05ad
+			IL_05a7: ldloc.s 26
+			IL_05a9: isinst [System.Runtime]System.String
+			IL_05ae: dup
+			IL_05af: brtrue IL_05c7
 
-			IL_05a1: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_05a6: stloc.s 26
-			IL_05a8: br IL_05bc
+			IL_05b4: pop
+			IL_05b5: ldloc.s 26
+			IL_05b7: ldstr "trim"
+			IL_05bc: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_05c1: dup
+			IL_05c2: brfalse IL_05d3
 
-			IL_05ad: pop
+			IL_05c7: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_05cc: stloc.s 26
+			IL_05ce: br IL_05e2
 
-			IL_05ae: ldloc.s 26
-			IL_05b0: ldstr "trim"
-			IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_05ba: stloc.s 26
+			IL_05d3: pop
 
-			IL_05bc: ldloc.s 22
-			IL_05be: ldloc.s 21
-			IL_05c0: ldloc.s 12
-			IL_05c2: ldloc.s 26
-			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05c9: stloc.s 13
-			IL_05cb: ldloc.s 13
-			IL_05cd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_05d2: ldc.i4.0
-			IL_05d3: ceq
-			IL_05d5: stloc.s 23
-			IL_05d7: ldloc.s 23
-			IL_05d9: brfalse IL_0655
+			IL_05d4: ldloc.s 26
+			IL_05d6: ldstr "trim"
+			IL_05db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_05e0: stloc.s 26
 
-			IL_05de: ldloc.1
-			IL_05df: ldstr "section"
-			IL_05e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05e9: stloc.s 26
-			IL_05eb: ldloc.s 26
-			IL_05ed: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05f2: stloc.s 27
-			IL_05f4: ldstr "Could not find section '"
-			IL_05f9: ldloc.s 27
-			IL_05fb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0600: ldstr "' in multipage index: "
-			IL_0605: call string [System.Runtime]System.String::Concat(string, string)
-			IL_060a: ldloc.s 11
-			IL_060c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0611: stloc.s 27
-			IL_0613: ldloc.s 27
-			IL_0615: call string [System.Runtime]System.String::Concat(string, string)
-			IL_061a: stloc.s 27
-			IL_061c: ldloc.s 27
-			IL_061e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0623: stloc.s 14
-			IL_0625: ldloc.0
-			IL_0626: ldc.i4.m1
-			IL_0627: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_062c: ldloc.0
-			IL_062d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0632: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0637: ldarg.0
-			IL_0638: ldc.i4.1
-			IL_0639: newarr [System.Runtime]System.Object
-			IL_063e: dup
-			IL_063f: ldc.i4.0
-			IL_0640: ldloc.s 14
-			IL_0642: stelem.ref
-			IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0648: pop
-			IL_0649: ldloc.0
-			IL_064a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_064f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0654: ret
+			IL_05e2: ldloc.s 22
+			IL_05e4: ldloc.s 21
+			IL_05e6: ldloc.s 12
+			IL_05e8: ldloc.s 26
+			IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05ef: stloc.s 13
+			IL_05f1: ldloc.s 13
+			IL_05f3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_05f8: ldc.i4.0
+			IL_05f9: ceq
+			IL_05fb: stloc.s 23
+			IL_05fd: ldloc.s 23
+			IL_05ff: brfalse IL_067b
 
-			IL_0655: ldarg.0
-			IL_0656: ldc.i4.1
-			IL_0657: ldelem.ref
-			IL_0658: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_065d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_0662: stloc.s 26
-			IL_0664: ldloc.s 13
-			IL_0666: ldstr "filePart"
-			IL_066b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0670: stloc.s 22
-			IL_0672: ldloc.s 22
-			IL_0674: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0679: stloc.s 23
-			IL_067b: ldloc.s 23
-			IL_067d: brtrue IL_0699
+			IL_0604: ldloc.1
+			IL_0605: ldstr "section"
+			IL_060a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_060f: stloc.s 26
+			IL_0611: ldloc.s 26
+			IL_0613: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0618: stloc.s 27
+			IL_061a: ldstr "Could not find section '"
+			IL_061f: ldloc.s 27
+			IL_0621: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0626: ldstr "' in multipage index: "
+			IL_062b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0630: ldloc.s 11
+			IL_0632: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0637: stloc.s 27
+			IL_0639: ldloc.s 27
+			IL_063b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0640: stloc.s 27
+			IL_0642: ldloc.s 27
+			IL_0644: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0649: stloc.s 14
+			IL_064b: ldloc.0
+			IL_064c: ldc.i4.m1
+			IL_064d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0652: ldloc.0
+			IL_0653: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0658: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_065d: ldarg.0
+			IL_065e: ldc.i4.1
+			IL_065f: newarr [System.Runtime]System.Object
+			IL_0664: dup
+			IL_0665: ldc.i4.0
+			IL_0666: ldloc.s 14
+			IL_0668: stelem.ref
+			IL_0669: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_066e: pop
+			IL_066f: ldloc.0
+			IL_0670: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0675: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_067a: ret
 
-			IL_0682: ldloc.s 13
-			IL_0684: ldstr "href"
-			IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_068e: stloc.s 28
-			IL_0690: ldloc.s 28
-			IL_0692: stloc.s 29
-			IL_0694: br IL_069d
+			IL_067b: ldarg.0
+			IL_067c: ldc.i4.1
+			IL_067d: ldelem.ref
+			IL_067e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0683: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_0688: stloc.s 26
+			IL_068a: ldloc.s 13
+			IL_068c: ldstr "filePart"
+			IL_0691: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0696: stloc.s 22
+			IL_0698: ldloc.s 22
+			IL_069a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_069f: stloc.s 23
+			IL_06a1: ldloc.s 23
+			IL_06a3: brtrue IL_06bf
 
-			IL_0699: ldloc.s 22
-			IL_069b: stloc.s 29
+			IL_06a8: ldloc.s 13
+			IL_06aa: ldstr "href"
+			IL_06af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06b4: stloc.s 28
+			IL_06b6: ldloc.s 28
+			IL_06b8: stloc.s 29
+			IL_06ba: br IL_06c3
 
-			IL_069d: ldloc.s 26
-			IL_069f: dup
-			IL_06a0: ldloc.s 29
-			IL_06a2: ldloc.s 11
-			IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
-			IL_06a9: stloc.s 26
-			IL_06ab: ldloc.s 26
-			IL_06ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06b2: stloc.s 26
-			IL_06b4: ldloc.s 26
-			IL_06b6: ldstr "toString"
-			IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_06c0: stloc.s 15
-			IL_06c2: ldarg.0
-			IL_06c3: ldc.i4.1
-			IL_06c4: ldelem.ref
-			IL_06c5: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_06ca: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_06cf: ldc.i4.1
-			IL_06d0: newarr [System.Runtime]System.Object
-			IL_06d5: dup
-			IL_06d6: ldc.i4.0
-			IL_06d7: ldarg.0
-			IL_06d8: ldc.i4.1
-			IL_06d9: ldelem.ref
-			IL_06da: stelem.ref
-			IL_06db: stloc.s 21
-			IL_06dd: ldloc.s 21
-			IL_06df: ldloc.s 15
-			IL_06e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_06e6: stloc.s 26
-			IL_06e8: ldloc.0
-			IL_06e9: ldc.i4.2
-			IL_06ea: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06ef: ldloc.0
-			IL_06f0: ldloc.s 26
-			IL_06f2: ldarg.0
-			IL_06f3: ldc.i4.2
-			IL_06f4: ldloc.0
-			IL_06f5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_06fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_06ff: ldloc.0
-			IL_0700: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0705: dup
-			IL_0706: ldc.i4.0
-			IL_0707: ldloc.1
-			IL_0708: stelem.ref
-			IL_0709: dup
-			IL_070a: ldc.i4.1
-			IL_070b: ldloc.2
-			IL_070c: stelem.ref
-			IL_070d: dup
-			IL_070e: ldc.i4.2
-			IL_070f: ldloc.3
-			IL_0710: stelem.ref
-			IL_0711: dup
-			IL_0712: ldc.i4.3
-			IL_0713: ldloc.s 4
-			IL_0715: stelem.ref
-			IL_0716: dup
-			IL_0717: ldc.i4.4
-			IL_0718: ldloc.s 5
-			IL_071a: stelem.ref
-			IL_071b: dup
-			IL_071c: ldc.i4.5
-			IL_071d: ldloc.s 6
-			IL_071f: stelem.ref
-			IL_0720: dup
-			IL_0721: ldc.i4.6
-			IL_0722: ldloc.s 7
-			IL_0724: stelem.ref
-			IL_0725: dup
-			IL_0726: ldc.i4.7
-			IL_0727: ldloc.s 8
-			IL_0729: stelem.ref
-			IL_072a: dup
-			IL_072b: ldc.i4.8
-			IL_072c: ldloc.s 9
+			IL_06bf: ldloc.s 22
+			IL_06c1: stloc.s 29
+
+			IL_06c3: ldloc.s 26
+			IL_06c5: dup
+			IL_06c6: ldloc.s 29
+			IL_06c8: ldloc.s 11
+			IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
+			IL_06cf: stloc.s 26
+			IL_06d1: ldloc.s 26
+			IL_06d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06d8: stloc.s 26
+			IL_06da: ldloc.s 26
+			IL_06dc: ldstr "toString"
+			IL_06e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_06e6: stloc.s 15
+			IL_06e8: ldarg.0
+			IL_06e9: ldc.i4.1
+			IL_06ea: ldelem.ref
+			IL_06eb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_06f0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_06f5: ldc.i4.1
+			IL_06f6: newarr [System.Runtime]System.Object
+			IL_06fb: dup
+			IL_06fc: ldc.i4.0
+			IL_06fd: ldarg.0
+			IL_06fe: ldc.i4.1
+			IL_06ff: ldelem.ref
+			IL_0700: stelem.ref
+			IL_0701: stloc.s 21
+			IL_0703: ldloc.s 21
+			IL_0705: ldloc.s 15
+			IL_0707: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_070c: stloc.s 26
+			IL_070e: ldloc.0
+			IL_070f: ldc.i4.2
+			IL_0710: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0715: ldloc.0
+			IL_0716: ldloc.s 26
+			IL_0718: ldarg.0
+			IL_0719: ldc.i4.2
+			IL_071a: ldloc.0
+			IL_071b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0720: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_0725: ldloc.0
+			IL_0726: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_072b: dup
+			IL_072c: ldc.i4.0
+			IL_072d: ldloc.1
 			IL_072e: stelem.ref
 			IL_072f: dup
-			IL_0730: ldc.i4.s 9
-			IL_0732: ldloc.s 10
-			IL_0734: stelem.ref
-			IL_0735: dup
-			IL_0736: ldc.i4.s 10
-			IL_0738: ldloc.s 11
-			IL_073a: stelem.ref
-			IL_073b: dup
-			IL_073c: ldc.i4.s 11
-			IL_073e: ldloc.s 12
+			IL_0730: ldc.i4.1
+			IL_0731: ldloc.2
+			IL_0732: stelem.ref
+			IL_0733: dup
+			IL_0734: ldc.i4.2
+			IL_0735: ldloc.3
+			IL_0736: stelem.ref
+			IL_0737: dup
+			IL_0738: ldc.i4.3
+			IL_0739: ldloc.s 4
+			IL_073b: stelem.ref
+			IL_073c: dup
+			IL_073d: ldc.i4.4
+			IL_073e: ldloc.s 5
 			IL_0740: stelem.ref
 			IL_0741: dup
-			IL_0742: ldc.i4.s 12
-			IL_0744: ldloc.s 13
-			IL_0746: stelem.ref
-			IL_0747: dup
-			IL_0748: ldc.i4.s 13
-			IL_074a: ldloc.s 14
-			IL_074c: stelem.ref
-			IL_074d: dup
-			IL_074e: ldc.i4.s 14
-			IL_0750: ldloc.s 15
-			IL_0752: stelem.ref
-			IL_0753: dup
-			IL_0754: ldc.i4.s 15
-			IL_0756: ldloc.s 16
-			IL_0758: stelem.ref
-			IL_0759: dup
-			IL_075a: ldc.i4.s 16
-			IL_075c: ldloc.s 17
-			IL_075e: stelem.ref
-			IL_075f: dup
-			IL_0760: ldc.i4.s 17
-			IL_0762: ldloc.s 18
-			IL_0764: stelem.ref
-			IL_0765: dup
-			IL_0766: ldc.i4.s 18
-			IL_0768: ldloc.s 19
-			IL_076a: stelem.ref
-			IL_076b: dup
-			IL_076c: ldc.i4.s 19
-			IL_076e: ldloc.s 20
-			IL_0770: stelem.ref
-			IL_0771: dup
-			IL_0772: ldc.i4.s 20
-			IL_0774: ldloc.s 21
-			IL_0776: stelem.ref
-			IL_0777: dup
-			IL_0778: ldc.i4.s 21
-			IL_077a: ldloc.s 22
-			IL_077c: stelem.ref
-			IL_077d: dup
-			IL_077e: ldc.i4.s 22
-			IL_0780: ldloc.s 23
-			IL_0782: box [System.Runtime]System.Boolean
-			IL_0787: stelem.ref
-			IL_0788: dup
-			IL_0789: ldc.i4.s 23
-			IL_078b: ldloc.s 24
-			IL_078d: stelem.ref
-			IL_078e: dup
-			IL_078f: ldc.i4.s 24
-			IL_0791: ldloc.s 25
-			IL_0793: stelem.ref
-			IL_0794: dup
-			IL_0795: ldc.i4.s 25
-			IL_0797: ldloc.s 26
-			IL_0799: stelem.ref
-			IL_079a: dup
-			IL_079b: ldc.i4.s 26
-			IL_079d: ldloc.s 27
-			IL_079f: stelem.ref
-			IL_07a0: dup
-			IL_07a1: ldc.i4.s 27
-			IL_07a3: ldloc.s 28
-			IL_07a5: stelem.ref
-			IL_07a6: dup
-			IL_07a7: ldc.i4.s 28
-			IL_07a9: ldloc.s 29
-			IL_07ab: stelem.ref
-			IL_07ac: dup
-			IL_07ad: ldc.i4.s 29
-			IL_07af: ldloc.s 30
-			IL_07b1: stelem.ref
-			IL_07b2: dup
-			IL_07b3: ldc.i4.s 30
-			IL_07b5: ldloc.s 31
-			IL_07b7: stelem.ref
-			IL_07b8: dup
-			IL_07b9: ldc.i4.s 31
-			IL_07bb: ldloc.s 32
-			IL_07bd: stelem.ref
-			IL_07be: dup
-			IL_07bf: ldc.i4.s 32
-			IL_07c1: ldloc.s 33
-			IL_07c3: stelem.ref
-			IL_07c4: pop
-			IL_07c5: ldloc.0
-			IL_07c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07cb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_07d0: ret
+			IL_0742: ldc.i4.5
+			IL_0743: ldloc.s 6
+			IL_0745: stelem.ref
+			IL_0746: dup
+			IL_0747: ldc.i4.6
+			IL_0748: ldloc.s 7
+			IL_074a: stelem.ref
+			IL_074b: dup
+			IL_074c: ldc.i4.7
+			IL_074d: ldloc.s 8
+			IL_074f: stelem.ref
+			IL_0750: dup
+			IL_0751: ldc.i4.8
+			IL_0752: ldloc.s 9
+			IL_0754: stelem.ref
+			IL_0755: dup
+			IL_0756: ldc.i4.s 9
+			IL_0758: ldloc.s 10
+			IL_075a: stelem.ref
+			IL_075b: dup
+			IL_075c: ldc.i4.s 10
+			IL_075e: ldloc.s 11
+			IL_0760: stelem.ref
+			IL_0761: dup
+			IL_0762: ldc.i4.s 11
+			IL_0764: ldloc.s 12
+			IL_0766: stelem.ref
+			IL_0767: dup
+			IL_0768: ldc.i4.s 12
+			IL_076a: ldloc.s 13
+			IL_076c: stelem.ref
+			IL_076d: dup
+			IL_076e: ldc.i4.s 13
+			IL_0770: ldloc.s 14
+			IL_0772: stelem.ref
+			IL_0773: dup
+			IL_0774: ldc.i4.s 14
+			IL_0776: ldloc.s 15
+			IL_0778: stelem.ref
+			IL_0779: dup
+			IL_077a: ldc.i4.s 15
+			IL_077c: ldloc.s 16
+			IL_077e: stelem.ref
+			IL_077f: dup
+			IL_0780: ldc.i4.s 16
+			IL_0782: ldloc.s 17
+			IL_0784: stelem.ref
+			IL_0785: dup
+			IL_0786: ldc.i4.s 17
+			IL_0788: ldloc.s 18
+			IL_078a: stelem.ref
+			IL_078b: dup
+			IL_078c: ldc.i4.s 18
+			IL_078e: ldloc.s 19
+			IL_0790: stelem.ref
+			IL_0791: dup
+			IL_0792: ldc.i4.s 19
+			IL_0794: ldloc.s 20
+			IL_0796: stelem.ref
+			IL_0797: dup
+			IL_0798: ldc.i4.s 20
+			IL_079a: ldloc.s 21
+			IL_079c: stelem.ref
+			IL_079d: dup
+			IL_079e: ldc.i4.s 21
+			IL_07a0: ldloc.s 22
+			IL_07a2: stelem.ref
+			IL_07a3: dup
+			IL_07a4: ldc.i4.s 22
+			IL_07a6: ldloc.s 23
+			IL_07a8: box [System.Runtime]System.Boolean
+			IL_07ad: stelem.ref
+			IL_07ae: dup
+			IL_07af: ldc.i4.s 23
+			IL_07b1: ldloc.s 24
+			IL_07b3: stelem.ref
+			IL_07b4: dup
+			IL_07b5: ldc.i4.s 24
+			IL_07b7: ldloc.s 25
+			IL_07b9: stelem.ref
+			IL_07ba: dup
+			IL_07bb: ldc.i4.s 25
+			IL_07bd: ldloc.s 26
+			IL_07bf: stelem.ref
+			IL_07c0: dup
+			IL_07c1: ldc.i4.s 26
+			IL_07c3: ldloc.s 27
+			IL_07c5: stelem.ref
+			IL_07c6: dup
+			IL_07c7: ldc.i4.s 27
+			IL_07c9: ldloc.s 28
+			IL_07cb: stelem.ref
+			IL_07cc: dup
+			IL_07cd: ldc.i4.s 28
+			IL_07cf: ldloc.s 29
+			IL_07d1: stelem.ref
+			IL_07d2: dup
+			IL_07d3: ldc.i4.s 29
+			IL_07d5: ldloc.s 30
+			IL_07d7: stelem.ref
+			IL_07d8: dup
+			IL_07d9: ldc.i4.s 30
+			IL_07db: ldloc.s 31
+			IL_07dd: stelem.ref
+			IL_07de: dup
+			IL_07df: ldc.i4.s 31
+			IL_07e1: ldloc.s 32
+			IL_07e3: stelem.ref
+			IL_07e4: dup
+			IL_07e5: ldc.i4.s 32
+			IL_07e7: ldloc.s 33
+			IL_07e9: stelem.ref
+			IL_07ea: pop
+			IL_07eb: ldloc.0
+			IL_07ec: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_07f1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_07f6: ret
 
-			IL_07d1: ldloc.0
-			IL_07d2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_07d7: stloc.s 26
-			IL_07d9: ldloc.s 26
-			IL_07db: stloc.s 8
-			IL_07dd: ldloc.s 15
-			IL_07df: stloc.s 26
-			IL_07e1: ldloc.s 26
-			IL_07e3: stloc.s 10
-			IL_07e5: ldloc.s 9
-			IL_07e7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_07ec: ldc.i4.0
-			IL_07ed: ceq
-			IL_07ef: stloc.s 23
-			IL_07f1: ldloc.s 23
-			IL_07f3: brfalse IL_082a
+			IL_07f7: ldloc.0
+			IL_07f8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_07fd: stloc.s 26
+			IL_07ff: ldloc.s 26
+			IL_0801: stloc.s 8
+			IL_0803: ldloc.s 15
+			IL_0805: stloc.s 26
+			IL_0807: ldloc.s 26
+			IL_0809: stloc.s 10
+			IL_080b: ldloc.s 9
+			IL_080d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0812: ldc.i4.0
+			IL_0813: ceq
+			IL_0815: stloc.s 23
+			IL_0817: ldloc.s 23
+			IL_0819: brfalse IL_0850
 
-			IL_07f8: ldloc.s 13
-			IL_07fa: ldstr "fragment"
-			IL_07ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0804: stloc.s 26
-			IL_0806: ldloc.s 26
-			IL_0808: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_080d: stloc.s 23
-			IL_080f: ldloc.s 23
-			IL_0811: brtrue IL_0822
+			IL_081e: ldloc.s 13
+			IL_0820: ldstr "fragment"
+			IL_0825: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_082a: stloc.s 26
+			IL_082c: ldloc.s 26
+			IL_082e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0833: stloc.s 23
+			IL_0835: ldloc.s 23
+			IL_0837: brtrue IL_0848
 
-			IL_0816: ldstr ""
-			IL_081b: stloc.s 30
-			IL_081d: br IL_0826
+			IL_083c: ldstr ""
+			IL_0841: stloc.s 30
+			IL_0843: br IL_084c
 
-			IL_0822: ldloc.s 26
-			IL_0824: stloc.s 30
+			IL_0848: ldloc.s 26
+			IL_084a: stloc.s 30
 
-			IL_0826: ldloc.s 30
-			IL_0828: stloc.s 9
+			IL_084c: ldloc.s 30
+			IL_084e: stloc.s 9
 
-			IL_082a: br IL_099b
+			IL_0850: br IL_09d4
 
-			IL_082f: ldloc.1
-			IL_0830: ldstr "url"
-			IL_0835: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_083a: stloc.s 26
-			IL_083c: ldloc.s 26
-			IL_083e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0843: stloc.s 26
-			IL_0845: ldc.i4.0
-			IL_0846: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_084b: brfalse IL_086a
+			IL_0855: ldloc.1
+			IL_0856: ldstr "url"
+			IL_085b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0860: stloc.s 26
+			IL_0862: ldloc.s 26
+			IL_0864: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0869: stloc.s 26
+			IL_086b: ldc.i4.0
+			IL_086c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0871: brfalse IL_08a3
 
-			IL_0850: ldloc.s 26
-			IL_0852: isinst [System.Runtime]System.String
-			IL_0857: dup
-			IL_0858: brfalse IL_0869
+			IL_0876: ldloc.s 26
+			IL_0878: isinst [System.Runtime]System.String
+			IL_087d: dup
+			IL_087e: brtrue IL_0896
 
-			IL_085d: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0862: stloc.s 16
-			IL_0864: br IL_0878
+			IL_0883: pop
+			IL_0884: ldloc.s 26
+			IL_0886: ldstr "trim"
+			IL_088b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0890: dup
+			IL_0891: brfalse IL_08a2
 
-			IL_0869: pop
+			IL_0896: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_089b: stloc.s 16
+			IL_089d: br IL_08b1
 
-			IL_086a: ldloc.s 26
-			IL_086c: ldstr "trim"
-			IL_0871: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0876: stloc.s 16
+			IL_08a2: pop
 
-			IL_0878: ldarg.0
-			IL_0879: ldc.i4.1
-			IL_087a: ldelem.ref
-			IL_087b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0880: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0885: ldc.i4.1
-			IL_0886: newarr [System.Runtime]System.Object
-			IL_088b: dup
-			IL_088c: ldc.i4.0
-			IL_088d: ldarg.0
-			IL_088e: ldc.i4.1
-			IL_088f: ldelem.ref
-			IL_0890: stelem.ref
-			IL_0891: stloc.s 21
-			IL_0893: ldloc.s 21
-			IL_0895: ldloc.s 16
-			IL_0897: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_089c: stloc.s 26
-			IL_089e: ldloc.0
-			IL_089f: ldc.i4.3
-			IL_08a0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_08a5: ldloc.0
-			IL_08a6: ldloc.s 26
-			IL_08a8: ldarg.0
-			IL_08a9: ldc.i4.3
-			IL_08aa: ldloc.0
-			IL_08ab: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_08b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_08b5: ldloc.0
-			IL_08b6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_08bb: dup
-			IL_08bc: ldc.i4.0
-			IL_08bd: ldloc.1
-			IL_08be: stelem.ref
-			IL_08bf: dup
-			IL_08c0: ldc.i4.1
-			IL_08c1: ldloc.2
-			IL_08c2: stelem.ref
-			IL_08c3: dup
-			IL_08c4: ldc.i4.2
-			IL_08c5: ldloc.3
-			IL_08c6: stelem.ref
-			IL_08c7: dup
-			IL_08c8: ldc.i4.3
-			IL_08c9: ldloc.s 4
-			IL_08cb: stelem.ref
-			IL_08cc: dup
-			IL_08cd: ldc.i4.4
-			IL_08ce: ldloc.s 5
-			IL_08d0: stelem.ref
-			IL_08d1: dup
-			IL_08d2: ldc.i4.5
-			IL_08d3: ldloc.s 6
-			IL_08d5: stelem.ref
-			IL_08d6: dup
-			IL_08d7: ldc.i4.6
-			IL_08d8: ldloc.s 7
-			IL_08da: stelem.ref
-			IL_08db: dup
-			IL_08dc: ldc.i4.7
-			IL_08dd: ldloc.s 8
-			IL_08df: stelem.ref
-			IL_08e0: dup
-			IL_08e1: ldc.i4.8
-			IL_08e2: ldloc.s 9
-			IL_08e4: stelem.ref
-			IL_08e5: dup
-			IL_08e6: ldc.i4.s 9
-			IL_08e8: ldloc.s 10
-			IL_08ea: stelem.ref
-			IL_08eb: dup
-			IL_08ec: ldc.i4.s 10
-			IL_08ee: ldloc.s 11
-			IL_08f0: stelem.ref
-			IL_08f1: dup
-			IL_08f2: ldc.i4.s 11
-			IL_08f4: ldloc.s 12
-			IL_08f6: stelem.ref
-			IL_08f7: dup
-			IL_08f8: ldc.i4.s 12
-			IL_08fa: ldloc.s 13
-			IL_08fc: stelem.ref
-			IL_08fd: dup
-			IL_08fe: ldc.i4.s 13
-			IL_0900: ldloc.s 14
-			IL_0902: stelem.ref
-			IL_0903: dup
-			IL_0904: ldc.i4.s 14
-			IL_0906: ldloc.s 15
-			IL_0908: stelem.ref
-			IL_0909: dup
-			IL_090a: ldc.i4.s 15
-			IL_090c: ldloc.s 16
+			IL_08a3: ldloc.s 26
+			IL_08a5: ldstr "trim"
+			IL_08aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_08af: stloc.s 16
+
+			IL_08b1: ldarg.0
+			IL_08b2: ldc.i4.1
+			IL_08b3: ldelem.ref
+			IL_08b4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_08b9: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_08be: ldc.i4.1
+			IL_08bf: newarr [System.Runtime]System.Object
+			IL_08c4: dup
+			IL_08c5: ldc.i4.0
+			IL_08c6: ldarg.0
+			IL_08c7: ldc.i4.1
+			IL_08c8: ldelem.ref
+			IL_08c9: stelem.ref
+			IL_08ca: stloc.s 21
+			IL_08cc: ldloc.s 21
+			IL_08ce: ldloc.s 16
+			IL_08d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_08d5: stloc.s 26
+			IL_08d7: ldloc.0
+			IL_08d8: ldc.i4.3
+			IL_08d9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08de: ldloc.0
+			IL_08df: ldloc.s 26
+			IL_08e1: ldarg.0
+			IL_08e2: ldc.i4.3
+			IL_08e3: ldloc.0
+			IL_08e4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_08e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_08ee: ldloc.0
+			IL_08ef: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_08f4: dup
+			IL_08f5: ldc.i4.0
+			IL_08f6: ldloc.1
+			IL_08f7: stelem.ref
+			IL_08f8: dup
+			IL_08f9: ldc.i4.1
+			IL_08fa: ldloc.2
+			IL_08fb: stelem.ref
+			IL_08fc: dup
+			IL_08fd: ldc.i4.2
+			IL_08fe: ldloc.3
+			IL_08ff: stelem.ref
+			IL_0900: dup
+			IL_0901: ldc.i4.3
+			IL_0902: ldloc.s 4
+			IL_0904: stelem.ref
+			IL_0905: dup
+			IL_0906: ldc.i4.4
+			IL_0907: ldloc.s 5
+			IL_0909: stelem.ref
+			IL_090a: dup
+			IL_090b: ldc.i4.5
+			IL_090c: ldloc.s 6
 			IL_090e: stelem.ref
 			IL_090f: dup
-			IL_0910: ldc.i4.s 16
-			IL_0912: ldloc.s 17
-			IL_0914: stelem.ref
-			IL_0915: dup
-			IL_0916: ldc.i4.s 17
-			IL_0918: ldloc.s 18
-			IL_091a: stelem.ref
-			IL_091b: dup
-			IL_091c: ldc.i4.s 18
-			IL_091e: ldloc.s 19
-			IL_0920: stelem.ref
-			IL_0921: dup
-			IL_0922: ldc.i4.s 19
-			IL_0924: ldloc.s 20
-			IL_0926: stelem.ref
-			IL_0927: dup
-			IL_0928: ldc.i4.s 20
-			IL_092a: ldloc.s 21
-			IL_092c: stelem.ref
-			IL_092d: dup
-			IL_092e: ldc.i4.s 21
-			IL_0930: ldloc.s 22
-			IL_0932: stelem.ref
-			IL_0933: dup
-			IL_0934: ldc.i4.s 22
-			IL_0936: ldloc.s 23
-			IL_0938: box [System.Runtime]System.Boolean
-			IL_093d: stelem.ref
-			IL_093e: dup
-			IL_093f: ldc.i4.s 23
-			IL_0941: ldloc.s 24
-			IL_0943: stelem.ref
-			IL_0944: dup
-			IL_0945: ldc.i4.s 24
-			IL_0947: ldloc.s 25
-			IL_0949: stelem.ref
-			IL_094a: dup
-			IL_094b: ldc.i4.s 25
-			IL_094d: ldloc.s 26
-			IL_094f: stelem.ref
-			IL_0950: dup
-			IL_0951: ldc.i4.s 26
-			IL_0953: ldloc.s 27
-			IL_0955: stelem.ref
-			IL_0956: dup
-			IL_0957: ldc.i4.s 27
-			IL_0959: ldloc.s 28
-			IL_095b: stelem.ref
-			IL_095c: dup
-			IL_095d: ldc.i4.s 28
-			IL_095f: ldloc.s 29
-			IL_0961: stelem.ref
-			IL_0962: dup
-			IL_0963: ldc.i4.s 29
-			IL_0965: ldloc.s 30
-			IL_0967: stelem.ref
-			IL_0968: dup
-			IL_0969: ldc.i4.s 30
-			IL_096b: ldloc.s 31
-			IL_096d: stelem.ref
-			IL_096e: dup
-			IL_096f: ldc.i4.s 31
-			IL_0971: ldloc.s 32
-			IL_0973: stelem.ref
-			IL_0974: dup
-			IL_0975: ldc.i4.s 32
-			IL_0977: ldloc.s 33
-			IL_0979: stelem.ref
-			IL_097a: pop
-			IL_097b: ldloc.0
-			IL_097c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0981: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0986: ret
+			IL_0910: ldc.i4.6
+			IL_0911: ldloc.s 7
+			IL_0913: stelem.ref
+			IL_0914: dup
+			IL_0915: ldc.i4.7
+			IL_0916: ldloc.s 8
+			IL_0918: stelem.ref
+			IL_0919: dup
+			IL_091a: ldc.i4.8
+			IL_091b: ldloc.s 9
+			IL_091d: stelem.ref
+			IL_091e: dup
+			IL_091f: ldc.i4.s 9
+			IL_0921: ldloc.s 10
+			IL_0923: stelem.ref
+			IL_0924: dup
+			IL_0925: ldc.i4.s 10
+			IL_0927: ldloc.s 11
+			IL_0929: stelem.ref
+			IL_092a: dup
+			IL_092b: ldc.i4.s 11
+			IL_092d: ldloc.s 12
+			IL_092f: stelem.ref
+			IL_0930: dup
+			IL_0931: ldc.i4.s 12
+			IL_0933: ldloc.s 13
+			IL_0935: stelem.ref
+			IL_0936: dup
+			IL_0937: ldc.i4.s 13
+			IL_0939: ldloc.s 14
+			IL_093b: stelem.ref
+			IL_093c: dup
+			IL_093d: ldc.i4.s 14
+			IL_093f: ldloc.s 15
+			IL_0941: stelem.ref
+			IL_0942: dup
+			IL_0943: ldc.i4.s 15
+			IL_0945: ldloc.s 16
+			IL_0947: stelem.ref
+			IL_0948: dup
+			IL_0949: ldc.i4.s 16
+			IL_094b: ldloc.s 17
+			IL_094d: stelem.ref
+			IL_094e: dup
+			IL_094f: ldc.i4.s 17
+			IL_0951: ldloc.s 18
+			IL_0953: stelem.ref
+			IL_0954: dup
+			IL_0955: ldc.i4.s 18
+			IL_0957: ldloc.s 19
+			IL_0959: stelem.ref
+			IL_095a: dup
+			IL_095b: ldc.i4.s 19
+			IL_095d: ldloc.s 20
+			IL_095f: stelem.ref
+			IL_0960: dup
+			IL_0961: ldc.i4.s 20
+			IL_0963: ldloc.s 21
+			IL_0965: stelem.ref
+			IL_0966: dup
+			IL_0967: ldc.i4.s 21
+			IL_0969: ldloc.s 22
+			IL_096b: stelem.ref
+			IL_096c: dup
+			IL_096d: ldc.i4.s 22
+			IL_096f: ldloc.s 23
+			IL_0971: box [System.Runtime]System.Boolean
+			IL_0976: stelem.ref
+			IL_0977: dup
+			IL_0978: ldc.i4.s 23
+			IL_097a: ldloc.s 24
+			IL_097c: stelem.ref
+			IL_097d: dup
+			IL_097e: ldc.i4.s 24
+			IL_0980: ldloc.s 25
+			IL_0982: stelem.ref
+			IL_0983: dup
+			IL_0984: ldc.i4.s 25
+			IL_0986: ldloc.s 26
+			IL_0988: stelem.ref
+			IL_0989: dup
+			IL_098a: ldc.i4.s 26
+			IL_098c: ldloc.s 27
+			IL_098e: stelem.ref
+			IL_098f: dup
+			IL_0990: ldc.i4.s 27
+			IL_0992: ldloc.s 28
+			IL_0994: stelem.ref
+			IL_0995: dup
+			IL_0996: ldc.i4.s 28
+			IL_0998: ldloc.s 29
+			IL_099a: stelem.ref
+			IL_099b: dup
+			IL_099c: ldc.i4.s 29
+			IL_099e: ldloc.s 30
+			IL_09a0: stelem.ref
+			IL_09a1: dup
+			IL_09a2: ldc.i4.s 30
+			IL_09a4: ldloc.s 31
+			IL_09a6: stelem.ref
+			IL_09a7: dup
+			IL_09a8: ldc.i4.s 31
+			IL_09aa: ldloc.s 32
+			IL_09ac: stelem.ref
+			IL_09ad: dup
+			IL_09ae: ldc.i4.s 32
+			IL_09b0: ldloc.s 33
+			IL_09b2: stelem.ref
+			IL_09b3: pop
+			IL_09b4: ldloc.0
+			IL_09b5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09ba: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_09bf: ret
 
-			IL_0987: ldloc.0
-			IL_0988: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_098d: stloc.s 26
-			IL_098f: ldloc.s 26
-			IL_0991: stloc.s 8
-			IL_0993: ldloc.s 16
-			IL_0995: stloc.s 26
-			IL_0997: ldloc.s 26
-			IL_0999: stloc.s 10
+			IL_09c0: ldloc.0
+			IL_09c1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_09c6: stloc.s 26
+			IL_09c8: ldloc.s 26
+			IL_09ca: stloc.s 8
+			IL_09cc: ldloc.s 16
+			IL_09ce: stloc.s 26
+			IL_09d0: ldloc.s 26
+			IL_09d2: stloc.s 10
 
-			IL_099b: ldloc.s 9
-			IL_099d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_09a2: ldc.i4.0
-			IL_09a3: ceq
-			IL_09a5: stloc.s 23
-			IL_09a7: ldloc.s 23
-			IL_09a9: brfalse IL_0a15
+			IL_09d4: ldloc.s 9
+			IL_09d6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_09db: ldc.i4.0
+			IL_09dc: ceq
+			IL_09de: stloc.s 23
+			IL_09e0: ldloc.s 23
+			IL_09e2: brfalse IL_0a4e
 
-			IL_09ae: ldloc.1
-			IL_09af: ldstr "section"
-			IL_09b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09b9: stloc.s 26
-			IL_09bb: ldloc.s 26
-			IL_09bd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_09c2: stloc.s 27
-			IL_09c4: ldstr "Could not infer an element id for section '"
-			IL_09c9: ldloc.s 27
-			IL_09cb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09d0: ldstr "'. Try passing --id sec-... explicitly."
-			IL_09d5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09da: stloc.s 27
-			IL_09dc: ldloc.s 27
-			IL_09de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_09e3: stloc.s 17
-			IL_09e5: ldloc.0
-			IL_09e6: ldc.i4.m1
-			IL_09e7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_09ec: ldloc.0
-			IL_09ed: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_09f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_09f7: ldarg.0
-			IL_09f8: ldc.i4.1
-			IL_09f9: newarr [System.Runtime]System.Object
-			IL_09fe: dup
-			IL_09ff: ldc.i4.0
-			IL_0a00: ldloc.s 17
-			IL_0a02: stelem.ref
-			IL_0a03: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0a08: pop
-			IL_0a09: ldloc.0
-			IL_0a0a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a0f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0a14: ret
+			IL_09e7: ldloc.1
+			IL_09e8: ldstr "section"
+			IL_09ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09f2: stloc.s 26
+			IL_09f4: ldloc.s 26
+			IL_09f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_09fb: stloc.s 27
+			IL_09fd: ldstr "Could not infer an element id for section '"
+			IL_0a02: ldloc.s 27
+			IL_0a04: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a09: ldstr "'. Try passing --id sec-... explicitly."
+			IL_0a0e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a13: stloc.s 27
+			IL_0a15: ldloc.s 27
+			IL_0a17: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0a1c: stloc.s 17
+			IL_0a1e: ldloc.0
+			IL_0a1f: ldc.i4.m1
+			IL_0a20: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0a25: ldloc.0
+			IL_0a26: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a2b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0a30: ldarg.0
+			IL_0a31: ldc.i4.1
+			IL_0a32: newarr [System.Runtime]System.Object
+			IL_0a37: dup
+			IL_0a38: ldc.i4.0
+			IL_0a39: ldloc.s 17
+			IL_0a3b: stelem.ref
+			IL_0a3c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0a41: pop
+			IL_0a42: ldloc.0
+			IL_0a43: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a48: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0a4d: ret
 
-			IL_0a15: ldarg.0
-			IL_0a16: ldc.i4.1
-			IL_0a17: ldelem.ref
-			IL_0a18: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a1d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
-			IL_0a22: ldc.i4.1
-			IL_0a23: newarr [System.Runtime]System.Object
-			IL_0a28: dup
-			IL_0a29: ldc.i4.0
-			IL_0a2a: ldarg.0
-			IL_0a2b: ldc.i4.1
-			IL_0a2c: ldelem.ref
-			IL_0a2d: stelem.ref
-			IL_0a2e: stloc.s 21
-			IL_0a30: ldloc.s 21
-			IL_0a32: ldloc.s 8
-			IL_0a34: ldloc.s 9
-			IL_0a36: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0a3b: stloc.s 18
-			IL_0a3d: ldarg.0
-			IL_0a3e: ldc.i4.1
-			IL_0a3f: ldelem.ref
-			IL_0a40: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a45: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_0a4a: stloc.s 31
-			IL_0a4c: ldstr "process"
-			IL_0a51: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a56: stloc.s 26
-			IL_0a58: ldloc.s 26
-			IL_0a5a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a5f: stloc.s 26
-			IL_0a61: ldloc.s 26
-			IL_0a63: ldstr "cwd"
-			IL_0a68: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0a6d: stloc.s 26
-			IL_0a6f: ldloc.1
-			IL_0a70: ldstr "outFile"
-			IL_0a75: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a7a: stloc.s 22
-			IL_0a7c: ldloc.s 31
-			IL_0a7e: ldc.i4.2
-			IL_0a7f: newarr [System.Runtime]System.Object
-			IL_0a84: dup
-			IL_0a85: ldc.i4.0
-			IL_0a86: ldloc.s 26
-			IL_0a88: stelem.ref
-			IL_0a89: dup
-			IL_0a8a: ldc.i4.1
-			IL_0a8b: ldloc.s 22
-			IL_0a8d: stelem.ref
-			IL_0a8e: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0a93: stloc.s 19
-			IL_0a95: ldarg.0
-			IL_0a96: ldc.i4.1
-			IL_0a97: ldelem.ref
-			IL_0a98: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a9d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
-			IL_0aa2: ldc.i4.1
-			IL_0aa3: newarr [System.Runtime]System.Object
-			IL_0aa8: dup
-			IL_0aa9: ldc.i4.0
-			IL_0aaa: ldarg.0
-			IL_0aab: ldc.i4.1
-			IL_0aac: ldelem.ref
-			IL_0aad: stelem.ref
-			IL_0aae: stloc.s 21
-			IL_0ab0: ldloc.s 18
-			IL_0ab2: ldstr "html"
-			IL_0ab7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0abc: stloc.s 22
-			IL_0abe: ldloc.1
-			IL_0abf: ldstr "section"
-			IL_0ac4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ac9: stloc.s 26
-			IL_0acb: ldloc.s 26
-			IL_0acd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ad2: stloc.s 27
-			IL_0ad4: ldstr "ECMA-262 "
-			IL_0ad9: ldloc.s 27
-			IL_0adb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ae0: stloc.s 27
-			IL_0ae2: ldloc.s 21
-			IL_0ae4: ldloc.s 22
-			IL_0ae6: ldloc.s 27
-			IL_0ae8: ldloc.s 10
-			IL_0aea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0aef: stloc.s 20
-			IL_0af1: ldarg.0
-			IL_0af2: ldc.i4.1
-			IL_0af3: ldelem.ref
-			IL_0af4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0af9: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0afe: stloc.s 32
-			IL_0b00: ldloc.s 32
-			IL_0b02: ldloc.s 19
-			IL_0b04: ldloc.s 20
-			IL_0b06: ldstr "utf8"
-			IL_0b0b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_0b10: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0b15: stloc.s 33
-			IL_0b17: ldarg.0
-			IL_0b18: ldc.i4.1
-			IL_0b19: ldelem.ref
-			IL_0b1a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b1f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0b24: ldc.i4.1
-			IL_0b25: newarr [System.Runtime]System.Object
-			IL_0b2a: dup
-			IL_0b2b: ldc.i4.0
-			IL_0b2c: ldarg.0
-			IL_0b2d: ldc.i4.1
-			IL_0b2e: ldelem.ref
-			IL_0b2f: stelem.ref
-			IL_0b30: stloc.s 21
-			IL_0b32: ldloc.1
-			IL_0b33: ldstr "section"
-			IL_0b38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b3d: stloc.s 22
-			IL_0b3f: ldloc.s 22
-			IL_0b41: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b46: stloc.s 27
-			IL_0b48: ldstr "Extracted section "
-			IL_0b4d: ldloc.s 27
-			IL_0b4f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b54: ldstr " (id="
-			IL_0b59: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b5e: ldloc.s 9
-			IL_0b60: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b65: stloc.s 27
-			IL_0b67: ldloc.s 27
-			IL_0b69: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b6e: ldstr ", tag="
-			IL_0b73: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b78: ldloc.s 18
-			IL_0b7a: ldstr "tagName"
-			IL_0b7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b84: stloc.s 22
-			IL_0b86: ldloc.s 22
-			IL_0b88: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b8d: stloc.s 27
-			IL_0b8f: ldloc.s 27
-			IL_0b91: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b96: ldstr ") -> "
-			IL_0b9b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ba0: ldloc.s 19
-			IL_0ba2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ba7: stloc.s 27
-			IL_0ba9: ldloc.s 27
-			IL_0bab: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0bb0: stloc.s 27
-			IL_0bb2: ldloc.s 21
-			IL_0bb4: ldloc.s 27
-			IL_0bb6: ldloc.s 19
-			IL_0bb8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0a4e: ldarg.0
+			IL_0a4f: ldc.i4.1
+			IL_0a50: ldelem.ref
+			IL_0a51: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a56: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
+			IL_0a5b: ldc.i4.1
+			IL_0a5c: newarr [System.Runtime]System.Object
+			IL_0a61: dup
+			IL_0a62: ldc.i4.0
+			IL_0a63: ldarg.0
+			IL_0a64: ldc.i4.1
+			IL_0a65: ldelem.ref
+			IL_0a66: stelem.ref
+			IL_0a67: stloc.s 21
+			IL_0a69: ldloc.s 21
+			IL_0a6b: ldloc.s 8
+			IL_0a6d: ldloc.s 9
+			IL_0a6f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0a74: stloc.s 18
+			IL_0a76: ldarg.0
+			IL_0a77: ldc.i4.1
+			IL_0a78: ldelem.ref
+			IL_0a79: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a7e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_0a83: stloc.s 31
+			IL_0a85: ldstr "process"
+			IL_0a8a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a8f: stloc.s 26
+			IL_0a91: ldloc.s 26
+			IL_0a93: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a98: stloc.s 26
+			IL_0a9a: ldloc.s 26
+			IL_0a9c: ldstr "cwd"
+			IL_0aa1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0aa6: stloc.s 26
+			IL_0aa8: ldloc.1
+			IL_0aa9: ldstr "outFile"
+			IL_0aae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ab3: stloc.s 22
+			IL_0ab5: ldloc.s 31
+			IL_0ab7: ldc.i4.2
+			IL_0ab8: newarr [System.Runtime]System.Object
+			IL_0abd: dup
+			IL_0abe: ldc.i4.0
+			IL_0abf: ldloc.s 26
+			IL_0ac1: stelem.ref
+			IL_0ac2: dup
+			IL_0ac3: ldc.i4.1
+			IL_0ac4: ldloc.s 22
+			IL_0ac6: stelem.ref
+			IL_0ac7: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0acc: stloc.s 19
+			IL_0ace: ldarg.0
+			IL_0acf: ldc.i4.1
+			IL_0ad0: ldelem.ref
+			IL_0ad1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0ad6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
+			IL_0adb: ldc.i4.1
+			IL_0adc: newarr [System.Runtime]System.Object
+			IL_0ae1: dup
+			IL_0ae2: ldc.i4.0
+			IL_0ae3: ldarg.0
+			IL_0ae4: ldc.i4.1
+			IL_0ae5: ldelem.ref
+			IL_0ae6: stelem.ref
+			IL_0ae7: stloc.s 21
+			IL_0ae9: ldloc.s 18
+			IL_0aeb: ldstr "html"
+			IL_0af0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0af5: stloc.s 22
+			IL_0af7: ldloc.1
+			IL_0af8: ldstr "section"
+			IL_0afd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b02: stloc.s 26
+			IL_0b04: ldloc.s 26
+			IL_0b06: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b0b: stloc.s 27
+			IL_0b0d: ldstr "ECMA-262 "
+			IL_0b12: ldloc.s 27
+			IL_0b14: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b19: stloc.s 27
+			IL_0b1b: ldloc.s 21
+			IL_0b1d: ldloc.s 22
+			IL_0b1f: ldloc.s 27
+			IL_0b21: ldloc.s 10
+			IL_0b23: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0b28: stloc.s 20
+			IL_0b2a: ldarg.0
+			IL_0b2b: ldc.i4.1
+			IL_0b2c: ldelem.ref
+			IL_0b2d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b32: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0b37: stloc.s 32
+			IL_0b39: ldloc.s 32
+			IL_0b3b: ldloc.s 19
+			IL_0b3d: ldloc.s 20
+			IL_0b3f: ldstr "utf8"
+			IL_0b44: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_0b49: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0b4e: stloc.s 33
+			IL_0b50: ldarg.0
+			IL_0b51: ldc.i4.1
+			IL_0b52: ldelem.ref
+			IL_0b53: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b58: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0b5d: ldc.i4.1
+			IL_0b5e: newarr [System.Runtime]System.Object
+			IL_0b63: dup
+			IL_0b64: ldc.i4.0
+			IL_0b65: ldarg.0
+			IL_0b66: ldc.i4.1
+			IL_0b67: ldelem.ref
+			IL_0b68: stelem.ref
+			IL_0b69: stloc.s 21
+			IL_0b6b: ldloc.1
+			IL_0b6c: ldstr "section"
+			IL_0b71: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b76: stloc.s 22
+			IL_0b78: ldloc.s 22
+			IL_0b7a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b7f: stloc.s 27
+			IL_0b81: ldstr "Extracted section "
+			IL_0b86: ldloc.s 27
+			IL_0b88: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b8d: ldstr " (id="
+			IL_0b92: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b97: ldloc.s 9
+			IL_0b99: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b9e: stloc.s 27
+			IL_0ba0: ldloc.s 27
+			IL_0ba2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ba7: ldstr ", tag="
+			IL_0bac: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0bb1: ldloc.s 18
+			IL_0bb3: ldstr "tagName"
+			IL_0bb8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0bbd: stloc.s 22
-			IL_0bbf: ldloc.s 33
-			IL_0bc1: ldloc.s 22
-			IL_0bc3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0bc8: pop
-			IL_0bc9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0bce: stloc.s 33
-			IL_0bd0: ldarg.0
-			IL_0bd1: ldc.i4.1
-			IL_0bd2: ldelem.ref
-			IL_0bd3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0bd8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0bdd: stloc.s 22
-			IL_0bdf: ldc.i4.1
-			IL_0be0: newarr [System.Runtime]System.Object
-			IL_0be5: dup
-			IL_0be6: ldc.i4.0
-			IL_0be7: ldarg.0
-			IL_0be8: ldc.i4.1
-			IL_0be9: ldelem.ref
-			IL_0bea: stelem.ref
-			IL_0beb: stloc.s 21
-			IL_0bed: ldarg.0
-			IL_0bee: ldc.i4.1
-			IL_0bef: ldelem.ref
-			IL_0bf0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0bf5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0bfa: stloc.s 32
-			IL_0bfc: ldloc.s 32
-			IL_0bfe: ldloc.s 19
-			IL_0c00: ldstr "utf8"
-			IL_0c05: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0c0a: stloc.s 26
-			IL_0c0c: ldloc.s 22
-			IL_0c0e: ldloc.s 21
-			IL_0c10: ldloc.s 26
-			IL_0c12: ldloc.s 19
-			IL_0c14: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0c19: stloc.s 26
-			IL_0c1b: ldloc.s 33
-			IL_0c1d: ldloc.s 26
-			IL_0c1f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0c24: pop
-			IL_0c25: ldloc.0
-			IL_0c26: ldc.i4.m1
-			IL_0c27: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0c2c: ldloc.0
-			IL_0c2d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c32: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0c37: ldarg.0
-			IL_0c38: ldc.i4.1
-			IL_0c39: newarr [System.Runtime]System.Object
-			IL_0c3e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0c43: pop
-			IL_0c44: ldloc.0
-			IL_0c45: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c4a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0c4f: ret
+			IL_0bbf: ldloc.s 22
+			IL_0bc1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0bc6: stloc.s 27
+			IL_0bc8: ldloc.s 27
+			IL_0bca: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0bcf: ldstr ") -> "
+			IL_0bd4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0bd9: ldloc.s 19
+			IL_0bdb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0be0: stloc.s 27
+			IL_0be2: ldloc.s 27
+			IL_0be4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0be9: stloc.s 27
+			IL_0beb: ldloc.s 21
+			IL_0bed: ldloc.s 27
+			IL_0bef: ldloc.s 19
+			IL_0bf1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0bf6: stloc.s 22
+			IL_0bf8: ldloc.s 33
+			IL_0bfa: ldloc.s 22
+			IL_0bfc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0c01: pop
+			IL_0c02: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0c07: stloc.s 33
+			IL_0c09: ldarg.0
+			IL_0c0a: ldc.i4.1
+			IL_0c0b: ldelem.ref
+			IL_0c0c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0c11: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0c16: stloc.s 22
+			IL_0c18: ldc.i4.1
+			IL_0c19: newarr [System.Runtime]System.Object
+			IL_0c1e: dup
+			IL_0c1f: ldc.i4.0
+			IL_0c20: ldarg.0
+			IL_0c21: ldc.i4.1
+			IL_0c22: ldelem.ref
+			IL_0c23: stelem.ref
+			IL_0c24: stloc.s 21
+			IL_0c26: ldarg.0
+			IL_0c27: ldc.i4.1
+			IL_0c28: ldelem.ref
+			IL_0c29: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0c2e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0c33: stloc.s 32
+			IL_0c35: ldloc.s 32
+			IL_0c37: ldloc.s 19
+			IL_0c39: ldstr "utf8"
+			IL_0c3e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0c43: stloc.s 26
+			IL_0c45: ldloc.s 22
+			IL_0c47: ldloc.s 21
+			IL_0c49: ldloc.s 26
+			IL_0c4b: ldloc.s 19
+			IL_0c4d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0c52: stloc.s 26
+			IL_0c54: ldloc.s 33
+			IL_0c56: ldloc.s 26
+			IL_0c58: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0c5d: pop
+			IL_0c5e: ldloc.0
+			IL_0c5f: ldc.i4.m1
+			IL_0c60: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0c65: ldloc.0
+			IL_0c66: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c6b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0c70: ldarg.0
+			IL_0c71: ldc.i4.1
+			IL_0c72: newarr [System.Runtime]System.Object
+			IL_0c77: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0c7c: pop
+			IL_0c7d: ldloc.0
+			IL_0c7e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c83: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0c88: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -740,7 +740,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 436 (0x1b4)
+			// Code size: 490 (0x1ea)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -755,153 +755,174 @@
 			IL_0006: stloc.0
 			IL_0007: ldc.i4.0
 			IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_000d: brfalse IL_0034
+			IL_000d: brfalse IL_0046
 
 			IL_0012: ldloc.0
 			IL_0013: isinst [System.Runtime]System.String
 			IL_0018: dup
-			IL_0019: brfalse IL_0033
+			IL_0019: brtrue IL_0030
 
-			IL_001e: ldstr " -> "
-			IL_0023: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-			IL_0028: box [System.Runtime]System.Boolean
-			IL_002d: stloc.0
-			IL_002e: br IL_0045
+			IL_001e: pop
+			IL_001f: ldloc.0
+			IL_0020: ldstr "includes"
+			IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_002a: dup
+			IL_002b: brfalse IL_0045
 
-			IL_0033: pop
+			IL_0030: ldstr " -> "
+			IL_0035: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_003a: box [System.Runtime]System.Boolean
+			IL_003f: stloc.0
+			IL_0040: br IL_0057
 
-			IL_0034: ldloc.0
-			IL_0035: ldstr "includes"
-			IL_003a: ldstr " -> "
-			IL_003f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0044: stloc.0
+			IL_0045: pop
 
-			IL_0045: ldloc.0
-			IL_0046: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_004b: stloc.1
-			IL_004c: ldloc.1
-			IL_004d: brfalse IL_010a
+			IL_0046: ldloc.0
+			IL_0047: ldstr "includes"
+			IL_004c: ldstr " -> "
+			IL_0051: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0056: stloc.0
 
-			IL_0052: ldarg.1
-			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0058: stloc.0
-			IL_0059: ldarg.1
-			IL_005a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_005f: stloc.2
-			IL_0060: ldc.i4.0
-			IL_0061: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0066: brfalse IL_008d
+			IL_0057: ldloc.0
+			IL_0058: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_005d: stloc.1
+			IL_005e: ldloc.1
+			IL_005f: brfalse IL_0140
 
-			IL_006b: ldloc.2
-			IL_006c: isinst [System.Runtime]System.String
-			IL_0071: dup
-			IL_0072: brfalse IL_008c
+			IL_0064: ldarg.1
+			IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_006a: stloc.0
+			IL_006b: ldarg.1
+			IL_006c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0071: stloc.2
+			IL_0072: ldc.i4.0
+			IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0078: brfalse IL_00b1
 
-			IL_0077: ldstr " -> "
-			IL_007c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_0081: box [System.Runtime]System.Double
-			IL_0086: stloc.2
-			IL_0087: br IL_009e
+			IL_007d: ldloc.2
+			IL_007e: isinst [System.Runtime]System.String
+			IL_0083: dup
+			IL_0084: brtrue IL_009b
 
-			IL_008c: pop
+			IL_0089: pop
+			IL_008a: ldloc.2
+			IL_008b: ldstr "indexOf"
+			IL_0090: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0095: dup
+			IL_0096: brfalse IL_00b0
 
-			IL_008d: ldloc.2
-			IL_008e: ldstr "indexOf"
-			IL_0093: ldstr " -> "
-			IL_0098: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_009d: stloc.2
+			IL_009b: ldstr " -> "
+			IL_00a0: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_00a5: box [System.Runtime]System.Double
+			IL_00aa: stloc.2
+			IL_00ab: br IL_00c2
 
-			IL_009e: ldloc.2
-			IL_009f: ldc.r8 4
-			IL_00a8: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
-			IL_00ad: stloc.3
-			IL_00ae: ldc.i4.0
-			IL_00af: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_00b4: brfalse IL_00e0
+			IL_00b0: pop
 
-			IL_00b9: ldloc.0
-			IL_00ba: isinst [System.Runtime]System.String
-			IL_00bf: dup
-			IL_00c0: brfalse IL_00df
+			IL_00b1: ldloc.2
+			IL_00b2: ldstr "indexOf"
+			IL_00b7: ldstr " -> "
+			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00c1: stloc.2
 
-			IL_00c5: ldc.r8 0.0
-			IL_00ce: box [System.Runtime]System.Double
-			IL_00d3: ldloc.3
-			IL_00d4: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_00d9: stloc.0
-			IL_00da: br IL_00fb
+			IL_00c2: ldloc.2
+			IL_00c3: ldc.r8 4
+			IL_00cc: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, float64)
+			IL_00d1: stloc.3
+			IL_00d2: ldc.i4.0
+			IL_00d3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00d8: brfalse IL_0116
 
-			IL_00df: pop
+			IL_00dd: ldloc.0
+			IL_00de: isinst [System.Runtime]System.String
+			IL_00e3: dup
+			IL_00e4: brtrue IL_00fb
 
-			IL_00e0: ldloc.0
-			IL_00e1: ldstr "substring"
-			IL_00e6: ldc.r8 0.0
-			IL_00ef: box [System.Runtime]System.Double
-			IL_00f4: ldloc.3
-			IL_00f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_00fa: stloc.0
+			IL_00e9: pop
+			IL_00ea: ldloc.0
+			IL_00eb: ldstr "substring"
+			IL_00f0: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_00f5: dup
+			IL_00f6: brfalse IL_0115
 
-			IL_00fb: ldloc.0
-			IL_00fc: ldstr "<outFile>"
-			IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0106: stloc.3
-			IL_0107: ldloc.3
-			IL_0108: starg.s text
+			IL_00fb: ldc.r8 0.0
+			IL_0104: box [System.Runtime]System.Double
+			IL_0109: ldloc.3
+			IL_010a: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_010f: stloc.0
+			IL_0110: br IL_0131
 
-			IL_010a: ldarg.1
-			IL_010b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0110: stloc.0
-			IL_0111: ldarg.2
-			IL_0112: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0117: stloc.2
-			IL_0118: ldstr "[.*+?^${}()|[\\]\\\\]"
-			IL_011d: ldstr "g"
-			IL_0122: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0127: stloc.s 4
-			IL_0129: ldloc.2
-			IL_012a: ldstr "replace"
-			IL_012f: ldloc.s 4
-			IL_0131: ldstr "\\$&"
-			IL_0136: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_013b: stloc.2
-			IL_013c: ldloc.2
-			IL_013d: ldstr "g"
-			IL_0142: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0147: stloc.s 4
-			IL_0149: ldloc.0
-			IL_014a: ldstr "replace"
-			IL_014f: ldloc.s 4
-			IL_0151: ldstr "<outFile>"
-			IL_0156: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_015b: stloc.0
-			IL_015c: ldloc.0
-			IL_015d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0162: stloc.0
-			IL_0163: ldstr "127\\.0\\.0\\.1:\\d+"
-			IL_0168: ldstr "g"
-			IL_016d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_0172: stloc.s 4
-			IL_0174: ldloc.0
-			IL_0175: ldstr "replace"
-			IL_017a: ldloc.s 4
-			IL_017c: ldstr "127.0.0.1:<port>"
-			IL_0181: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0186: stloc.0
-			IL_0187: ldloc.0
-			IL_0188: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018d: stloc.0
-			IL_018e: ldstr "\\r\\n"
-			IL_0193: ldstr "g"
-			IL_0198: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_019d: stloc.s 4
-			IL_019f: ldloc.0
-			IL_01a0: ldstr "replace"
-			IL_01a5: ldloc.s 4
-			IL_01a7: ldstr "\n"
-			IL_01ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_01b1: stloc.0
-			IL_01b2: ldloc.0
-			IL_01b3: ret
+			IL_0115: pop
+
+			IL_0116: ldloc.0
+			IL_0117: ldstr "substring"
+			IL_011c: ldc.r8 0.0
+			IL_0125: box [System.Runtime]System.Double
+			IL_012a: ldloc.3
+			IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0130: stloc.0
+
+			IL_0131: ldloc.0
+			IL_0132: ldstr "<outFile>"
+			IL_0137: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_013c: stloc.3
+			IL_013d: ldloc.3
+			IL_013e: starg.s text
+
+			IL_0140: ldarg.1
+			IL_0141: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0146: stloc.0
+			IL_0147: ldarg.2
+			IL_0148: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_014d: stloc.2
+			IL_014e: ldstr "[.*+?^${}()|[\\]\\\\]"
+			IL_0153: ldstr "g"
+			IL_0158: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_015d: stloc.s 4
+			IL_015f: ldloc.2
+			IL_0160: ldstr "replace"
+			IL_0165: ldloc.s 4
+			IL_0167: ldstr "\\$&"
+			IL_016c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0171: stloc.2
+			IL_0172: ldloc.2
+			IL_0173: ldstr "g"
+			IL_0178: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_017d: stloc.s 4
+			IL_017f: ldloc.0
+			IL_0180: ldstr "replace"
+			IL_0185: ldloc.s 4
+			IL_0187: ldstr "<outFile>"
+			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0191: stloc.0
+			IL_0192: ldloc.0
+			IL_0193: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0198: stloc.0
+			IL_0199: ldstr "127\\.0\\.0\\.1:\\d+"
+			IL_019e: ldstr "g"
+			IL_01a3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_01a8: stloc.s 4
+			IL_01aa: ldloc.0
+			IL_01ab: ldstr "replace"
+			IL_01b0: ldloc.s 4
+			IL_01b2: ldstr "127.0.0.1:<port>"
+			IL_01b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01bc: stloc.0
+			IL_01bd: ldloc.0
+			IL_01be: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_01c3: stloc.0
+			IL_01c4: ldstr "\\r\\n"
+			IL_01c9: ldstr "g"
+			IL_01ce: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_01d3: stloc.s 4
+			IL_01d5: ldloc.0
+			IL_01d6: ldstr "replace"
+			IL_01db: ldloc.s 4
+			IL_01dd: ldstr "\n"
+			IL_01e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01e7: stloc.0
+			IL_01e8: ldloc.0
+			IL_01e9: ret
 		} // end of method normalize::__js_call__
 
 	} // end of class normalize
@@ -3555,7 +3576,7 @@
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
-			// Code size: 542 (0x21e)
+			// Code size: 561 (0x231)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -3765,30 +3786,37 @@
 			IL_01e0: stloc.s 9
 			IL_01e2: ldc.i4.0
 			IL_01e3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_01e8: brfalse IL_020a
+			IL_01e8: brfalse IL_021d
 
 			IL_01ed: ldloc.s 5
 			IL_01ef: isinst [System.Runtime]System.String
 			IL_01f4: dup
-			IL_01f5: brfalse IL_0209
+			IL_01f5: brtrue IL_020d
 
-			IL_01fa: ldloc.s 9
-			IL_01fc: ldloc.0
-			IL_01fd: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-			IL_0202: stloc.s 5
-			IL_0204: br IL_021b
+			IL_01fa: pop
+			IL_01fb: ldloc.s 5
+			IL_01fd: ldstr "substring"
+			IL_0202: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0207: dup
+			IL_0208: brfalse IL_021c
 
-			IL_0209: pop
+			IL_020d: ldloc.s 9
+			IL_020f: ldloc.0
+			IL_0210: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+			IL_0215: stloc.s 5
+			IL_0217: br IL_022e
 
-			IL_020a: ldloc.s 5
-			IL_020c: ldstr "substring"
-			IL_0211: ldloc.s 9
-			IL_0213: ldloc.0
-			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0219: stloc.s 5
+			IL_021c: pop
 
-			IL_021b: ldloc.s 5
-			IL_021d: ret
+			IL_021d: ldloc.s 5
+			IL_021f: ldstr "substring"
+			IL_0224: ldloc.s 9
+			IL_0226: ldloc.0
+			IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_022c: stloc.s 5
+
+			IL_022e: ldloc.s 5
+			IL_0230: ret
 		} // end of method findTagNameAt::__js_call__
 
 	} // end of class findTagNameAt
@@ -4141,7 +4169,7 @@
 				74 61 54 6f 6b 65 6e 16 00 00 02
 			)
 			// Header size: 12
-			// Code size: 1172 (0x494)
+			// Code size: 1267 (0x4f3)
 			.maxstack 8
 			.locals init (
 				[0] string,
@@ -4191,406 +4219,441 @@
 			IL_0044: stloc.s 15
 			IL_0046: ldc.i4.0
 			IL_0047: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_004c: brfalse IL_0070
+			IL_004c: brfalse IL_0083
 
 			IL_0051: ldloc.s 15
 			IL_0053: isinst [System.Runtime]System.String
 			IL_0058: dup
-			IL_0059: brfalse IL_006f
+			IL_0059: brtrue IL_0071
 
-			IL_005e: ldloc.0
-			IL_005f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_0064: box [System.Runtime]System.Double
-			IL_0069: stloc.2
-			IL_006a: br IL_007e
+			IL_005e: pop
+			IL_005f: ldloc.s 15
+			IL_0061: ldstr "indexOf"
+			IL_0066: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_006b: dup
+			IL_006c: brfalse IL_0082
 
-			IL_006f: pop
+			IL_0071: ldloc.0
+			IL_0072: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_0077: box [System.Runtime]System.Double
+			IL_007c: stloc.2
+			IL_007d: br IL_0091
 
-			IL_0070: ldloc.s 15
-			IL_0072: ldstr "indexOf"
-			IL_0077: ldloc.0
-			IL_0078: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_007d: stloc.2
+			IL_0082: pop
 
-			IL_007e: ldloc.2
-			IL_007f: stloc.s 15
-			IL_0081: ldloc.s 15
-			IL_0083: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0088: ldc.r8 0.0
-			IL_0091: clt
-			IL_0093: brfalse IL_00dd
+			IL_0083: ldloc.s 15
+			IL_0085: ldstr "indexOf"
+			IL_008a: ldloc.0
+			IL_008b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0090: stloc.2
 
-			IL_0098: ldarg.2
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_009e: stloc.s 15
-			IL_00a0: ldc.i4.0
-			IL_00a1: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_00a6: brfalse IL_00cb
+			IL_0091: ldloc.2
+			IL_0092: stloc.s 15
+			IL_0094: ldloc.s 15
+			IL_0096: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_009b: ldc.r8 0.0
+			IL_00a4: clt
+			IL_00a6: brfalse IL_0103
 
-			IL_00ab: ldloc.s 15
-			IL_00ad: isinst [System.Runtime]System.String
-			IL_00b2: dup
-			IL_00b3: brfalse IL_00ca
+			IL_00ab: ldarg.2
+			IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00b1: stloc.s 15
+			IL_00b3: ldc.i4.0
+			IL_00b4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00b9: brfalse IL_00f1
 
-			IL_00b8: ldloc.1
-			IL_00b9: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_00be: box [System.Runtime]System.Double
-			IL_00c3: stloc.s 15
-			IL_00c5: br IL_00da
+			IL_00be: ldloc.s 15
+			IL_00c0: isinst [System.Runtime]System.String
+			IL_00c5: dup
+			IL_00c6: brtrue IL_00de
 
-			IL_00ca: pop
+			IL_00cb: pop
+			IL_00cc: ldloc.s 15
+			IL_00ce: ldstr "indexOf"
+			IL_00d3: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_00d8: dup
+			IL_00d9: brfalse IL_00f0
 
-			IL_00cb: ldloc.s 15
-			IL_00cd: ldstr "indexOf"
-			IL_00d2: ldloc.1
-			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00d8: stloc.s 15
+			IL_00de: ldloc.1
+			IL_00df: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_00e4: box [System.Runtime]System.Double
+			IL_00e9: stloc.s 15
+			IL_00eb: br IL_0100
 
-			IL_00da: ldloc.s 15
-			IL_00dc: stloc.2
+			IL_00f0: pop
 
-			IL_00dd: ldloc.2
-			IL_00de: stloc.s 15
-			IL_00e0: ldloc.s 15
-			IL_00e2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00e7: ldc.r8 0.0
-			IL_00f0: clt
-			IL_00f2: brfalse IL_0134
+			IL_00f1: ldloc.s 15
+			IL_00f3: ldstr "indexOf"
+			IL_00f8: ldloc.1
+			IL_00f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00fe: stloc.s 15
 
-			IL_00f7: ldarg.3
-			IL_00f8: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_00fd: stloc.s 14
-			IL_00ff: ldstr "Could not find id '"
-			IL_0104: ldloc.s 14
-			IL_0106: call string [System.Runtime]System.String::Concat(string, string)
-			IL_010b: ldstr "' in input HTML."
-			IL_0110: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0115: stloc.s 14
-			IL_0117: ldloc.s 14
-			IL_0119: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_011e: stloc.3
-			IL_011f: ldloc.3
-			IL_0120: isinst [System.Runtime]System.Exception
-			IL_0125: dup
-			IL_0126: brtrue IL_0133
+			IL_0100: ldloc.s 15
+			IL_0102: stloc.2
 
-			IL_012b: pop
-			IL_012c: ldloc.3
-			IL_012d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0132: throw
+			IL_0103: ldloc.2
+			IL_0104: stloc.s 15
+			IL_0106: ldloc.s 15
+			IL_0108: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_010d: ldc.r8 0.0
+			IL_0116: clt
+			IL_0118: brfalse IL_015a
 
-			IL_0133: throw
+			IL_011d: ldarg.3
+			IL_011e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0123: stloc.s 14
+			IL_0125: ldstr "Could not find id '"
+			IL_012a: ldloc.s 14
+			IL_012c: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0131: ldstr "' in input HTML."
+			IL_0136: call string [System.Runtime]System.String::Concat(string, string)
+			IL_013b: stloc.s 14
+			IL_013d: ldloc.s 14
+			IL_013f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0144: stloc.3
+			IL_0145: ldloc.3
+			IL_0146: isinst [System.Runtime]System.Exception
+			IL_014b: dup
+			IL_014c: brtrue IL_0159
 
-			IL_0134: ldarg.2
-			IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_013a: stloc.s 15
-			IL_013c: ldc.i4.0
-			IL_013d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0142: brfalse IL_016c
+			IL_0151: pop
+			IL_0152: ldloc.3
+			IL_0153: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_0158: throw
 
-			IL_0147: ldloc.s 15
-			IL_0149: isinst [System.Runtime]System.String
-			IL_014e: dup
-			IL_014f: brfalse IL_016b
+			IL_0159: throw
 
-			IL_0154: ldstr "<"
-			IL_0159: ldloc.2
-			IL_015a: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
-			IL_015f: box [System.Runtime]System.Double
-			IL_0164: stloc.s 4
-			IL_0166: br IL_0180
+			IL_015a: ldarg.2
+			IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0160: stloc.s 15
+			IL_0162: ldc.i4.0
+			IL_0163: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0168: brfalse IL_01a5
 
-			IL_016b: pop
+			IL_016d: ldloc.s 15
+			IL_016f: isinst [System.Runtime]System.String
+			IL_0174: dup
+			IL_0175: brtrue IL_018d
 
-			IL_016c: ldloc.s 15
-			IL_016e: ldstr "lastIndexOf"
-			IL_0173: ldstr "<"
-			IL_0178: ldloc.2
-			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_017e: stloc.s 4
+			IL_017a: pop
+			IL_017b: ldloc.s 15
+			IL_017d: ldstr "lastIndexOf"
+			IL_0182: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0187: dup
+			IL_0188: brfalse IL_01a4
 
-			IL_0180: ldloc.s 4
-			IL_0182: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0187: ldc.r8 0.0
-			IL_0190: clt
-			IL_0192: brfalse IL_01d7
+			IL_018d: ldstr "<"
+			IL_0192: ldloc.2
+			IL_0193: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::LastIndexOf(string, string, object)
+			IL_0198: box [System.Runtime]System.Double
+			IL_019d: stloc.s 4
+			IL_019f: br IL_01b9
 
-			IL_0197: ldarg.3
-			IL_0198: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_019d: stloc.s 14
-			IL_019f: ldstr "Could not locate tag start for id '"
-			IL_01a4: ldloc.s 14
-			IL_01a6: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01ab: ldstr "'."
-			IL_01b0: call string [System.Runtime]System.String::Concat(string, string)
-			IL_01b5: stloc.s 14
-			IL_01b7: ldloc.s 14
-			IL_01b9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_01be: stloc.s 5
-			IL_01c0: ldloc.s 5
-			IL_01c2: isinst [System.Runtime]System.Exception
-			IL_01c7: dup
-			IL_01c8: brtrue IL_01d6
+			IL_01a4: pop
 
-			IL_01cd: pop
-			IL_01ce: ldloc.s 5
-			IL_01d0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_01d5: throw
+			IL_01a5: ldloc.s 15
+			IL_01a7: ldstr "lastIndexOf"
+			IL_01ac: ldstr "<"
+			IL_01b1: ldloc.2
+			IL_01b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_01b7: stloc.s 4
 
-			IL_01d6: throw
+			IL_01b9: ldloc.s 4
+			IL_01bb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_01c0: ldc.r8 0.0
+			IL_01c9: clt
+			IL_01cb: brfalse IL_0210
 
-			IL_01d7: ldarg.0
-			IL_01d8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
-			IL_01dd: ldc.i4.1
-			IL_01de: newarr [System.Runtime]System.Object
-			IL_01e3: dup
-			IL_01e4: ldc.i4.0
-			IL_01e5: ldarg.0
-			IL_01e6: stelem.ref
-			IL_01e7: stloc.s 16
-			IL_01e9: ldloc.s 16
-			IL_01eb: ldarg.2
-			IL_01ec: ldloc.s 4
-			IL_01ee: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_01f3: stloc.s 6
-			IL_01f5: ldloc.s 6
-			IL_01f7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_01fc: ldc.i4.0
-			IL_01fd: ceq
-			IL_01ff: stloc.s 17
-			IL_0201: ldloc.s 17
-			IL_0203: brfalse IL_0248
+			IL_01d0: ldarg.3
+			IL_01d1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_01d6: stloc.s 14
+			IL_01d8: ldstr "Could not locate tag start for id '"
+			IL_01dd: ldloc.s 14
+			IL_01df: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01e4: ldstr "'."
+			IL_01e9: call string [System.Runtime]System.String::Concat(string, string)
+			IL_01ee: stloc.s 14
+			IL_01f0: ldloc.s 14
+			IL_01f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_01f7: stloc.s 5
+			IL_01f9: ldloc.s 5
+			IL_01fb: isinst [System.Runtime]System.Exception
+			IL_0200: dup
+			IL_0201: brtrue IL_020f
 
-			IL_0208: ldarg.3
-			IL_0209: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_020e: stloc.s 14
-			IL_0210: ldstr "Could not determine tag name for id '"
-			IL_0215: ldloc.s 14
-			IL_0217: call string [System.Runtime]System.String::Concat(string, string)
-			IL_021c: ldstr "'."
-			IL_0221: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0226: stloc.s 14
-			IL_0228: ldloc.s 14
-			IL_022a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_022f: stloc.s 7
-			IL_0231: ldloc.s 7
-			IL_0233: isinst [System.Runtime]System.Exception
-			IL_0238: dup
-			IL_0239: brtrue IL_0247
+			IL_0206: pop
+			IL_0207: ldloc.s 5
+			IL_0209: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_020e: throw
 
-			IL_023e: pop
-			IL_023f: ldloc.s 7
-			IL_0241: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0246: throw
+			IL_020f: throw
 
-			IL_0247: throw
+			IL_0210: ldarg.0
+			IL_0211: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::findTagNameAt
+			IL_0216: ldc.i4.1
+			IL_0217: newarr [System.Runtime]System.Object
+			IL_021c: dup
+			IL_021d: ldc.i4.0
+			IL_021e: ldarg.0
+			IL_021f: stelem.ref
+			IL_0220: stloc.s 16
+			IL_0222: ldloc.s 16
+			IL_0224: ldarg.2
+			IL_0225: ldloc.s 4
+			IL_0227: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_022c: stloc.s 6
+			IL_022e: ldloc.s 6
+			IL_0230: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0235: ldc.i4.0
+			IL_0236: ceq
+			IL_0238: stloc.s 17
+			IL_023a: ldloc.s 17
+			IL_023c: brfalse IL_0281
 
-			IL_0248: ldarg.0
-			IL_0249: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
-			IL_024e: ldc.i4.1
-			IL_024f: newarr [System.Runtime]System.Object
-			IL_0254: dup
-			IL_0255: ldc.i4.0
-			IL_0256: ldarg.0
-			IL_0257: stelem.ref
-			IL_0258: ldloc.s 6
-			IL_025a: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_025f: stloc.s 15
-			IL_0261: ldloc.s 15
-			IL_0263: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0268: stloc.s 14
-			IL_026a: ldstr "<\\/?"
-			IL_026f: ldloc.s 14
-			IL_0271: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0276: ldstr "\\b[^>]*>"
-			IL_027b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0280: stloc.s 14
-			IL_0282: ldloc.s 14
-			IL_0284: ldstr "gi"
-			IL_0289: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-			IL_028e: stloc.s 8
-			IL_0290: ldloc.s 8
-			IL_0292: ldstr "lastIndex"
-			IL_0297: ldloc.s 4
-			IL_0299: ldc.i4.1
-			IL_029a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-			IL_029f: pop
-			IL_02a0: ldc.r8 0.0
-			IL_02a9: stloc.s 9
-			IL_02ab: ldc.r8 1
-			IL_02b4: neg
-			IL_02b5: stloc.s 18
-			IL_02b7: ldloc.s 18
-			IL_02b9: box [System.Runtime]System.Double
-			IL_02be: stloc.s 10
-			// loop start (head: IL_02c0)
-				IL_02c0: ldc.i4.1
-				IL_02c1: brfalse IL_0438
+			IL_0241: ldarg.3
+			IL_0242: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0247: stloc.s 14
+			IL_0249: ldstr "Could not determine tag name for id '"
+			IL_024e: ldloc.s 14
+			IL_0250: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0255: ldstr "'."
+			IL_025a: call string [System.Runtime]System.String::Concat(string, string)
+			IL_025f: stloc.s 14
+			IL_0261: ldloc.s 14
+			IL_0263: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0268: stloc.s 7
+			IL_026a: ldloc.s 7
+			IL_026c: isinst [System.Runtime]System.Exception
+			IL_0271: dup
+			IL_0272: brtrue IL_0280
 
-				IL_02c6: ldloc.s 8
-				IL_02c8: ldstr "exec"
-				IL_02cd: ldarg.2
-				IL_02ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_02d3: stloc.s 11
-				IL_02d5: ldloc.s 11
-				IL_02d7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-				IL_02dc: ldc.i4.0
-				IL_02dd: ceq
-				IL_02df: stloc.s 17
-				IL_02e1: ldloc.s 17
-				IL_02e3: brfalse IL_02ed
+			IL_0277: pop
+			IL_0278: ldloc.s 7
+			IL_027a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_027f: throw
 
-				IL_02e8: br IL_0438
+			IL_0280: throw
 
-				IL_02ed: ldloc.s 11
-				IL_02ef: ldc.r8 0.0
-				IL_02f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-				IL_02fd: stloc.s 12
-				IL_02ff: ldloc.s 10
-				IL_0301: stloc.s 19
-				IL_0303: ldloc.s 19
-				IL_0305: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_030a: ldc.r8 0.0
-				IL_0313: clt
-				IL_0315: brfalse IL_032c
+			IL_0281: ldarg.0
+			IL_0282: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::escapeRegExp
+			IL_0287: ldc.i4.1
+			IL_0288: newarr [System.Runtime]System.Object
+			IL_028d: dup
+			IL_028e: ldc.i4.0
+			IL_028f: ldarg.0
+			IL_0290: stelem.ref
+			IL_0291: ldloc.s 6
+			IL_0293: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0298: stloc.s 15
+			IL_029a: ldloc.s 15
+			IL_029c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_02a1: stloc.s 14
+			IL_02a3: ldstr "<\\/?"
+			IL_02a8: ldloc.s 14
+			IL_02aa: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02af: ldstr "\\b[^>]*>"
+			IL_02b4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_02b9: stloc.s 14
+			IL_02bb: ldloc.s 14
+			IL_02bd: ldstr "gi"
+			IL_02c2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+			IL_02c7: stloc.s 8
+			IL_02c9: ldloc.s 8
+			IL_02cb: ldstr "lastIndex"
+			IL_02d0: ldloc.s 4
+			IL_02d2: ldc.i4.1
+			IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_02d8: pop
+			IL_02d9: ldc.r8 0.0
+			IL_02e2: stloc.s 9
+			IL_02e4: ldc.r8 1
+			IL_02ed: neg
+			IL_02ee: stloc.s 18
+			IL_02f0: ldloc.s 18
+			IL_02f2: box [System.Runtime]System.Double
+			IL_02f7: stloc.s 10
+			// loop start (head: IL_02f9)
+				IL_02f9: ldc.i4.1
+				IL_02fa: brfalse IL_0497
 
-				IL_031a: ldloc.s 11
-				IL_031c: ldstr "index"
-				IL_0321: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0326: stloc.s 15
-				IL_0328: ldloc.s 15
-				IL_032a: stloc.s 10
+				IL_02ff: ldloc.s 8
+				IL_0301: ldstr "exec"
+				IL_0306: ldarg.2
+				IL_0307: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_030c: stloc.s 11
+				IL_030e: ldloc.s 11
+				IL_0310: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0315: ldc.i4.0
+				IL_0316: ceq
+				IL_0318: stloc.s 17
+				IL_031a: ldloc.s 17
+				IL_031c: brfalse IL_0326
 
-				IL_032c: ldloc.s 12
-				IL_032e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_0333: stloc.s 15
-				IL_0335: ldc.i4.0
-				IL_0336: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_033b: brfalse IL_0364
+				IL_0321: br IL_0497
 
-				IL_0340: ldloc.s 15
-				IL_0342: isinst [System.Runtime]System.String
-				IL_0347: dup
-				IL_0348: brfalse IL_0363
+				IL_0326: ldloc.s 11
+				IL_0328: ldc.r8 0.0
+				IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+				IL_0336: stloc.s 12
+				IL_0338: ldloc.s 10
+				IL_033a: stloc.s 19
+				IL_033c: ldloc.s 19
+				IL_033e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0343: ldc.r8 0.0
+				IL_034c: clt
+				IL_034e: brfalse IL_0365
 
-				IL_034d: ldstr "</"
-				IL_0352: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-				IL_0357: box [System.Runtime]System.Boolean
-				IL_035c: stloc.s 15
-				IL_035e: br IL_0377
+				IL_0353: ldloc.s 11
+				IL_0355: ldstr "index"
+				IL_035a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_035f: stloc.s 15
+				IL_0361: ldloc.s 15
+				IL_0363: stloc.s 10
 
-				IL_0363: pop
+				IL_0365: ldloc.s 12
+				IL_0367: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_036c: stloc.s 15
+				IL_036e: ldc.i4.0
+				IL_036f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0374: brfalse IL_03b0
 
-				IL_0364: ldloc.s 15
-				IL_0366: ldstr "startsWith"
-				IL_036b: ldstr "</"
-				IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0375: stloc.s 15
+				IL_0379: ldloc.s 15
+				IL_037b: isinst [System.Runtime]System.String
+				IL_0380: dup
+				IL_0381: brtrue IL_0399
 
-				IL_0377: ldloc.s 15
-				IL_0379: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-				IL_037e: stloc.s 17
-				IL_0380: ldloc.s 17
-				IL_0382: brfalse IL_0425
+				IL_0386: pop
+				IL_0387: ldloc.s 15
+				IL_0389: ldstr "startsWith"
+				IL_038e: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0393: dup
+				IL_0394: brfalse IL_03af
 
-				IL_0387: ldloc.s 9
-				IL_0389: ldc.r8 1
-				IL_0392: sub
-				IL_0393: stloc.s 9
-				IL_0395: ldloc.s 9
-				IL_0397: stloc.s 18
-				IL_0399: ldloc.s 18
-				IL_039b: ldc.r8 0.0
-				IL_03a4: ceq
-				IL_03a6: brfalse IL_0420
+				IL_0399: ldstr "</"
+				IL_039e: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+				IL_03a3: box [System.Runtime]System.Boolean
+				IL_03a8: stloc.s 15
+				IL_03aa: br IL_03c3
 
-				IL_03ab: ldarg.2
-				IL_03ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_03b1: stloc.s 15
-				IL_03b3: ldloc.s 8
-				IL_03b5: ldstr "lastIndex"
-				IL_03ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_03bf: stloc.s 20
-				IL_03c1: ldc.i4.0
-				IL_03c2: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_03c7: brfalse IL_03ea
+				IL_03af: pop
 
-				IL_03cc: ldloc.s 15
-				IL_03ce: isinst [System.Runtime]System.String
-				IL_03d3: dup
-				IL_03d4: brfalse IL_03e9
+				IL_03b0: ldloc.s 15
+				IL_03b2: ldstr "startsWith"
+				IL_03b7: ldstr "</"
+				IL_03bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_03c1: stloc.s 15
 
-				IL_03d9: ldloc.s 10
-				IL_03db: ldloc.s 20
-				IL_03dd: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
-				IL_03e2: stloc.s 20
-				IL_03e4: br IL_03fc
+				IL_03c3: ldloc.s 15
+				IL_03c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_03ca: stloc.s 17
+				IL_03cc: ldloc.s 17
+				IL_03ce: brfalse IL_0484
 
-				IL_03e9: pop
+				IL_03d3: ldloc.s 9
+				IL_03d5: ldc.r8 1
+				IL_03de: sub
+				IL_03df: stloc.s 9
+				IL_03e1: ldloc.s 9
+				IL_03e3: stloc.s 18
+				IL_03e5: ldloc.s 18
+				IL_03e7: ldc.r8 0.0
+				IL_03f0: ceq
+				IL_03f2: brfalse IL_047f
 
-				IL_03ea: ldloc.s 15
-				IL_03ec: ldstr "substring"
-				IL_03f1: ldloc.s 10
-				IL_03f3: ldloc.s 20
-				IL_03f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-				IL_03fa: stloc.s 20
+				IL_03f7: ldarg.2
+				IL_03f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_03fd: stloc.s 15
+				IL_03ff: ldloc.s 8
+				IL_0401: ldstr "lastIndex"
+				IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_040b: stloc.s 20
+				IL_040d: ldc.i4.0
+				IL_040e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_0413: brfalse IL_0449
 
-				IL_03fc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-				IL_0401: dup
-				IL_0402: ldstr "tagName"
-				IL_0407: ldloc.s 6
-				IL_0409: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_040e: dup
-				IL_040f: ldstr "html"
-				IL_0414: ldloc.s 20
-				IL_0416: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-				IL_041b: stloc.s 21
-				IL_041d: ldloc.s 21
-				IL_041f: ret
+				IL_0418: ldloc.s 15
+				IL_041a: isinst [System.Runtime]System.String
+				IL_041f: dup
+				IL_0420: brtrue IL_0438
 
-				IL_0420: br IL_0433
+				IL_0425: pop
+				IL_0426: ldloc.s 15
+				IL_0428: ldstr "substring"
+				IL_042d: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0432: dup
+				IL_0433: brfalse IL_0448
 
-				IL_0425: ldloc.s 9
-				IL_0427: ldc.r8 1
-				IL_0430: add
-				IL_0431: stloc.s 9
+				IL_0438: ldloc.s 10
+				IL_043a: ldloc.s 20
+				IL_043c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Substring(string, object, object)
+				IL_0441: stloc.s 20
+				IL_0443: br IL_045b
 
-				IL_0433: br IL_02c0
+				IL_0448: pop
+
+				IL_0449: ldloc.s 15
+				IL_044b: ldstr "substring"
+				IL_0450: ldloc.s 10
+				IL_0452: ldloc.s 20
+				IL_0454: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+				IL_0459: stloc.s 20
+
+				IL_045b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+				IL_0460: dup
+				IL_0461: ldstr "tagName"
+				IL_0466: ldloc.s 6
+				IL_0468: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_046d: dup
+				IL_046e: ldstr "html"
+				IL_0473: ldloc.s 20
+				IL_0475: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+				IL_047a: stloc.s 21
+				IL_047c: ldloc.s 21
+				IL_047e: ret
+
+				IL_047f: br IL_0492
+
+				IL_0484: ldloc.s 9
+				IL_0486: ldc.r8 1
+				IL_048f: add
+				IL_0490: stloc.s 9
+
+				IL_0492: br IL_02f9
 			// end loop
 
-			IL_0438: ldloc.s 6
-			IL_043a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_043f: stloc.s 14
-			IL_0441: ldstr "Could not find a matching closing </"
-			IL_0446: ldloc.s 14
-			IL_0448: call string [System.Runtime]System.String::Concat(string, string)
-			IL_044d: ldstr "> for id '"
-			IL_0452: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0457: ldarg.3
-			IL_0458: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_045d: stloc.s 14
-			IL_045f: ldloc.s 14
-			IL_0461: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0466: ldstr "'."
-			IL_046b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0470: stloc.s 14
-			IL_0472: ldloc.s 14
-			IL_0474: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0479: stloc.s 13
-			IL_047b: ldloc.s 13
-			IL_047d: isinst [System.Runtime]System.Exception
-			IL_0482: dup
-			IL_0483: brtrue IL_0491
+			IL_0497: ldloc.s 6
+			IL_0499: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_049e: stloc.s 14
+			IL_04a0: ldstr "Could not find a matching closing </"
+			IL_04a5: ldloc.s 14
+			IL_04a7: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04ac: ldstr "> for id '"
+			IL_04b1: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04b6: ldarg.3
+			IL_04b7: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_04bc: stloc.s 14
+			IL_04be: ldloc.s 14
+			IL_04c0: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04c5: ldstr "'."
+			IL_04ca: call string [System.Runtime]System.String::Concat(string, string)
+			IL_04cf: stloc.s 14
+			IL_04d1: ldloc.s 14
+			IL_04d3: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_04d8: stloc.s 13
+			IL_04da: ldloc.s 13
+			IL_04dc: isinst [System.Runtime]System.Exception
+			IL_04e1: dup
+			IL_04e2: brtrue IL_04f0
 
-			IL_0488: pop
-			IL_0489: ldloc.s 13
-			IL_048b: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
-			IL_0490: throw
+			IL_04e7: pop
+			IL_04e8: ldloc.s 13
+			IL_04ea: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::.ctor(object)
+			IL_04ef: throw
 
-			IL_0491: throw
+			IL_04f0: throw
 
-			IL_0492: ldnull
-			IL_0493: ret
+			IL_04f1: ldnull
+			IL_04f2: ret
 		} // end of method extractElementById::__js_call__
 
 	} // end of class extractElementById
@@ -5476,7 +5539,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 3152 (0xc50)
+			// Code size: 3209 (0xc89)
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope,
@@ -5709,7 +5772,7 @@
 
 			IL_0172: ldloc.0
 			IL_0173: ldfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0178: switch (IL_018d, IL_054e, IL_07d1, IL_0987)
+			IL_0178: switch (IL_018d, IL_0561, IL_07f7, IL_09c0)
 
 			IL_018d: ldarg.0
 			IL_018e: ldc.i4.1
@@ -5928,7 +5991,7 @@
 			IL_03e8: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_03ed: stloc.s 23
 			IL_03ef: ldloc.s 23
-			IL_03f1: brfalse IL_082f
+			IL_03f1: brfalse IL_0855
 
 			IL_03f6: ldloc.1
 			IL_03f7: ldstr "indexUrl"
@@ -5939,1003 +6002,1024 @@
 			IL_040a: stloc.s 22
 			IL_040c: ldc.i4.0
 			IL_040d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0412: brfalse IL_0431
+			IL_0412: brfalse IL_0444
 
 			IL_0417: ldloc.s 22
 			IL_0419: isinst [System.Runtime]System.String
 			IL_041e: dup
-			IL_041f: brfalse IL_0430
+			IL_041f: brtrue IL_0437
 
-			IL_0424: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0429: stloc.s 11
-			IL_042b: br IL_043f
+			IL_0424: pop
+			IL_0425: ldloc.s 22
+			IL_0427: ldstr "trim"
+			IL_042c: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0431: dup
+			IL_0432: brfalse IL_0443
 
-			IL_0430: pop
+			IL_0437: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_043c: stloc.s 11
+			IL_043e: br IL_0452
 
-			IL_0431: ldloc.s 22
-			IL_0433: ldstr "trim"
-			IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_043d: stloc.s 11
+			IL_0443: pop
 
-			IL_043f: ldarg.0
-			IL_0440: ldc.i4.1
-			IL_0441: ldelem.ref
-			IL_0442: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0447: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_044c: ldc.i4.1
-			IL_044d: newarr [System.Runtime]System.Object
-			IL_0452: dup
-			IL_0453: ldc.i4.0
-			IL_0454: ldarg.0
-			IL_0455: ldc.i4.1
-			IL_0456: ldelem.ref
-			IL_0457: stelem.ref
-			IL_0458: stloc.s 21
-			IL_045a: ldloc.s 21
-			IL_045c: ldloc.s 11
-			IL_045e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_0463: stloc.s 22
-			IL_0465: ldloc.0
-			IL_0466: ldc.i4.1
-			IL_0467: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_046c: ldloc.0
-			IL_046d: ldloc.s 22
-			IL_046f: ldarg.0
-			IL_0470: ldc.i4.1
-			IL_0471: ldloc.0
-			IL_0472: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_0477: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_047c: ldloc.0
-			IL_047d: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0482: dup
-			IL_0483: ldc.i4.0
-			IL_0484: ldloc.1
-			IL_0485: stelem.ref
-			IL_0486: dup
-			IL_0487: ldc.i4.1
-			IL_0488: ldloc.2
-			IL_0489: stelem.ref
-			IL_048a: dup
-			IL_048b: ldc.i4.2
-			IL_048c: ldloc.3
-			IL_048d: stelem.ref
-			IL_048e: dup
-			IL_048f: ldc.i4.3
-			IL_0490: ldloc.s 4
-			IL_0492: stelem.ref
-			IL_0493: dup
-			IL_0494: ldc.i4.4
-			IL_0495: ldloc.s 5
-			IL_0497: stelem.ref
-			IL_0498: dup
-			IL_0499: ldc.i4.5
-			IL_049a: ldloc.s 6
+			IL_0444: ldloc.s 22
+			IL_0446: ldstr "trim"
+			IL_044b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0450: stloc.s 11
+
+			IL_0452: ldarg.0
+			IL_0453: ldc.i4.1
+			IL_0454: ldelem.ref
+			IL_0455: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_045a: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_045f: ldc.i4.1
+			IL_0460: newarr [System.Runtime]System.Object
+			IL_0465: dup
+			IL_0466: ldc.i4.0
+			IL_0467: ldarg.0
+			IL_0468: ldc.i4.1
+			IL_0469: ldelem.ref
+			IL_046a: stelem.ref
+			IL_046b: stloc.s 21
+			IL_046d: ldloc.s 21
+			IL_046f: ldloc.s 11
+			IL_0471: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_0476: stloc.s 22
+			IL_0478: ldloc.0
+			IL_0479: ldc.i4.1
+			IL_047a: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_047f: ldloc.0
+			IL_0480: ldloc.s 22
+			IL_0482: ldarg.0
+			IL_0483: ldc.i4.1
+			IL_0484: ldloc.0
+			IL_0485: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_048a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_048f: ldloc.0
+			IL_0490: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_0495: dup
+			IL_0496: ldc.i4.0
+			IL_0497: ldloc.1
+			IL_0498: stelem.ref
+			IL_0499: dup
+			IL_049a: ldc.i4.1
+			IL_049b: ldloc.2
 			IL_049c: stelem.ref
 			IL_049d: dup
-			IL_049e: ldc.i4.6
-			IL_049f: ldloc.s 7
-			IL_04a1: stelem.ref
-			IL_04a2: dup
-			IL_04a3: ldc.i4.7
-			IL_04a4: ldloc.s 8
-			IL_04a6: stelem.ref
-			IL_04a7: dup
-			IL_04a8: ldc.i4.8
-			IL_04a9: ldloc.s 9
-			IL_04ab: stelem.ref
-			IL_04ac: dup
-			IL_04ad: ldc.i4.s 9
-			IL_04af: ldloc.s 10
-			IL_04b1: stelem.ref
-			IL_04b2: dup
-			IL_04b3: ldc.i4.s 10
-			IL_04b5: ldloc.s 11
-			IL_04b7: stelem.ref
-			IL_04b8: dup
-			IL_04b9: ldc.i4.s 11
-			IL_04bb: ldloc.s 12
-			IL_04bd: stelem.ref
-			IL_04be: dup
-			IL_04bf: ldc.i4.s 12
-			IL_04c1: ldloc.s 13
-			IL_04c3: stelem.ref
-			IL_04c4: dup
-			IL_04c5: ldc.i4.s 13
-			IL_04c7: ldloc.s 14
-			IL_04c9: stelem.ref
-			IL_04ca: dup
-			IL_04cb: ldc.i4.s 14
-			IL_04cd: ldloc.s 15
-			IL_04cf: stelem.ref
-			IL_04d0: dup
-			IL_04d1: ldc.i4.s 15
-			IL_04d3: ldloc.s 16
-			IL_04d5: stelem.ref
-			IL_04d6: dup
-			IL_04d7: ldc.i4.s 16
-			IL_04d9: ldloc.s 17
-			IL_04db: stelem.ref
-			IL_04dc: dup
-			IL_04dd: ldc.i4.s 17
-			IL_04df: ldloc.s 18
-			IL_04e1: stelem.ref
-			IL_04e2: dup
-			IL_04e3: ldc.i4.s 18
-			IL_04e5: ldloc.s 19
-			IL_04e7: stelem.ref
-			IL_04e8: dup
-			IL_04e9: ldc.i4.s 19
-			IL_04eb: ldloc.s 20
-			IL_04ed: stelem.ref
-			IL_04ee: dup
-			IL_04ef: ldc.i4.s 20
-			IL_04f1: ldloc.s 21
-			IL_04f3: stelem.ref
-			IL_04f4: dup
-			IL_04f5: ldc.i4.s 21
-			IL_04f7: ldloc.s 22
-			IL_04f9: stelem.ref
-			IL_04fa: dup
-			IL_04fb: ldc.i4.s 22
-			IL_04fd: ldloc.s 23
-			IL_04ff: box [System.Runtime]System.Boolean
-			IL_0504: stelem.ref
-			IL_0505: dup
-			IL_0506: ldc.i4.s 23
-			IL_0508: ldloc.s 24
-			IL_050a: stelem.ref
-			IL_050b: dup
-			IL_050c: ldc.i4.s 24
-			IL_050e: ldloc.s 25
-			IL_0510: stelem.ref
-			IL_0511: dup
-			IL_0512: ldc.i4.s 25
-			IL_0514: ldloc.s 26
-			IL_0516: stelem.ref
-			IL_0517: dup
-			IL_0518: ldc.i4.s 26
-			IL_051a: ldloc.s 27
-			IL_051c: stelem.ref
-			IL_051d: dup
-			IL_051e: ldc.i4.s 27
-			IL_0520: ldloc.s 28
-			IL_0522: stelem.ref
-			IL_0523: dup
-			IL_0524: ldc.i4.s 28
-			IL_0526: ldloc.s 29
-			IL_0528: stelem.ref
-			IL_0529: dup
-			IL_052a: ldc.i4.s 29
-			IL_052c: ldloc.s 30
-			IL_052e: stelem.ref
-			IL_052f: dup
-			IL_0530: ldc.i4.s 30
-			IL_0532: ldloc.s 31
-			IL_0534: stelem.ref
-			IL_0535: dup
-			IL_0536: ldc.i4.s 31
-			IL_0538: ldloc.s 32
-			IL_053a: stelem.ref
-			IL_053b: dup
-			IL_053c: ldc.i4.s 32
-			IL_053e: ldloc.s 33
-			IL_0540: stelem.ref
-			IL_0541: pop
-			IL_0542: ldloc.0
-			IL_0543: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0548: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_054d: ret
+			IL_049e: ldc.i4.2
+			IL_049f: ldloc.3
+			IL_04a0: stelem.ref
+			IL_04a1: dup
+			IL_04a2: ldc.i4.3
+			IL_04a3: ldloc.s 4
+			IL_04a5: stelem.ref
+			IL_04a6: dup
+			IL_04a7: ldc.i4.4
+			IL_04a8: ldloc.s 5
+			IL_04aa: stelem.ref
+			IL_04ab: dup
+			IL_04ac: ldc.i4.5
+			IL_04ad: ldloc.s 6
+			IL_04af: stelem.ref
+			IL_04b0: dup
+			IL_04b1: ldc.i4.6
+			IL_04b2: ldloc.s 7
+			IL_04b4: stelem.ref
+			IL_04b5: dup
+			IL_04b6: ldc.i4.7
+			IL_04b7: ldloc.s 8
+			IL_04b9: stelem.ref
+			IL_04ba: dup
+			IL_04bb: ldc.i4.8
+			IL_04bc: ldloc.s 9
+			IL_04be: stelem.ref
+			IL_04bf: dup
+			IL_04c0: ldc.i4.s 9
+			IL_04c2: ldloc.s 10
+			IL_04c4: stelem.ref
+			IL_04c5: dup
+			IL_04c6: ldc.i4.s 10
+			IL_04c8: ldloc.s 11
+			IL_04ca: stelem.ref
+			IL_04cb: dup
+			IL_04cc: ldc.i4.s 11
+			IL_04ce: ldloc.s 12
+			IL_04d0: stelem.ref
+			IL_04d1: dup
+			IL_04d2: ldc.i4.s 12
+			IL_04d4: ldloc.s 13
+			IL_04d6: stelem.ref
+			IL_04d7: dup
+			IL_04d8: ldc.i4.s 13
+			IL_04da: ldloc.s 14
+			IL_04dc: stelem.ref
+			IL_04dd: dup
+			IL_04de: ldc.i4.s 14
+			IL_04e0: ldloc.s 15
+			IL_04e2: stelem.ref
+			IL_04e3: dup
+			IL_04e4: ldc.i4.s 15
+			IL_04e6: ldloc.s 16
+			IL_04e8: stelem.ref
+			IL_04e9: dup
+			IL_04ea: ldc.i4.s 16
+			IL_04ec: ldloc.s 17
+			IL_04ee: stelem.ref
+			IL_04ef: dup
+			IL_04f0: ldc.i4.s 17
+			IL_04f2: ldloc.s 18
+			IL_04f4: stelem.ref
+			IL_04f5: dup
+			IL_04f6: ldc.i4.s 18
+			IL_04f8: ldloc.s 19
+			IL_04fa: stelem.ref
+			IL_04fb: dup
+			IL_04fc: ldc.i4.s 19
+			IL_04fe: ldloc.s 20
+			IL_0500: stelem.ref
+			IL_0501: dup
+			IL_0502: ldc.i4.s 20
+			IL_0504: ldloc.s 21
+			IL_0506: stelem.ref
+			IL_0507: dup
+			IL_0508: ldc.i4.s 21
+			IL_050a: ldloc.s 22
+			IL_050c: stelem.ref
+			IL_050d: dup
+			IL_050e: ldc.i4.s 22
+			IL_0510: ldloc.s 23
+			IL_0512: box [System.Runtime]System.Boolean
+			IL_0517: stelem.ref
+			IL_0518: dup
+			IL_0519: ldc.i4.s 23
+			IL_051b: ldloc.s 24
+			IL_051d: stelem.ref
+			IL_051e: dup
+			IL_051f: ldc.i4.s 24
+			IL_0521: ldloc.s 25
+			IL_0523: stelem.ref
+			IL_0524: dup
+			IL_0525: ldc.i4.s 25
+			IL_0527: ldloc.s 26
+			IL_0529: stelem.ref
+			IL_052a: dup
+			IL_052b: ldc.i4.s 26
+			IL_052d: ldloc.s 27
+			IL_052f: stelem.ref
+			IL_0530: dup
+			IL_0531: ldc.i4.s 27
+			IL_0533: ldloc.s 28
+			IL_0535: stelem.ref
+			IL_0536: dup
+			IL_0537: ldc.i4.s 28
+			IL_0539: ldloc.s 29
+			IL_053b: stelem.ref
+			IL_053c: dup
+			IL_053d: ldc.i4.s 29
+			IL_053f: ldloc.s 30
+			IL_0541: stelem.ref
+			IL_0542: dup
+			IL_0543: ldc.i4.s 30
+			IL_0545: ldloc.s 31
+			IL_0547: stelem.ref
+			IL_0548: dup
+			IL_0549: ldc.i4.s 31
+			IL_054b: ldloc.s 32
+			IL_054d: stelem.ref
+			IL_054e: dup
+			IL_054f: ldc.i4.s 32
+			IL_0551: ldloc.s 33
+			IL_0553: stelem.ref
+			IL_0554: pop
+			IL_0555: ldloc.0
+			IL_0556: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_055b: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0560: ret
 
-			IL_054e: ldloc.0
-			IL_054f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
-			IL_0554: stloc.s 12
-			IL_0556: ldarg.0
-			IL_0557: ldc.i4.1
-			IL_0558: ldelem.ref
-			IL_0559: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_055e: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
-			IL_0563: stloc.s 22
-			IL_0565: ldc.i4.1
-			IL_0566: newarr [System.Runtime]System.Object
-			IL_056b: dup
-			IL_056c: ldc.i4.0
-			IL_056d: ldarg.0
-			IL_056e: ldc.i4.1
-			IL_056f: ldelem.ref
-			IL_0570: stelem.ref
-			IL_0571: stloc.s 21
-			IL_0573: ldloc.1
-			IL_0574: ldstr "section"
-			IL_0579: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_057e: stloc.s 26
-			IL_0580: ldloc.s 26
-			IL_0582: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0587: stloc.s 26
-			IL_0589: ldc.i4.0
-			IL_058a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_058f: brfalse IL_05ae
+			IL_0561: ldloc.0
+			IL_0562: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited1
+			IL_0567: stloc.s 12
+			IL_0569: ldarg.0
+			IL_056a: ldc.i4.1
+			IL_056b: ldelem.ref
+			IL_056c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0571: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::resolveSectionLinkFromMultipageIndexHtml
+			IL_0576: stloc.s 22
+			IL_0578: ldc.i4.1
+			IL_0579: newarr [System.Runtime]System.Object
+			IL_057e: dup
+			IL_057f: ldc.i4.0
+			IL_0580: ldarg.0
+			IL_0581: ldc.i4.1
+			IL_0582: ldelem.ref
+			IL_0583: stelem.ref
+			IL_0584: stloc.s 21
+			IL_0586: ldloc.1
+			IL_0587: ldstr "section"
+			IL_058c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0591: stloc.s 26
+			IL_0593: ldloc.s 26
+			IL_0595: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_059a: stloc.s 26
+			IL_059c: ldc.i4.0
+			IL_059d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_05a2: brfalse IL_05d4
 
-			IL_0594: ldloc.s 26
-			IL_0596: isinst [System.Runtime]System.String
-			IL_059b: dup
-			IL_059c: brfalse IL_05ad
+			IL_05a7: ldloc.s 26
+			IL_05a9: isinst [System.Runtime]System.String
+			IL_05ae: dup
+			IL_05af: brtrue IL_05c7
 
-			IL_05a1: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_05a6: stloc.s 26
-			IL_05a8: br IL_05bc
+			IL_05b4: pop
+			IL_05b5: ldloc.s 26
+			IL_05b7: ldstr "trim"
+			IL_05bc: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_05c1: dup
+			IL_05c2: brfalse IL_05d3
 
-			IL_05ad: pop
+			IL_05c7: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_05cc: stloc.s 26
+			IL_05ce: br IL_05e2
 
-			IL_05ae: ldloc.s 26
-			IL_05b0: ldstr "trim"
-			IL_05b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_05ba: stloc.s 26
+			IL_05d3: pop
 
-			IL_05bc: ldloc.s 22
-			IL_05be: ldloc.s 21
-			IL_05c0: ldloc.s 12
-			IL_05c2: ldloc.s 26
-			IL_05c4: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_05c9: stloc.s 13
-			IL_05cb: ldloc.s 13
-			IL_05cd: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_05d2: ldc.i4.0
-			IL_05d3: ceq
-			IL_05d5: stloc.s 23
-			IL_05d7: ldloc.s 23
-			IL_05d9: brfalse IL_0655
+			IL_05d4: ldloc.s 26
+			IL_05d6: ldstr "trim"
+			IL_05db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_05e0: stloc.s 26
 
-			IL_05de: ldloc.1
-			IL_05df: ldstr "section"
-			IL_05e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_05e9: stloc.s 26
-			IL_05eb: ldloc.s 26
-			IL_05ed: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_05f2: stloc.s 27
-			IL_05f4: ldstr "Could not find section '"
-			IL_05f9: ldloc.s 27
-			IL_05fb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0600: ldstr "' in multipage index: "
-			IL_0605: call string [System.Runtime]System.String::Concat(string, string)
-			IL_060a: ldloc.s 11
-			IL_060c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0611: stloc.s 27
-			IL_0613: ldloc.s 27
-			IL_0615: call string [System.Runtime]System.String::Concat(string, string)
-			IL_061a: stloc.s 27
-			IL_061c: ldloc.s 27
-			IL_061e: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_0623: stloc.s 14
-			IL_0625: ldloc.0
-			IL_0626: ldc.i4.m1
-			IL_0627: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_062c: ldloc.0
-			IL_062d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0632: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_0637: ldarg.0
-			IL_0638: ldc.i4.1
-			IL_0639: newarr [System.Runtime]System.Object
-			IL_063e: dup
-			IL_063f: ldc.i4.0
-			IL_0640: ldloc.s 14
-			IL_0642: stelem.ref
-			IL_0643: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0648: pop
-			IL_0649: ldloc.0
-			IL_064a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_064f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0654: ret
+			IL_05e2: ldloc.s 22
+			IL_05e4: ldloc.s 21
+			IL_05e6: ldloc.s 12
+			IL_05e8: ldloc.s 26
+			IL_05ea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_05ef: stloc.s 13
+			IL_05f1: ldloc.s 13
+			IL_05f3: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_05f8: ldc.i4.0
+			IL_05f9: ceq
+			IL_05fb: stloc.s 23
+			IL_05fd: ldloc.s 23
+			IL_05ff: brfalse IL_067b
 
-			IL_0655: ldarg.0
-			IL_0656: ldc.i4.1
-			IL_0657: ldelem.ref
-			IL_0658: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_065d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
-			IL_0662: stloc.s 26
-			IL_0664: ldloc.s 13
-			IL_0666: ldstr "filePart"
-			IL_066b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0670: stloc.s 22
-			IL_0672: ldloc.s 22
-			IL_0674: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_0679: stloc.s 23
-			IL_067b: ldloc.s 23
-			IL_067d: brtrue IL_0699
+			IL_0604: ldloc.1
+			IL_0605: ldstr "section"
+			IL_060a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_060f: stloc.s 26
+			IL_0611: ldloc.s 26
+			IL_0613: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0618: stloc.s 27
+			IL_061a: ldstr "Could not find section '"
+			IL_061f: ldloc.s 27
+			IL_0621: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0626: ldstr "' in multipage index: "
+			IL_062b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0630: ldloc.s 11
+			IL_0632: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0637: stloc.s 27
+			IL_0639: ldloc.s 27
+			IL_063b: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0640: stloc.s 27
+			IL_0642: ldloc.s 27
+			IL_0644: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0649: stloc.s 14
+			IL_064b: ldloc.0
+			IL_064c: ldc.i4.m1
+			IL_064d: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0652: ldloc.0
+			IL_0653: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0658: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_065d: ldarg.0
+			IL_065e: ldc.i4.1
+			IL_065f: newarr [System.Runtime]System.Object
+			IL_0664: dup
+			IL_0665: ldc.i4.0
+			IL_0666: ldloc.s 14
+			IL_0668: stelem.ref
+			IL_0669: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_066e: pop
+			IL_066f: ldloc.0
+			IL_0670: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0675: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_067a: ret
 
-			IL_0682: ldloc.s 13
-			IL_0684: ldstr "href"
-			IL_0689: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_068e: stloc.s 28
-			IL_0690: ldloc.s 28
-			IL_0692: stloc.s 29
-			IL_0694: br IL_069d
+			IL_067b: ldarg.0
+			IL_067c: ldc.i4.1
+			IL_067d: ldelem.ref
+			IL_067e: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0683: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::NodeUrl
+			IL_0688: stloc.s 26
+			IL_068a: ldloc.s 13
+			IL_068c: ldstr "filePart"
+			IL_0691: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0696: stloc.s 22
+			IL_0698: ldloc.s 22
+			IL_069a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_069f: stloc.s 23
+			IL_06a1: ldloc.s 23
+			IL_06a3: brtrue IL_06bf
 
-			IL_0699: ldloc.s 22
-			IL_069b: stloc.s 29
+			IL_06a8: ldloc.s 13
+			IL_06aa: ldstr "href"
+			IL_06af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_06b4: stloc.s 28
+			IL_06b6: ldloc.s 28
+			IL_06b8: stloc.s 29
+			IL_06ba: br IL_06c3
 
-			IL_069d: ldloc.s 26
-			IL_069f: dup
-			IL_06a0: ldloc.s 29
-			IL_06a2: ldloc.s 11
-			IL_06a4: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
-			IL_06a9: stloc.s 26
-			IL_06ab: ldloc.s 26
-			IL_06ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_06b2: stloc.s 26
-			IL_06b4: ldloc.s 26
-			IL_06b6: ldstr "toString"
-			IL_06bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_06c0: stloc.s 15
-			IL_06c2: ldarg.0
-			IL_06c3: ldc.i4.1
-			IL_06c4: ldelem.ref
-			IL_06c5: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_06ca: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_06cf: ldc.i4.1
-			IL_06d0: newarr [System.Runtime]System.Object
-			IL_06d5: dup
-			IL_06d6: ldc.i4.0
-			IL_06d7: ldarg.0
-			IL_06d8: ldc.i4.1
-			IL_06d9: ldelem.ref
-			IL_06da: stelem.ref
-			IL_06db: stloc.s 21
-			IL_06dd: ldloc.s 21
-			IL_06df: ldloc.s 15
-			IL_06e1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_06e6: stloc.s 26
-			IL_06e8: ldloc.0
-			IL_06e9: ldc.i4.2
-			IL_06ea: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_06ef: ldloc.0
-			IL_06f0: ldloc.s 26
-			IL_06f2: ldarg.0
-			IL_06f3: ldc.i4.2
-			IL_06f4: ldloc.0
-			IL_06f5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_06fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_06ff: ldloc.0
-			IL_0700: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_0705: dup
-			IL_0706: ldc.i4.0
-			IL_0707: ldloc.1
-			IL_0708: stelem.ref
-			IL_0709: dup
-			IL_070a: ldc.i4.1
-			IL_070b: ldloc.2
-			IL_070c: stelem.ref
-			IL_070d: dup
-			IL_070e: ldc.i4.2
-			IL_070f: ldloc.3
-			IL_0710: stelem.ref
-			IL_0711: dup
-			IL_0712: ldc.i4.3
-			IL_0713: ldloc.s 4
-			IL_0715: stelem.ref
-			IL_0716: dup
-			IL_0717: ldc.i4.4
-			IL_0718: ldloc.s 5
-			IL_071a: stelem.ref
-			IL_071b: dup
-			IL_071c: ldc.i4.5
-			IL_071d: ldloc.s 6
-			IL_071f: stelem.ref
-			IL_0720: dup
-			IL_0721: ldc.i4.6
-			IL_0722: ldloc.s 7
-			IL_0724: stelem.ref
-			IL_0725: dup
-			IL_0726: ldc.i4.7
-			IL_0727: ldloc.s 8
-			IL_0729: stelem.ref
-			IL_072a: dup
-			IL_072b: ldc.i4.8
-			IL_072c: ldloc.s 9
+			IL_06bf: ldloc.s 22
+			IL_06c1: stloc.s 29
+
+			IL_06c3: ldloc.s 26
+			IL_06c5: dup
+			IL_06c6: ldloc.s 29
+			IL_06c8: ldloc.s 11
+			IL_06ca: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct2(object, object, object, object)
+			IL_06cf: stloc.s 26
+			IL_06d1: ldloc.s 26
+			IL_06d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_06d8: stloc.s 26
+			IL_06da: ldloc.s 26
+			IL_06dc: ldstr "toString"
+			IL_06e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_06e6: stloc.s 15
+			IL_06e8: ldarg.0
+			IL_06e9: ldc.i4.1
+			IL_06ea: ldelem.ref
+			IL_06eb: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_06f0: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_06f5: ldc.i4.1
+			IL_06f6: newarr [System.Runtime]System.Object
+			IL_06fb: dup
+			IL_06fc: ldc.i4.0
+			IL_06fd: ldarg.0
+			IL_06fe: ldc.i4.1
+			IL_06ff: ldelem.ref
+			IL_0700: stelem.ref
+			IL_0701: stloc.s 21
+			IL_0703: ldloc.s 21
+			IL_0705: ldloc.s 15
+			IL_0707: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_070c: stloc.s 26
+			IL_070e: ldloc.0
+			IL_070f: ldc.i4.2
+			IL_0710: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0715: ldloc.0
+			IL_0716: ldloc.s 26
+			IL_0718: ldarg.0
+			IL_0719: ldc.i4.2
+			IL_071a: ldloc.0
+			IL_071b: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_0720: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_0725: ldloc.0
+			IL_0726: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_072b: dup
+			IL_072c: ldc.i4.0
+			IL_072d: ldloc.1
 			IL_072e: stelem.ref
 			IL_072f: dup
-			IL_0730: ldc.i4.s 9
-			IL_0732: ldloc.s 10
-			IL_0734: stelem.ref
-			IL_0735: dup
-			IL_0736: ldc.i4.s 10
-			IL_0738: ldloc.s 11
-			IL_073a: stelem.ref
-			IL_073b: dup
-			IL_073c: ldc.i4.s 11
-			IL_073e: ldloc.s 12
+			IL_0730: ldc.i4.1
+			IL_0731: ldloc.2
+			IL_0732: stelem.ref
+			IL_0733: dup
+			IL_0734: ldc.i4.2
+			IL_0735: ldloc.3
+			IL_0736: stelem.ref
+			IL_0737: dup
+			IL_0738: ldc.i4.3
+			IL_0739: ldloc.s 4
+			IL_073b: stelem.ref
+			IL_073c: dup
+			IL_073d: ldc.i4.4
+			IL_073e: ldloc.s 5
 			IL_0740: stelem.ref
 			IL_0741: dup
-			IL_0742: ldc.i4.s 12
-			IL_0744: ldloc.s 13
-			IL_0746: stelem.ref
-			IL_0747: dup
-			IL_0748: ldc.i4.s 13
-			IL_074a: ldloc.s 14
-			IL_074c: stelem.ref
-			IL_074d: dup
-			IL_074e: ldc.i4.s 14
-			IL_0750: ldloc.s 15
-			IL_0752: stelem.ref
-			IL_0753: dup
-			IL_0754: ldc.i4.s 15
-			IL_0756: ldloc.s 16
-			IL_0758: stelem.ref
-			IL_0759: dup
-			IL_075a: ldc.i4.s 16
-			IL_075c: ldloc.s 17
-			IL_075e: stelem.ref
-			IL_075f: dup
-			IL_0760: ldc.i4.s 17
-			IL_0762: ldloc.s 18
-			IL_0764: stelem.ref
-			IL_0765: dup
-			IL_0766: ldc.i4.s 18
-			IL_0768: ldloc.s 19
-			IL_076a: stelem.ref
-			IL_076b: dup
-			IL_076c: ldc.i4.s 19
-			IL_076e: ldloc.s 20
-			IL_0770: stelem.ref
-			IL_0771: dup
-			IL_0772: ldc.i4.s 20
-			IL_0774: ldloc.s 21
-			IL_0776: stelem.ref
-			IL_0777: dup
-			IL_0778: ldc.i4.s 21
-			IL_077a: ldloc.s 22
-			IL_077c: stelem.ref
-			IL_077d: dup
-			IL_077e: ldc.i4.s 22
-			IL_0780: ldloc.s 23
-			IL_0782: box [System.Runtime]System.Boolean
-			IL_0787: stelem.ref
-			IL_0788: dup
-			IL_0789: ldc.i4.s 23
-			IL_078b: ldloc.s 24
-			IL_078d: stelem.ref
-			IL_078e: dup
-			IL_078f: ldc.i4.s 24
-			IL_0791: ldloc.s 25
-			IL_0793: stelem.ref
-			IL_0794: dup
-			IL_0795: ldc.i4.s 25
-			IL_0797: ldloc.s 26
-			IL_0799: stelem.ref
-			IL_079a: dup
-			IL_079b: ldc.i4.s 26
-			IL_079d: ldloc.s 27
-			IL_079f: stelem.ref
-			IL_07a0: dup
-			IL_07a1: ldc.i4.s 27
-			IL_07a3: ldloc.s 28
-			IL_07a5: stelem.ref
-			IL_07a6: dup
-			IL_07a7: ldc.i4.s 28
-			IL_07a9: ldloc.s 29
-			IL_07ab: stelem.ref
-			IL_07ac: dup
-			IL_07ad: ldc.i4.s 29
-			IL_07af: ldloc.s 30
-			IL_07b1: stelem.ref
-			IL_07b2: dup
-			IL_07b3: ldc.i4.s 30
-			IL_07b5: ldloc.s 31
-			IL_07b7: stelem.ref
-			IL_07b8: dup
-			IL_07b9: ldc.i4.s 31
-			IL_07bb: ldloc.s 32
-			IL_07bd: stelem.ref
-			IL_07be: dup
-			IL_07bf: ldc.i4.s 32
-			IL_07c1: ldloc.s 33
-			IL_07c3: stelem.ref
-			IL_07c4: pop
-			IL_07c5: ldloc.0
-			IL_07c6: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_07cb: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_07d0: ret
+			IL_0742: ldc.i4.5
+			IL_0743: ldloc.s 6
+			IL_0745: stelem.ref
+			IL_0746: dup
+			IL_0747: ldc.i4.6
+			IL_0748: ldloc.s 7
+			IL_074a: stelem.ref
+			IL_074b: dup
+			IL_074c: ldc.i4.7
+			IL_074d: ldloc.s 8
+			IL_074f: stelem.ref
+			IL_0750: dup
+			IL_0751: ldc.i4.8
+			IL_0752: ldloc.s 9
+			IL_0754: stelem.ref
+			IL_0755: dup
+			IL_0756: ldc.i4.s 9
+			IL_0758: ldloc.s 10
+			IL_075a: stelem.ref
+			IL_075b: dup
+			IL_075c: ldc.i4.s 10
+			IL_075e: ldloc.s 11
+			IL_0760: stelem.ref
+			IL_0761: dup
+			IL_0762: ldc.i4.s 11
+			IL_0764: ldloc.s 12
+			IL_0766: stelem.ref
+			IL_0767: dup
+			IL_0768: ldc.i4.s 12
+			IL_076a: ldloc.s 13
+			IL_076c: stelem.ref
+			IL_076d: dup
+			IL_076e: ldc.i4.s 13
+			IL_0770: ldloc.s 14
+			IL_0772: stelem.ref
+			IL_0773: dup
+			IL_0774: ldc.i4.s 14
+			IL_0776: ldloc.s 15
+			IL_0778: stelem.ref
+			IL_0779: dup
+			IL_077a: ldc.i4.s 15
+			IL_077c: ldloc.s 16
+			IL_077e: stelem.ref
+			IL_077f: dup
+			IL_0780: ldc.i4.s 16
+			IL_0782: ldloc.s 17
+			IL_0784: stelem.ref
+			IL_0785: dup
+			IL_0786: ldc.i4.s 17
+			IL_0788: ldloc.s 18
+			IL_078a: stelem.ref
+			IL_078b: dup
+			IL_078c: ldc.i4.s 18
+			IL_078e: ldloc.s 19
+			IL_0790: stelem.ref
+			IL_0791: dup
+			IL_0792: ldc.i4.s 19
+			IL_0794: ldloc.s 20
+			IL_0796: stelem.ref
+			IL_0797: dup
+			IL_0798: ldc.i4.s 20
+			IL_079a: ldloc.s 21
+			IL_079c: stelem.ref
+			IL_079d: dup
+			IL_079e: ldc.i4.s 21
+			IL_07a0: ldloc.s 22
+			IL_07a2: stelem.ref
+			IL_07a3: dup
+			IL_07a4: ldc.i4.s 22
+			IL_07a6: ldloc.s 23
+			IL_07a8: box [System.Runtime]System.Boolean
+			IL_07ad: stelem.ref
+			IL_07ae: dup
+			IL_07af: ldc.i4.s 23
+			IL_07b1: ldloc.s 24
+			IL_07b3: stelem.ref
+			IL_07b4: dup
+			IL_07b5: ldc.i4.s 24
+			IL_07b7: ldloc.s 25
+			IL_07b9: stelem.ref
+			IL_07ba: dup
+			IL_07bb: ldc.i4.s 25
+			IL_07bd: ldloc.s 26
+			IL_07bf: stelem.ref
+			IL_07c0: dup
+			IL_07c1: ldc.i4.s 26
+			IL_07c3: ldloc.s 27
+			IL_07c5: stelem.ref
+			IL_07c6: dup
+			IL_07c7: ldc.i4.s 27
+			IL_07c9: ldloc.s 28
+			IL_07cb: stelem.ref
+			IL_07cc: dup
+			IL_07cd: ldc.i4.s 28
+			IL_07cf: ldloc.s 29
+			IL_07d1: stelem.ref
+			IL_07d2: dup
+			IL_07d3: ldc.i4.s 29
+			IL_07d5: ldloc.s 30
+			IL_07d7: stelem.ref
+			IL_07d8: dup
+			IL_07d9: ldc.i4.s 30
+			IL_07db: ldloc.s 31
+			IL_07dd: stelem.ref
+			IL_07de: dup
+			IL_07df: ldc.i4.s 31
+			IL_07e1: ldloc.s 32
+			IL_07e3: stelem.ref
+			IL_07e4: dup
+			IL_07e5: ldc.i4.s 32
+			IL_07e7: ldloc.s 33
+			IL_07e9: stelem.ref
+			IL_07ea: pop
+			IL_07eb: ldloc.0
+			IL_07ec: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_07f1: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_07f6: ret
 
-			IL_07d1: ldloc.0
-			IL_07d2: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
-			IL_07d7: stloc.s 26
-			IL_07d9: ldloc.s 26
-			IL_07db: stloc.s 8
-			IL_07dd: ldloc.s 15
-			IL_07df: stloc.s 26
-			IL_07e1: ldloc.s 26
-			IL_07e3: stloc.s 10
-			IL_07e5: ldloc.s 9
-			IL_07e7: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_07ec: ldc.i4.0
-			IL_07ed: ceq
-			IL_07ef: stloc.s 23
-			IL_07f1: ldloc.s 23
-			IL_07f3: brfalse IL_082a
+			IL_07f7: ldloc.0
+			IL_07f8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited2
+			IL_07fd: stloc.s 26
+			IL_07ff: ldloc.s 26
+			IL_0801: stloc.s 8
+			IL_0803: ldloc.s 15
+			IL_0805: stloc.s 26
+			IL_0807: ldloc.s 26
+			IL_0809: stloc.s 10
+			IL_080b: ldloc.s 9
+			IL_080d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_0812: ldc.i4.0
+			IL_0813: ceq
+			IL_0815: stloc.s 23
+			IL_0817: ldloc.s 23
+			IL_0819: brfalse IL_0850
 
-			IL_07f8: ldloc.s 13
-			IL_07fa: ldstr "fragment"
-			IL_07ff: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0804: stloc.s 26
-			IL_0806: ldloc.s 26
-			IL_0808: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-			IL_080d: stloc.s 23
-			IL_080f: ldloc.s 23
-			IL_0811: brtrue IL_0822
+			IL_081e: ldloc.s 13
+			IL_0820: ldstr "fragment"
+			IL_0825: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_082a: stloc.s 26
+			IL_082c: ldloc.s 26
+			IL_082e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_0833: stloc.s 23
+			IL_0835: ldloc.s 23
+			IL_0837: brtrue IL_0848
 
-			IL_0816: ldstr ""
-			IL_081b: stloc.s 30
-			IL_081d: br IL_0826
+			IL_083c: ldstr ""
+			IL_0841: stloc.s 30
+			IL_0843: br IL_084c
 
-			IL_0822: ldloc.s 26
-			IL_0824: stloc.s 30
+			IL_0848: ldloc.s 26
+			IL_084a: stloc.s 30
 
-			IL_0826: ldloc.s 30
-			IL_0828: stloc.s 9
+			IL_084c: ldloc.s 30
+			IL_084e: stloc.s 9
 
-			IL_082a: br IL_099b
+			IL_0850: br IL_09d4
 
-			IL_082f: ldloc.1
-			IL_0830: ldstr "url"
-			IL_0835: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_083a: stloc.s 26
-			IL_083c: ldloc.s 26
-			IL_083e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0843: stloc.s 26
-			IL_0845: ldc.i4.0
-			IL_0846: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_084b: brfalse IL_086a
+			IL_0855: ldloc.1
+			IL_0856: ldstr "url"
+			IL_085b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0860: stloc.s 26
+			IL_0862: ldloc.s 26
+			IL_0864: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0869: stloc.s 26
+			IL_086b: ldc.i4.0
+			IL_086c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0871: brfalse IL_08a3
 
-			IL_0850: ldloc.s 26
-			IL_0852: isinst [System.Runtime]System.String
-			IL_0857: dup
-			IL_0858: brfalse IL_0869
+			IL_0876: ldloc.s 26
+			IL_0878: isinst [System.Runtime]System.String
+			IL_087d: dup
+			IL_087e: brtrue IL_0896
 
-			IL_085d: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0862: stloc.s 16
-			IL_0864: br IL_0878
+			IL_0883: pop
+			IL_0884: ldloc.s 26
+			IL_0886: ldstr "trim"
+			IL_088b: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0890: dup
+			IL_0891: brfalse IL_08a2
 
-			IL_0869: pop
+			IL_0896: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_089b: stloc.s 16
+			IL_089d: br IL_08b1
 
-			IL_086a: ldloc.s 26
-			IL_086c: ldstr "trim"
-			IL_0871: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0876: stloc.s 16
+			IL_08a2: pop
 
-			IL_0878: ldarg.0
-			IL_0879: ldc.i4.1
-			IL_087a: ldelem.ref
-			IL_087b: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0880: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
-			IL_0885: ldc.i4.1
-			IL_0886: newarr [System.Runtime]System.Object
-			IL_088b: dup
-			IL_088c: ldc.i4.0
-			IL_088d: ldarg.0
-			IL_088e: ldc.i4.1
-			IL_088f: ldelem.ref
-			IL_0890: stelem.ref
-			IL_0891: stloc.s 21
-			IL_0893: ldloc.s 21
-			IL_0895: ldloc.s 16
-			IL_0897: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-			IL_089c: stloc.s 26
-			IL_089e: ldloc.0
-			IL_089f: ldc.i4.3
-			IL_08a0: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_08a5: ldloc.0
-			IL_08a6: ldloc.s 26
-			IL_08a8: ldarg.0
-			IL_08a9: ldc.i4.3
-			IL_08aa: ldloc.0
-			IL_08ab: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
-			IL_08b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
-			IL_08b5: ldloc.0
-			IL_08b6: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
-			IL_08bb: dup
-			IL_08bc: ldc.i4.0
-			IL_08bd: ldloc.1
-			IL_08be: stelem.ref
-			IL_08bf: dup
-			IL_08c0: ldc.i4.1
-			IL_08c1: ldloc.2
-			IL_08c2: stelem.ref
-			IL_08c3: dup
-			IL_08c4: ldc.i4.2
-			IL_08c5: ldloc.3
-			IL_08c6: stelem.ref
-			IL_08c7: dup
-			IL_08c8: ldc.i4.3
-			IL_08c9: ldloc.s 4
-			IL_08cb: stelem.ref
-			IL_08cc: dup
-			IL_08cd: ldc.i4.4
-			IL_08ce: ldloc.s 5
-			IL_08d0: stelem.ref
-			IL_08d1: dup
-			IL_08d2: ldc.i4.5
-			IL_08d3: ldloc.s 6
-			IL_08d5: stelem.ref
-			IL_08d6: dup
-			IL_08d7: ldc.i4.6
-			IL_08d8: ldloc.s 7
-			IL_08da: stelem.ref
-			IL_08db: dup
-			IL_08dc: ldc.i4.7
-			IL_08dd: ldloc.s 8
-			IL_08df: stelem.ref
-			IL_08e0: dup
-			IL_08e1: ldc.i4.8
-			IL_08e2: ldloc.s 9
-			IL_08e4: stelem.ref
-			IL_08e5: dup
-			IL_08e6: ldc.i4.s 9
-			IL_08e8: ldloc.s 10
-			IL_08ea: stelem.ref
-			IL_08eb: dup
-			IL_08ec: ldc.i4.s 10
-			IL_08ee: ldloc.s 11
-			IL_08f0: stelem.ref
-			IL_08f1: dup
-			IL_08f2: ldc.i4.s 11
-			IL_08f4: ldloc.s 12
-			IL_08f6: stelem.ref
-			IL_08f7: dup
-			IL_08f8: ldc.i4.s 12
-			IL_08fa: ldloc.s 13
-			IL_08fc: stelem.ref
-			IL_08fd: dup
-			IL_08fe: ldc.i4.s 13
-			IL_0900: ldloc.s 14
-			IL_0902: stelem.ref
-			IL_0903: dup
-			IL_0904: ldc.i4.s 14
-			IL_0906: ldloc.s 15
-			IL_0908: stelem.ref
-			IL_0909: dup
-			IL_090a: ldc.i4.s 15
-			IL_090c: ldloc.s 16
+			IL_08a3: ldloc.s 26
+			IL_08a5: ldstr "trim"
+			IL_08aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_08af: stloc.s 16
+
+			IL_08b1: ldarg.0
+			IL_08b2: ldc.i4.1
+			IL_08b3: ldelem.ref
+			IL_08b4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_08b9: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fetchText
+			IL_08be: ldc.i4.1
+			IL_08bf: newarr [System.Runtime]System.Object
+			IL_08c4: dup
+			IL_08c5: ldc.i4.0
+			IL_08c6: ldarg.0
+			IL_08c7: ldc.i4.1
+			IL_08c8: ldelem.ref
+			IL_08c9: stelem.ref
+			IL_08ca: stloc.s 21
+			IL_08cc: ldloc.s 21
+			IL_08ce: ldloc.s 16
+			IL_08d0: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+			IL_08d5: stloc.s 26
+			IL_08d7: ldloc.0
+			IL_08d8: ldc.i4.3
+			IL_08d9: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_08de: ldloc.0
+			IL_08df: ldloc.s 26
+			IL_08e1: ldarg.0
+			IL_08e2: ldc.i4.3
+			IL_08e3: ldloc.0
+			IL_08e4: ldfld class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_moveNext
+			IL_08e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::SetupAwaitContinuationTyped(object, object[], int32, class [JavaScriptRuntime]JavaScriptRuntime.CompiledContinuation)
+			IL_08ee: ldloc.0
+			IL_08ef: ldfld object[] [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_locals
+			IL_08f4: dup
+			IL_08f5: ldc.i4.0
+			IL_08f6: ldloc.1
+			IL_08f7: stelem.ref
+			IL_08f8: dup
+			IL_08f9: ldc.i4.1
+			IL_08fa: ldloc.2
+			IL_08fb: stelem.ref
+			IL_08fc: dup
+			IL_08fd: ldc.i4.2
+			IL_08fe: ldloc.3
+			IL_08ff: stelem.ref
+			IL_0900: dup
+			IL_0901: ldc.i4.3
+			IL_0902: ldloc.s 4
+			IL_0904: stelem.ref
+			IL_0905: dup
+			IL_0906: ldc.i4.4
+			IL_0907: ldloc.s 5
+			IL_0909: stelem.ref
+			IL_090a: dup
+			IL_090b: ldc.i4.5
+			IL_090c: ldloc.s 6
 			IL_090e: stelem.ref
 			IL_090f: dup
-			IL_0910: ldc.i4.s 16
-			IL_0912: ldloc.s 17
-			IL_0914: stelem.ref
-			IL_0915: dup
-			IL_0916: ldc.i4.s 17
-			IL_0918: ldloc.s 18
-			IL_091a: stelem.ref
-			IL_091b: dup
-			IL_091c: ldc.i4.s 18
-			IL_091e: ldloc.s 19
-			IL_0920: stelem.ref
-			IL_0921: dup
-			IL_0922: ldc.i4.s 19
-			IL_0924: ldloc.s 20
-			IL_0926: stelem.ref
-			IL_0927: dup
-			IL_0928: ldc.i4.s 20
-			IL_092a: ldloc.s 21
-			IL_092c: stelem.ref
-			IL_092d: dup
-			IL_092e: ldc.i4.s 21
-			IL_0930: ldloc.s 22
-			IL_0932: stelem.ref
-			IL_0933: dup
-			IL_0934: ldc.i4.s 22
-			IL_0936: ldloc.s 23
-			IL_0938: box [System.Runtime]System.Boolean
-			IL_093d: stelem.ref
-			IL_093e: dup
-			IL_093f: ldc.i4.s 23
-			IL_0941: ldloc.s 24
-			IL_0943: stelem.ref
-			IL_0944: dup
-			IL_0945: ldc.i4.s 24
-			IL_0947: ldloc.s 25
-			IL_0949: stelem.ref
-			IL_094a: dup
-			IL_094b: ldc.i4.s 25
-			IL_094d: ldloc.s 26
-			IL_094f: stelem.ref
-			IL_0950: dup
-			IL_0951: ldc.i4.s 26
-			IL_0953: ldloc.s 27
-			IL_0955: stelem.ref
-			IL_0956: dup
-			IL_0957: ldc.i4.s 27
-			IL_0959: ldloc.s 28
-			IL_095b: stelem.ref
-			IL_095c: dup
-			IL_095d: ldc.i4.s 28
-			IL_095f: ldloc.s 29
-			IL_0961: stelem.ref
-			IL_0962: dup
-			IL_0963: ldc.i4.s 29
-			IL_0965: ldloc.s 30
-			IL_0967: stelem.ref
-			IL_0968: dup
-			IL_0969: ldc.i4.s 30
-			IL_096b: ldloc.s 31
-			IL_096d: stelem.ref
-			IL_096e: dup
-			IL_096f: ldc.i4.s 31
-			IL_0971: ldloc.s 32
-			IL_0973: stelem.ref
-			IL_0974: dup
-			IL_0975: ldc.i4.s 32
-			IL_0977: ldloc.s 33
-			IL_0979: stelem.ref
-			IL_097a: pop
-			IL_097b: ldloc.0
-			IL_097c: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0981: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0986: ret
+			IL_0910: ldc.i4.6
+			IL_0911: ldloc.s 7
+			IL_0913: stelem.ref
+			IL_0914: dup
+			IL_0915: ldc.i4.7
+			IL_0916: ldloc.s 8
+			IL_0918: stelem.ref
+			IL_0919: dup
+			IL_091a: ldc.i4.8
+			IL_091b: ldloc.s 9
+			IL_091d: stelem.ref
+			IL_091e: dup
+			IL_091f: ldc.i4.s 9
+			IL_0921: ldloc.s 10
+			IL_0923: stelem.ref
+			IL_0924: dup
+			IL_0925: ldc.i4.s 10
+			IL_0927: ldloc.s 11
+			IL_0929: stelem.ref
+			IL_092a: dup
+			IL_092b: ldc.i4.s 11
+			IL_092d: ldloc.s 12
+			IL_092f: stelem.ref
+			IL_0930: dup
+			IL_0931: ldc.i4.s 12
+			IL_0933: ldloc.s 13
+			IL_0935: stelem.ref
+			IL_0936: dup
+			IL_0937: ldc.i4.s 13
+			IL_0939: ldloc.s 14
+			IL_093b: stelem.ref
+			IL_093c: dup
+			IL_093d: ldc.i4.s 14
+			IL_093f: ldloc.s 15
+			IL_0941: stelem.ref
+			IL_0942: dup
+			IL_0943: ldc.i4.s 15
+			IL_0945: ldloc.s 16
+			IL_0947: stelem.ref
+			IL_0948: dup
+			IL_0949: ldc.i4.s 16
+			IL_094b: ldloc.s 17
+			IL_094d: stelem.ref
+			IL_094e: dup
+			IL_094f: ldc.i4.s 17
+			IL_0951: ldloc.s 18
+			IL_0953: stelem.ref
+			IL_0954: dup
+			IL_0955: ldc.i4.s 18
+			IL_0957: ldloc.s 19
+			IL_0959: stelem.ref
+			IL_095a: dup
+			IL_095b: ldc.i4.s 19
+			IL_095d: ldloc.s 20
+			IL_095f: stelem.ref
+			IL_0960: dup
+			IL_0961: ldc.i4.s 20
+			IL_0963: ldloc.s 21
+			IL_0965: stelem.ref
+			IL_0966: dup
+			IL_0967: ldc.i4.s 21
+			IL_0969: ldloc.s 22
+			IL_096b: stelem.ref
+			IL_096c: dup
+			IL_096d: ldc.i4.s 22
+			IL_096f: ldloc.s 23
+			IL_0971: box [System.Runtime]System.Boolean
+			IL_0976: stelem.ref
+			IL_0977: dup
+			IL_0978: ldc.i4.s 23
+			IL_097a: ldloc.s 24
+			IL_097c: stelem.ref
+			IL_097d: dup
+			IL_097e: ldc.i4.s 24
+			IL_0980: ldloc.s 25
+			IL_0982: stelem.ref
+			IL_0983: dup
+			IL_0984: ldc.i4.s 25
+			IL_0986: ldloc.s 26
+			IL_0988: stelem.ref
+			IL_0989: dup
+			IL_098a: ldc.i4.s 26
+			IL_098c: ldloc.s 27
+			IL_098e: stelem.ref
+			IL_098f: dup
+			IL_0990: ldc.i4.s 27
+			IL_0992: ldloc.s 28
+			IL_0994: stelem.ref
+			IL_0995: dup
+			IL_0996: ldc.i4.s 28
+			IL_0998: ldloc.s 29
+			IL_099a: stelem.ref
+			IL_099b: dup
+			IL_099c: ldc.i4.s 29
+			IL_099e: ldloc.s 30
+			IL_09a0: stelem.ref
+			IL_09a1: dup
+			IL_09a2: ldc.i4.s 30
+			IL_09a4: ldloc.s 31
+			IL_09a6: stelem.ref
+			IL_09a7: dup
+			IL_09a8: ldc.i4.s 31
+			IL_09aa: ldloc.s 32
+			IL_09ac: stelem.ref
+			IL_09ad: dup
+			IL_09ae: ldc.i4.s 32
+			IL_09b0: ldloc.s 33
+			IL_09b2: stelem.ref
+			IL_09b3: pop
+			IL_09b4: ldloc.0
+			IL_09b5: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_09ba: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_09bf: ret
 
-			IL_0987: ldloc.0
-			IL_0988: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
-			IL_098d: stloc.s 26
-			IL_098f: ldloc.s 26
-			IL_0991: stloc.s 8
-			IL_0993: ldloc.s 16
-			IL_0995: stloc.s 26
-			IL_0997: ldloc.s 26
-			IL_0999: stloc.s 10
+			IL_09c0: ldloc.0
+			IL_09c1: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/Scope::_awaited3
+			IL_09c6: stloc.s 26
+			IL_09c8: ldloc.s 26
+			IL_09ca: stloc.s 8
+			IL_09cc: ldloc.s 16
+			IL_09ce: stloc.s 26
+			IL_09d0: ldloc.s 26
+			IL_09d2: stloc.s 10
 
-			IL_099b: ldloc.s 9
-			IL_099d: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-			IL_09a2: ldc.i4.0
-			IL_09a3: ceq
-			IL_09a5: stloc.s 23
-			IL_09a7: ldloc.s 23
-			IL_09a9: brfalse IL_0a15
+			IL_09d4: ldloc.s 9
+			IL_09d6: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+			IL_09db: ldc.i4.0
+			IL_09dc: ceq
+			IL_09de: stloc.s 23
+			IL_09e0: ldloc.s 23
+			IL_09e2: brfalse IL_0a4e
 
-			IL_09ae: ldloc.1
-			IL_09af: ldstr "section"
-			IL_09b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_09b9: stloc.s 26
-			IL_09bb: ldloc.s 26
-			IL_09bd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_09c2: stloc.s 27
-			IL_09c4: ldstr "Could not infer an element id for section '"
-			IL_09c9: ldloc.s 27
-			IL_09cb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09d0: ldstr "'. Try passing --id sec-... explicitly."
-			IL_09d5: call string [System.Runtime]System.String::Concat(string, string)
-			IL_09da: stloc.s 27
-			IL_09dc: ldloc.s 27
-			IL_09de: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
-			IL_09e3: stloc.s 17
-			IL_09e5: ldloc.0
-			IL_09e6: ldc.i4.m1
-			IL_09e7: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_09ec: ldloc.0
-			IL_09ed: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_09f2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
-			IL_09f7: ldarg.0
-			IL_09f8: ldc.i4.1
-			IL_09f9: newarr [System.Runtime]System.Object
-			IL_09fe: dup
-			IL_09ff: ldc.i4.0
-			IL_0a00: ldloc.s 17
-			IL_0a02: stelem.ref
-			IL_0a03: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0a08: pop
-			IL_0a09: ldloc.0
-			IL_0a0a: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0a0f: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0a14: ret
+			IL_09e7: ldloc.1
+			IL_09e8: ldstr "section"
+			IL_09ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_09f2: stloc.s 26
+			IL_09f4: ldloc.s 26
+			IL_09f6: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_09fb: stloc.s 27
+			IL_09fd: ldstr "Could not infer an element id for section '"
+			IL_0a02: ldloc.s 27
+			IL_0a04: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a09: ldstr "'. Try passing --id sec-... explicitly."
+			IL_0a0e: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0a13: stloc.s 27
+			IL_0a15: ldloc.s 27
+			IL_0a17: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Error::.ctor(string)
+			IL_0a1c: stloc.s 17
+			IL_0a1e: ldloc.0
+			IL_0a1f: ldc.i4.m1
+			IL_0a20: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0a25: ldloc.0
+			IL_0a26: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a2b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_reject()
+			IL_0a30: ldarg.0
+			IL_0a31: ldc.i4.1
+			IL_0a32: newarr [System.Runtime]System.Object
+			IL_0a37: dup
+			IL_0a38: ldc.i4.0
+			IL_0a39: ldloc.s 17
+			IL_0a3b: stelem.ref
+			IL_0a3c: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0a41: pop
+			IL_0a42: ldloc.0
+			IL_0a43: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0a48: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0a4d: ret
 
-			IL_0a15: ldarg.0
-			IL_0a16: ldc.i4.1
-			IL_0a17: ldelem.ref
-			IL_0a18: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a1d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
-			IL_0a22: ldc.i4.1
-			IL_0a23: newarr [System.Runtime]System.Object
-			IL_0a28: dup
-			IL_0a29: ldc.i4.0
-			IL_0a2a: ldarg.0
-			IL_0a2b: ldc.i4.1
-			IL_0a2c: ldelem.ref
-			IL_0a2d: stelem.ref
-			IL_0a2e: stloc.s 21
-			IL_0a30: ldloc.s 21
-			IL_0a32: ldloc.s 8
-			IL_0a34: ldloc.s 9
-			IL_0a36: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0a3b: stloc.s 18
-			IL_0a3d: ldarg.0
-			IL_0a3e: ldc.i4.1
-			IL_0a3f: ldelem.ref
-			IL_0a40: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a45: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
-			IL_0a4a: stloc.s 31
-			IL_0a4c: ldstr "process"
-			IL_0a51: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_0a56: stloc.s 26
-			IL_0a58: ldloc.s 26
-			IL_0a5a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0a5f: stloc.s 26
-			IL_0a61: ldloc.s 26
-			IL_0a63: ldstr "cwd"
-			IL_0a68: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0a6d: stloc.s 26
-			IL_0a6f: ldloc.1
-			IL_0a70: ldstr "outFile"
-			IL_0a75: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0a7a: stloc.s 22
-			IL_0a7c: ldloc.s 31
-			IL_0a7e: ldc.i4.2
-			IL_0a7f: newarr [System.Runtime]System.Object
-			IL_0a84: dup
-			IL_0a85: ldc.i4.0
-			IL_0a86: ldloc.s 26
-			IL_0a88: stelem.ref
-			IL_0a89: dup
-			IL_0a8a: ldc.i4.1
-			IL_0a8b: ldloc.s 22
-			IL_0a8d: stelem.ref
-			IL_0a8e: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
-			IL_0a93: stloc.s 19
-			IL_0a95: ldarg.0
-			IL_0a96: ldc.i4.1
-			IL_0a97: ldelem.ref
-			IL_0a98: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0a9d: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
-			IL_0aa2: ldc.i4.1
-			IL_0aa3: newarr [System.Runtime]System.Object
-			IL_0aa8: dup
-			IL_0aa9: ldc.i4.0
-			IL_0aaa: ldarg.0
-			IL_0aab: ldc.i4.1
-			IL_0aac: ldelem.ref
-			IL_0aad: stelem.ref
-			IL_0aae: stloc.s 21
-			IL_0ab0: ldloc.s 18
-			IL_0ab2: ldstr "html"
-			IL_0ab7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0abc: stloc.s 22
-			IL_0abe: ldloc.1
-			IL_0abf: ldstr "section"
-			IL_0ac4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0ac9: stloc.s 26
-			IL_0acb: ldloc.s 26
-			IL_0acd: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ad2: stloc.s 27
-			IL_0ad4: ldstr "ECMA-262 "
-			IL_0ad9: ldloc.s 27
-			IL_0adb: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ae0: stloc.s 27
-			IL_0ae2: ldloc.s 21
-			IL_0ae4: ldloc.s 22
-			IL_0ae6: ldloc.s 27
-			IL_0ae8: ldloc.s 10
-			IL_0aea: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
-			IL_0aef: stloc.s 20
-			IL_0af1: ldarg.0
-			IL_0af2: ldc.i4.1
-			IL_0af3: ldelem.ref
-			IL_0af4: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0af9: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0afe: stloc.s 32
-			IL_0b00: ldloc.s 32
-			IL_0b02: ldloc.s 19
-			IL_0b04: ldloc.s 20
-			IL_0b06: ldstr "utf8"
-			IL_0b0b: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
-			IL_0b10: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0b15: stloc.s 33
-			IL_0b17: ldarg.0
-			IL_0b18: ldc.i4.1
-			IL_0b19: ldelem.ref
-			IL_0b1a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0b1f: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0b24: ldc.i4.1
-			IL_0b25: newarr [System.Runtime]System.Object
-			IL_0b2a: dup
-			IL_0b2b: ldc.i4.0
-			IL_0b2c: ldarg.0
-			IL_0b2d: ldc.i4.1
-			IL_0b2e: ldelem.ref
-			IL_0b2f: stelem.ref
-			IL_0b30: stloc.s 21
-			IL_0b32: ldloc.1
-			IL_0b33: ldstr "section"
-			IL_0b38: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b3d: stloc.s 22
-			IL_0b3f: ldloc.s 22
-			IL_0b41: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b46: stloc.s 27
-			IL_0b48: ldstr "Extracted section "
-			IL_0b4d: ldloc.s 27
-			IL_0b4f: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b54: ldstr " (id="
-			IL_0b59: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b5e: ldloc.s 9
-			IL_0b60: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b65: stloc.s 27
-			IL_0b67: ldloc.s 27
-			IL_0b69: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b6e: ldstr ", tag="
-			IL_0b73: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b78: ldloc.s 18
-			IL_0b7a: ldstr "tagName"
-			IL_0b7f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0b84: stloc.s 22
-			IL_0b86: ldloc.s 22
-			IL_0b88: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0b8d: stloc.s 27
-			IL_0b8f: ldloc.s 27
-			IL_0b91: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0b96: ldstr ") -> "
-			IL_0b9b: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0ba0: ldloc.s 19
-			IL_0ba2: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-			IL_0ba7: stloc.s 27
-			IL_0ba9: ldloc.s 27
-			IL_0bab: call string [System.Runtime]System.String::Concat(string, string)
-			IL_0bb0: stloc.s 27
-			IL_0bb2: ldloc.s 21
-			IL_0bb4: ldloc.s 27
-			IL_0bb6: ldloc.s 19
-			IL_0bb8: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0a4e: ldarg.0
+			IL_0a4f: ldc.i4.1
+			IL_0a50: ldelem.ref
+			IL_0a51: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a56: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::extractElementById
+			IL_0a5b: ldc.i4.1
+			IL_0a5c: newarr [System.Runtime]System.Object
+			IL_0a61: dup
+			IL_0a62: ldc.i4.0
+			IL_0a63: ldarg.0
+			IL_0a64: ldc.i4.1
+			IL_0a65: ldelem.ref
+			IL_0a66: stelem.ref
+			IL_0a67: stloc.s 21
+			IL_0a69: ldloc.s 21
+			IL_0a6b: ldloc.s 8
+			IL_0a6d: ldloc.s 9
+			IL_0a6f: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0a74: stloc.s 18
+			IL_0a76: ldarg.0
+			IL_0a77: ldc.i4.1
+			IL_0a78: ldelem.ref
+			IL_0a79: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0a7e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::path
+			IL_0a83: stloc.s 31
+			IL_0a85: ldstr "process"
+			IL_0a8a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0a8f: stloc.s 26
+			IL_0a91: ldloc.s 26
+			IL_0a93: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0a98: stloc.s 26
+			IL_0a9a: ldloc.s 26
+			IL_0a9c: ldstr "cwd"
+			IL_0aa1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0aa6: stloc.s 26
+			IL_0aa8: ldloc.1
+			IL_0aa9: ldstr "outFile"
+			IL_0aae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0ab3: stloc.s 22
+			IL_0ab5: ldloc.s 31
+			IL_0ab7: ldc.i4.2
+			IL_0ab8: newarr [System.Runtime]System.Object
+			IL_0abd: dup
+			IL_0abe: ldc.i4.0
+			IL_0abf: ldloc.s 26
+			IL_0ac1: stelem.ref
+			IL_0ac2: dup
+			IL_0ac3: ldc.i4.1
+			IL_0ac4: ldloc.s 22
+			IL_0ac6: stelem.ref
+			IL_0ac7: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule::join(object[])
+			IL_0acc: stloc.s 19
+			IL_0ace: ldarg.0
+			IL_0acf: ldc.i4.1
+			IL_0ad0: ldelem.ref
+			IL_0ad1: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0ad6: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::wrapAsStandaloneHtml
+			IL_0adb: ldc.i4.1
+			IL_0adc: newarr [System.Runtime]System.Object
+			IL_0ae1: dup
+			IL_0ae2: ldc.i4.0
+			IL_0ae3: ldarg.0
+			IL_0ae4: ldc.i4.1
+			IL_0ae5: ldelem.ref
+			IL_0ae6: stelem.ref
+			IL_0ae7: stloc.s 21
+			IL_0ae9: ldloc.s 18
+			IL_0aeb: ldstr "html"
+			IL_0af0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0af5: stloc.s 22
+			IL_0af7: ldloc.1
+			IL_0af8: ldstr "section"
+			IL_0afd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b02: stloc.s 26
+			IL_0b04: ldloc.s 26
+			IL_0b06: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b0b: stloc.s 27
+			IL_0b0d: ldstr "ECMA-262 "
+			IL_0b12: ldloc.s 27
+			IL_0b14: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b19: stloc.s 27
+			IL_0b1b: ldloc.s 21
+			IL_0b1d: ldloc.s 22
+			IL_0b1f: ldloc.s 27
+			IL_0b21: ldloc.s 10
+			IL_0b23: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs3(object, object[], object, object, object)
+			IL_0b28: stloc.s 20
+			IL_0b2a: ldarg.0
+			IL_0b2b: ldc.i4.1
+			IL_0b2c: ldelem.ref
+			IL_0b2d: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b32: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0b37: stloc.s 32
+			IL_0b39: ldloc.s 32
+			IL_0b3b: ldloc.s 19
+			IL_0b3d: ldloc.s 20
+			IL_0b3f: ldstr "utf8"
+			IL_0b44: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::writeFileSync(object, object, object)
+			IL_0b49: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0b4e: stloc.s 33
+			IL_0b50: ldarg.0
+			IL_0b51: ldc.i4.1
+			IL_0b52: ldelem.ref
+			IL_0b53: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0b58: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0b5d: ldc.i4.1
+			IL_0b5e: newarr [System.Runtime]System.Object
+			IL_0b63: dup
+			IL_0b64: ldc.i4.0
+			IL_0b65: ldarg.0
+			IL_0b66: ldc.i4.1
+			IL_0b67: ldelem.ref
+			IL_0b68: stelem.ref
+			IL_0b69: stloc.s 21
+			IL_0b6b: ldloc.1
+			IL_0b6c: ldstr "section"
+			IL_0b71: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0b76: stloc.s 22
+			IL_0b78: ldloc.s 22
+			IL_0b7a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b7f: stloc.s 27
+			IL_0b81: ldstr "Extracted section "
+			IL_0b86: ldloc.s 27
+			IL_0b88: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b8d: ldstr " (id="
+			IL_0b92: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0b97: ldloc.s 9
+			IL_0b99: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0b9e: stloc.s 27
+			IL_0ba0: ldloc.s 27
+			IL_0ba2: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0ba7: ldstr ", tag="
+			IL_0bac: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0bb1: ldloc.s 18
+			IL_0bb3: ldstr "tagName"
+			IL_0bb8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
 			IL_0bbd: stloc.s 22
-			IL_0bbf: ldloc.s 33
-			IL_0bc1: ldloc.s 22
-			IL_0bc3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0bc8: pop
-			IL_0bc9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0bce: stloc.s 33
-			IL_0bd0: ldarg.0
-			IL_0bd1: ldc.i4.1
-			IL_0bd2: ldelem.ref
-			IL_0bd3: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0bd8: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
-			IL_0bdd: stloc.s 22
-			IL_0bdf: ldc.i4.1
-			IL_0be0: newarr [System.Runtime]System.Object
-			IL_0be5: dup
-			IL_0be6: ldc.i4.0
-			IL_0be7: ldarg.0
-			IL_0be8: ldc.i4.1
-			IL_0be9: ldelem.ref
-			IL_0bea: stelem.ref
-			IL_0beb: stloc.s 21
-			IL_0bed: ldarg.0
-			IL_0bee: ldc.i4.1
-			IL_0bef: ldelem.ref
-			IL_0bf0: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-			IL_0bf5: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
-			IL_0bfa: stloc.s 32
-			IL_0bfc: ldloc.s 32
-			IL_0bfe: ldloc.s 19
-			IL_0c00: ldstr "utf8"
-			IL_0c05: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
-			IL_0c0a: stloc.s 26
-			IL_0c0c: ldloc.s 22
-			IL_0c0e: ldloc.s 21
-			IL_0c10: ldloc.s 26
-			IL_0c12: ldloc.s 19
-			IL_0c14: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
-			IL_0c19: stloc.s 26
-			IL_0c1b: ldloc.s 33
-			IL_0c1d: ldloc.s 26
-			IL_0c1f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_0c24: pop
-			IL_0c25: ldloc.0
-			IL_0c26: ldc.i4.m1
-			IL_0c27: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
-			IL_0c2c: ldloc.0
-			IL_0c2d: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c32: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
-			IL_0c37: ldarg.0
-			IL_0c38: ldc.i4.1
-			IL_0c39: newarr [System.Runtime]System.Object
-			IL_0c3e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
-			IL_0c43: pop
-			IL_0c44: ldloc.0
-			IL_0c45: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
-			IL_0c4a: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
-			IL_0c4f: ret
+			IL_0bbf: ldloc.s 22
+			IL_0bc1: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0bc6: stloc.s 27
+			IL_0bc8: ldloc.s 27
+			IL_0bca: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0bcf: ldstr ") -> "
+			IL_0bd4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0bd9: ldloc.s 19
+			IL_0bdb: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+			IL_0be0: stloc.s 27
+			IL_0be2: ldloc.s 27
+			IL_0be4: call string [System.Runtime]System.String::Concat(string, string)
+			IL_0be9: stloc.s 27
+			IL_0beb: ldloc.s 21
+			IL_0bed: ldloc.s 27
+			IL_0bef: ldloc.s 19
+			IL_0bf1: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0bf6: stloc.s 22
+			IL_0bf8: ldloc.s 33
+			IL_0bfa: ldloc.s 22
+			IL_0bfc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0c01: pop
+			IL_0c02: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0c07: stloc.s 33
+			IL_0c09: ldarg.0
+			IL_0c0a: ldc.i4.1
+			IL_0c0b: ldelem.ref
+			IL_0c0c: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0c11: ldfld object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::normalize
+			IL_0c16: stloc.s 22
+			IL_0c18: ldc.i4.1
+			IL_0c19: newarr [System.Runtime]System.Object
+			IL_0c1e: dup
+			IL_0c1f: ldc.i4.0
+			IL_0c20: ldarg.0
+			IL_0c21: ldc.i4.1
+			IL_0c22: ldelem.ref
+			IL_0c23: stelem.ref
+			IL_0c24: stloc.s 21
+			IL_0c26: ldarg.0
+			IL_0c27: ldc.i4.1
+			IL_0c28: ldelem.ref
+			IL_0c29: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
+			IL_0c2e: ldfld class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope::fs
+			IL_0c33: stloc.s 32
+			IL_0c35: ldloc.s 32
+			IL_0c37: ldloc.s 19
+			IL_0c39: ldstr "utf8"
+			IL_0c3e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::readFileSync(object, object)
+			IL_0c43: stloc.s 26
+			IL_0c45: ldloc.s 22
+			IL_0c47: ldloc.s 21
+			IL_0c49: ldloc.s 26
+			IL_0c4b: ldloc.s 19
+			IL_0c4d: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+			IL_0c52: stloc.s 26
+			IL_0c54: ldloc.s 33
+			IL_0c56: ldloc.s 26
+			IL_0c58: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0c5d: pop
+			IL_0c5e: ldloc.0
+			IL_0c5f: ldc.i4.m1
+			IL_0c60: stfld int32 [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_asyncState
+			IL_0c65: ldloc.0
+			IL_0c66: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c6b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_resolve()
+			IL_0c70: ldarg.0
+			IL_0c71: ldc.i4.1
+			IL_0c72: newarr [System.Runtime]System.Object
+			IL_0c77: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeWithArgs(object, object[], object[])
+			IL_0c7c: pop
+			IL_0c7d: ldloc.0
+			IL_0c7e: ldfld class [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers [JavaScriptRuntime]JavaScriptRuntime.AsyncScope::_deferred
+			IL_0c83: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.Promise [JavaScriptRuntime]JavaScriptRuntime.PromiseWithResolvers::get_promise()
+			IL_0c88: ret
 		} // end of method runHarnessCli::__js_call__
 
 	} // end of class runHarnessCli

--- a/tests/Jroc.Tests/IntrinsicPrototypeEpochTests.cs
+++ b/tests/Jroc.Tests/IntrinsicPrototypeEpochTests.cs
@@ -162,6 +162,77 @@ public sealed class IntrinsicPrototypeEpochTests
     }
 
     [Fact]
+    public void ArrayAndTypedArrayEpochsTrackTheirPrototypeChains()
+    {
+        WithRealm(
+            () =>
+            {
+                _ = GlobalThis.globalThis;
+                Assert.Equal(
+                    0,
+                    IntrinsicPrototypeEpochs.Read(
+                        IntrinsicPrototypeFamily.Array));
+                Assert.Equal(
+                    0,
+                    IntrinsicPrototypeEpochs.Read(
+                        IntrinsicPrototypeFamily.TypedArray));
+
+                AssertAdvances(
+                    IntrinsicPrototypeFamily.Array,
+                    () => ObjectRuntime.SetProperty(
+                        JavaScriptRuntime.Array.Prototype,
+                        "push",
+                        new EpochFunction()));
+                Assert.Equal(
+                    0,
+                    IntrinsicPrototypeEpochs.Read(
+                        IntrinsicPrototypeFamily.TypedArray));
+
+                AssertAdvances(
+                    IntrinsicPrototypeFamily.TypedArray,
+                    () => ObjectRuntime.SetProperty(
+                        RuntimeIntrinsics.Current
+                            .TypedArrayPrototype,
+                        "includes",
+                        new EpochFunction()));
+                AssertAdvances(
+                    IntrinsicPrototypeFamily.TypedArray,
+                    () => ObjectRuntime.SetProperty(
+                        RuntimeIntrinsics.Current
+                            .Int32ArrayPrototype,
+                        "concreteMutation",
+                        true));
+            });
+    }
+
+    [Fact]
+    public void ObjectPrototypeMutationInvalidatesEveryGuardedFamily()
+    {
+        WithRealm(
+            () =>
+            {
+                _ = GlobalThis.globalThis;
+                var before = Enum.GetValues<
+                        IntrinsicPrototypeFamily>()
+                    .ToDictionary(
+                        static family => family,
+                        IntrinsicPrototypeEpochs.Read);
+
+                ObjectRuntime.SetProperty(
+                    GlobalThis.ObjectPrototypeValue,
+                    "sharedMutation",
+                    true);
+
+                foreach (var family in before.Keys)
+                {
+                    Assert.True(
+                        IntrinsicPrototypeEpochs.Read(family)
+                        > before[family]);
+                }
+            });
+    }
+
+    [Fact]
     public void EpochReadAndValidationAllocateNothing()
     {
         WithRealm(
@@ -232,22 +303,27 @@ public sealed class IntrinsicPrototypeEpochTests
     }
 
     private static void AssertAdvances(Action mutation)
+        => AssertAdvances(
+            IntrinsicPrototypeFamily.String,
+            mutation);
+
+    private static void AssertAdvances(
+        IntrinsicPrototypeFamily family,
+        Action mutation)
     {
-        var before = IntrinsicPrototypeEpochs.Read(
-            IntrinsicPrototypeFamily.String);
+        var before = IntrinsicPrototypeEpochs.Read(family);
 
         mutation();
 
-        var after = IntrinsicPrototypeEpochs.Read(
-            IntrinsicPrototypeFamily.String);
+        var after = IntrinsicPrototypeEpochs.Read(family);
         Assert.True(after > before);
         Assert.False(
             IntrinsicPrototypeEpochs.IsCurrent(
-                IntrinsicPrototypeFamily.String,
+                family,
                 before));
         Assert.False(
             IntrinsicPrototypeEpochs.IsPristine(
-                IntrinsicPrototypeFamily.String));
+                family));
     }
 
     private static JsObject DataDescriptor(

--- a/tests/Jroc.Tests/IntrinsicPrototypeEpochTests.cs
+++ b/tests/Jroc.Tests/IntrinsicPrototypeEpochTests.cs
@@ -302,6 +302,197 @@ public sealed class IntrinsicPrototypeEpochTests
             });
     }
 
+    [Fact]
+    public void StringObjectUnwrapRequiresDefaultUnshadowedReceiver()
+    {
+        WithRealm(
+            () =>
+            {
+                _ = GlobalThis.globalThis;
+                var receiver = JsString.Construct(
+                    [" value "],
+                    newTarget: null);
+
+                Assert.Equal(
+                    " value ",
+                    IntrinsicPrototypeEpochs
+                        .TryUnwrapStringObjectReceiver(
+                            receiver,
+                            "trim"));
+
+                ObjectRuntime.SetProperty(
+                    receiver,
+                    "trim",
+                    new EpochFunction());
+                Assert.Null(
+                    IntrinsicPrototypeEpochs
+                        .TryUnwrapStringObjectReceiver(
+                            receiver,
+                            "trim"));
+
+                var descriptorReceiver = JsString.Construct(
+                    ["descriptor"],
+                    newTarget: null);
+                JavaScriptRuntime.Object.defineProperty(
+                    descriptorReceiver,
+                    "trim",
+                    DataDescriptor(
+                        new EpochFunction(),
+                        enumerable: false));
+                Assert.Null(
+                    IntrinsicPrototypeEpochs
+                        .TryUnwrapStringObjectReceiver(
+                            descriptorReceiver,
+                            "trim"));
+
+                var customPrototypeReceiver = JsString.Construct(
+                    ["custom"],
+                    newTarget: null);
+                JavaScriptRuntime.Object.setPrototypeOf(
+                    customPrototypeReceiver,
+                    new JsObject());
+                Assert.Null(
+                    IntrinsicPrototypeEpochs
+                        .TryUnwrapStringObjectReceiver(
+                            customPrototypeReceiver,
+                            "trim"));
+            });
+    }
+
+    [Fact]
+    public void StringObjectUnwrapRejectsReceiverFromAnotherRealm()
+    {
+        var firstServices = RuntimeServices.BuildServiceProvider();
+        var secondServices = RuntimeServices.BuildServiceProvider();
+        var firstContext =
+            RuntimeExecutionContext.GetOrCreate(firstServices);
+        var secondContext =
+            RuntimeExecutionContext.GetOrCreate(secondServices);
+        object receiver;
+
+        try
+        {
+            using (firstContext.EnterAsRoot())
+            {
+                _ = GlobalThis.globalThis;
+                receiver = JsString.Construct(
+                    ["first"],
+                    newTarget: null);
+            }
+
+            using (secondContext.EnterAsRoot())
+            {
+                _ = GlobalThis.globalThis;
+                Assert.Null(
+                    IntrinsicPrototypeEpochs
+                        .TryUnwrapStringObjectReceiver(
+                            receiver,
+                            "trim"));
+            }
+        }
+        finally
+        {
+            firstServices.OwningRealm!.Agent.Cluster.Dispose();
+            secondServices.OwningRealm!.Agent.Cluster.Dispose();
+        }
+    }
+
+    [Fact]
+    public void StringObjectUnwrapAllocatesNothing()
+    {
+        WithRealm(
+            () =>
+            {
+                _ = GlobalThis.globalThis;
+                var receiver = JsString.Construct(
+                    ["value"],
+                    newTarget: null);
+                string? result = null;
+                for (var index = 0; index < 32; index++)
+                {
+                    result = IntrinsicPrototypeEpochs
+                        .TryUnwrapStringObjectReceiver(
+                            receiver,
+                            "trim");
+                }
+
+                var before =
+                    GC.GetAllocatedBytesForCurrentThread();
+                for (var index = 0; index < 10_000; index++)
+                {
+                    result = IntrinsicPrototypeEpochs
+                        .TryUnwrapStringObjectReceiver(
+                            receiver,
+                            "trim");
+                }
+                var allocated =
+                    GC.GetAllocatedBytesForCurrentThread() - before;
+
+                GC.KeepAlive(result);
+                Assert.Equal(0, allocated);
+            });
+    }
+
+    [Fact]
+    public void GuardedStringElementHelperPreservesFallbackSemantics()
+    {
+        WithRealm(
+            () =>
+            {
+                _ = GlobalThis.globalThis;
+
+                Assert.Equal(
+                    "b",
+                    ObjectRuntime.GetStringElementWithFallback(
+                        "abc",
+                        1d));
+                var receiver = new JsObject();
+                ObjectRuntime.SetProperty(
+                    receiver,
+                    "1",
+                    "fallback-index");
+
+                Assert.Equal(
+                    "fallback-index",
+                    ObjectRuntime.GetStringElementWithFallback(
+                        receiver,
+                        1d));
+            });
+    }
+
+    [Fact]
+    public void GuardedStringElementFastPathAllocatesNothing()
+    {
+        WithRealm(
+            () =>
+            {
+                _ = GlobalThis.globalThis;
+                object? result = null;
+                for (var index = 0; index < 32; index++)
+                {
+                    result =
+                        ObjectRuntime.GetStringElementWithFallback(
+                            "value",
+                            1d);
+                }
+
+                var before =
+                    GC.GetAllocatedBytesForCurrentThread();
+                for (var index = 0; index < 10_000; index++)
+                {
+                    result =
+                        ObjectRuntime.GetStringElementWithFallback(
+                            "value",
+                            1d);
+                }
+                var allocated =
+                    GC.GetAllocatedBytesForCurrentThread() - before;
+
+                GC.KeepAlive(result);
+                Assert.Equal(0, allocated);
+            });
+    }
+
     private static void AssertAdvances(Action mutation)
         => AssertAdvances(
             IntrinsicPrototypeFamily.String,

--- a/tests/Jroc.Tests/Jroc.Tests.csproj
+++ b/tests/Jroc.Tests/Jroc.Tests.csproj
@@ -59,6 +59,9 @@
     <EmbeddedResource Include="..\performance\Benchmarks\Scenarios\dromaeo\dromaeo-object-regexp.js">
       <LogicalName>Jroc.Tests.Integration.JavaScript.Compile_Performance_Dromaeo_Object_Regexp.js</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\performance\Benchmarks\Scenarios\dromaeo\dromaeo-object-string.js">
+      <LogicalName>Jroc.Tests.Integration.JavaScript.Compile_Performance_Dromaeo_Object_String.js</LogicalName>
+    </EmbeddedResource>
     <EmbeddedResource Include="..\performance\PrimeJavaScript.js">
       <LogicalName>Jroc.Tests.Integration.JavaScript.Compile_Performance_PrimeJavaScript.js</LogicalName>
     </EmbeddedResource>

--- a/tests/Jroc.Tests/LIRIntrinsicNormalizationTests.cs
+++ b/tests/Jroc.Tests/LIRIntrinsicNormalizationTests.cs
@@ -232,8 +232,10 @@ public sealed class LIRIntrinsicNormalizationTests
             "Construct",
             [],
             receiver));
+        body.Instructions.Add(new LIRLabel(100));
         body.Instructions.Add(
             new LIRCallMember0(receiver, "pop", result));
+        body.Instructions.Add(new LIRBranch(100));
         body.ReceiverTypeFlowFacts =
             ReceiverTypeFlowAnalysis.Analyze(body);
 
@@ -241,7 +243,7 @@ public sealed class LIRIntrinsicNormalizationTests
 
         var guarded =
             Assert.IsType<LIRCallGuardedIntrinsicMember>(
-                body.Instructions[1]);
+                body.Instructions[2]);
         Assert.Equal(
             typeof(JavaScriptRuntime.Array),
             guarded.ReceiverClrType);
@@ -275,12 +277,14 @@ public sealed class LIRIntrinsicNormalizationTests
             "Construct",
             [],
             receiver));
+        body.Instructions.Add(new LIRLabel(100));
         body.Instructions.Add(
             new LIRCallMember1(
                 receiver,
                 "includes",
                 argument,
                 result));
+        body.Instructions.Add(new LIRBranch(100));
         body.ReceiverTypeFlowFacts =
             ReceiverTypeFlowAnalysis.Analyze(body);
 
@@ -288,7 +292,7 @@ public sealed class LIRIntrinsicNormalizationTests
 
         var guarded =
             Assert.IsType<LIRCallGuardedIntrinsicMember>(
-                body.Instructions[1]);
+                body.Instructions[2]);
         Assert.Equal(
             typeof(JavaScriptRuntime.Int32Array),
             guarded.ReceiverClrType);
@@ -327,12 +331,14 @@ public sealed class LIRIntrinsicNormalizationTests
             "Call",
             [],
             receiver));
+        body.Instructions.Add(new LIRLabel(100));
         body.Instructions.Add(
             new LIRCallMember1(
                 receiver,
                 "push",
                 argument,
                 result));
+        body.Instructions.Add(new LIRBranch(100));
         body.ReceiverTypeFlowFacts =
             ReceiverTypeFlowAnalysis.Analyze(body);
 
@@ -340,11 +346,113 @@ public sealed class LIRIntrinsicNormalizationTests
 
         var guarded =
             Assert.IsType<LIRCallGuardedIntrinsicMember>(
-                body.Instructions[1]);
+                body.Instructions[2]);
         Assert.Equal(
             typeof(JavaScriptRuntime.Array),
             guarded.ReceiverClrType);
         Assert.False(guarded.ReceiverIsProvenType);
+    }
+
+    [Fact]
+    public void ReceiverSpecialization_KeepsColdCandidateCallGeneric()
+    {
+        var body = new MethodBodyIR();
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        body.Instructions.Add(new LIRCallIntrinsicStatic(
+            nameof(JavaScriptRuntime.Array),
+            "Construct",
+            [],
+            receiver));
+        body.Instructions.Add(
+            new LIRCallMember0(receiver, "pop", result));
+        body.ReceiverTypeFlowFacts =
+            ReceiverTypeFlowAnalysis.Analyze(body);
+
+        LIRReceiverSpecialization.Normalize(body);
+
+        Assert.IsType<LIRCallMember0>(body.Instructions[1]);
+        Assert.Equal(
+            0,
+            Assert.IsType<LIRLoopNestingFacts>(
+                    body.LoopNestingFacts)
+                .GetDepth(1));
+    }
+
+    [Fact]
+    public void LoopNestingAnalysis_ComputesNestedNaturalLoopDepth()
+    {
+        var body = new MethodBodyIR();
+        var condition = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.UnboxedValue,
+                typeof(bool)));
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+
+        body.Instructions.Add(new LIRLabel(100));
+        body.Instructions.Add(new LIRLabel(200));
+        body.Instructions.Add(
+            new LIRCallMember0(receiver, "pop", result));
+        body.Instructions.Add(
+            new LIRBranchIfFalse(condition, 300));
+        body.Instructions.Add(new LIRBranch(200));
+        body.Instructions.Add(new LIRLabel(300));
+        body.Instructions.Add(
+            new LIRBranchIfFalse(condition, 400));
+        body.Instructions.Add(new LIRBranch(100));
+        body.Instructions.Add(new LIRLabel(400));
+
+        var facts = LIRLoopNestingAnalysis.Analyze(body);
+
+        Assert.Equal(2, facts.GetDepth(2));
+        Assert.Equal(1, facts.GetDepth(5));
+        Assert.Equal(0, facts.GetDepth(8));
+    }
+
+    [Fact]
+    public void LoopNestingAnalysis_MergesMultipleLatchesForOneHeader()
+    {
+        var body = new MethodBodyIR();
+        var condition = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.UnboxedValue,
+                typeof(bool)));
+
+        body.Instructions.Add(new LIRLabel(100));
+        body.Instructions.Add(
+            new LIRBranchIfFalse(condition, 200));
+        body.Instructions.Add(new LIRBranch(100));
+        body.Instructions.Add(new LIRLabel(200));
+        body.Instructions.Add(
+            new LIRBranchIfFalse(condition, 300));
+        body.Instructions.Add(new LIRBranch(100));
+        body.Instructions.Add(new LIRLabel(300));
+
+        var facts = LIRLoopNestingAnalysis.Analyze(body);
+
+        Assert.Equal(1, facts.GetDepth(0));
+        Assert.Equal(1, facts.GetDepth(2));
+        Assert.Equal(1, facts.GetDepth(5));
+        Assert.Equal(0, facts.GetDepth(6));
     }
 
     [Fact]

--- a/tests/Jroc.Tests/LIRIntrinsicNormalizationTests.cs
+++ b/tests/Jroc.Tests/LIRIntrinsicNormalizationTests.cs
@@ -115,7 +115,7 @@ public sealed class LIRIntrinsicNormalizationTests
     }
 
     [Fact]
-    public void Normalize_Rewrites_StringCandidateFieldMemberCall_WithReceiverTypeTest()
+    public void Normalize_DoesNotRewrite_StringCandidateFieldMemberCall_WithKnownNonStringType()
     {
         var parser = new JavaScriptParser();
         var program = parser.ParseJavaScript("var value;", "candidate.js");
@@ -150,9 +150,7 @@ public sealed class LIRIntrinsicNormalizationTests
 
         LIRIntrinsicNormalization.Normalize(body, new ClassRegistry());
 
-        var guarded = Assert.IsType<LIRCallGuardedStringIntrinsic>(
-            body.Instructions[1]);
-        Assert.False(guarded.ReceiverIsProvenString);
+        Assert.IsType<LIRCallMember0>(body.Instructions[1]);
     }
 
     [Fact]

--- a/tests/Jroc.Tests/LIRIntrinsicNormalizationTests.cs
+++ b/tests/Jroc.Tests/LIRIntrinsicNormalizationTests.cs
@@ -409,6 +409,95 @@ public sealed class LIRIntrinsicNormalizationTests
     }
 
     [Fact]
+    public void ReceiverSpecialization_RewritesHotStringElementCandidate()
+    {
+        var body = new MethodBodyIR();
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        var index = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.UnboxedValue,
+                typeof(double)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        body.ReceiverTempTypeSummaries[receiver.Index] =
+            new ReceiverTypeSummary(
+                includesUnknown: true,
+                includesNonCandidate: true,
+                [typeof(string)]);
+        body.Instructions.Add(new LIRLabel(100));
+        body.Instructions.Add(
+            new LIRGetItem(receiver, index, result));
+        body.Instructions.Add(new LIRBranch(100));
+
+        var diagnostics = new ReceiverTypeFlowDiagnosticTrace();
+        LIRReceiverSpecialization.Normalize(
+            body,
+            diagnostics);
+
+        var call = Assert.IsType<LIRCallIntrinsicStatic>(
+            body.Instructions[1]);
+        Assert.Equal(
+            nameof(JavaScriptRuntime.ObjectRuntime),
+            call.IntrinsicName);
+        Assert.Equal(
+            nameof(JavaScriptRuntime.ObjectRuntime
+                .GetStringElementWithFallback),
+            call.MethodName);
+        Assert.Equal([receiver, index], call.Arguments);
+        Assert.Contains(
+            diagnostics.Events,
+            item => item.Kind
+                    == ReceiverTypeFlowDiagnosticKind.Specialization
+                && item.Message.Contains(
+                    "member=[index]",
+                    StringComparison.Ordinal)
+                && item.Message.Contains(
+                    "loop-depth=1",
+                    StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ReceiverSpecialization_KeepsColdStringElementCandidateGeneric()
+    {
+        var body = new MethodBodyIR();
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        var index = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.UnboxedValue,
+                typeof(double)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        body.ReceiverTempTypeSummaries[receiver.Index] =
+            new ReceiverTypeSummary(
+                includesUnknown: true,
+                includesNonCandidate: true,
+                [typeof(string)]);
+        body.Instructions.Add(
+            new LIRGetItem(receiver, index, result));
+
+        LIRReceiverSpecialization.Normalize(body);
+
+        Assert.IsType<LIRGetItem>(
+            Assert.Single(body.Instructions));
+    }
+
+    [Fact]
     public void LoopNestingAnalysis_ComputesNestedNaturalLoopDepth()
     {
         var body = new MethodBodyIR();

--- a/tests/Jroc.Tests/LIRIntrinsicNormalizationTests.cs
+++ b/tests/Jroc.Tests/LIRIntrinsicNormalizationTests.cs
@@ -173,6 +173,181 @@ public sealed class LIRIntrinsicNormalizationTests
     }
 
     [Fact]
+    public void Normalize_KeepsProvenArrayMemberCallDirect()
+    {
+        var body = new MethodBodyIR();
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(JavaScriptRuntime.Array)));
+        var argument = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        body.Instructions.Add(
+            new LIRCallMember1(
+                receiver,
+                "push",
+                argument,
+                result));
+
+        LIRIntrinsicNormalization.Normalize(
+            body,
+            new ClassRegistry());
+
+        var direct =
+            Assert.IsType<LIRCallInstanceMethod>(
+                body.Instructions[0]);
+        Assert.Equal(
+            typeof(JavaScriptRuntime.Array),
+            direct.ReceiverClrType);
+        Assert.Equal(
+            typeof(double),
+            body.TempStorages[result.Index].ClrType);
+    }
+
+    [Fact]
+    public void ReceiverSpecialization_ConsumesArrayFlowCandidate()
+    {
+        var body = new MethodBodyIR();
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        body.Instructions.Add(new LIRCallIntrinsicStatic(
+            nameof(JavaScriptRuntime.Array),
+            "Construct",
+            [],
+            receiver));
+        body.Instructions.Add(
+            new LIRCallMember0(receiver, "pop", result));
+        body.ReceiverTypeFlowFacts =
+            ReceiverTypeFlowAnalysis.Analyze(body);
+
+        LIRReceiverSpecialization.Normalize(body);
+
+        var guarded =
+            Assert.IsType<LIRCallGuardedIntrinsicMember>(
+                body.Instructions[1]);
+        Assert.Equal(
+            typeof(JavaScriptRuntime.Array),
+            guarded.ReceiverClrType);
+        Assert.True(guarded.ReceiverIsProvenType);
+    }
+
+    [Fact]
+    public void ReceiverSpecialization_ConsumesTypedArrayFlowCandidate()
+    {
+        var body = new MethodBodyIR();
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        var argument = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        body.ReceiverTempTypeSummaries[receiver.Index] =
+            ReceiverTypeSummary.ForCandidate(
+                typeof(JavaScriptRuntime.Int32Array));
+        body.Instructions.Add(new LIRCallIntrinsicStatic(
+            "Int32Array",
+            "Construct",
+            [],
+            receiver));
+        body.Instructions.Add(
+            new LIRCallMember1(
+                receiver,
+                "includes",
+                argument,
+                result));
+        body.ReceiverTypeFlowFacts =
+            ReceiverTypeFlowAnalysis.Analyze(body);
+
+        LIRReceiverSpecialization.Normalize(body);
+
+        var guarded =
+            Assert.IsType<LIRCallGuardedIntrinsicMember>(
+                body.Instructions[1]);
+        Assert.Equal(
+            typeof(JavaScriptRuntime.Int32Array),
+            guarded.ReceiverClrType);
+        Assert.Equal(
+            JavaScriptRuntime.IntrinsicPrototypeFamily.TypedArray,
+            guarded.PrototypeFamily);
+        Assert.True(guarded.ReceiverIsProvenType);
+    }
+
+    [Fact]
+    public void ReceiverSpecialization_KeepsTypeGuardForUncertainArrayCandidate()
+    {
+        var body = new MethodBodyIR();
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        var argument = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        body.ReceiverTempTypeSummaries[receiver.Index] =
+            new ReceiverTypeSummary(
+                includesUnknown: true,
+                includesNonCandidate: true,
+                [typeof(JavaScriptRuntime.Array)]);
+        body.Instructions.Add(new LIRCallIntrinsicStatic(
+            "Unknown",
+            "Call",
+            [],
+            receiver));
+        body.Instructions.Add(
+            new LIRCallMember1(
+                receiver,
+                "push",
+                argument,
+                result));
+        body.ReceiverTypeFlowFacts =
+            ReceiverTypeFlowAnalysis.Analyze(body);
+
+        LIRReceiverSpecialization.Normalize(body);
+
+        var guarded =
+            Assert.IsType<LIRCallGuardedIntrinsicMember>(
+                body.Instructions[1]);
+        Assert.Equal(
+            typeof(JavaScriptRuntime.Array),
+            guarded.ReceiverClrType);
+        Assert.False(guarded.ReceiverIsProvenType);
+    }
+
+    [Fact]
     public void Normalize_Fuses_CharCodeAtNumberConversion_IntoGuardedIntrinsic()
     {
         var body = new MethodBodyIR();

--- a/tests/Jroc.Tests/LIRIntrinsicNormalizationTests.cs
+++ b/tests/Jroc.Tests/LIRIntrinsicNormalizationTests.cs
@@ -1,5 +1,7 @@
+using Acornima;
 using Jroc.IR;
 using Jroc.Services;
+using Jroc.SymbolTables;
 using Xunit;
 
 namespace Jroc.Tests;
@@ -110,6 +112,47 @@ public sealed class LIRIntrinsicNormalizationTests
         Assert.False(guarded.ReceiverIsProvenString);
         Assert.Equal("trim", guarded.MemberName);
         Assert.Empty(guarded.Arguments);
+    }
+
+    [Fact]
+    public void Normalize_Rewrites_StringCandidateFieldMemberCall_WithReceiverTypeTest()
+    {
+        var parser = new JavaScriptParser();
+        var program = parser.ParseJavaScript("var value;", "candidate.js");
+        var scope = new Jroc.SymbolTables.Scope(
+            "GlobalScope",
+            ScopeKind.Global,
+            parent: null,
+            program);
+        var binding = new BindingInfo("value", BindingKind.Var, scope, program)
+        {
+            ClrType = typeof(JavaScriptRuntime.String)
+        };
+        binding.ReceiverCandidateClrTypes.Add(typeof(string));
+
+        var body = new MethodBodyIR();
+        var scopeInstance = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        body.Instructions.Add(new LIRLoadScopeField(
+            scopeInstance,
+            binding,
+            new FieldId("GlobalScope", "value"),
+            new ScopeId("GlobalScope"),
+            receiver));
+        body.Instructions.Add(new LIRCallMember0(receiver, "trim", result));
+
+        LIRIntrinsicNormalization.Normalize(body, new ClassRegistry());
+
+        var guarded = Assert.IsType<LIRCallGuardedStringIntrinsic>(
+            body.Instructions[1]);
+        Assert.False(guarded.ReceiverIsProvenString);
     }
 
     [Fact]

--- a/tests/Jroc.Tests/LIRIntrinsicNormalizationTests.cs
+++ b/tests/Jroc.Tests/LIRIntrinsicNormalizationTests.cs
@@ -239,7 +239,10 @@ public sealed class LIRIntrinsicNormalizationTests
         body.ReceiverTypeFlowFacts =
             ReceiverTypeFlowAnalysis.Analyze(body);
 
-        LIRReceiverSpecialization.Normalize(body);
+        var diagnostics = new ReceiverTypeFlowDiagnosticTrace();
+        LIRReceiverSpecialization.Normalize(
+            body,
+            diagnostics);
 
         var guarded =
             Assert.IsType<LIRCallGuardedIntrinsicMember>(
@@ -248,6 +251,13 @@ public sealed class LIRIntrinsicNormalizationTests
             typeof(JavaScriptRuntime.Array),
             guarded.ReceiverClrType);
         Assert.True(guarded.ReceiverIsProvenType);
+        Assert.Contains(
+            diagnostics.Events,
+            item => item.Kind
+                    == ReceiverTypeFlowDiagnosticKind.Specialization
+                && item.Message.Contains(
+                    "loop-depth=1 type-proven=true action=guarded",
+                    StringComparison.Ordinal));
     }
 
     [Fact]
@@ -377,7 +387,10 @@ public sealed class LIRIntrinsicNormalizationTests
         body.ReceiverTypeFlowFacts =
             ReceiverTypeFlowAnalysis.Analyze(body);
 
-        LIRReceiverSpecialization.Normalize(body);
+        var diagnostics = new ReceiverTypeFlowDiagnosticTrace();
+        LIRReceiverSpecialization.Normalize(
+            body,
+            diagnostics);
 
         Assert.IsType<LIRCallMember0>(body.Instructions[1]);
         Assert.Equal(
@@ -385,6 +398,14 @@ public sealed class LIRIntrinsicNormalizationTests
             Assert.IsType<LIRLoopNestingFacts>(
                     body.LoopNestingFacts)
                 .GetDepth(1));
+        Assert.Contains(
+            diagnostics.Events,
+            item => item.Kind
+                    == ReceiverTypeFlowDiagnosticKind.Specialization
+                && item.Message.Contains(
+                    "loop-depth=0 type-proven=true "
+                    + "action=retained-generic(cold)",
+                    StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -3091,7 +3091,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 950 (0x3b6)
+		// Code size: 969 (0x3c9)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope,
@@ -3196,244 +3196,251 @@
 		IL_0124: stloc.s 5
 		IL_0126: ldc.i4.0
 		IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_012c: brfalse IL_0155
+		IL_012c: brfalse IL_0168
 
 		IL_0131: ldloc.s 5
 		IL_0133: isinst [System.Runtime]System.String
 		IL_0138: dup
-		IL_0139: brfalse IL_0154
+		IL_0139: brtrue IL_0151
 
-		IL_013e: ldstr "verbose"
-		IL_0143: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-		IL_0148: box [System.Runtime]System.Boolean
-		IL_014d: stloc.s 5
-		IL_014f: br IL_0168
+		IL_013e: pop
+		IL_013f: ldloc.s 5
+		IL_0141: ldstr "includes"
+		IL_0146: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_014b: dup
+		IL_014c: brfalse IL_0167
 
-		IL_0154: pop
+		IL_0151: ldstr "verbose"
+		IL_0156: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_015b: box [System.Runtime]System.Boolean
+		IL_0160: stloc.s 5
+		IL_0162: br IL_017b
 
-		IL_0155: ldloc.s 5
-		IL_0157: ldstr "includes"
-		IL_015c: ldstr "verbose"
-		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0166: stloc.s 5
+		IL_0167: pop
 
-		IL_0168: ldloc.1
-		IL_0169: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
-		IL_016e: ldloc.s 5
-		IL_0170: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_verbose(object)
-		IL_0175: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_017a: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_017f: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_0184: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0189: stloc.s 8
-		IL_018b: ldloc.s 8
-		IL_018d: ldstr "prototype"
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0197: stloc.s 5
-		IL_0199: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_019e: stloc.s 9
-		IL_01a0: ldloc.s 5
-		IL_01a2: ldstr "setBitTrue"
-		IL_01a7: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject::.ctor()
-		IL_01ac: ldc.i4.1
-		IL_01ad: conv.r8
-		IL_01ae: ldstr "setBitTrue"
-		IL_01b3: ldc.i4.1
-		IL_01b4: ldc.i4.1
-		IL_01b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject>(!!0)
-		IL_01bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01c4: pop
-		IL_01c5: ldc.i4.1
-		IL_01c6: newarr [System.Runtime]System.Object
-		IL_01cb: dup
-		IL_01cc: ldc.i4.0
-		IL_01cd: ldloc.0
-		IL_01ce: stelem.ref
-		IL_01cf: stloc.s 9
-		IL_01d1: ldloc.s 5
-		IL_01d3: ldstr "setBitsTrue"
-		IL_01d8: ldloc.s 9
-		IL_01da: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject::.ctor(object[])
-		IL_01df: ldc.i4.3
-		IL_01e0: conv.r8
-		IL_01e1: ldstr "setBitsTrue"
-		IL_01e6: ldc.i4.1
-		IL_01e7: ldc.i4.1
-		IL_01e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject>(!!0)
-		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_01f7: pop
-		IL_01f8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_01fd: stloc.s 9
-		IL_01ff: ldloc.s 5
-		IL_0201: ldstr "testBitTrue"
-		IL_0206: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject::.ctor()
-		IL_020b: ldc.i4.1
-		IL_020c: conv.r8
-		IL_020d: ldstr "testBitTrue"
-		IL_0212: ldc.i4.1
-		IL_0213: ldc.i4.1
-		IL_0214: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0219: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject>(!!0)
-		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0223: pop
-		IL_0224: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0229: stloc.s 9
-		IL_022b: ldloc.s 5
-		IL_022d: ldstr "searchBitFalse"
-		IL_0232: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject::.ctor()
-		IL_0237: ldc.i4.1
-		IL_0238: conv.r8
-		IL_0239: ldstr "searchBitFalse"
-		IL_023e: ldc.i4.1
-		IL_023f: ldc.i4.1
-		IL_0240: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0245: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject>(!!0)
-		IL_024a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_024f: pop
-		IL_0250: ldc.i4.1
-		IL_0251: newarr [System.Runtime]System.Object
-		IL_0256: dup
-		IL_0257: ldc.i4.0
-		IL_0258: ldloc.0
-		IL_0259: stelem.ref
-		IL_025a: stloc.s 9
-		IL_025c: ldloc.s 9
-		IL_025e: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
-		IL_0263: ldloc.s 8
-		IL_0265: ldloc.s 9
-		IL_0267: ldc.i4.1
-		IL_0268: conv.r8
-		IL_0269: ldc.i4.0
-		IL_026a: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_026f: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_ctor/FunctionObject
-		IL_0274: stloc.s 10
-		IL_0276: ldloc.0
-		IL_0277: ldloc.s 10
-		IL_0279: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
-		IL_027e: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0283: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0288: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_028d: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-		IL_0292: stloc.s 8
-		IL_0294: ldloc.s 8
-		IL_0296: ldstr "prototype"
-		IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02a0: stloc.s 5
-		IL_02a2: ldc.i4.1
-		IL_02a3: newarr [System.Runtime]System.Object
-		IL_02a8: dup
-		IL_02a9: ldc.i4.0
-		IL_02aa: ldloc.0
-		IL_02ab: stelem.ref
-		IL_02ac: stloc.s 9
-		IL_02ae: ldloc.s 5
-		IL_02b0: ldstr "runSieve"
-		IL_02b5: ldloc.s 9
-		IL_02b7: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject::.ctor(object[])
+		IL_0168: ldloc.s 5
+		IL_016a: ldstr "includes"
+		IL_016f: ldstr "verbose"
+		IL_0174: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0179: stloc.s 5
+
+		IL_017b: ldloc.1
+		IL_017c: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config
+		IL_0181: ldloc.s 5
+		IL_0183: callvirt instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ObjectLiterals/L26C14_config::set_verbose(object)
+		IL_0188: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+		IL_018d: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0192: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+		IL_0197: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_019c: stloc.s 8
+		IL_019e: ldloc.s 8
+		IL_01a0: ldstr "prototype"
+		IL_01a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01aa: stloc.s 5
+		IL_01ac: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_01b1: stloc.s 9
+		IL_01b3: ldloc.s 5
+		IL_01b5: ldstr "setBitTrue"
+		IL_01ba: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject::.ctor()
+		IL_01bf: ldc.i4.1
+		IL_01c0: conv.r8
+		IL_01c1: ldstr "setBitTrue"
+		IL_01c6: ldc.i4.1
+		IL_01c7: ldc.i4.1
+		IL_01c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitTrue/FunctionObject>(!!0)
+		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_01d7: pop
+		IL_01d8: ldc.i4.1
+		IL_01d9: newarr [System.Runtime]System.Object
+		IL_01de: dup
+		IL_01df: ldc.i4.0
+		IL_01e0: ldloc.0
+		IL_01e1: stelem.ref
+		IL_01e2: stloc.s 9
+		IL_01e4: ldloc.s 5
+		IL_01e6: ldstr "setBitsTrue"
+		IL_01eb: ldloc.s 9
+		IL_01ed: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject::.ctor(object[])
+		IL_01f2: ldc.i4.3
+		IL_01f3: conv.r8
+		IL_01f4: ldstr "setBitsTrue"
+		IL_01f9: ldc.i4.1
+		IL_01fa: ldc.i4.1
+		IL_01fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0200: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_setBitsTrue/FunctionObject>(!!0)
+		IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_020a: pop
+		IL_020b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0210: stloc.s 9
+		IL_0212: ldloc.s 5
+		IL_0214: ldstr "testBitTrue"
+		IL_0219: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject::.ctor()
+		IL_021e: ldc.i4.1
+		IL_021f: conv.r8
+		IL_0220: ldstr "testBitTrue"
+		IL_0225: ldc.i4.1
+		IL_0226: ldc.i4.1
+		IL_0227: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_022c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_testBitTrue/FunctionObject>(!!0)
+		IL_0231: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0236: pop
+		IL_0237: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_023c: stloc.s 9
+		IL_023e: ldloc.s 5
+		IL_0240: ldstr "searchBitFalse"
+		IL_0245: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject::.ctor()
+		IL_024a: ldc.i4.1
+		IL_024b: conv.r8
+		IL_024c: ldstr "searchBitFalse"
+		IL_0251: ldc.i4.1
+		IL_0252: ldc.i4.1
+		IL_0253: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0258: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_searchBitFalse/FunctionObject>(!!0)
+		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0262: pop
+		IL_0263: ldc.i4.1
+		IL_0264: newarr [System.Runtime]System.Object
+		IL_0269: dup
+		IL_026a: ldc.i4.0
+		IL_026b: ldloc.0
+		IL_026c: stelem.ref
+		IL_026d: stloc.s 9
+		IL_026f: ldloc.s 9
+		IL_0271: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_ctor/FunctionObject::.ctor(object[])
+		IL_0276: ldloc.s 8
+		IL_0278: ldloc.s 9
+		IL_027a: ldc.i4.1
+		IL_027b: conv.r8
+		IL_027c: ldc.i4.0
+		IL_027d: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_0282: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/Scope_ctor/FunctionObject
+		IL_0287: stloc.s 10
+		IL_0289: ldloc.0
+		IL_028a: ldloc.s 10
+		IL_028c: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::BitArray
+		IL_0291: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_0296: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_029b: ldtoken Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+		IL_02a0: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_02a5: stloc.s 8
+		IL_02a7: ldloc.s 8
+		IL_02a9: ldstr "prototype"
+		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02b3: stloc.s 5
+		IL_02b5: ldc.i4.1
+		IL_02b6: newarr [System.Runtime]System.Object
+		IL_02bb: dup
 		IL_02bc: ldc.i4.0
-		IL_02bd: conv.r8
-		IL_02be: ldstr "runSieve"
-		IL_02c3: ldc.i4.1
-		IL_02c4: ldc.i4.1
-		IL_02c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02ca: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject>(!!0)
-		IL_02cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_02d4: pop
-		IL_02d5: ldc.i4.1
-		IL_02d6: newarr [System.Runtime]System.Object
-		IL_02db: dup
-		IL_02dc: ldc.i4.0
-		IL_02dd: ldloc.0
-		IL_02de: stelem.ref
-		IL_02df: stloc.s 9
-		IL_02e1: ldloc.s 5
-		IL_02e3: ldstr "countPrimes"
-		IL_02e8: ldloc.s 9
-		IL_02ea: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject::.ctor(object[])
+		IL_02bd: ldloc.0
+		IL_02be: stelem.ref
+		IL_02bf: stloc.s 9
+		IL_02c1: ldloc.s 5
+		IL_02c3: ldstr "runSieve"
+		IL_02c8: ldloc.s 9
+		IL_02ca: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject::.ctor(object[])
+		IL_02cf: ldc.i4.0
+		IL_02d0: conv.r8
+		IL_02d1: ldstr "runSieve"
+		IL_02d6: ldc.i4.1
+		IL_02d7: ldc.i4.1
+		IL_02d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_runSieve/FunctionObject>(!!0)
+		IL_02e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_02e7: pop
+		IL_02e8: ldc.i4.1
+		IL_02e9: newarr [System.Runtime]System.Object
+		IL_02ee: dup
 		IL_02ef: ldc.i4.0
-		IL_02f0: conv.r8
-		IL_02f1: ldstr "countPrimes"
-		IL_02f6: ldc.i4.1
-		IL_02f7: ldc.i4.1
-		IL_02f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject>(!!0)
-		IL_0302: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_0307: pop
-		IL_0308: ldc.i4.1
-		IL_0309: newarr [System.Runtime]System.Object
-		IL_030e: dup
-		IL_030f: ldc.i4.0
-		IL_0310: ldloc.0
-		IL_0311: stelem.ref
-		IL_0312: stloc.s 9
-		IL_0314: ldloc.s 5
-		IL_0316: ldstr "getPrimes"
-		IL_031b: ldloc.s 9
-		IL_031d: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject::.ctor(object[])
+		IL_02f0: ldloc.0
+		IL_02f1: stelem.ref
+		IL_02f2: stloc.s 9
+		IL_02f4: ldloc.s 5
+		IL_02f6: ldstr "countPrimes"
+		IL_02fb: ldloc.s 9
+		IL_02fd: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject::.ctor(object[])
+		IL_0302: ldc.i4.0
+		IL_0303: conv.r8
+		IL_0304: ldstr "countPrimes"
+		IL_0309: ldc.i4.1
+		IL_030a: ldc.i4.1
+		IL_030b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0310: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_countPrimes/FunctionObject>(!!0)
+		IL_0315: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_031a: pop
+		IL_031b: ldc.i4.1
+		IL_031c: newarr [System.Runtime]System.Object
+		IL_0321: dup
 		IL_0322: ldc.i4.0
-		IL_0323: conv.r8
-		IL_0324: ldstr "getPrimes"
-		IL_0329: ldc.i4.1
-		IL_032a: ldc.i4.1
-		IL_032b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0330: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject>(!!0)
-		IL_0335: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_033a: pop
-		IL_033b: ldc.i4.1
-		IL_033c: newarr [System.Runtime]System.Object
-		IL_0341: dup
-		IL_0342: ldc.i4.0
-		IL_0343: ldloc.0
-		IL_0344: stelem.ref
-		IL_0345: stloc.s 9
-		IL_0347: ldloc.s 5
-		IL_0349: ldstr "validatePrimeCount"
-		IL_034e: ldloc.s 9
-		IL_0350: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject::.ctor(object[])
-		IL_0355: ldc.i4.1
-		IL_0356: conv.r8
-		IL_0357: ldstr "validatePrimeCount"
-		IL_035c: ldc.i4.1
-		IL_035d: ldc.i4.1
-		IL_035e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0363: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject>(!!0)
-		IL_0368: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
-		IL_036d: pop
-		IL_036e: ldc.i4.1
-		IL_036f: newarr [System.Runtime]System.Object
-		IL_0374: dup
-		IL_0375: ldc.i4.0
-		IL_0376: ldloc.0
-		IL_0377: stelem.ref
-		IL_0378: stloc.s 9
-		IL_037a: ldloc.s 9
-		IL_037c: ldc.i4.0
-		IL_037d: ldelem.ref
-		IL_037e: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_0383: ldloc.s 9
-		IL_0385: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object[])
-		IL_038a: ldloc.s 8
-		IL_038c: ldloc.s 9
-		IL_038e: ldc.i4.1
-		IL_038f: conv.r8
-		IL_0390: ldc.i4.0
-		IL_0391: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
-		IL_0396: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject
-		IL_039b: stloc.s 11
-		IL_039d: ldloc.0
-		IL_039e: ldloc.s 11
-		IL_03a0: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
-		IL_03a5: nop
-		IL_03a6: nop
-		IL_03a7: ldloc.0
-		IL_03a8: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
-		IL_03ad: ldnull
-		IL_03ae: ldloc.1
-		IL_03af: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
-		IL_03b4: pop
-		IL_03b5: ret
+		IL_0323: ldloc.0
+		IL_0324: stelem.ref
+		IL_0325: stloc.s 9
+		IL_0327: ldloc.s 5
+		IL_0329: ldstr "getPrimes"
+		IL_032e: ldloc.s 9
+		IL_0330: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject::.ctor(object[])
+		IL_0335: ldc.i4.0
+		IL_0336: conv.r8
+		IL_0337: ldstr "getPrimes"
+		IL_033c: ldc.i4.1
+		IL_033d: ldc.i4.1
+		IL_033e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0343: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_getPrimes/FunctionObject>(!!0)
+		IL_0348: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_034d: pop
+		IL_034e: ldc.i4.1
+		IL_034f: newarr [System.Runtime]System.Object
+		IL_0354: dup
+		IL_0355: ldc.i4.0
+		IL_0356: ldloc.0
+		IL_0357: stelem.ref
+		IL_0358: stloc.s 9
+		IL_035a: ldloc.s 5
+		IL_035c: ldstr "validatePrimeCount"
+		IL_0361: ldloc.s 9
+		IL_0363: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject::.ctor(object[])
+		IL_0368: ldc.i4.1
+		IL_0369: conv.r8
+		IL_036a: ldstr "validatePrimeCount"
+		IL_036f: ldc.i4.1
+		IL_0370: ldc.i4.1
+		IL_0371: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0376: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_validatePrimeCount/FunctionObject>(!!0)
+		IL_037b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
+		IL_0380: pop
+		IL_0381: ldc.i4.1
+		IL_0382: newarr [System.Runtime]System.Object
+		IL_0387: dup
+		IL_0388: ldc.i4.0
+		IL_0389: ldloc.0
+		IL_038a: stelem.ref
+		IL_038b: stloc.s 9
+		IL_038d: ldloc.s 9
+		IL_038f: ldc.i4.0
+		IL_0390: ldelem.ref
+		IL_0391: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_0396: ldloc.s 9
+		IL_0398: newobj instance void Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject::.ctor(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object[])
+		IL_039d: ldloc.s 8
+		IL_039f: ldloc.s 9
+		IL_03a1: ldc.i4.1
+		IL_03a2: conv.r8
+		IL_03a3: ldc.i4.0
+		IL_03a4: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_03a9: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/Scope_ctor/FunctionObject
+		IL_03ae: stloc.s 11
+		IL_03b0: ldloc.0
+		IL_03b1: ldloc.s 11
+		IL_03b3: stfld object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope::PrimeSieve
+		IL_03b8: nop
+		IL_03b9: nop
+		IL_03ba: ldloc.0
+		IL_03bb: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope
+		IL_03c0: ldnull
+		IL_03c1: ldloc.1
+		IL_03c2: call object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/ArrowFunction_L232C14::__js_call__(class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope, object, object)
+		IL_03c7: pop
+		IL_03c8: ret
 	} // end of method Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes::__js_module_init__
 
 } // end of class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_ExecFileSync_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_ExecFileSync_Basic.verified.txt
@@ -78,7 +78,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 784 (0x310)
+		// Code size: 822 (0x336)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_ChildProcess_ExecFileSync_Basic/Scope,
@@ -181,204 +181,218 @@
 		IL_00db: stloc.s 14
 		IL_00dd: ldc.i4.0
 		IL_00de: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_00e3: brfalse IL_010c
+		IL_00e3: brfalse IL_011f
 
 		IL_00e8: ldloc.s 14
 		IL_00ea: isinst [System.Runtime]System.String
 		IL_00ef: dup
-		IL_00f0: brfalse IL_010b
+		IL_00f0: brtrue IL_0108
 
-		IL_00f5: ldstr "hello"
-		IL_00fa: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-		IL_00ff: box [System.Runtime]System.Double
-		IL_0104: stloc.s 14
-		IL_0106: br IL_011f
+		IL_00f5: pop
+		IL_00f6: ldloc.s 14
+		IL_00f8: ldstr "indexOf"
+		IL_00fd: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_0102: dup
+		IL_0103: brfalse IL_011e
 
-		IL_010b: pop
+		IL_0108: ldstr "hello"
+		IL_010d: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_0112: box [System.Runtime]System.Double
+		IL_0117: stloc.s 14
+		IL_0119: br IL_0132
 
-		IL_010c: ldloc.s 14
-		IL_010e: ldstr "indexOf"
-		IL_0113: ldstr "hello"
-		IL_0118: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011d: stloc.s 14
+		IL_011e: pop
 
 		IL_011f: ldloc.s 14
-		IL_0121: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0126: ldc.r8 0.0
-		IL_012f: clt
-		IL_0131: ldc.i4.0
-		IL_0132: ceq
-		IL_0134: stloc.s 18
-		IL_0136: ldloc.s 18
-		IL_0138: box [System.Runtime]System.Boolean
-		IL_013d: stloc.s 19
-		IL_013f: ldloc.s 17
-		IL_0141: ldstr "stdout contains hello:"
-		IL_0146: ldloc.s 19
-		IL_0148: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_014d: pop
+		IL_0121: ldstr "indexOf"
+		IL_0126: ldstr "hello"
+		IL_012b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0130: stloc.s 14
+
+		IL_0132: ldloc.s 14
+		IL_0134: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0139: ldc.r8 0.0
+		IL_0142: clt
+		IL_0144: ldc.i4.0
+		IL_0145: ceq
+		IL_0147: stloc.s 18
+		IL_0149: ldloc.s 18
+		IL_014b: box [System.Runtime]System.Boolean
+		IL_0150: stloc.s 19
+		IL_0152: ldloc.s 17
+		IL_0154: ldstr "stdout contains hello:"
+		IL_0159: ldloc.s 19
+		IL_015b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0160: pop
 		.try
 		{
-			IL_014e: nop
-			IL_014f: ldloc.2
-			IL_0150: brfalse IL_017c
+			IL_0161: nop
+			IL_0162: ldloc.2
+			IL_0163: brfalse IL_018f
 
-			IL_0155: ldc.i4.2
-			IL_0156: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_015b: dup
-			IL_015c: ldstr "/c"
-			IL_0161: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0166: dup
-			IL_0167: ldstr "exit 5"
-			IL_016c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0171: stloc.s 15
-			IL_0173: ldloc.s 15
-			IL_0175: stloc.s 8
-			IL_0177: br IL_019e
+			IL_0168: ldc.i4.2
+			IL_0169: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_016e: dup
+			IL_016f: ldstr "/c"
+			IL_0174: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0179: dup
+			IL_017a: ldstr "exit 5"
+			IL_017f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0184: stloc.s 15
+			IL_0186: ldloc.s 15
+			IL_0188: stloc.s 8
+			IL_018a: br IL_01b1
 
-			IL_017c: ldc.i4.2
-			IL_017d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0182: dup
-			IL_0183: ldstr "-c"
-			IL_0188: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_018d: dup
-			IL_018e: ldstr "exit 5"
-			IL_0193: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0198: stloc.s 15
-			IL_019a: ldloc.s 15
-			IL_019c: stloc.s 8
+			IL_018f: ldc.i4.2
+			IL_0190: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0195: dup
+			IL_0196: ldstr "-c"
+			IL_019b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01a0: dup
+			IL_01a1: ldstr "exit 5"
+			IL_01a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_01ab: stloc.s 15
+			IL_01ad: ldloc.s 15
+			IL_01af: stloc.s 8
 
-			IL_019e: ldloc.s 8
-			IL_01a0: stloc.s 9
-			IL_01a2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_01a7: dup
-			IL_01a8: ldstr "encoding"
-			IL_01ad: ldstr "utf8"
-			IL_01b2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_01b7: stloc.s 16
-			IL_01b9: ldloc.1
-			IL_01ba: ldstr "execFileSync"
-			IL_01bf: ldloc.s 4
-			IL_01c1: ldloc.s 9
-			IL_01c3: ldloc.s 16
-			IL_01c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_01ca: pop
-			IL_01cb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_01d0: stloc.s 17
-			IL_01d2: ldloc.s 17
-			IL_01d4: ldstr "expected error not thrown"
-			IL_01d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_01de: pop
-			IL_01df: leave IL_030c
+			IL_01b1: ldloc.s 8
+			IL_01b3: stloc.s 9
+			IL_01b5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_01ba: dup
+			IL_01bb: ldstr "encoding"
+			IL_01c0: ldstr "utf8"
+			IL_01c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_01ca: stloc.s 16
+			IL_01cc: ldloc.1
+			IL_01cd: ldstr "execFileSync"
+			IL_01d2: ldloc.s 4
+			IL_01d4: ldloc.s 9
+			IL_01d6: ldloc.s 16
+			IL_01d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_01dd: pop
+			IL_01de: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_01e3: stloc.s 17
+			IL_01e5: ldloc.s 17
+			IL_01e7: ldstr "expected error not thrown"
+			IL_01ec: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_01f1: pop
+			IL_01f2: leave IL_0332
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_01e4: stloc.s 10
-			IL_01e6: ldloc.s 10
-			IL_01e8: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_01ed: dup
-			IL_01ee: brtrue IL_0204
+			IL_01f7: stloc.s 10
+			IL_01f9: ldloc.s 10
+			IL_01fb: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0200: dup
+			IL_0201: brtrue IL_0217
 
-			IL_01f3: pop
-			IL_01f4: ldloc.s 10
-			IL_01f6: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_01fb: dup
-			IL_01fc: brtrue IL_0210
+			IL_0206: pop
+			IL_0207: ldloc.s 10
+			IL_0209: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_020e: dup
+			IL_020f: brtrue IL_0223
 
-			IL_0201: pop
-			IL_0202: rethrow
+			IL_0214: pop
+			IL_0215: rethrow
 
-			IL_0204: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0209: stloc.s 11
-			IL_020b: br IL_0212
+			IL_0217: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_021c: stloc.s 11
+			IL_021e: br IL_0225
 
-			IL_0210: stloc.s 11
+			IL_0223: stloc.s 11
 
-			IL_0212: ldloc.s 11
-			IL_0214: stloc.s 12
-			IL_0216: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_021b: stloc.s 17
-			IL_021d: ldloc.s 17
-			IL_021f: ldstr "throws on non-zero:"
-			IL_0224: ldc.i4.1
-			IL_0225: box [System.Runtime]System.Boolean
-			IL_022a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_022f: pop
-			IL_0230: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0235: stloc.s 17
-			IL_0237: ldloc.s 12
-			IL_0239: ldstr "status"
-			IL_023e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0243: stloc.s 14
-			IL_0245: ldloc.s 17
-			IL_0247: ldstr "status:"
-			IL_024c: ldloc.s 14
-			IL_024e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0253: pop
-			IL_0254: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0259: stloc.s 17
-			IL_025b: ldloc.s 12
-			IL_025d: ldstr "code"
-			IL_0262: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0267: stloc.s 14
-			IL_0269: ldloc.s 17
-			IL_026b: ldstr "code:"
-			IL_0270: ldloc.s 14
-			IL_0272: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0277: pop
-			IL_0278: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_027d: stloc.s 17
-			IL_027f: ldloc.s 12
-			IL_0281: ldstr "message"
-			IL_0286: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_028b: stloc.s 14
-			IL_028d: ldloc.s 14
-			IL_028f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0294: stloc.s 14
-			IL_0296: ldc.i4.0
-			IL_0297: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_029c: brfalse IL_02c5
+			IL_0225: ldloc.s 11
+			IL_0227: stloc.s 12
+			IL_0229: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_022e: stloc.s 17
+			IL_0230: ldloc.s 17
+			IL_0232: ldstr "throws on non-zero:"
+			IL_0237: ldc.i4.1
+			IL_0238: box [System.Runtime]System.Boolean
+			IL_023d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0242: pop
+			IL_0243: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0248: stloc.s 17
+			IL_024a: ldloc.s 12
+			IL_024c: ldstr "status"
+			IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0256: stloc.s 14
+			IL_0258: ldloc.s 17
+			IL_025a: ldstr "status:"
+			IL_025f: ldloc.s 14
+			IL_0261: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0266: pop
+			IL_0267: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_026c: stloc.s 17
+			IL_026e: ldloc.s 12
+			IL_0270: ldstr "code"
+			IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_027a: stloc.s 14
+			IL_027c: ldloc.s 17
+			IL_027e: ldstr "code:"
+			IL_0283: ldloc.s 14
+			IL_0285: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_028a: pop
+			IL_028b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0290: stloc.s 17
+			IL_0292: ldloc.s 12
+			IL_0294: ldstr "message"
+			IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_029e: stloc.s 14
+			IL_02a0: ldloc.s 14
+			IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_02a7: stloc.s 14
+			IL_02a9: ldc.i4.0
+			IL_02aa: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_02af: brfalse IL_02eb
 
-			IL_02a1: ldloc.s 14
-			IL_02a3: isinst [System.Runtime]System.String
-			IL_02a8: dup
-			IL_02a9: brfalse IL_02c4
+			IL_02b4: ldloc.s 14
+			IL_02b6: isinst [System.Runtime]System.String
+			IL_02bb: dup
+			IL_02bc: brtrue IL_02d4
 
-			IL_02ae: ldstr "exit code 5"
-			IL_02b3: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_02b8: box [System.Runtime]System.Double
-			IL_02bd: stloc.s 14
-			IL_02bf: br IL_02d8
+			IL_02c1: pop
+			IL_02c2: ldloc.s 14
+			IL_02c4: ldstr "indexOf"
+			IL_02c9: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_02ce: dup
+			IL_02cf: brfalse IL_02ea
 
-			IL_02c4: pop
+			IL_02d4: ldstr "exit code 5"
+			IL_02d9: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_02de: box [System.Runtime]System.Double
+			IL_02e3: stloc.s 14
+			IL_02e5: br IL_02fe
 
-			IL_02c5: ldloc.s 14
-			IL_02c7: ldstr "indexOf"
-			IL_02cc: ldstr "exit code 5"
-			IL_02d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_02d6: stloc.s 14
+			IL_02ea: pop
 
-			IL_02d8: ldloc.s 14
-			IL_02da: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_02df: ldc.r8 0.0
-			IL_02e8: clt
-			IL_02ea: ldc.i4.0
-			IL_02eb: ceq
-			IL_02ed: stloc.s 18
-			IL_02ef: ldloc.s 18
-			IL_02f1: box [System.Runtime]System.Boolean
-			IL_02f6: stloc.s 19
-			IL_02f8: ldloc.s 17
-			IL_02fa: ldstr "message has exit code:"
-			IL_02ff: ldloc.s 19
-			IL_0301: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0306: pop
-			IL_0307: leave IL_030c
+			IL_02eb: ldloc.s 14
+			IL_02ed: ldstr "indexOf"
+			IL_02f2: ldstr "exit code 5"
+			IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02fc: stloc.s 14
+
+			IL_02fe: ldloc.s 14
+			IL_0300: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0305: ldc.r8 0.0
+			IL_030e: clt
+			IL_0310: ldc.i4.0
+			IL_0311: ceq
+			IL_0313: stloc.s 18
+			IL_0315: ldloc.s 18
+			IL_0317: box [System.Runtime]System.Boolean
+			IL_031c: stloc.s 19
+			IL_031e: ldloc.s 17
+			IL_0320: ldstr "message has exit code:"
+			IL_0325: ldloc.s 19
+			IL_0327: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_032c: pop
+			IL_032d: leave IL_0332
 		} // end handler
 
-		IL_030c: ldnull
-		IL_030d: stloc.s 13
-		IL_030f: ret
+		IL_0332: ldnull
+		IL_0333: stloc.s 13
+		IL_0335: ret
 	} // end of method Require_ChildProcess_ExecFileSync_Basic::__js_module_init__
 
 } // end of class Modules.Require_ChildProcess_ExecFileSync_Basic

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_ExecFile_NonZero.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_ExecFile_NonZero.verified.txt
@@ -132,7 +132,7 @@
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
 			// Header size: 12
-			// Code size: 422 (0x1a6)
+			// Code size: 440 (0x1b8)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -218,7 +218,7 @@
 			IL_00a0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
 			IL_00a5: stloc.1
 			IL_00a6: ldloc.1
-			IL_00a7: brfalse IL_0121
+			IL_00a7: brfalse IL_0133
 
 			IL_00ac: ldarg.2
 			IL_00ad: ldstr "message"
@@ -229,88 +229,95 @@
 			IL_00be: stloc.3
 			IL_00bf: ldc.i4.0
 			IL_00c0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_00c5: brfalse IL_00ec
+			IL_00c5: brfalse IL_00fe
 
 			IL_00ca: ldloc.3
 			IL_00cb: isinst [System.Runtime]System.String
 			IL_00d0: dup
-			IL_00d1: brfalse IL_00eb
+			IL_00d1: brtrue IL_00e8
 
-			IL_00d6: ldstr "exit code 7"
-			IL_00db: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_00e0: box [System.Runtime]System.Double
-			IL_00e5: stloc.3
-			IL_00e6: br IL_00fd
+			IL_00d6: pop
+			IL_00d7: ldloc.3
+			IL_00d8: ldstr "indexOf"
+			IL_00dd: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_00e2: dup
+			IL_00e3: brfalse IL_00fd
 
-			IL_00eb: pop
+			IL_00e8: ldstr "exit code 7"
+			IL_00ed: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_00f2: box [System.Runtime]System.Double
+			IL_00f7: stloc.3
+			IL_00f8: br IL_010f
 
-			IL_00ec: ldloc.3
-			IL_00ed: ldstr "indexOf"
-			IL_00f2: ldstr "exit code 7"
-			IL_00f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00fc: stloc.3
+			IL_00fd: pop
 
-			IL_00fd: ldloc.3
-			IL_00fe: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_0103: ldc.r8 0.0
-			IL_010c: clt
-			IL_010e: ldc.i4.0
-			IL_010f: ceq
-			IL_0111: stloc.1
-			IL_0112: ldloc.1
-			IL_0113: box [System.Runtime]System.Boolean
-			IL_0118: stloc.2
-			IL_0119: ldloc.2
-			IL_011a: stloc.s 7
-			IL_011c: br IL_0124
+			IL_00fe: ldloc.3
+			IL_00ff: ldstr "indexOf"
+			IL_0104: ldstr "exit code 7"
+			IL_0109: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_010e: stloc.3
 
-			IL_0121: ldarg.2
-			IL_0122: stloc.s 7
+			IL_010f: ldloc.3
+			IL_0110: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_0115: ldc.r8 0.0
+			IL_011e: clt
+			IL_0120: ldc.i4.0
+			IL_0121: ceq
+			IL_0123: stloc.1
+			IL_0124: ldloc.1
+			IL_0125: box [System.Runtime]System.Boolean
+			IL_012a: stloc.2
+			IL_012b: ldloc.2
+			IL_012c: stloc.s 7
+			IL_012e: br IL_0136
 
-			IL_0124: ldloc.0
-			IL_0125: ldstr "message has exit code:"
-			IL_012a: ldloc.s 7
-			IL_012c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0131: pop
-			IL_0132: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0137: stloc.0
-			IL_0138: ldarg.3
-			IL_0139: ldstr "length"
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0143: stloc.3
-			IL_0144: ldloc.0
-			IL_0145: ldstr "stdout length:"
-			IL_014a: ldloc.3
-			IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0150: pop
-			IL_0151: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0156: stloc.0
-			IL_0157: ldarg.s stderr
-			IL_0159: ldstr "length"
-			IL_015e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0163: stloc.3
-			IL_0164: ldloc.0
-			IL_0165: ldstr "stderr length:"
-			IL_016a: ldloc.3
-			IL_016b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0170: pop
-			IL_0171: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0176: stloc.0
-			IL_0177: ldarg.0
-			IL_0178: ldfld object Modules.Require_ChildProcess_ExecFile_NonZero/Scope::child
-			IL_017d: ldstr "Cannot access 'child' before initialization"
-			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_018c: ldstr "kill"
-			IL_0191: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0196: stloc.3
-			IL_0197: ldloc.0
-			IL_0198: ldstr "kill after callback:"
-			IL_019d: ldloc.3
-			IL_019e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_01a3: pop
-			IL_01a4: ldnull
-			IL_01a5: ret
+			IL_0133: ldarg.2
+			IL_0134: stloc.s 7
+
+			IL_0136: ldloc.0
+			IL_0137: ldstr "message has exit code:"
+			IL_013c: ldloc.s 7
+			IL_013e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0143: pop
+			IL_0144: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0149: stloc.0
+			IL_014a: ldarg.3
+			IL_014b: ldstr "length"
+			IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0155: stloc.3
+			IL_0156: ldloc.0
+			IL_0157: ldstr "stdout length:"
+			IL_015c: ldloc.3
+			IL_015d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0162: pop
+			IL_0163: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0168: stloc.0
+			IL_0169: ldarg.s stderr
+			IL_016b: ldstr "length"
+			IL_0170: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0175: stloc.3
+			IL_0176: ldloc.0
+			IL_0177: ldstr "stderr length:"
+			IL_017c: ldloc.3
+			IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0182: pop
+			IL_0183: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0188: stloc.0
+			IL_0189: ldarg.0
+			IL_018a: ldfld object Modules.Require_ChildProcess_ExecFile_NonZero/Scope::child
+			IL_018f: ldstr "Cannot access 'child' before initialization"
+			IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_0199: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_019e: ldstr "kill"
+			IL_01a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_01a8: stloc.3
+			IL_01a9: ldloc.0
+			IL_01aa: ldstr "kill after callback:"
+			IL_01af: ldloc.3
+			IL_01b0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_01b5: pop
+			IL_01b6: ldnull
+			IL_01b7: ret
 		} // end of method ArrowFunction_L11C49::__js_call__
 
 	} // end of class ArrowFunction_L11C49

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Exec_Callback.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Exec_Callback.verified.txt
@@ -132,7 +132,7 @@
 				74 61 54 6f 6b 65 6e 04 00 00 02
 			)
 			// Header size: 12
-			// Code size: 197 (0xc5)
+			// Code size: 215 (0xd7)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -163,57 +163,64 @@
 			IL_0033: stloc.3
 			IL_0034: ldc.i4.0
 			IL_0035: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_003a: brfalse IL_0057
+			IL_003a: brfalse IL_0069
 
 			IL_003f: ldloc.3
 			IL_0040: isinst [System.Runtime]System.String
 			IL_0045: dup
-			IL_0046: brfalse IL_0056
+			IL_0046: brtrue IL_005d
 
-			IL_004b: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0050: stloc.3
-			IL_0051: br IL_0063
+			IL_004b: pop
+			IL_004c: ldloc.3
+			IL_004d: ldstr "trim"
+			IL_0052: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0057: dup
+			IL_0058: brfalse IL_0068
 
-			IL_0056: pop
-
-			IL_0057: ldloc.3
-			IL_0058: ldstr "trim"
-			IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_005d: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
 			IL_0062: stloc.3
+			IL_0063: br IL_0075
 
-			IL_0063: ldloc.0
-			IL_0064: ldstr "stdout:"
+			IL_0068: pop
+
 			IL_0069: ldloc.3
-			IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_006f: pop
-			IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0075: stloc.0
-			IL_0076: ldarg.s stderr
-			IL_0078: ldstr "length"
-			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0082: stloc.3
-			IL_0083: ldloc.0
-			IL_0084: ldstr "stderr length:"
-			IL_0089: ldloc.3
-			IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_008f: pop
-			IL_0090: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0095: stloc.0
-			IL_0096: ldarg.0
-			IL_0097: ldfld object Modules.Require_ChildProcess_Exec_Callback/Scope::child
-			IL_009c: ldstr "Cannot access 'child' before initialization"
-			IL_00a1: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
-			IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00ab: ldstr "kill"
-			IL_00b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_00b5: stloc.3
-			IL_00b6: ldloc.0
-			IL_00b7: ldstr "kill after callback:"
-			IL_00bc: ldloc.3
-			IL_00bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_00c2: pop
-			IL_00c3: ldnull
-			IL_00c4: ret
+			IL_006a: ldstr "trim"
+			IL_006f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0074: stloc.3
+
+			IL_0075: ldloc.0
+			IL_0076: ldstr "stdout:"
+			IL_007b: ldloc.3
+			IL_007c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0081: pop
+			IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0087: stloc.0
+			IL_0088: ldarg.s stderr
+			IL_008a: ldstr "length"
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0094: stloc.3
+			IL_0095: ldloc.0
+			IL_0096: ldstr "stderr length:"
+			IL_009b: ldloc.3
+			IL_009c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00a1: pop
+			IL_00a2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00a7: stloc.0
+			IL_00a8: ldarg.0
+			IL_00a9: ldfld object Modules.Require_ChildProcess_Exec_Callback/Scope::child
+			IL_00ae: ldstr "Cannot access 'child' before initialization"
+			IL_00b3: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EnsureTemporalDeadZoneInitialized(object, string)
+			IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00bd: ldstr "kill"
+			IL_00c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_00c7: stloc.3
+			IL_00c8: ldloc.0
+			IL_00c9: ldstr "kill after callback:"
+			IL_00ce: ldloc.3
+			IL_00cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00d4: pop
+			IL_00d5: ldnull
+			IL_00d6: ret
 		} // end of method ArrowFunction_L9C42::__js_call__
 
 	} // end of class ArrowFunction_L9C42

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Exec_Callback_Function_Objects.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Exec_Callback_Function_Objects.verified.txt
@@ -406,7 +406,7 @@
 				01 00 02 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 188 (0xbc)
+			// Code size: 206 (0xce)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -446,49 +446,56 @@
 			IL_0046: stloc.1
 			IL_0047: ldc.i4.0
 			IL_0048: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_004d: brfalse IL_006a
+			IL_004d: brfalse IL_007c
 
 			IL_0052: ldloc.1
 			IL_0053: isinst [System.Runtime]System.String
 			IL_0058: dup
-			IL_0059: brfalse IL_0069
+			IL_0059: brtrue IL_0070
 
-			IL_005e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0063: stloc.1
-			IL_0064: br IL_0076
+			IL_005e: pop
+			IL_005f: ldloc.1
+			IL_0060: ldstr "trim"
+			IL_0065: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_006a: dup
+			IL_006b: brfalse IL_007b
 
-			IL_0069: pop
-
-			IL_006a: ldloc.1
-			IL_006b: ldstr "trim"
-			IL_0070: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0070: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
 			IL_0075: stloc.1
+			IL_0076: br IL_0088
 
-			IL_0076: ldstr "async-stdout:"
-			IL_007b: ldloc.1
-			IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0081: stloc.s 5
-			IL_0083: ldloc.2
-			IL_0084: ldloc.s 5
-			IL_0086: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_008b: pop
-			IL_008c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0091: stloc.2
-			IL_0092: ldarg.s stderr
-			IL_0094: ldstr "length"
-			IL_0099: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_009e: stloc.1
-			IL_009f: ldstr "async-stderr:"
-			IL_00a4: ldloc.1
-			IL_00a5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00aa: stloc.s 5
-			IL_00ac: ldloc.2
-			IL_00ad: ldloc.s 5
-			IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00b4: pop
-			IL_00b5: ldnull
-			IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
-			IL_00bb: ret
+			IL_007b: pop
+
+			IL_007c: ldloc.1
+			IL_007d: ldstr "trim"
+			IL_0082: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0087: stloc.1
+
+			IL_0088: ldstr "async-stdout:"
+			IL_008d: ldloc.1
+			IL_008e: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0093: stloc.s 5
+			IL_0095: ldloc.2
+			IL_0096: ldloc.s 5
+			IL_0098: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_009d: pop
+			IL_009e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00a3: stloc.2
+			IL_00a4: ldarg.s stderr
+			IL_00a6: ldstr "length"
+			IL_00ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_00b0: stloc.1
+			IL_00b1: ldstr "async-stderr:"
+			IL_00b6: ldloc.1
+			IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00bc: stloc.s 5
+			IL_00be: ldloc.2
+			IL_00bf: ldloc.s 5
+			IL_00c1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00c6: pop
+			IL_00c7: ldnull
+			IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.Promise::resolve(object)
+			IL_00cd: ret
 		} // end of method asyncCallback::__js_call__
 
 	} // end of class asyncCallback

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Kill_And_Env.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Kill_And_Env.verified.txt
@@ -682,7 +682,7 @@
 				74 61 54 6f 6b 65 6e 0b 00 00 02
 			)
 			// Header size: 12
-			// Code size: 157 (0x9d)
+			// Code size: 175 (0xaf)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -728,31 +728,38 @@
 			IL_005e: stloc.3
 			IL_005f: ldc.i4.0
 			IL_0060: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0065: brfalse IL_0082
+			IL_0065: brfalse IL_0094
 
 			IL_006a: ldloc.3
 			IL_006b: isinst [System.Runtime]System.String
 			IL_0070: dup
-			IL_0071: brfalse IL_0081
+			IL_0071: brtrue IL_0088
 
-			IL_0076: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_007b: stloc.3
-			IL_007c: br IL_008e
+			IL_0076: pop
+			IL_0077: ldloc.3
+			IL_0078: ldstr "trim"
+			IL_007d: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0082: dup
+			IL_0083: brfalse IL_0093
 
-			IL_0081: pop
-
-			IL_0082: ldloc.3
-			IL_0083: ldstr "trim"
-			IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0088: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
 			IL_008d: stloc.3
+			IL_008e: br IL_00a0
 
-			IL_008e: ldloc.0
-			IL_008f: ldstr "stderr:"
+			IL_0093: pop
+
 			IL_0094: ldloc.3
-			IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_009a: pop
-			IL_009b: ldnull
-			IL_009c: ret
+			IL_0095: ldstr "trim"
+			IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_009f: stloc.3
+
+			IL_00a0: ldloc.0
+			IL_00a1: ldstr "stderr:"
+			IL_00a6: ldloc.3
+			IL_00a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00ac: pop
+			IL_00ad: ldnull
+			IL_00ae: ret
 		} // end of method ArrowFunction_L40C19::__js_call__
 
 	} // end of class ArrowFunction_L40C19

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_MessagePassing.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_MessagePassing.verified.txt
@@ -1057,7 +1057,7 @@
 				74 61 54 6f 6b 65 6e 0d 00 00 02
 			)
 			// Header size: 12
-			// Code size: 339 (0x153)
+			// Code size: 375 (0x177)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -1143,62 +1143,76 @@
 			IL_00c6: stloc.1
 			IL_00c7: ldc.i4.0
 			IL_00c8: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_00cd: brfalse IL_00ea
+			IL_00cd: brfalse IL_00fc
 
 			IL_00d2: ldloc.1
 			IL_00d3: isinst [System.Runtime]System.String
 			IL_00d8: dup
-			IL_00d9: brfalse IL_00e9
+			IL_00d9: brtrue IL_00f0
 
-			IL_00de: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_00e3: stloc.1
-			IL_00e4: br IL_00f6
+			IL_00de: pop
+			IL_00df: ldloc.1
+			IL_00e0: ldstr "trim"
+			IL_00e5: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_00ea: dup
+			IL_00eb: brfalse IL_00fb
 
-			IL_00e9: pop
-
-			IL_00ea: ldloc.1
-			IL_00eb: ldstr "trim"
-			IL_00f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_00f0: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
 			IL_00f5: stloc.1
+			IL_00f6: br IL_0108
 
-			IL_00f6: ldloc.0
-			IL_00f7: ldstr "stdout:"
+			IL_00fb: pop
+
 			IL_00fc: ldloc.1
-			IL_00fd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0102: pop
-			IL_0103: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0108: stloc.0
-			IL_0109: ldarg.0
-			IL_010a: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stderr
-			IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0114: stloc.1
-			IL_0115: ldc.i4.0
-			IL_0116: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_011b: brfalse IL_0138
+			IL_00fd: ldstr "trim"
+			IL_0102: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0107: stloc.1
 
-			IL_0120: ldloc.1
-			IL_0121: isinst [System.Runtime]System.String
-			IL_0126: dup
-			IL_0127: brfalse IL_0137
+			IL_0108: ldloc.0
+			IL_0109: ldstr "stdout:"
+			IL_010e: ldloc.1
+			IL_010f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0114: pop
+			IL_0115: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_011a: stloc.0
+			IL_011b: ldarg.0
+			IL_011c: ldfld object Modules.Require_ChildProcess_Fork_MessagePassing/Scope::stderr
+			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0126: stloc.1
+			IL_0127: ldc.i4.0
+			IL_0128: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_012d: brfalse IL_015c
 
-			IL_012c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0131: stloc.1
-			IL_0132: br IL_0144
+			IL_0132: ldloc.1
+			IL_0133: isinst [System.Runtime]System.String
+			IL_0138: dup
+			IL_0139: brtrue IL_0150
 
-			IL_0137: pop
+			IL_013e: pop
+			IL_013f: ldloc.1
+			IL_0140: ldstr "trim"
+			IL_0145: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_014a: dup
+			IL_014b: brfalse IL_015b
 
-			IL_0138: ldloc.1
-			IL_0139: ldstr "trim"
-			IL_013e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_0143: stloc.1
+			IL_0150: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+			IL_0155: stloc.1
+			IL_0156: br IL_0168
 
-			IL_0144: ldloc.0
-			IL_0145: ldstr "stderr:"
-			IL_014a: ldloc.1
-			IL_014b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0150: pop
-			IL_0151: ldnull
-			IL_0152: ret
+			IL_015b: pop
+
+			IL_015c: ldloc.1
+			IL_015d: ldstr "trim"
+			IL_0162: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0167: stloc.1
+
+			IL_0168: ldloc.0
+			IL_0169: ldstr "stderr:"
+			IL_016e: ldloc.1
+			IL_016f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0174: pop
+			IL_0175: ldnull
+			IL_0176: ret
 		} // end of method ArrowFunction_L63C19::__js_call__
 
 	} // end of class ArrowFunction_L63C19

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
@@ -594,7 +594,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 316 (0x13c)
+				// Code size: 352 (0x160)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -621,114 +621,128 @@
 				IL_002b: stloc.1
 				IL_002c: ldc.i4.0
 				IL_002d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0032: brfalse IL_0059
+				IL_0032: brfalse IL_006b
 
 				IL_0037: ldloc.1
 				IL_0038: isinst [System.Runtime]System.String
 				IL_003d: dup
-				IL_003e: brfalse IL_0058
+				IL_003e: brtrue IL_0055
 
-				IL_0043: ldstr "silent child stdout"
-				IL_0048: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-				IL_004d: box [System.Runtime]System.Double
-				IL_0052: stloc.1
-				IL_0053: br IL_006a
+				IL_0043: pop
+				IL_0044: ldloc.1
+				IL_0045: ldstr "indexOf"
+				IL_004a: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_004f: dup
+				IL_0050: brfalse IL_006a
 
-				IL_0058: pop
+				IL_0055: ldstr "silent child stdout"
+				IL_005a: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+				IL_005f: box [System.Runtime]System.Double
+				IL_0064: stloc.1
+				IL_0065: br IL_007c
 
-				IL_0059: ldloc.1
-				IL_005a: ldstr "indexOf"
-				IL_005f: ldstr "silent child stdout"
-				IL_0064: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0069: stloc.1
+				IL_006a: pop
 
-				IL_006a: ldloc.1
-				IL_006b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_0070: ldc.r8 0.0
-				IL_0079: clt
-				IL_007b: ldc.i4.0
-				IL_007c: ceq
-				IL_007e: stloc.2
-				IL_007f: ldloc.2
-				IL_0080: box [System.Runtime]System.Boolean
-				IL_0085: stloc.3
-				IL_0086: ldloc.0
-				IL_0087: ldstr "silent true stdout marker:"
-				IL_008c: ldloc.3
-				IL_008d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_0092: pop
-				IL_0093: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-				IL_0098: stloc.0
-				IL_0099: ldarg.0
-				IL_009a: ldc.i4.1
-				IL_009b: ldelem.ref
-				IL_009c: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
-				IL_00a1: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stderr
-				IL_00a6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00ab: stloc.1
-				IL_00ac: ldc.i4.0
-				IL_00ad: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_00b2: brfalse IL_00d9
+				IL_006b: ldloc.1
+				IL_006c: ldstr "indexOf"
+				IL_0071: ldstr "silent child stdout"
+				IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_007b: stloc.1
 
-				IL_00b7: ldloc.1
-				IL_00b8: isinst [System.Runtime]System.String
-				IL_00bd: dup
-				IL_00be: brfalse IL_00d8
+				IL_007c: ldloc.1
+				IL_007d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0082: ldc.r8 0.0
+				IL_008b: clt
+				IL_008d: ldc.i4.0
+				IL_008e: ceq
+				IL_0090: stloc.2
+				IL_0091: ldloc.2
+				IL_0092: box [System.Runtime]System.Boolean
+				IL_0097: stloc.3
+				IL_0098: ldloc.0
+				IL_0099: ldstr "silent true stdout marker:"
+				IL_009e: ldloc.3
+				IL_009f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_00a4: pop
+				IL_00a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+				IL_00aa: stloc.0
+				IL_00ab: ldarg.0
+				IL_00ac: ldc.i4.1
+				IL_00ad: ldelem.ref
+				IL_00ae: castclass Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope
+				IL_00b3: ldfld object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/Scope::stderr
+				IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00bd: stloc.1
+				IL_00be: ldc.i4.0
+				IL_00bf: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_00c4: brfalse IL_00fd
 
-				IL_00c3: ldstr "silent child stderr"
-				IL_00c8: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-				IL_00cd: box [System.Runtime]System.Double
-				IL_00d2: stloc.1
-				IL_00d3: br IL_00ea
+				IL_00c9: ldloc.1
+				IL_00ca: isinst [System.Runtime]System.String
+				IL_00cf: dup
+				IL_00d0: brtrue IL_00e7
 
-				IL_00d8: pop
+				IL_00d5: pop
+				IL_00d6: ldloc.1
+				IL_00d7: ldstr "indexOf"
+				IL_00dc: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_00e1: dup
+				IL_00e2: brfalse IL_00fc
 
-				IL_00d9: ldloc.1
-				IL_00da: ldstr "indexOf"
-				IL_00df: ldstr "silent child stderr"
-				IL_00e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_00e9: stloc.1
+				IL_00e7: ldstr "silent child stderr"
+				IL_00ec: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+				IL_00f1: box [System.Runtime]System.Double
+				IL_00f6: stloc.1
+				IL_00f7: br IL_010e
 
-				IL_00ea: ldloc.1
-				IL_00eb: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-				IL_00f0: ldc.r8 0.0
-				IL_00f9: clt
-				IL_00fb: ldc.i4.0
-				IL_00fc: ceq
-				IL_00fe: stloc.2
-				IL_00ff: ldloc.2
-				IL_0100: box [System.Runtime]System.Boolean
-				IL_0105: stloc.3
-				IL_0106: ldloc.0
-				IL_0107: ldstr "silent true stderr marker:"
-				IL_010c: ldloc.3
-				IL_010d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-				IL_0112: pop
-				IL_0113: ldarg.0
-				IL_0114: ldc.i4.0
-				IL_0115: ldelem.ref
-				IL_0116: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
-				IL_011b: ldfld object Modules.Require_ChildProcess_Fork_Silent/Scope::runSilentFalse
-				IL_0120: stloc.1
-				IL_0121: ldloc.1
-				IL_0122: ldc.i4.2
-				IL_0123: newarr [System.Runtime]System.Object
-				IL_0128: dup
-				IL_0129: ldc.i4.0
-				IL_012a: ldarg.0
-				IL_012b: ldc.i4.0
-				IL_012c: ldelem.ref
-				IL_012d: stelem.ref
-				IL_012e: dup
-				IL_012f: ldc.i4.1
-				IL_0130: ldarg.0
-				IL_0131: ldc.i4.1
-				IL_0132: ldelem.ref
-				IL_0133: stelem.ref
-				IL_0134: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
-				IL_0139: pop
-				IL_013a: ldnull
-				IL_013b: ret
+				IL_00fc: pop
+
+				IL_00fd: ldloc.1
+				IL_00fe: ldstr "indexOf"
+				IL_0103: ldstr "silent child stderr"
+				IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_010d: stloc.1
+
+				IL_010e: ldloc.1
+				IL_010f: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0114: ldc.r8 0.0
+				IL_011d: clt
+				IL_011f: ldc.i4.0
+				IL_0120: ceq
+				IL_0122: stloc.2
+				IL_0123: ldloc.2
+				IL_0124: box [System.Runtime]System.Boolean
+				IL_0129: stloc.3
+				IL_012a: ldloc.0
+				IL_012b: ldstr "silent true stderr marker:"
+				IL_0130: ldloc.3
+				IL_0131: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+				IL_0136: pop
+				IL_0137: ldarg.0
+				IL_0138: ldc.i4.0
+				IL_0139: ldelem.ref
+				IL_013a: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
+				IL_013f: ldfld object Modules.Require_ChildProcess_Fork_Silent/Scope::runSilentFalse
+				IL_0144: stloc.1
+				IL_0145: ldloc.1
+				IL_0146: ldc.i4.2
+				IL_0147: newarr [System.Runtime]System.Object
+				IL_014c: dup
+				IL_014d: ldc.i4.0
+				IL_014e: ldarg.0
+				IL_014f: ldc.i4.0
+				IL_0150: ldelem.ref
+				IL_0151: stelem.ref
+				IL_0152: dup
+				IL_0153: ldc.i4.1
+				IL_0154: ldarg.0
+				IL_0155: ldc.i4.1
+				IL_0156: ldelem.ref
+				IL_0157: stelem.ref
+				IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs0(object, object[])
+				IL_015d: pop
+				IL_015e: ldnull
+				IL_015f: ret
 			} // end of method ArrowFunction_L31C23::__js_call__
 
 		} // end of class ArrowFunction_L31C23

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Unsupported_Options.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Unsupported_Options.verified.txt
@@ -192,7 +192,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1257 (0x4e9)
+		// Code size: 1314 (0x522)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_ChildProcess_Fork_Unsupported_Options/Scope,
@@ -249,7 +249,7 @@
 			IL_0037: ldloc.s 22
 			IL_0039: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::fork(object, object, object)
 			IL_003e: pop
-			IL_003f: leave IL_0104
+			IL_003f: leave IL_0117
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
@@ -287,406 +287,427 @@
 			IL_008c: stloc.s 24
 			IL_008e: ldc.i4.0
 			IL_008f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0094: brfalse IL_00bd
+			IL_0094: brfalse IL_00d0
 
 			IL_0099: ldloc.s 24
 			IL_009b: isinst [System.Runtime]System.String
 			IL_00a0: dup
-			IL_00a1: brfalse IL_00bc
+			IL_00a1: brtrue IL_00b9
 
-			IL_00a6: ldstr "detached child processes"
-			IL_00ab: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_00b0: box [System.Runtime]System.Double
-			IL_00b5: stloc.s 24
-			IL_00b7: br IL_00d0
+			IL_00a6: pop
+			IL_00a7: ldloc.s 24
+			IL_00a9: ldstr "indexOf"
+			IL_00ae: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_00b3: dup
+			IL_00b4: brfalse IL_00cf
 
-			IL_00bc: pop
+			IL_00b9: ldstr "detached child processes"
+			IL_00be: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_00c3: box [System.Runtime]System.Double
+			IL_00c8: stloc.s 24
+			IL_00ca: br IL_00e3
 
-			IL_00bd: ldloc.s 24
-			IL_00bf: ldstr "indexOf"
-			IL_00c4: ldstr "detached child processes"
-			IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00ce: stloc.s 24
+			IL_00cf: pop
 
 			IL_00d0: ldloc.s 24
-			IL_00d2: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_00d7: ldc.r8 0.0
-			IL_00e0: clt
-			IL_00e2: ldc.i4.0
-			IL_00e3: ceq
-			IL_00e5: stloc.s 25
-			IL_00e7: ldloc.s 25
-			IL_00e9: box [System.Runtime]System.Boolean
-			IL_00ee: stloc.s 26
-			IL_00f0: ldloc.s 23
-			IL_00f2: ldstr "detached error:"
-			IL_00f7: ldloc.s 26
-			IL_00f9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_00fe: pop
-			IL_00ff: leave IL_0104
+			IL_00d2: ldstr "indexOf"
+			IL_00d7: ldstr "detached child processes"
+			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00e1: stloc.s 24
+
+			IL_00e3: ldloc.s 24
+			IL_00e5: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_00ea: ldc.r8 0.0
+			IL_00f3: clt
+			IL_00f5: ldc.i4.0
+			IL_00f6: ceq
+			IL_00f8: stloc.s 25
+			IL_00fa: ldloc.s 25
+			IL_00fc: box [System.Runtime]System.Boolean
+			IL_0101: stloc.s 26
+			IL_0103: ldloc.s 23
+			IL_0105: ldstr "detached error:"
+			IL_010a: ldloc.s 26
+			IL_010c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0111: pop
+			IL_0112: leave IL_0117
 		} // end handler
 		.try
 		{
-			IL_0104: nop
-			IL_0105: ldc.i4.0
-			IL_0106: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_010b: stloc.s 21
-			IL_010d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_0112: dup
-			IL_0113: ldstr "serialization"
-			IL_0118: ldstr "advanced"
-			IL_011d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_0122: stloc.s 22
-			IL_0124: ldloc.1
-			IL_0125: ldstr "./Require_ChildProcess_Fork_MessagePassing_Child"
-			IL_012a: ldloc.s 21
-			IL_012c: ldloc.s 22
-			IL_012e: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::fork(object, object, object)
-			IL_0133: pop
-			IL_0134: leave IL_01ff
+			IL_0117: nop
+			IL_0118: ldc.i4.0
+			IL_0119: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_011e: stloc.s 21
+			IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0125: dup
+			IL_0126: ldstr "serialization"
+			IL_012b: ldstr "advanced"
+			IL_0130: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_0135: stloc.s 22
+			IL_0137: ldloc.1
+			IL_0138: ldstr "./Require_ChildProcess_Fork_MessagePassing_Child"
+			IL_013d: ldloc.s 21
+			IL_013f: ldloc.s 22
+			IL_0141: callvirt instance object [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule::fork(object, object, object)
+			IL_0146: pop
+			IL_0147: leave IL_0225
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0139: stloc.s 5
-			IL_013b: ldloc.s 5
-			IL_013d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0142: dup
-			IL_0143: brtrue IL_0159
+			IL_014c: stloc.s 5
+			IL_014e: ldloc.s 5
+			IL_0150: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0155: dup
+			IL_0156: brtrue IL_016c
 
-			IL_0148: pop
-			IL_0149: ldloc.s 5
-			IL_014b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0150: dup
-			IL_0151: brtrue IL_0165
+			IL_015b: pop
+			IL_015c: ldloc.s 5
+			IL_015e: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_0163: dup
+			IL_0164: brtrue IL_0178
 
-			IL_0156: pop
-			IL_0157: rethrow
+			IL_0169: pop
+			IL_016a: rethrow
 
-			IL_0159: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_015e: stloc.s 6
-			IL_0160: br IL_0167
+			IL_016c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_0171: stloc.s 6
+			IL_0173: br IL_017a
 
-			IL_0165: stloc.s 6
+			IL_0178: stloc.s 6
 
-			IL_0167: ldloc.s 6
-			IL_0169: stloc.s 7
-			IL_016b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0170: stloc.s 23
-			IL_0172: ldloc.s 7
-			IL_0174: ldstr "message"
-			IL_0179: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_017e: stloc.s 24
-			IL_0180: ldloc.s 24
-			IL_0182: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0187: stloc.s 24
-			IL_0189: ldc.i4.0
-			IL_018a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_018f: brfalse IL_01b8
+			IL_017a: ldloc.s 6
+			IL_017c: stloc.s 7
+			IL_017e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0183: stloc.s 23
+			IL_0185: ldloc.s 7
+			IL_0187: ldstr "message"
+			IL_018c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0191: stloc.s 24
+			IL_0193: ldloc.s 24
+			IL_0195: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_019a: stloc.s 24
+			IL_019c: ldc.i4.0
+			IL_019d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01a2: brfalse IL_01de
 
-			IL_0194: ldloc.s 24
-			IL_0196: isinst [System.Runtime]System.String
-			IL_019b: dup
-			IL_019c: brfalse IL_01b7
+			IL_01a7: ldloc.s 24
+			IL_01a9: isinst [System.Runtime]System.String
+			IL_01ae: dup
+			IL_01af: brtrue IL_01c7
 
-			IL_01a1: ldstr "JSON message serialization"
-			IL_01a6: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_01ab: box [System.Runtime]System.Double
-			IL_01b0: stloc.s 24
-			IL_01b2: br IL_01cb
+			IL_01b4: pop
+			IL_01b5: ldloc.s 24
+			IL_01b7: ldstr "indexOf"
+			IL_01bc: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_01c1: dup
+			IL_01c2: brfalse IL_01dd
 
-			IL_01b7: pop
+			IL_01c7: ldstr "JSON message serialization"
+			IL_01cc: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_01d1: box [System.Runtime]System.Double
+			IL_01d6: stloc.s 24
+			IL_01d8: br IL_01f1
 
-			IL_01b8: ldloc.s 24
-			IL_01ba: ldstr "indexOf"
-			IL_01bf: ldstr "JSON message serialization"
-			IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_01c9: stloc.s 24
+			IL_01dd: pop
 
-			IL_01cb: ldloc.s 24
-			IL_01cd: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_01d2: ldc.r8 0.0
-			IL_01db: clt
-			IL_01dd: ldc.i4.0
-			IL_01de: ceq
-			IL_01e0: stloc.s 25
-			IL_01e2: ldloc.s 25
-			IL_01e4: box [System.Runtime]System.Boolean
-			IL_01e9: stloc.s 26
-			IL_01eb: ldloc.s 23
-			IL_01ed: ldstr "serialization error:"
-			IL_01f2: ldloc.s 26
-			IL_01f4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_01f9: pop
-			IL_01fa: leave IL_01ff
+			IL_01de: ldloc.s 24
+			IL_01e0: ldstr "indexOf"
+			IL_01e5: ldstr "JSON message serialization"
+			IL_01ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01ef: stloc.s 24
+
+			IL_01f1: ldloc.s 24
+			IL_01f3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_01f8: ldc.r8 0.0
+			IL_0201: clt
+			IL_0203: ldc.i4.0
+			IL_0204: ceq
+			IL_0206: stloc.s 25
+			IL_0208: ldloc.s 25
+			IL_020a: box [System.Runtime]System.Boolean
+			IL_020f: stloc.s 26
+			IL_0211: ldloc.s 23
+			IL_0213: ldstr "serialization error:"
+			IL_0218: ldloc.s 26
+			IL_021a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_021f: pop
+			IL_0220: leave IL_0225
 		} // end handler
 		.try
 		{
-			IL_01ff: nop
-			IL_0200: ldstr "process"
-			IL_0205: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_020a: ldstr "platform"
-			IL_020f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0214: stloc.s 24
-			IL_0216: ldloc.s 24
-			IL_0218: ldstr "win32"
-			IL_021d: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0222: stloc.s 8
-			IL_0224: ldloc.s 8
-			IL_0226: brfalse IL_0237
+			IL_0225: nop
+			IL_0226: ldstr "process"
+			IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0230: ldstr "platform"
+			IL_0235: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_023a: stloc.s 24
+			IL_023c: ldloc.s 24
+			IL_023e: ldstr "win32"
+			IL_0243: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0248: stloc.s 8
+			IL_024a: ldloc.s 8
+			IL_024c: brfalse IL_025d
 
-			IL_022b: ldstr "cmd.exe"
-			IL_0230: stloc.s 9
-			IL_0232: br IL_023e
+			IL_0251: ldstr "cmd.exe"
+			IL_0256: stloc.s 9
+			IL_0258: br IL_0264
 
-			IL_0237: ldstr "/bin/sh"
-			IL_023c: stloc.s 9
+			IL_025d: ldstr "/bin/sh"
+			IL_0262: stloc.s 9
 
-			IL_023e: ldloc.s 8
-			IL_0240: brfalse IL_0282
+			IL_0264: ldloc.s 8
+			IL_0266: brfalse IL_02a8
 
-			IL_0245: ldc.i4.4
-			IL_0246: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_024b: dup
-			IL_024c: ldstr "/d"
-			IL_0251: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0256: dup
-			IL_0257: ldstr "/s"
-			IL_025c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0261: dup
-			IL_0262: ldstr "/c"
-			IL_0267: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_026c: dup
-			IL_026d: ldstr "exit /b 0"
-			IL_0272: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0277: stloc.s 21
-			IL_0279: ldloc.s 21
-			IL_027b: stloc.s 10
-			IL_027d: br IL_02a4
+			IL_026b: ldc.i4.4
+			IL_026c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_0271: dup
+			IL_0272: ldstr "/d"
+			IL_0277: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_027c: dup
+			IL_027d: ldstr "/s"
+			IL_0282: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0287: dup
+			IL_0288: ldstr "/c"
+			IL_028d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0292: dup
+			IL_0293: ldstr "exit /b 0"
+			IL_0298: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_029d: stloc.s 21
+			IL_029f: ldloc.s 21
+			IL_02a1: stloc.s 10
+			IL_02a3: br IL_02ca
 
-			IL_0282: ldc.i4.2
-			IL_0283: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_0288: dup
-			IL_0289: ldstr "-c"
-			IL_028e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_0293: dup
-			IL_0294: ldstr "exit 0"
-			IL_0299: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_029e: stloc.s 21
-			IL_02a0: ldloc.s 21
-			IL_02a2: stloc.s 10
+			IL_02a8: ldc.i4.2
+			IL_02a9: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02ae: dup
+			IL_02af: ldstr "-c"
+			IL_02b4: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02b9: dup
+			IL_02ba: ldstr "exit 0"
+			IL_02bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02c4: stloc.s 21
+			IL_02c6: ldloc.s 21
+			IL_02c8: stloc.s 10
 
-			IL_02a4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02a9: dup
-			IL_02aa: ldstr "stdio"
-			IL_02af: ldc.i4.4
-			IL_02b0: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_02b5: dup
-			IL_02b6: ldstr "pipe"
-			IL_02bb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02c0: dup
-			IL_02c1: ldstr "pipe"
-			IL_02c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02cb: dup
-			IL_02cc: ldstr "pipe"
-			IL_02d1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02d6: dup
-			IL_02d7: ldstr "ipc"
-			IL_02dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_02e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-			IL_02e6: stloc.s 22
-			IL_02e8: ldloc.1
-			IL_02e9: ldstr "spawn"
-			IL_02ee: ldloc.s 9
-			IL_02f0: ldloc.s 10
-			IL_02f2: ldloc.s 22
-			IL_02f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_02f9: pop
-			IL_02fa: leave IL_0350
+			IL_02ca: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_02cf: dup
+			IL_02d0: ldstr "stdio"
+			IL_02d5: ldc.i4.4
+			IL_02d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_02db: dup
+			IL_02dc: ldstr "pipe"
+			IL_02e1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02e6: dup
+			IL_02e7: ldstr "pipe"
+			IL_02ec: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02f1: dup
+			IL_02f2: ldstr "pipe"
+			IL_02f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_02fc: dup
+			IL_02fd: ldstr "ipc"
+			IL_0302: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0307: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+			IL_030c: stloc.s 22
+			IL_030e: ldloc.1
+			IL_030f: ldstr "spawn"
+			IL_0314: ldloc.s 9
+			IL_0316: ldloc.s 10
+			IL_0318: ldloc.s 22
+			IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_031f: pop
+			IL_0320: leave IL_0376
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_02ff: stloc.s 11
-			IL_0301: ldloc.s 11
-			IL_0303: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0308: dup
-			IL_0309: brtrue IL_031f
+			IL_0325: stloc.s 11
+			IL_0327: ldloc.s 11
+			IL_0329: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_032e: dup
+			IL_032f: brtrue IL_0345
 
-			IL_030e: pop
-			IL_030f: ldloc.s 11
-			IL_0311: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0316: dup
-			IL_0317: brtrue IL_032b
+			IL_0334: pop
+			IL_0335: ldloc.s 11
+			IL_0337: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_033c: dup
+			IL_033d: brtrue IL_0351
 
-			IL_031c: pop
-			IL_031d: rethrow
+			IL_0342: pop
+			IL_0343: rethrow
 
-			IL_031f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0324: stloc.s 12
-			IL_0326: br IL_032d
+			IL_0345: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_034a: stloc.s 12
+			IL_034c: br IL_0353
 
-			IL_032b: stloc.s 12
+			IL_0351: stloc.s 12
 
-			IL_032d: ldloc.s 12
-			IL_032f: stloc.s 13
-			IL_0331: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0336: stloc.s 23
-			IL_0338: ldloc.s 23
-			IL_033a: ldstr "spawn ipc error:"
-			IL_033f: ldc.i4.1
-			IL_0340: box [System.Runtime]System.Boolean
-			IL_0345: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_034a: pop
-			IL_034b: leave IL_0350
+			IL_0353: ldloc.s 12
+			IL_0355: stloc.s 13
+			IL_0357: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_035c: stloc.s 23
+			IL_035e: ldloc.s 23
+			IL_0360: ldstr "spawn ipc error:"
+			IL_0365: ldc.i4.1
+			IL_0366: box [System.Runtime]System.Boolean
+			IL_036b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0370: pop
+			IL_0371: leave IL_0376
 		} // end handler
 		.try
 		{
-			IL_0350: nop
-			IL_0351: ldstr "process"
-			IL_0356: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-			IL_035b: ldstr "platform"
-			IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0365: stloc.s 24
-			IL_0367: ldloc.s 24
-			IL_0369: ldstr "win32"
-			IL_036e: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_0373: stloc.s 14
-			IL_0375: ldloc.s 14
-			IL_0377: brfalse IL_0388
+			IL_0376: nop
+			IL_0377: ldstr "process"
+			IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0381: ldstr "platform"
+			IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_038b: stloc.s 24
+			IL_038d: ldloc.s 24
+			IL_038f: ldstr "win32"
+			IL_0394: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0399: stloc.s 14
+			IL_039b: ldloc.s 14
+			IL_039d: brfalse IL_03ae
 
-			IL_037c: ldstr "cmd.exe"
-			IL_0381: stloc.s 15
-			IL_0383: br IL_038f
+			IL_03a2: ldstr "cmd.exe"
+			IL_03a7: stloc.s 15
+			IL_03a9: br IL_03b5
 
-			IL_0388: ldstr "/bin/sh"
-			IL_038d: stloc.s 15
+			IL_03ae: ldstr "/bin/sh"
+			IL_03b3: stloc.s 15
 
-			IL_038f: ldloc.s 14
-			IL_0391: brfalse IL_03d3
+			IL_03b5: ldloc.s 14
+			IL_03b7: brfalse IL_03f9
 
-			IL_0396: ldc.i4.4
-			IL_0397: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_039c: dup
-			IL_039d: ldstr "/d"
-			IL_03a2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03a7: dup
-			IL_03a8: ldstr "/s"
-			IL_03ad: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03b2: dup
-			IL_03b3: ldstr "/c"
-			IL_03b8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03bd: dup
-			IL_03be: ldstr "exit /b 0"
-			IL_03c3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03c8: stloc.s 21
-			IL_03ca: ldloc.s 21
-			IL_03cc: stloc.s 16
-			IL_03ce: br IL_03f5
+			IL_03bc: ldc.i4.4
+			IL_03bd: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_03c2: dup
+			IL_03c3: ldstr "/d"
+			IL_03c8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03cd: dup
+			IL_03ce: ldstr "/s"
+			IL_03d3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03d8: dup
+			IL_03d9: ldstr "/c"
+			IL_03de: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03e3: dup
+			IL_03e4: ldstr "exit /b 0"
+			IL_03e9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_03ee: stloc.s 21
+			IL_03f0: ldloc.s 21
+			IL_03f2: stloc.s 16
+			IL_03f4: br IL_041b
 
-			IL_03d3: ldc.i4.2
-			IL_03d4: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-			IL_03d9: dup
-			IL_03da: ldstr "-c"
-			IL_03df: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03e4: dup
-			IL_03e5: ldstr "exit 0"
-			IL_03ea: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-			IL_03ef: stloc.s 21
-			IL_03f1: ldloc.s 21
-			IL_03f3: stloc.s 16
+			IL_03f9: ldc.i4.2
+			IL_03fa: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+			IL_03ff: dup
+			IL_0400: ldstr "-c"
+			IL_0405: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_040a: dup
+			IL_040b: ldstr "exit 0"
+			IL_0410: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+			IL_0415: stloc.s 21
+			IL_0417: ldloc.s 21
+			IL_0419: stloc.s 16
 
-			IL_03f5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_03fa: dup
-			IL_03fb: ldstr "detached"
-			IL_0400: ldc.i4.1
-			IL_0401: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0406: stloc.s 22
-			IL_0408: ldloc.1
-			IL_0409: ldstr "spawn"
-			IL_040e: ldloc.s 15
-			IL_0410: ldloc.s 16
-			IL_0412: ldloc.s 22
-			IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-			IL_0419: pop
-			IL_041a: leave IL_04e5
+			IL_041b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0420: dup
+			IL_0421: ldstr "detached"
+			IL_0426: ldc.i4.1
+			IL_0427: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_042c: stloc.s 22
+			IL_042e: ldloc.1
+			IL_042f: ldstr "spawn"
+			IL_0434: ldloc.s 15
+			IL_0436: ldloc.s 16
+			IL_0438: ldloc.s 22
+			IL_043a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+			IL_043f: pop
+			IL_0440: leave IL_051e
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_041f: stloc.s 17
-			IL_0421: ldloc.s 17
-			IL_0423: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0428: dup
-			IL_0429: brtrue IL_043f
+			IL_0445: stloc.s 17
+			IL_0447: ldloc.s 17
+			IL_0449: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_044e: dup
+			IL_044f: brtrue IL_0465
 
-			IL_042e: pop
-			IL_042f: ldloc.s 17
-			IL_0431: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0436: dup
-			IL_0437: brtrue IL_044b
+			IL_0454: pop
+			IL_0455: ldloc.s 17
+			IL_0457: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_045c: dup
+			IL_045d: brtrue IL_0471
 
-			IL_043c: pop
-			IL_043d: rethrow
+			IL_0462: pop
+			IL_0463: rethrow
 
-			IL_043f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_0444: stloc.s 18
-			IL_0446: br IL_044d
+			IL_0465: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_046a: stloc.s 18
+			IL_046c: br IL_0473
 
-			IL_044b: stloc.s 18
+			IL_0471: stloc.s 18
 
-			IL_044d: ldloc.s 18
-			IL_044f: stloc.s 19
-			IL_0451: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0456: stloc.s 23
-			IL_0458: ldloc.s 19
-			IL_045a: ldstr "message"
-			IL_045f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0464: stloc.s 24
-			IL_0466: ldloc.s 24
-			IL_0468: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_046d: stloc.s 24
-			IL_046f: ldc.i4.0
-			IL_0470: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0475: brfalse IL_049e
+			IL_0473: ldloc.s 18
+			IL_0475: stloc.s 19
+			IL_0477: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_047c: stloc.s 23
+			IL_047e: ldloc.s 19
+			IL_0480: ldstr "message"
+			IL_0485: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_048a: stloc.s 24
+			IL_048c: ldloc.s 24
+			IL_048e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0493: stloc.s 24
+			IL_0495: ldc.i4.0
+			IL_0496: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_049b: brfalse IL_04d7
 
-			IL_047a: ldloc.s 24
-			IL_047c: isinst [System.Runtime]System.String
-			IL_0481: dup
-			IL_0482: brfalse IL_049d
+			IL_04a0: ldloc.s 24
+			IL_04a2: isinst [System.Runtime]System.String
+			IL_04a7: dup
+			IL_04a8: brtrue IL_04c0
 
-			IL_0487: ldstr "detached child processes"
-			IL_048c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_0491: box [System.Runtime]System.Double
-			IL_0496: stloc.s 24
-			IL_0498: br IL_04b1
+			IL_04ad: pop
+			IL_04ae: ldloc.s 24
+			IL_04b0: ldstr "indexOf"
+			IL_04b5: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_04ba: dup
+			IL_04bb: brfalse IL_04d6
 
-			IL_049d: pop
+			IL_04c0: ldstr "detached child processes"
+			IL_04c5: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_04ca: box [System.Runtime]System.Double
+			IL_04cf: stloc.s 24
+			IL_04d1: br IL_04ea
 
-			IL_049e: ldloc.s 24
-			IL_04a0: ldstr "indexOf"
-			IL_04a5: ldstr "detached child processes"
-			IL_04aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_04af: stloc.s 24
+			IL_04d6: pop
 
-			IL_04b1: ldloc.s 24
-			IL_04b3: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-			IL_04b8: ldc.r8 0.0
-			IL_04c1: clt
-			IL_04c3: ldc.i4.0
-			IL_04c4: ceq
-			IL_04c6: stloc.s 25
-			IL_04c8: ldloc.s 25
-			IL_04ca: box [System.Runtime]System.Boolean
-			IL_04cf: stloc.s 26
-			IL_04d1: ldloc.s 23
-			IL_04d3: ldstr "spawn detached error:"
-			IL_04d8: ldloc.s 26
-			IL_04da: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_04df: pop
-			IL_04e0: leave IL_04e5
+			IL_04d7: ldloc.s 24
+			IL_04d9: ldstr "indexOf"
+			IL_04de: ldstr "detached child processes"
+			IL_04e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_04e8: stloc.s 24
+
+			IL_04ea: ldloc.s 24
+			IL_04ec: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+			IL_04f1: ldc.r8 0.0
+			IL_04fa: clt
+			IL_04fc: ldc.i4.0
+			IL_04fd: ceq
+			IL_04ff: stloc.s 25
+			IL_0501: ldloc.s 25
+			IL_0503: box [System.Runtime]System.Boolean
+			IL_0508: stloc.s 26
+			IL_050a: ldloc.s 23
+			IL_050c: ldstr "spawn detached error:"
+			IL_0511: ldloc.s 26
+			IL_0513: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0518: pop
+			IL_0519: leave IL_051e
 		} // end handler
 
-		IL_04e5: ldnull
-		IL_04e6: stloc.s 20
-		IL_04e8: ret
+		IL_051e: ldnull
+		IL_051f: stloc.s 20
+		IL_0521: ret
 	} // end of method Require_ChildProcess_Fork_Unsupported_Options::__js_module_init__
 
 } // end of class Modules.Require_ChildProcess_Fork_Unsupported_Options

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Spawn_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Spawn_Basic.verified.txt
@@ -511,7 +511,7 @@
 				74 61 54 6f 6b 65 6e 07 00 00 02
 			)
 			// Header size: 12
-			// Code size: 176 (0xb0)
+			// Code size: 194 (0xc2)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -533,56 +533,63 @@
 			IL_0024: stloc.1
 			IL_0025: ldc.i4.0
 			IL_0026: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_002b: brfalse IL_0048
+			IL_002b: brfalse IL_005a
 
 			IL_0030: ldloc.1
 			IL_0031: isinst [System.Runtime]System.String
 			IL_0036: dup
-			IL_0037: brfalse IL_0047
+			IL_0037: brtrue IL_004e
 
-			IL_003c: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0041: stloc.1
-			IL_0042: br IL_0054
+			IL_003c: pop
+			IL_003d: ldloc.1
+			IL_003e: ldstr "trim"
+			IL_0043: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0048: dup
+			IL_0049: brfalse IL_0059
 
-			IL_0047: pop
-
-			IL_0048: ldloc.1
-			IL_0049: ldstr "trim"
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_004e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
 			IL_0053: stloc.1
+			IL_0054: br IL_0066
 
-			IL_0054: ldloc.0
-			IL_0055: ldstr "stdout:"
+			IL_0059: pop
+
 			IL_005a: ldloc.1
-			IL_005b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0060: pop
-			IL_0061: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_0066: stloc.0
-			IL_0067: ldarg.0
-			IL_0068: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stderr
-			IL_006d: ldstr "length"
-			IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0077: stloc.1
-			IL_0078: ldloc.0
-			IL_0079: ldstr "stderr length:"
-			IL_007e: ldloc.1
-			IL_007f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_0084: pop
-			IL_0085: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_008a: stloc.0
-			IL_008b: ldarg.0
-			IL_008c: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
-			IL_0091: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0096: ldstr "kill"
-			IL_009b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-			IL_00a0: stloc.1
-			IL_00a1: ldloc.0
-			IL_00a2: ldstr "kill after close:"
-			IL_00a7: ldloc.1
-			IL_00a8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_00ad: pop
-			IL_00ae: ldnull
-			IL_00af: ret
+			IL_005b: ldstr "trim"
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0065: stloc.1
+
+			IL_0066: ldloc.0
+			IL_0067: ldstr "stdout:"
+			IL_006c: ldloc.1
+			IL_006d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0072: pop
+			IL_0073: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0078: stloc.0
+			IL_0079: ldarg.0
+			IL_007a: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::stderr
+			IL_007f: ldstr "length"
+			IL_0084: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0089: stloc.1
+			IL_008a: ldloc.0
+			IL_008b: ldstr "stderr length:"
+			IL_0090: ldloc.1
+			IL_0091: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_0096: pop
+			IL_0097: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_009c: stloc.0
+			IL_009d: ldarg.0
+			IL_009e: ldfld object Modules.Require_ChildProcess_Spawn_Basic/Scope::child
+			IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_00a8: ldstr "kill"
+			IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_00b2: stloc.1
+			IL_00b3: ldloc.0
+			IL_00b4: ldstr "kill after close:"
+			IL_00b9: ldloc.1
+			IL_00ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00bf: pop
+			IL_00c0: ldnull
+			IL_00c1: ret
 		} // end of method ArrowFunction_L29C19::__js_call__
 
 	} // end of class ArrowFunction_L29C19

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Realpath.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FSPromises_Realpath.verified.txt
@@ -120,7 +120,7 @@
 				74 61 54 6f 6b 65 6e 05 00 00 02
 			)
 			// Header size: 12
-			// Code size: 228 (0xe4)
+			// Code size: 246 (0xf6)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -157,65 +157,72 @@
 			IL_0044: stloc.1
 			IL_0045: ldc.i4.0
 			IL_0046: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_004b: brfalse IL_0072
+			IL_004b: brfalse IL_0084
 
 			IL_0050: ldloc.1
 			IL_0051: isinst [System.Runtime]System.String
 			IL_0056: dup
-			IL_0057: brfalse IL_0071
+			IL_0057: brtrue IL_006e
 
-			IL_005c: ldstr "test-realpath.txt"
-			IL_0061: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-			IL_0066: box [System.Runtime]System.Boolean
-			IL_006b: stloc.1
-			IL_006c: br IL_0083
+			IL_005c: pop
+			IL_005d: ldloc.1
+			IL_005e: ldstr "includes"
+			IL_0063: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0068: dup
+			IL_0069: brfalse IL_0083
 
-			IL_0071: pop
+			IL_006e: ldstr "test-realpath.txt"
+			IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_0078: box [System.Runtime]System.Boolean
+			IL_007d: stloc.1
+			IL_007e: br IL_0095
 
-			IL_0072: ldloc.1
-			IL_0073: ldstr "includes"
-			IL_0078: ldstr "test-realpath.txt"
-			IL_007d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0082: stloc.1
+			IL_0083: pop
 
-			IL_0083: ldloc.0
-			IL_0084: ldstr "Contains filename:"
-			IL_0089: ldloc.1
-			IL_008a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-			IL_008f: pop
-			IL_0090: ldarg.0
-			IL_0091: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.FSPromises_Realpath/Scope::require
-			IL_0096: stloc.s 4
-			IL_0098: ldloc.s 4
-			IL_009a: ldstr "fs"
-			IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule>(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object)
-			IL_00a4: stloc.s 5
-			IL_00a6: ldarg.0
-			IL_00a7: ldfld object Modules.FSPromises_Realpath/Scope::testFile
-			IL_00ac: stloc.1
-			IL_00ad: ldloc.s 5
-			IL_00af: ldstr "rmSync"
-			IL_00b4: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
-			IL_00b9: brtrue IL_00cb
+			IL_0084: ldloc.1
+			IL_0085: ldstr "includes"
+			IL_008a: ldstr "test-realpath.txt"
+			IL_008f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0094: stloc.1
 
-			IL_00be: ldloc.s 5
-			IL_00c0: ldloc.1
-			IL_00c1: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object)
-			IL_00c6: br IL_00e2
+			IL_0095: ldloc.0
+			IL_0096: ldstr "Contains filename:"
+			IL_009b: ldloc.1
+			IL_009c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+			IL_00a1: pop
+			IL_00a2: ldarg.0
+			IL_00a3: ldfld class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate Modules.FSPromises_Realpath/Scope::require
+			IL_00a8: stloc.s 4
+			IL_00aa: ldloc.s 4
+			IL_00ac: ldstr "fs"
+			IL_00b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireRuntime::RequireObject<class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule>(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object)
+			IL_00b6: stloc.s 5
+			IL_00b8: ldarg.0
+			IL_00b9: ldfld object Modules.FSPromises_Realpath/Scope::testFile
+			IL_00be: stloc.1
+			IL_00bf: ldloc.s 5
+			IL_00c1: ldstr "rmSync"
+			IL_00c6: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnPropertyOverride(object, string)
+			IL_00cb: brtrue IL_00dd
 
-			IL_00cb: ldloc.s 5
-			IL_00cd: ldstr "rmSync"
-			IL_00d2: ldc.i4.1
-			IL_00d3: newarr [System.Runtime]System.Object
-			IL_00d8: dup
-			IL_00d9: ldc.i4.0
-			IL_00da: ldloc.1
-			IL_00db: stelem.ref
-			IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
-			IL_00e1: pop
+			IL_00d0: ldloc.s 5
+			IL_00d2: ldloc.1
+			IL_00d3: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object)
+			IL_00d8: br IL_00f4
 
-			IL_00e2: ldnull
-			IL_00e3: ret
+			IL_00dd: ldloc.s 5
+			IL_00df: ldstr "rmSync"
+			IL_00e4: ldc.i4.1
+			IL_00e5: newarr [System.Runtime]System.Object
+			IL_00ea: dup
+			IL_00eb: ldc.i4.0
+			IL_00ec: ldloc.1
+			IL_00ed: stelem.ref
+			IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallOwnPropertyMember(object, string, object[])
+			IL_00f3: pop
+
+			IL_00f4: ldnull
+			IL_00f5: ret
 		} // end of method ArrowFunction_L8C28::__js_call__
 
 	} // end of class ArrowFunction_L8C28

--- a/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_UnlinkSync_ReleaseCleanup.verified.txt
+++ b/tests/Jroc.Tests/Node/FS/Snapshots/GeneratorTests.FS_UnlinkSync_ReleaseCleanup.verified.txt
@@ -118,7 +118,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 794 (0x31a)
+		// Code size: 832 (0x340)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.FS_UnlinkSync_ReleaseCleanup/Scope,
@@ -314,7 +314,7 @@
 				IL_01d9: ldloc.1
 				IL_01da: ldloc.s 6
 				IL_01dc: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::unlinkSync(object)
-				IL_01e1: leave IL_02e7
+				IL_01e1: leave IL_030d
 			} // end .try
 			catch [System.Runtime]System.Exception
 			{
@@ -352,90 +352,104 @@
 				IL_0234: stloc.s 12
 				IL_0236: ldc.i4.0
 				IL_0237: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_023c: brfalse IL_0265
+				IL_023c: brfalse IL_0278
 
 				IL_0241: ldloc.s 12
 				IL_0243: isinst [System.Runtime]System.String
 				IL_0248: dup
-				IL_0249: brfalse IL_0264
+				IL_0249: brtrue IL_0261
 
-				IL_024e: ldstr "ENOENT:"
-				IL_0253: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-				IL_0258: box [System.Runtime]System.Boolean
-				IL_025d: stloc.s 12
-				IL_025f: br IL_0278
+				IL_024e: pop
+				IL_024f: ldloc.s 12
+				IL_0251: ldstr "includes"
+				IL_0256: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_025b: dup
+				IL_025c: brfalse IL_0277
 
-				IL_0264: pop
+				IL_0261: ldstr "ENOENT:"
+				IL_0266: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+				IL_026b: box [System.Runtime]System.Boolean
+				IL_0270: stloc.s 12
+				IL_0272: br IL_028b
 
-				IL_0265: ldloc.s 12
-				IL_0267: ldstr "includes"
-				IL_026c: ldstr "ENOENT:"
-				IL_0271: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0276: stloc.s 12
+				IL_0277: pop
 
-				IL_0278: ldloc.s 10
-				IL_027a: ldstr "message"
-				IL_027f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-				IL_0284: stloc.s 17
-				IL_0286: ldloc.s 17
-				IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_028d: stloc.s 17
-				IL_028f: ldc.i4.0
-				IL_0290: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0295: brfalse IL_02be
+				IL_0278: ldloc.s 12
+				IL_027a: ldstr "includes"
+				IL_027f: ldstr "ENOENT:"
+				IL_0284: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_0289: stloc.s 12
 
-				IL_029a: ldloc.s 17
-				IL_029c: isinst [System.Runtime]System.String
-				IL_02a1: dup
-				IL_02a2: brfalse IL_02bd
+				IL_028b: ldloc.s 10
+				IL_028d: ldstr "message"
+				IL_0292: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+				IL_0297: stloc.s 17
+				IL_0299: ldloc.s 17
+				IL_029b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_02a0: stloc.s 17
+				IL_02a2: ldc.i4.0
+				IL_02a3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+				IL_02a8: brfalse IL_02e4
 
-				IL_02a7: ldstr "pr-body.md"
-				IL_02ac: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-				IL_02b1: box [System.Runtime]System.Boolean
-				IL_02b6: stloc.s 17
-				IL_02b8: br IL_02d1
+				IL_02ad: ldloc.s 17
+				IL_02af: isinst [System.Runtime]System.String
+				IL_02b4: dup
+				IL_02b5: brtrue IL_02cd
 
-				IL_02bd: pop
+				IL_02ba: pop
+				IL_02bb: ldloc.s 17
+				IL_02bd: ldstr "includes"
+				IL_02c2: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_02c7: dup
+				IL_02c8: brfalse IL_02e3
 
-				IL_02be: ldloc.s 17
-				IL_02c0: ldstr "includes"
-				IL_02c5: ldstr "pr-body.md"
-				IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_02cf: stloc.s 17
+				IL_02cd: ldstr "pr-body.md"
+				IL_02d2: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+				IL_02d7: box [System.Runtime]System.Boolean
+				IL_02dc: stloc.s 17
+				IL_02de: br IL_02f7
 
-				IL_02d1: ldloc.s 16
-				IL_02d3: ldstr "MissingError:"
-				IL_02d8: ldloc.s 12
-				IL_02da: ldloc.s 17
-				IL_02dc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
-				IL_02e1: pop
-				IL_02e2: leave IL_02e7
+				IL_02e3: pop
+
+				IL_02e4: ldloc.s 17
+				IL_02e6: ldstr "includes"
+				IL_02eb: ldstr "pr-body.md"
+				IL_02f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_02f5: stloc.s 17
+
+				IL_02f7: ldloc.s 16
+				IL_02f9: ldstr "MissingError:"
+				IL_02fe: ldloc.s 12
+				IL_0300: ldloc.s 17
+				IL_0302: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object, object)
+				IL_0307: pop
+				IL_0308: leave IL_030d
 			} // end handler
 
-			IL_02e7: leave IL_0316
+			IL_030d: leave IL_033c
 		} // end .try
 		finally
 		{
-			IL_02ec: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-			IL_02f1: dup
-			IL_02f2: ldstr "recursive"
-			IL_02f7: ldc.i4.1
-			IL_02f8: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_02fd: dup
-			IL_02fe: ldstr "force"
-			IL_0303: ldc.i4.1
-			IL_0304: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
-			IL_0309: stloc.s 15
-			IL_030b: ldloc.1
-			IL_030c: ldloc.s 5
-			IL_030e: ldloc.s 15
-			IL_0310: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
-			IL_0315: endfinally
+			IL_0312: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0317: dup
+			IL_0318: ldstr "recursive"
+			IL_031d: ldc.i4.1
+			IL_031e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_0323: dup
+			IL_0324: ldstr "force"
+			IL_0329: ldc.i4.1
+			IL_032a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+			IL_032f: stloc.s 15
+			IL_0331: ldloc.1
+			IL_0332: ldloc.s 5
+			IL_0334: ldloc.s 15
+			IL_0336: callvirt instance void [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule::rmSync(object, object)
+			IL_033b: endfinally
 		} // end handler
 
-		IL_0316: ldnull
-		IL_0317: stloc.s 11
-		IL_0319: ret
+		IL_033c: ldnull
+		IL_033d: stloc.s 11
+		IL_033f: ret
 	} // end of method FS_UnlinkSync_ReleaseCleanup::__js_module_init__
 
 } // end of class Modules.FS_UnlinkSync_ReleaseCleanup

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_CreateServer_Get_Loopback.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_CreateServer_Get_Loopback.verified.txt
@@ -144,7 +144,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 322 (0x142)
+			// Code size: 340 (0x154)
 			.maxstack 8
 			.locals init (
 				[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -198,74 +198,81 @@
 			IL_0070: stloc.1
 			IL_0071: ldc.i4.0
 			IL_0072: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0077: brfalse IL_009e
+			IL_0077: brfalse IL_00b0
 
 			IL_007c: ldloc.1
 			IL_007d: isinst [System.Runtime]System.String
 			IL_0082: dup
-			IL_0083: brfalse IL_009d
+			IL_0083: brtrue IL_009a
 
-			IL_0088: ldstr "127.0.0.1:"
-			IL_008d: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-			IL_0092: box [System.Runtime]System.Double
-			IL_0097: stloc.1
-			IL_0098: br IL_00af
+			IL_0088: pop
+			IL_0089: ldloc.1
+			IL_008a: ldstr "indexOf"
+			IL_008f: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_0094: dup
+			IL_0095: brfalse IL_00af
 
-			IL_009d: pop
+			IL_009a: ldstr "127.0.0.1:"
+			IL_009f: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+			IL_00a4: box [System.Runtime]System.Double
+			IL_00a9: stloc.1
+			IL_00aa: br IL_00c1
 
-			IL_009e: ldloc.1
-			IL_009f: ldstr "indexOf"
-			IL_00a4: ldstr "127.0.0.1:"
-			IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_00ae: stloc.1
+			IL_00af: pop
 
-			IL_00af: ldloc.1
-			IL_00b0: ldc.r8 0.0
-			IL_00b9: box [System.Runtime]System.Double
-			IL_00be: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-			IL_00c3: stloc.3
-			IL_00c4: ldloc.3
-			IL_00c5: box [System.Runtime]System.Boolean
-			IL_00ca: stloc.s 4
-			IL_00cc: ldstr "req host:"
-			IL_00d1: ldloc.s 4
-			IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_00d8: stloc.2
-			IL_00d9: ldloc.0
-			IL_00da: ldloc.2
-			IL_00db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_00e0: pop
-			IL_00e1: ldarg.2
-			IL_00e2: ldstr "statusCode"
-			IL_00e7: ldc.r8 201
-			IL_00f0: ldc.i4.1
-			IL_00f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
-			IL_00f6: pop
-			IL_00f7: ldarg.2
-			IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_00fd: ldstr "setHeader"
-			IL_0102: ldstr "X-Answer"
-			IL_0107: ldstr "42"
-			IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-			IL_0111: pop
-			IL_0112: ldarg.2
-			IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-			IL_0118: stloc.1
-			IL_0119: ldarg.1
-			IL_011a: ldstr "url"
-			IL_011f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_0124: stloc.s 5
-			IL_0126: ldstr "hello:"
-			IL_012b: ldloc.s 5
-			IL_012d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-			IL_0132: stloc.2
-			IL_0133: ldloc.1
-			IL_0134: ldstr "end"
-			IL_0139: ldloc.2
-			IL_013a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_013f: pop
-			IL_0140: ldnull
-			IL_0141: ret
+			IL_00b0: ldloc.1
+			IL_00b1: ldstr "indexOf"
+			IL_00b6: ldstr "127.0.0.1:"
+			IL_00bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_00c0: stloc.1
+
+			IL_00c1: ldloc.1
+			IL_00c2: ldc.r8 0.0
+			IL_00cb: box [System.Runtime]System.Double
+			IL_00d0: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_00d5: stloc.3
+			IL_00d6: ldloc.3
+			IL_00d7: box [System.Runtime]System.Boolean
+			IL_00dc: stloc.s 4
+			IL_00de: ldstr "req host:"
+			IL_00e3: ldloc.s 4
+			IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_00ea: stloc.2
+			IL_00eb: ldloc.0
+			IL_00ec: ldloc.2
+			IL_00ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_00f2: pop
+			IL_00f3: ldarg.2
+			IL_00f4: ldstr "statusCode"
+			IL_00f9: ldc.r8 201
+			IL_0102: ldc.i4.1
+			IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, float64, bool)
+			IL_0108: pop
+			IL_0109: ldarg.2
+			IL_010a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_010f: ldstr "setHeader"
+			IL_0114: ldstr "X-Answer"
+			IL_0119: ldstr "42"
+			IL_011e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+			IL_0123: pop
+			IL_0124: ldarg.2
+			IL_0125: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_012a: stloc.1
+			IL_012b: ldarg.1
+			IL_012c: ldstr "url"
+			IL_0131: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0136: stloc.s 5
+			IL_0138: ldstr "hello:"
+			IL_013d: ldloc.s 5
+			IL_013f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+			IL_0144: stloc.2
+			IL_0145: ldloc.1
+			IL_0146: ldstr "end"
+			IL_014b: ldloc.2
+			IL_014c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0151: pop
+			IL_0152: ldnull
+			IL_0153: ret
 		} // end of method FunctionExpression_server::__js_call__
 
 	} // end of class FunctionExpression_server

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Post_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Post_Basic.verified.txt
@@ -339,7 +339,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 451 (0x1c3)
+				// Code size: 469 (0x1d5)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -485,31 +485,38 @@
 				IL_0184: stloc.3
 				IL_0185: ldc.i4.0
 				IL_0186: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_018b: brfalse IL_01a8
+				IL_018b: brfalse IL_01ba
 
 				IL_0190: ldloc.3
 				IL_0191: isinst [System.Runtime]System.String
 				IL_0196: dup
-				IL_0197: brfalse IL_01a7
+				IL_0197: brtrue IL_01ae
 
-				IL_019c: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
-				IL_01a1: stloc.3
-				IL_01a2: br IL_01b4
+				IL_019c: pop
+				IL_019d: ldloc.3
+				IL_019e: ldstr "toUpperCase"
+				IL_01a3: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_01a8: dup
+				IL_01a9: brfalse IL_01b9
 
-				IL_01a7: pop
-
-				IL_01a8: ldloc.3
-				IL_01a9: ldstr "toUpperCase"
-				IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_01ae: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
 				IL_01b3: stloc.3
+				IL_01b4: br IL_01c6
 
-				IL_01b4: ldloc.1
-				IL_01b5: ldstr "end"
+				IL_01b9: pop
+
 				IL_01ba: ldloc.3
-				IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_01c0: pop
-				IL_01c1: ldnull
-				IL_01c2: ret
+				IL_01bb: ldstr "toUpperCase"
+				IL_01c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_01c5: stloc.3
+
+				IL_01c6: ldloc.1
+				IL_01c7: ldstr "end"
+				IL_01cc: ldloc.3
+				IL_01cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_01d2: pop
+				IL_01d3: ldnull
+				IL_01d4: ret
 			} // end of method FunctionExpression_server_L13C16::__js_call__
 
 		} // end of class FunctionExpression_server_L13C16

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_AllowHalfOpen_Delayed_Response.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_AllowHalfOpen_Delayed_Response.verified.txt
@@ -350,7 +350,7 @@
 						01 00 02 00 00 00 00 00
 					)
 					// Header size: 12
-					// Code size: 162 (0xa2)
+					// Code size: 180 (0xb4)
 					.maxstack 8
 					.locals init (
 						[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -393,35 +393,42 @@
 					IL_0057: stloc.3
 					IL_0058: ldc.i4.0
 					IL_0059: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-					IL_005e: brfalse IL_007b
+					IL_005e: brfalse IL_008d
 
 					IL_0063: ldloc.3
 					IL_0064: isinst [System.Runtime]System.String
 					IL_0069: dup
-					IL_006a: brfalse IL_007a
+					IL_006a: brtrue IL_0081
 
-					IL_006f: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
-					IL_0074: stloc.3
-					IL_0075: br IL_0087
+					IL_006f: pop
+					IL_0070: ldloc.3
+					IL_0071: ldstr "toUpperCase"
+					IL_0076: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+					IL_007b: dup
+					IL_007c: brfalse IL_008c
 
-					IL_007a: pop
-
-					IL_007b: ldloc.3
-					IL_007c: ldstr "toUpperCase"
-					IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_0081: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
 					IL_0086: stloc.3
+					IL_0087: br IL_0099
 
-					IL_0087: ldstr "delayed:"
-					IL_008c: ldloc.3
-					IL_008d: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-					IL_0092: stloc.2
-					IL_0093: ldloc.1
-					IL_0094: ldstr "end"
-					IL_0099: ldloc.2
-					IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-					IL_009f: pop
-					IL_00a0: ldnull
-					IL_00a1: ret
+					IL_008c: pop
+
+					IL_008d: ldloc.3
+					IL_008e: ldstr "toUpperCase"
+					IL_0093: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+					IL_0098: stloc.3
+
+					IL_0099: ldstr "delayed:"
+					IL_009e: ldloc.3
+					IL_009f: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+					IL_00a4: stloc.2
+					IL_00a5: ldloc.1
+					IL_00a6: ldstr "end"
+					IL_00ab: ldloc.2
+					IL_00ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+					IL_00b1: pop
+					IL_00b2: ldnull
+					IL_00b3: ret
 				} // end of method FunctionExpression_server::__js_call__
 
 			} // end of class FunctionExpression_server

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_Connect_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_Connect_Basic.verified.txt
@@ -346,7 +346,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 181 (0xb5)
+				// Code size: 199 (0xc7)
 				.maxstack 8
 				.locals init (
 					[0] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -387,44 +387,51 @@
 				IL_004d: stloc.3
 				IL_004e: ldc.i4.0
 				IL_004f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0054: brfalse IL_0071
+				IL_0054: brfalse IL_0083
 
 				IL_0059: ldloc.3
 				IL_005a: isinst [System.Runtime]System.String
 				IL_005f: dup
-				IL_0060: brfalse IL_0070
+				IL_0060: brtrue IL_0077
 
-				IL_0065: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
-				IL_006a: stloc.3
-				IL_006b: br IL_007d
+				IL_0065: pop
+				IL_0066: ldloc.3
+				IL_0067: ldstr "toUpperCase"
+				IL_006c: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0071: dup
+				IL_0072: brfalse IL_0082
 
-				IL_0070: pop
-
-				IL_0071: ldloc.3
-				IL_0072: ldstr "toUpperCase"
-				IL_0077: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_0077: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
 				IL_007c: stloc.3
+				IL_007d: br IL_008f
 
-				IL_007d: ldstr "pong:"
-				IL_0082: ldloc.3
-				IL_0083: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
-				IL_0088: stloc.2
-				IL_0089: ldloc.1
-				IL_008a: ldstr "write"
-				IL_008f: ldloc.2
-				IL_0090: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0095: pop
-				IL_0096: ldarg.0
-				IL_0097: ldc.i4.1
-				IL_0098: ldelem.ref
-				IL_0099: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
-				IL_009e: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::socket
-				IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-				IL_00a8: ldstr "end"
-				IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-				IL_00b2: pop
-				IL_00b3: ldnull
-				IL_00b4: ret
+				IL_0082: pop
+
+				IL_0083: ldloc.3
+				IL_0084: ldstr "toUpperCase"
+				IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_008e: stloc.3
+
+				IL_008f: ldstr "pong:"
+				IL_0094: ldloc.3
+				IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.Operators::Add(object, object)
+				IL_009a: stloc.2
+				IL_009b: ldloc.1
+				IL_009c: ldstr "write"
+				IL_00a1: ldloc.2
+				IL_00a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_00a7: pop
+				IL_00a8: ldarg.0
+				IL_00a9: ldc.i4.1
+				IL_00aa: ldelem.ref
+				IL_00ab: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
+				IL_00b0: ldfld object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::socket
+				IL_00b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+				IL_00ba: ldstr "end"
+				IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+				IL_00c4: pop
+				IL_00c5: ldnull
+				IL_00c6: ret
 			} // end of method FunctionExpression_server_L12C19::__js_call__
 
 		} // end of class FunctionExpression_server_L12C19

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Transform_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Transform_Basic.verified.txt
@@ -156,7 +156,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 86 (0x56)
+			// Code size: 104 (0x68)
 			.maxstack 8
 			.locals init (
 				[0] object,
@@ -173,31 +173,38 @@
 			IL_0017: stloc.1
 			IL_0018: ldc.i4.0
 			IL_0019: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_001e: brfalse IL_003b
+			IL_001e: brfalse IL_004d
 
 			IL_0023: ldloc.1
 			IL_0024: isinst [System.Runtime]System.String
 			IL_0029: dup
-			IL_002a: brfalse IL_003a
+			IL_002a: brtrue IL_0041
 
-			IL_002f: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
-			IL_0034: stloc.1
-			IL_0035: br IL_0047
+			IL_002f: pop
+			IL_0030: ldloc.1
+			IL_0031: ldstr "toUpperCase"
+			IL_0036: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_003b: dup
+			IL_003c: brfalse IL_004c
 
-			IL_003a: pop
-
-			IL_003b: ldloc.1
-			IL_003c: ldstr "toUpperCase"
-			IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0041: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
 			IL_0046: stloc.1
+			IL_0047: br IL_0059
 
-			IL_0047: ldloc.0
-			IL_0048: ldstr "push"
+			IL_004c: pop
+
 			IL_004d: ldloc.1
-			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0053: pop
-			IL_0054: ldnull
-			IL_0055: ret
+			IL_004e: ldstr "toUpperCase"
+			IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0058: stloc.1
+
+			IL_0059: ldloc.0
+			IL_005a: ldstr "push"
+			IL_005f: ldloc.1
+			IL_0060: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0065: pop
+			IL_0066: ldnull
+			IL_0067: ret
 		} // end of method FunctionExpression_L9C23::__js_call__
 
 	} // end of class FunctionExpression_L9C23

--- a/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_File_Helpers.verified.txt
+++ b/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_File_Helpers.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 597 (0x255)
+		// Code size: 673 (0x2a1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Url_File_Helpers/Scope,
@@ -84,174 +84,202 @@
 		IL_005d: stloc.s 5
 		IL_005f: ldc.i4.0
 		IL_0060: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0065: brfalse IL_008e
+		IL_0065: brfalse IL_00a1
 
 		IL_006a: ldloc.s 5
 		IL_006c: isinst [System.Runtime]System.String
 		IL_0071: dup
-		IL_0072: brfalse IL_008d
+		IL_0072: brtrue IL_008a
 
-		IL_0077: ldstr "file://"
-		IL_007c: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-		IL_0081: box [System.Runtime]System.Boolean
-		IL_0086: stloc.s 5
-		IL_0088: br IL_00a1
+		IL_0077: pop
+		IL_0078: ldloc.s 5
+		IL_007a: ldstr "startsWith"
+		IL_007f: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_0084: dup
+		IL_0085: brfalse IL_00a0
 
-		IL_008d: pop
+		IL_008a: ldstr "file://"
+		IL_008f: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+		IL_0094: box [System.Runtime]System.Boolean
+		IL_0099: stloc.s 5
+		IL_009b: br IL_00b4
 
-		IL_008e: ldloc.s 5
-		IL_0090: ldstr "startsWith"
-		IL_0095: ldstr "file://"
-		IL_009a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_009f: stloc.s 5
+		IL_00a0: pop
 
-		IL_00a1: ldloc.s 4
-		IL_00a3: ldstr "href file:"
-		IL_00a8: ldloc.s 5
-		IL_00aa: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_00af: pop
-		IL_00b0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00b5: stloc.s 4
-		IL_00b7: ldloc.2
-		IL_00b8: ldstr "pathname"
-		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00c2: stloc.s 5
-		IL_00c4: ldloc.s 5
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00cb: stloc.s 5
-		IL_00cd: ldc.i4.0
-		IL_00ce: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_00d3: brfalse IL_00fc
+		IL_00a1: ldloc.s 5
+		IL_00a3: ldstr "startsWith"
+		IL_00a8: ldstr "file://"
+		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b2: stloc.s 5
 
-		IL_00d8: ldloc.s 5
-		IL_00da: isinst [System.Runtime]System.String
-		IL_00df: dup
-		IL_00e0: brfalse IL_00fb
+		IL_00b4: ldloc.s 4
+		IL_00b6: ldstr "href file:"
+		IL_00bb: ldloc.s 5
+		IL_00bd: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_00c2: pop
+		IL_00c3: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c8: stloc.s 4
+		IL_00ca: ldloc.2
+		IL_00cb: ldstr "pathname"
+		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00d5: stloc.s 5
+		IL_00d7: ldloc.s 5
+		IL_00d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00de: stloc.s 5
+		IL_00e0: ldc.i4.0
+		IL_00e1: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_00e6: brfalse IL_0122
 
-		IL_00e5: ldstr "folder%20with%20space"
-		IL_00ea: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-		IL_00ef: box [System.Runtime]System.Double
-		IL_00f4: stloc.s 5
-		IL_00f6: br IL_010f
+		IL_00eb: ldloc.s 5
+		IL_00ed: isinst [System.Runtime]System.String
+		IL_00f2: dup
+		IL_00f3: brtrue IL_010b
 
-		IL_00fb: pop
+		IL_00f8: pop
+		IL_00f9: ldloc.s 5
+		IL_00fb: ldstr "indexOf"
+		IL_0100: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_0105: dup
+		IL_0106: brfalse IL_0121
 
-		IL_00fc: ldloc.s 5
-		IL_00fe: ldstr "indexOf"
-		IL_0103: ldstr "folder%20with%20space"
-		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_010d: stloc.s 5
+		IL_010b: ldstr "folder%20with%20space"
+		IL_0110: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_0115: box [System.Runtime]System.Double
+		IL_011a: stloc.s 5
+		IL_011c: br IL_0135
 
-		IL_010f: ldloc.s 5
-		IL_0111: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0116: ldc.r8 0.0
-		IL_011f: clt
-		IL_0121: ldc.i4.0
-		IL_0122: ceq
-		IL_0124: stloc.s 6
-		IL_0126: ldloc.s 6
-		IL_0128: box [System.Runtime]System.Boolean
-		IL_012d: stloc.s 7
-		IL_012f: ldloc.s 4
-		IL_0131: ldstr "pathname escaped:"
-		IL_0136: ldloc.s 7
-		IL_0138: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_013d: pop
-		IL_013e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0143: stloc.s 4
-		IL_0145: ldloc.1
-		IL_0146: ldloc.2
-		IL_0147: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
-		IL_014c: stloc.s 5
-		IL_014e: ldloc.s 5
-		IL_0150: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0155: stloc.s 5
-		IL_0157: ldc.i4.0
-		IL_0158: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_015d: brfalse IL_0186
+		IL_0121: pop
 
-		IL_0162: ldloc.s 5
-		IL_0164: isinst [System.Runtime]System.String
-		IL_0169: dup
-		IL_016a: brfalse IL_0185
+		IL_0122: ldloc.s 5
+		IL_0124: ldstr "indexOf"
+		IL_0129: ldstr "folder%20with%20space"
+		IL_012e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0133: stloc.s 5
 
-		IL_016f: ldstr "folder with space"
-		IL_0174: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-		IL_0179: box [System.Runtime]System.Double
-		IL_017e: stloc.s 5
-		IL_0180: br IL_0199
+		IL_0135: ldloc.s 5
+		IL_0137: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_013c: ldc.r8 0.0
+		IL_0145: clt
+		IL_0147: ldc.i4.0
+		IL_0148: ceq
+		IL_014a: stloc.s 6
+		IL_014c: ldloc.s 6
+		IL_014e: box [System.Runtime]System.Boolean
+		IL_0153: stloc.s 7
+		IL_0155: ldloc.s 4
+		IL_0157: ldstr "pathname escaped:"
+		IL_015c: ldloc.s 7
+		IL_015e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0163: pop
+		IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0169: stloc.s 4
+		IL_016b: ldloc.1
+		IL_016c: ldloc.2
+		IL_016d: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
+		IL_0172: stloc.s 5
+		IL_0174: ldloc.s 5
+		IL_0176: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_017b: stloc.s 5
+		IL_017d: ldc.i4.0
+		IL_017e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0183: brfalse IL_01bf
 
-		IL_0185: pop
+		IL_0188: ldloc.s 5
+		IL_018a: isinst [System.Runtime]System.String
+		IL_018f: dup
+		IL_0190: brtrue IL_01a8
 
-		IL_0186: ldloc.s 5
-		IL_0188: ldstr "indexOf"
-		IL_018d: ldstr "folder with space"
-		IL_0192: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0197: stloc.s 5
+		IL_0195: pop
+		IL_0196: ldloc.s 5
+		IL_0198: ldstr "indexOf"
+		IL_019d: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_01a2: dup
+		IL_01a3: brfalse IL_01be
 
-		IL_0199: ldloc.s 5
-		IL_019b: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_01a0: ldc.r8 0.0
-		IL_01a9: clt
-		IL_01ab: ldc.i4.0
-		IL_01ac: ceq
-		IL_01ae: stloc.s 6
-		IL_01b0: ldloc.s 6
-		IL_01b2: box [System.Runtime]System.Boolean
-		IL_01b7: stloc.s 7
-		IL_01b9: ldloc.s 4
-		IL_01bb: ldstr "roundtrip contains:"
-		IL_01c0: ldloc.s 7
-		IL_01c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_01c7: pop
-		IL_01c8: ldloc.1
-		IL_01c9: ldstr "file:///var/example.txt"
-		IL_01ce: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
-		IL_01d3: stloc.3
-		IL_01d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01d9: stloc.s 4
-		IL_01db: ldloc.3
-		IL_01dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_01e1: stloc.s 5
-		IL_01e3: ldc.i4.0
-		IL_01e4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_01e9: brfalse IL_0212
+		IL_01a8: ldstr "folder with space"
+		IL_01ad: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_01b2: box [System.Runtime]System.Double
+		IL_01b7: stloc.s 5
+		IL_01b9: br IL_01d2
 
-		IL_01ee: ldloc.s 5
-		IL_01f0: isinst [System.Runtime]System.String
-		IL_01f5: dup
-		IL_01f6: brfalse IL_0211
+		IL_01be: pop
 
-		IL_01fb: ldstr "example.txt"
-		IL_0200: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
-		IL_0205: box [System.Runtime]System.Double
-		IL_020a: stloc.s 5
-		IL_020c: br IL_0225
+		IL_01bf: ldloc.s 5
+		IL_01c1: ldstr "indexOf"
+		IL_01c6: ldstr "folder with space"
+		IL_01cb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d0: stloc.s 5
 
-		IL_0211: pop
+		IL_01d2: ldloc.s 5
+		IL_01d4: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_01d9: ldc.r8 0.0
+		IL_01e2: clt
+		IL_01e4: ldc.i4.0
+		IL_01e5: ceq
+		IL_01e7: stloc.s 6
+		IL_01e9: ldloc.s 6
+		IL_01eb: box [System.Runtime]System.Boolean
+		IL_01f0: stloc.s 7
+		IL_01f2: ldloc.s 4
+		IL_01f4: ldstr "roundtrip contains:"
+		IL_01f9: ldloc.s 7
+		IL_01fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_0200: pop
+		IL_0201: ldloc.1
+		IL_0202: ldstr "file:///var/example.txt"
+		IL_0207: callvirt instance string [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule::fileURLToPath(object)
+		IL_020c: stloc.3
+		IL_020d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0212: stloc.s 4
+		IL_0214: ldloc.3
+		IL_0215: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_021a: stloc.s 5
+		IL_021c: ldc.i4.0
+		IL_021d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0222: brfalse IL_025e
 
-		IL_0212: ldloc.s 5
-		IL_0214: ldstr "indexOf"
-		IL_0219: ldstr "example.txt"
-		IL_021e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0223: stloc.s 5
+		IL_0227: ldloc.s 5
+		IL_0229: isinst [System.Runtime]System.String
+		IL_022e: dup
+		IL_022f: brtrue IL_0247
 
-		IL_0225: ldloc.s 5
-		IL_0227: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_022c: ldc.r8 0.0
-		IL_0235: clt
-		IL_0237: ldc.i4.0
-		IL_0238: ceq
-		IL_023a: stloc.s 6
-		IL_023c: ldloc.s 6
-		IL_023e: box [System.Runtime]System.Boolean
-		IL_0243: stloc.s 7
-		IL_0245: ldloc.s 4
-		IL_0247: ldstr "from string suffix:"
-		IL_024c: ldloc.s 7
-		IL_024e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
-		IL_0253: pop
-		IL_0254: ret
+		IL_0234: pop
+		IL_0235: ldloc.s 5
+		IL_0237: ldstr "indexOf"
+		IL_023c: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_0241: dup
+		IL_0242: brfalse IL_025d
+
+		IL_0247: ldstr "example.txt"
+		IL_024c: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::IndexOf(string, string)
+		IL_0251: box [System.Runtime]System.Double
+		IL_0256: stloc.s 5
+		IL_0258: br IL_0271
+
+		IL_025d: pop
+
+		IL_025e: ldloc.s 5
+		IL_0260: ldstr "indexOf"
+		IL_0265: ldstr "example.txt"
+		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_026f: stloc.s 5
+
+		IL_0271: ldloc.s 5
+		IL_0273: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_0278: ldc.r8 0.0
+		IL_0281: clt
+		IL_0283: ldc.i4.0
+		IL_0284: ceq
+		IL_0286: stloc.s 6
+		IL_0288: ldloc.s 6
+		IL_028a: box [System.Runtime]System.Boolean
+		IL_028f: stloc.s 7
+		IL_0291: ldloc.s 4
+		IL_0293: ldstr "from string suffix:"
+		IL_0298: ldloc.s 7
+		IL_029a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object, object)
+		IL_029f: pop
+		IL_02a0: ret
 	} // end of method Require_Url_File_Helpers::__js_module_init__
 
 } // end of class Modules.Require_Url_File_Helpers

--- a/tests/Jroc.Tests/Object/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Object/ExecutionTests.cs
@@ -62,6 +62,9 @@ namespace Jroc.Tests.Object
         public Task ObjectLiteral_EarlyBoundAccess_Parity() { var testName = nameof(ObjectLiteral_EarlyBoundAccess_Parity); return ExecutionTest(testName); }
 
         [Fact]
+        public Task ObjectLiteral_Method_DynamicOverride() { var testName = nameof(ObjectLiteral_Method_DynamicOverride); return ExecutionTest(testName); }
+
+        [Fact]
         public Task ObjectLiteral_EarlyBoundCapturedVarFunctionCall() { var testName = nameof(ObjectLiteral_EarlyBoundCapturedVarFunctionCall); return ExecutionTest(testName); }
 
         [Fact]

--- a/tests/Jroc.Tests/Object/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Object/GeneratorTests.cs
@@ -62,6 +62,9 @@ namespace Jroc.Tests.Object
         public Task ObjectLiteral_EarlyBoundAccess_Parity() { var testName = nameof(ObjectLiteral_EarlyBoundAccess_Parity); return GenerateTest(testName); }
 
         [Fact]
+        public Task ObjectLiteral_Method_DynamicOverride() { var testName = nameof(ObjectLiteral_Method_DynamicOverride); return GenerateTest(testName); }
+
+        [Fact]
         public Task ObjectLiteral_EarlyBoundCapturedVarFunctionCall() { var testName = nameof(ObjectLiteral_EarlyBoundCapturedVarFunctionCall); return GenerateTest(testName); }
 
         [Fact]

--- a/tests/Jroc.Tests/Object/JavaScript/ObjectLiteral_Method_DynamicOverride.js
+++ b/tests/Jroc.Tests/Object/JavaScript/ObjectLiteral_Method_DynamicOverride.js
@@ -1,0 +1,13 @@
+"use strict";
+
+let receiver = {
+    value() {
+        return "original";
+    }
+};
+
+console.log(receiver.value());
+receiver.value = function () {
+    return "override";
+};
+console.log(receiver.value());

--- a/tests/Jroc.Tests/Object/Snapshots/ExecutionTests.ObjectLiteral_Method_DynamicOverride.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/ExecutionTests.ObjectLiteral_Method_DynamicOverride.verified.txt
@@ -1,0 +1,2 @@
+original
+override

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_DestructuredParameterInference_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_DestructuredParameterInference_Parity.verified.txt
@@ -405,7 +405,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 226 (0xe2)
+		// Code size: 244 (0xf4)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_DestructuredParameterInference_Parity/Scope,
@@ -453,37 +453,44 @@
 		IL_008d: stloc.2
 		IL_008e: ldc.i4.0
 		IL_008f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0094: brfalse IL_00bb
+		IL_0094: brfalse IL_00cd
 
 		IL_0099: ldloc.2
 		IL_009a: isinst [System.Runtime]System.String
 		IL_009f: dup
-		IL_00a0: brfalse IL_00ba
+		IL_00a0: brtrue IL_00b7
 
-		IL_00a5: ldstr "verbose"
-		IL_00aa: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-		IL_00af: box [System.Runtime]System.Boolean
-		IL_00b4: stloc.2
-		IL_00b5: br IL_00cc
+		IL_00a5: pop
+		IL_00a6: ldloc.2
+		IL_00a7: ldstr "includes"
+		IL_00ac: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_00b1: dup
+		IL_00b2: brfalse IL_00cc
 
-		IL_00ba: pop
+		IL_00b7: ldstr "verbose"
+		IL_00bc: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+		IL_00c1: box [System.Runtime]System.Boolean
+		IL_00c6: stloc.2
+		IL_00c7: br IL_00de
 
-		IL_00bb: ldloc.2
-		IL_00bc: ldstr "includes"
-		IL_00c1: ldstr "verbose"
-		IL_00c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00cb: stloc.2
+		IL_00cc: pop
 
-		IL_00cc: ldloc.1
-		IL_00cd: castclass Modules.ObjectLiteral_DestructuredParameterInference_Parity/ObjectLiterals/L1C14_config
-		IL_00d2: ldloc.2
-		IL_00d3: callvirt instance void Modules.ObjectLiteral_DestructuredParameterInference_Parity/ObjectLiterals/L1C14_config::set_verbose(object)
-		IL_00d8: nop
-		IL_00d9: ldnull
-		IL_00da: ldloc.1
-		IL_00db: call object Modules.ObjectLiteral_DestructuredParameterInference_Parity/ArrowFunction_L11C14::__js_call__(object, object)
-		IL_00e0: pop
-		IL_00e1: ret
+		IL_00cd: ldloc.2
+		IL_00ce: ldstr "includes"
+		IL_00d3: ldstr "verbose"
+		IL_00d8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00dd: stloc.2
+
+		IL_00de: ldloc.1
+		IL_00df: castclass Modules.ObjectLiteral_DestructuredParameterInference_Parity/ObjectLiterals/L1C14_config
+		IL_00e4: ldloc.2
+		IL_00e5: callvirt instance void Modules.ObjectLiteral_DestructuredParameterInference_Parity/ObjectLiterals/L1C14_config::set_verbose(object)
+		IL_00ea: nop
+		IL_00eb: ldnull
+		IL_00ec: ldloc.1
+		IL_00ed: call object Modules.ObjectLiteral_DestructuredParameterInference_Parity/ArrowFunction_L11C14::__js_call__(object, object)
+		IL_00f2: pop
+		IL_00f3: ret
 	} // end of method ObjectLiteral_DestructuredParameterInference_Parity::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_DestructuredParameterInference_Parity

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_Method_DynamicOverride.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_Method_DynamicOverride.verified.txt
@@ -1,0 +1,379 @@
+﻿// IL code: ObjectLiteral_Method_DynamicOverride
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.ObjectLiteral_Method_DynamicOverride
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_receiver
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: call object Modules.ObjectLiteral_Method_DynamicOverride/FunctionExpression_receiver::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::CallCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 6 (0x6)
+			.maxstack 8
+
+			IL_0000: ldstr "original"
+			IL_0005: ret
+		} // end of method FunctionExpression_receiver::__js_call__
+
+	} // end of class FunctionExpression_receiver
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L10C17
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: call object Modules.ObjectLiteral_Method_DynamicOverride/FunctionExpression_L10C17::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.ObjectLiteral_Method_DynamicOverride/FunctionExpression_L10C17::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 6 (0x6)
+			.maxstack 8
+
+			IL_0000: ldstr "override"
+			IL_0005: ret
+		} // end of method FunctionExpression_L10C17::__js_call__
+
+	} // end of class FunctionExpression_L10C17
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Header size: 12
+		// Code size: 174 (0xae)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.ObjectLiteral_Method_DynamicOverride/Scope,
+			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[3] object[],
+			[4] class Modules.ObjectLiteral_Method_DynamicOverride/FunctionExpression_receiver/FunctionObject,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[6] object,
+			[7] class Modules.ObjectLiteral_Method_DynamicOverride/FunctionExpression_L10C17/FunctionObject
+		)
+
+		IL_0000: newobj instance void Modules.ObjectLiteral_Method_DynamicOverride/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: nop
+		IL_0007: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_000c: stloc.2
+		IL_000d: ldc.i4.1
+		IL_000e: newarr [System.Runtime]System.Object
+		IL_0013: dup
+		IL_0014: ldc.i4.0
+		IL_0015: ldloc.0
+		IL_0016: stelem.ref
+		IL_0017: stloc.3
+		IL_0018: newobj instance void Modules.ObjectLiteral_Method_DynamicOverride/FunctionExpression_receiver/FunctionObject::.ctor()
+		IL_001d: ldc.i4.0
+		IL_001e: conv.r8
+		IL_001f: ldstr ""
+		IL_0024: ldc.i4.0
+		IL_0025: ldc.i4.1
+		IL_0026: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Method_DynamicOverride/FunctionExpression_receiver/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_Method_DynamicOverride/FunctionExpression_receiver/FunctionObject>(!!0)
+		IL_0030: stloc.s 4
+		IL_0032: ldloc.2
+		IL_0033: ldstr "value"
+		IL_0038: ldloc.s 4
+		IL_003a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_003f: pop
+		IL_0040: ldloc.2
+		IL_0041: stloc.1
+		IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0047: stloc.s 5
+		IL_0049: ldloc.1
+		IL_004a: ldstr "value"
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0054: stloc.s 6
+		IL_0056: ldloc.s 5
+		IL_0058: ldloc.s 6
+		IL_005a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_005f: pop
+		IL_0060: ldc.i4.1
+		IL_0061: newarr [System.Runtime]System.Object
+		IL_0066: dup
+		IL_0067: ldc.i4.0
+		IL_0068: ldloc.0
+		IL_0069: stelem.ref
+		IL_006a: stloc.3
+		IL_006b: newobj instance void Modules.ObjectLiteral_Method_DynamicOverride/FunctionExpression_L10C17/FunctionObject::.ctor()
+		IL_0070: ldc.i4.0
+		IL_0071: conv.r8
+		IL_0072: ldstr ""
+		IL_0077: ldc.i4.0
+		IL_0078: ldc.i4.1
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Method_DynamicOverride/FunctionExpression_L10C17/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_007e: stloc.s 7
+		IL_0080: ldloc.1
+		IL_0081: ldstr "value"
+		IL_0086: ldloc.s 7
+		IL_0088: ldc.i4.1
+		IL_0089: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_008e: pop
+		IL_008f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0094: stloc.s 5
+		IL_0096: ldloc.1
+		IL_0097: ldstr "value"
+		IL_009c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00a1: stloc.s 6
+		IL_00a3: ldloc.s 5
+		IL_00a5: ldloc.s 6
+		IL_00a7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ac: pop
+		IL_00ad: ret
+	} // end of method ObjectLiteral_Method_DynamicOverride::__js_module_init__
+
+} // end of class Modules.ObjectLiteral_Method_DynamicOverride
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.ObjectLiteral_Method_DynamicOverride::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/tests/Jroc.Tests/ReceiverTypeFlowAnalysisTests.cs
+++ b/tests/Jroc.Tests/ReceiverTypeFlowAnalysisTests.cs
@@ -1,0 +1,520 @@
+using Acornima;
+using Jroc.IR;
+using Jroc.Services;
+using Jroc.SymbolTables;
+using Xunit;
+
+namespace Jroc.Tests;
+
+public sealed class ReceiverTypeFlowAnalysisTests
+{
+    [Fact]
+    public void Analyze_TracksStrongAssignmentsAtEachProgramPoint()
+    {
+        var body = new MethodBodyIR();
+        var stringValue = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(string)));
+        var variable = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var firstResult = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var arrayValue = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(JavaScriptRuntime.Array)));
+        var secondResult = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+
+        body.Instructions.Add(new LIRConstString("value", stringValue));
+        body.Instructions.Add(new LIRCopyTemp(stringValue, variable));
+        body.Instructions.Add(new LIRCallMember0(variable, "trim", firstResult));
+        body.Instructions.Add(new LIRNewJsArray([], arrayValue));
+        body.Instructions.Add(new LIRCopyTemp(arrayValue, variable));
+        body.Instructions.Add(new LIRCallMember0(variable, "join", secondResult));
+
+        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+
+        AssertKnownCandidates(
+            facts.GetTempBefore(2, variable),
+            typeof(string));
+        AssertKnownCandidates(
+            facts.GetTempBefore(5, variable),
+            typeof(JavaScriptRuntime.Array));
+    }
+
+    [Fact]
+    public void Analyze_UnionsBranchAssignmentsAtPhiLikeJoin()
+    {
+        var body = new MethodBodyIR();
+        var condition = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.UnboxedValue, typeof(bool)));
+        var stringValue = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(string)));
+        var arrayValue = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(JavaScriptRuntime.Array)));
+        var joined = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+
+        body.Instructions.Add(new LIRConstBoolean(true, condition));
+        body.Instructions.Add(new LIRBranchIfFalse(condition, 10));
+        body.Instructions.Add(new LIRConstString("value", stringValue));
+        body.Instructions.Add(new LIRCopyTemp(stringValue, joined));
+        body.Instructions.Add(new LIRBranch(20));
+        body.Instructions.Add(new LIRLabel(10));
+        body.Instructions.Add(new LIRNewJsArray([], arrayValue));
+        body.Instructions.Add(new LIRCopyTemp(arrayValue, joined));
+        body.Instructions.Add(new LIRLabel(20));
+        body.Instructions.Add(new LIRCallMember0(joined, "toString", result));
+
+        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+
+        AssertKnownCandidates(
+            facts.GetTempBefore(9, joined),
+            typeof(string),
+            typeof(JavaScriptRuntime.Array));
+    }
+
+    [Fact]
+    public void Analyze_PreservesNonCandidateUncertaintyAtBranchJoin()
+    {
+        var body = new MethodBodyIR();
+        var condition = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.UnboxedValue, typeof(bool)));
+        var stringValue = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(string)));
+        var numberValue = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.UnboxedValue, typeof(double)));
+        var joined = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+
+        body.Instructions.Add(new LIRConstBoolean(true, condition));
+        body.Instructions.Add(new LIRBranchIfFalse(condition, 10));
+        body.Instructions.Add(new LIRConstString("value", stringValue));
+        body.Instructions.Add(new LIRCopyTemp(stringValue, joined));
+        body.Instructions.Add(new LIRBranch(20));
+        body.Instructions.Add(new LIRLabel(10));
+        body.Instructions.Add(new LIRConstNumber(1, numberValue));
+        body.Instructions.Add(new LIRCopyTemp(numberValue, joined));
+        body.Instructions.Add(new LIRLabel(20));
+        body.Instructions.Add(new LIRCallMember0(joined, "toString", result));
+
+        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+        var joinedValue = facts.GetTempBefore(9, joined);
+
+        Assert.False(joinedValue.IncludesUnknown);
+        Assert.True(joinedValue.IncludesNonCandidate);
+        Assert.Equal(
+            [typeof(string)],
+            joinedValue.CandidateClrTypes);
+    }
+
+    [Fact]
+    public void Analyze_ReachesFixedPointAcrossLoopBackEdge()
+    {
+        var body = new MethodBodyIR();
+        var stringValue = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(string)));
+        var arrayValue = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(JavaScriptRuntime.Array)));
+        var loopValue = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)),
+            variableSlot: 0);
+        var result = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+
+        body.Instructions.Add(new LIRConstString("value", stringValue));
+        body.Instructions.Add(new LIRCopyTemp(stringValue, loopValue));
+        body.Instructions.Add(new LIRLabel(10));
+        body.Instructions.Add(new LIRCallMember0(loopValue, "toString", result));
+        body.Instructions.Add(new LIRNewJsArray([], arrayValue));
+        body.Instructions.Add(new LIRCopyTemp(arrayValue, loopValue));
+        body.Instructions.Add(new LIRBranch(10));
+
+        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+
+        AssertKnownCandidates(
+            facts.GetTempBefore(3, loopValue),
+            typeof(string),
+            typeof(JavaScriptRuntime.Array));
+    }
+
+    [Fact]
+    public void Analyze_TracksCapturedFieldAssignmentsAtEachRead()
+    {
+        var parser = new JavaScriptParser();
+        var program = parser.ParseJavaScript("var value;", "flow.js");
+        var scope = new Jroc.SymbolTables.Scope(
+            "GlobalScope",
+            ScopeKind.Global,
+            parent: null,
+            program);
+        var binding = new BindingInfo(
+            "value",
+            BindingKind.Var,
+            scope,
+            program);
+
+        var body = new MethodBodyIR();
+        var stringValue = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(string)));
+        var arrayValue = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(JavaScriptRuntime.Array)));
+        var firstRead = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var secondRead = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var scopeInstance = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var callResult = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+
+        var scopeId = new ScopeId("GlobalScope");
+        var fieldId = new FieldId("GlobalScope", "value");
+        body.Instructions.Add(new LIRConstString("value", stringValue));
+        body.Instructions.Add(new LIRStoreScopeField(
+            scopeInstance,
+            binding,
+            fieldId,
+            scopeId,
+            stringValue));
+        body.Instructions.Add(new LIRLoadScopeField(
+            scopeInstance,
+            binding,
+            fieldId,
+            scopeId,
+            firstRead));
+        body.Instructions.Add(new LIRCallMember0(
+            firstRead,
+            "toString",
+            callResult));
+        body.Instructions.Add(new LIRNewJsArray([], arrayValue));
+        body.Instructions.Add(new LIRStoreScopeField(
+            scopeInstance,
+            binding,
+            fieldId,
+            scopeId,
+            arrayValue));
+        body.Instructions.Add(new LIRLoadScopeField(
+            scopeInstance,
+            binding,
+            fieldId,
+            scopeId,
+            secondRead));
+        body.Instructions.Add(new LIRCallMember0(
+            secondRead,
+            "toString",
+            callResult));
+
+        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+
+        AssertKnownCandidates(
+            facts.GetTempAfter(2, firstRead),
+            typeof(string));
+        AssertKnownCandidates(
+            facts.GetTempAfter(6, secondRead),
+            typeof(JavaScriptRuntime.Array));
+    }
+
+    [Fact]
+    public void Analyze_InvalidatesCapturedFieldAcrossCall()
+    {
+        var (binding, scopeId, fieldId) = CreateCapturedBinding();
+        var body = new MethodBodyIR();
+        var stringValue = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(string)));
+        var scopeInstance = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var callReceiver = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var callResult = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var readAfterCall = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+
+        body.Instructions.Add(new LIRConstString("value", stringValue));
+        body.Instructions.Add(new LIRStoreScopeField(
+            scopeInstance,
+            binding,
+            fieldId,
+            scopeId,
+            stringValue));
+        body.Instructions.Add(new LIRCallMember0(
+            callReceiver,
+            "unknown",
+            callResult));
+        body.Instructions.Add(new LIRLoadScopeField(
+            scopeInstance,
+            binding,
+            fieldId,
+            scopeId,
+            readAfterCall));
+        body.Instructions.Add(new LIRCallMember0(
+            readAfterCall,
+            "toString",
+            callResult));
+
+        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+        var readValue = facts.GetTempAfter(3, readAfterCall);
+
+        Assert.True(readValue.IncludesUnknown);
+        Assert.DoesNotContain(
+            typeof(string),
+            readValue.CandidateClrTypes);
+    }
+
+    [Fact]
+    public void Analyze_ContinuesAcrossAwaitResumeBoundary()
+    {
+        var body = new MethodBodyIR();
+        var stringValue = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(string)));
+        var awaited = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var awaitResult = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var callResult = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+
+        body.Instructions.Add(new LIRConstString("value", stringValue));
+        body.Instructions.Add(new LIRAwait(
+            awaited,
+            AwaitId: 1,
+            ResumeStateId: 1,
+            ResumeLabelId: 100,
+            awaitResult));
+        body.Instructions.Add(new LIRCallMember0(
+            stringValue,
+            "trim",
+            callResult));
+
+        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+
+        AssertKnownCandidates(
+            facts.GetTempBefore(2, stringValue),
+            typeof(string));
+    }
+
+    [Fact]
+    public void Analyze_RecognizesSealedRuntimeReceiverTypes()
+    {
+        var body = new MethodBodyIR();
+        var typedArray = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(JavaScriptRuntime.Uint8Array)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+
+        body.Instructions.Add(new LIRCallIntrinsicStatic(
+            "Uint8Array",
+            "Construct",
+            [],
+            typedArray));
+        body.Instructions.Add(
+            new LIRCallMember0(typedArray, "join", result));
+
+        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+
+        AssertKnownCandidates(
+            facts.GetTempBefore(1, typedArray),
+            typeof(JavaScriptRuntime.Uint8Array));
+    }
+
+    [Fact]
+    public void Analyze_RecognizesArrayConstructorResults()
+    {
+        var body = new MethodBodyIR();
+        var array = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+
+        body.Instructions.Add(new LIRCallIntrinsicStatic(
+            "Array",
+            "Construct",
+            [],
+            array));
+        body.Instructions.Add(new LIRCallMember0(array, "join", result));
+
+        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+
+        AssertKnownCandidates(
+            facts.GetTempBefore(1, array),
+            typeof(JavaScriptRuntime.Array));
+    }
+
+    [Fact]
+    public void Analyze_DropsMutableFactsAcrossFinallyLeave()
+    {
+        var (binding, scopeId, fieldId) = CreateCapturedBinding();
+        var body = new MethodBodyIR();
+        var stringValue = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(string)));
+        var scopeInstance = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var readAfterFinally = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var callResult = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+
+        body.ExceptionRegions.Add(new ExceptionRegionInfo(
+            ExceptionRegionKind.Finally,
+            TryStartLabelId: 1,
+            TryEndLabelId: 2,
+            HandlerStartLabelId: 3,
+            HandlerEndLabelId: 4));
+        body.Instructions.Add(new LIRLabel(1));
+        body.Instructions.Add(new LIRConstString("value", stringValue));
+        body.Instructions.Add(new LIRStoreScopeField(
+            scopeInstance,
+            binding,
+            fieldId,
+            scopeId,
+            stringValue));
+        body.Instructions.Add(new LIRLeave(5));
+        body.Instructions.Add(new LIRLabel(2));
+        body.Instructions.Add(new LIRLabel(3));
+        body.Instructions.Add(new LIREndFinally());
+        body.Instructions.Add(new LIRLabel(4));
+        body.Instructions.Add(new LIRLabel(5));
+        body.Instructions.Add(new LIRLoadScopeField(
+            scopeInstance,
+            binding,
+            fieldId,
+            scopeId,
+            readAfterFinally));
+        body.Instructions.Add(new LIRCallMember0(
+            readAfterFinally,
+            "toString",
+            callResult));
+
+        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+        var readValue = facts.GetTempAfter(9, readAfterFinally);
+
+        Assert.True(readValue.IncludesUnknown);
+        Assert.DoesNotContain(
+            typeof(string),
+            readValue.CandidateClrTypes);
+    }
+
+    [Fact]
+    public void RequiresAnalysis_OnlyForDynamicReceiverSites()
+    {
+        var noReceiverBody = new MethodBodyIR();
+        var stringValue = AddTemp(
+            noReceiverBody,
+            new ValueStorage(ValueStorageKind.Reference, typeof(string)));
+        noReceiverBody.Instructions.Add(
+            new LIRConstString("value", stringValue));
+
+        var receiverBody = new MethodBodyIR();
+        var receiver = AddTemp(
+            receiverBody,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var result = AddTemp(
+            receiverBody,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        receiverBody.Instructions.Add(
+            new LIRCallMember0(receiver, "trim", result));
+
+        Assert.False(
+            ReceiverTypeFlowAnalysis.RequiresAnalysis(noReceiverBody));
+        Assert.True(
+            ReceiverTypeFlowAnalysis.RequiresAnalysis(receiverBody));
+    }
+
+    private static TempVariable AddTemp(
+        MethodBodyIR body,
+        ValueStorage storage,
+        int variableSlot = -1)
+    {
+        var temp = new TempVariable(body.Temps.Count);
+        body.Temps.Add(temp);
+        body.TempStorages.Add(storage);
+        body.TempVariableSlots.Add(variableSlot);
+        return temp;
+    }
+
+    private static (BindingInfo Binding, ScopeId Scope, FieldId Field)
+        CreateCapturedBinding()
+    {
+        var parser = new JavaScriptParser();
+        var program = parser.ParseJavaScript("var value;", "flow.js");
+        var scope = new Jroc.SymbolTables.Scope(
+            "GlobalScope",
+            ScopeKind.Global,
+            parent: null,
+            program);
+        return (
+            new BindingInfo(
+                "value",
+                BindingKind.Var,
+                scope,
+                program),
+            new ScopeId("GlobalScope"),
+            new FieldId("GlobalScope", "value"));
+    }
+
+    private static void AssertKnownCandidates(
+        ReceiverTypeFlowValue value,
+        params Type[] expected)
+    {
+        Assert.False(value.IncludesUnknown);
+        Assert.False(value.IncludesNonCandidate);
+        Assert.Equal(
+            expected.OrderBy(static type => type.FullName),
+            value.CandidateClrTypes.OrderBy(static type => type.FullName));
+    }
+}

--- a/tests/Jroc.Tests/ReceiverTypeFlowAnalysisTests.cs
+++ b/tests/Jroc.Tests/ReceiverTypeFlowAnalysisTests.cs
@@ -80,12 +80,33 @@ public sealed class ReceiverTypeFlowAnalysisTests
         body.Instructions.Add(new LIRLabel(20));
         body.Instructions.Add(new LIRCallMember0(joined, "toString", result));
 
-        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+        var diagnostics = new ReceiverTypeFlowDiagnosticTrace();
+        var facts = ReceiverTypeFlowAnalysis.Analyze(
+            body,
+            diagnostics);
 
         AssertKnownCandidates(
             facts.GetTempBefore(9, joined),
             typeof(string),
             typeof(JavaScriptRuntime.Array));
+        Assert.Contains(
+            diagnostics.Events,
+            item =>
+                item.Kind == ReceiverTypeFlowDiagnosticKind.Merge
+                && item.Message
+                    == "merge @8 temp:t3: "
+                    + "b1=candidates=[System.String]; unknown=false; non-candidate=false, "
+                    + "b2=candidates=[JavaScriptRuntime.Array]; unknown=false; non-candidate=false "
+                    + "=> candidates=[JavaScriptRuntime.Array, System.String]; "
+                    + "unknown=false; non-candidate=false");
+        Assert.Contains(
+            diagnostics.Events,
+            item =>
+                item.Kind == ReceiverTypeFlowDiagnosticKind.Retained
+                && item.Message
+                    == "retain @9 LIRCallMember0 receiver=t3: "
+                    + "candidates=[JavaScriptRuntime.Array, System.String]; "
+                    + "unknown=false; non-candidate=false");
     }
 
     [Fact]
@@ -293,13 +314,25 @@ public sealed class ReceiverTypeFlowAnalysisTests
             "toString",
             callResult));
 
-        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+        var diagnostics = new ReceiverTypeFlowDiagnosticTrace();
+        var facts = ReceiverTypeFlowAnalysis.Analyze(
+            body,
+            diagnostics);
         var readValue = facts.GetTempAfter(3, readAfterCall);
 
         Assert.True(readValue.IncludesUnknown);
         Assert.DoesNotContain(
             typeof(string),
             readValue.CandidateClrTypes);
+        var invalidation = Assert.Single(diagnostics.Events);
+        Assert.Equal(
+            ReceiverTypeFlowDiagnosticKind.Invalidation,
+            invalidation.Kind);
+        Assert.Equal(
+            "invalidate @2 LIRCallMember0 reason=call: "
+            + "binding:GlobalScope/value=candidates=[System.String]; "
+            + "unknown=false; non-candidate=false",
+            invalidation.Message);
     }
 
     [Theory]

--- a/tests/Jroc.Tests/ReceiverTypeFlowAnalysisTests.cs
+++ b/tests/Jroc.Tests/ReceiverTypeFlowAnalysisTests.cs
@@ -392,6 +392,105 @@ public sealed class ReceiverTypeFlowAnalysisTests
     }
 
     [Fact]
+    public void Analyze_SeedsInterproceduralParameterFacts()
+    {
+        var body = new MethodBodyIR();
+        var parameter = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        body.ReceiverParameterTypeSummaries[0] =
+            new ReceiverTypeSummary(
+                includesUnknown: false,
+                includesNonCandidate: false,
+                [typeof(string), typeof(JavaScriptRuntime.Array)]);
+
+        body.Instructions.Add(new LIRLoadParameter(0, parameter));
+        body.Instructions.Add(
+            new LIRCallMember0(parameter, "toString", result));
+
+        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+
+        AssertKnownCandidates(
+            facts.GetTempBefore(1, parameter),
+            typeof(string),
+            typeof(JavaScriptRuntime.Array));
+    }
+
+    [Fact]
+    public void Analyze_SeedsProvenCapturedClosureEntryFacts()
+    {
+        var (binding, scopeId, fieldId) = CreateCapturedBinding();
+        var body = new MethodBodyIR();
+        var scopeInstance = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var capturedValue = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        body.ReceiverCapturedEntryTypeSummaries[binding] =
+            ReceiverTypeSummary.ForCandidate(typeof(string));
+
+        body.Instructions.Add(new LIRLoadScopeField(
+            scopeInstance,
+            binding,
+            fieldId,
+            scopeId,
+            capturedValue));
+        body.Instructions.Add(new LIRCallMember0(
+            capturedValue,
+            "trim",
+            result));
+
+        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+
+        AssertKnownCandidates(
+            facts.GetTempBefore(1, capturedValue),
+            typeof(string));
+    }
+
+    [Fact]
+    public void Analyze_PropagatesKnownCallableReturnSummary()
+    {
+        var body = new MethodBodyIR();
+        var returnedValue = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        body.ReceiverTempTypeSummaries[returnedValue.Index] =
+            new ReceiverTypeSummary(
+                includesUnknown: true,
+                includesNonCandidate: true,
+                [typeof(string)]);
+
+        body.Instructions.Add(new LIRCallIntrinsicStatic(
+            "Unknown",
+            "Call",
+            [],
+            returnedValue));
+        body.Instructions.Add(new LIRCallMember0(
+            returnedValue,
+            "trim",
+            result));
+
+        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+        var returnedFact = facts.GetTempBefore(1, returnedValue);
+
+        Assert.True(returnedFact.IncludesUnknown);
+        Assert.True(returnedFact.IncludesNonCandidate);
+        Assert.Contains(
+            typeof(string),
+            returnedFact.CandidateClrTypes);
+    }
+
+    [Fact]
     public void Analyze_DropsMutableFactsAcrossFinallyLeave()
     {
         var (binding, scopeId, fieldId) = CreateCapturedBinding();

--- a/tests/Jroc.Tests/ReceiverTypeFlowAnalysisTests.cs
+++ b/tests/Jroc.Tests/ReceiverTypeFlowAnalysisTests.cs
@@ -302,6 +302,118 @@ public sealed class ReceiverTypeFlowAnalysisTests
             readValue.CandidateClrTypes);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    public void Analyze_InvalidatesCapturedFieldAcrossDynamicPropertyAccess(
+        int accessKind)
+    {
+        var (binding, scopeId, fieldId) = CreateCapturedBinding();
+        var body = new MethodBodyIR();
+        var stringValue = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(string)));
+        var scopeInstance = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var propertyReceiver = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var propertyName = AddTemp(
+            body,
+            accessKind == 2
+                ? new ValueStorage(
+                    ValueStorageKind.UnboxedValue,
+                    typeof(double))
+                : new ValueStorage(
+                    ValueStorageKind.Reference,
+                    typeof(string)));
+        var propertyValue = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var readAfterAccess = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+        var callResult = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+
+        body.Instructions.Add(new LIRConstString("value", stringValue));
+        body.Instructions.Add(new LIRStoreScopeField(
+            scopeInstance,
+            binding,
+            fieldId,
+            scopeId,
+            stringValue));
+        body.Instructions.Add(
+            accessKind == 2
+                ? new LIRConstNumber(0, propertyName)
+                : new LIRConstString("property", propertyName));
+        body.Instructions.Add(
+            accessKind switch
+            {
+                0 => new LIRGetItem(
+                    propertyReceiver,
+                    propertyName,
+                    propertyValue),
+                1 => new LIRSetItem(
+                    propertyReceiver,
+                    propertyName,
+                    stringValue,
+                    propertyValue),
+                _ => new LIRGetJsArrayElement(
+                    propertyReceiver,
+                    propertyName,
+                    propertyValue)
+            });
+        body.Instructions.Add(new LIRLoadScopeField(
+            scopeInstance,
+            binding,
+            fieldId,
+            scopeId,
+            readAfterAccess));
+        body.Instructions.Add(new LIRCallMember0(
+            readAfterAccess,
+            "toString",
+            callResult));
+
+        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+        var readValue = facts.GetTempAfter(4, readAfterAccess);
+
+        Assert.True(readValue.IncludesUnknown);
+        Assert.DoesNotContain(
+            typeof(string),
+            readValue.CandidateClrTypes);
+    }
+
+    [Fact]
+    public void Analyze_InvalidatesAllMutableFactsAtUnsupportedBarrier()
+    {
+        var body = new MethodBodyIR();
+        var stringValue = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(string)));
+        var variable = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)),
+            variableSlot: 0);
+        var result = AddTemp(
+            body,
+            new ValueStorage(ValueStorageKind.Reference, typeof(object)));
+
+        body.Instructions.Add(new LIRConstString("value", stringValue));
+        body.Instructions.Add(new LIRCopyTemp(stringValue, variable));
+        body.Instructions.Add(new UnknownInstruction());
+        body.Instructions.Add(new LIRCallMember0(variable, "trim", result));
+
+        var facts = ReceiverTypeFlowAnalysis.Analyze(body);
+        var value = facts.GetTempBefore(3, variable);
+
+        Assert.True(value.IncludesUnknown);
+        Assert.DoesNotContain(typeof(string), value.CandidateClrTypes);
+    }
+
     [Fact]
     public void Analyze_ContinuesAcrossAwaitResumeBoundary()
     {
@@ -616,4 +728,6 @@ public sealed class ReceiverTypeFlowAnalysisTests
             expected.OrderBy(static type => type.FullName),
             value.CandidateClrTypes.OrderBy(static type => type.FullName));
     }
+
+    private sealed record UnknownInstruction : LIRInstruction;
 }

--- a/tests/Jroc.Tests/ReceiverTypeFlowAnalysisTests.cs
+++ b/tests/Jroc.Tests/ReceiverTypeFlowAnalysisTests.cs
@@ -719,6 +719,56 @@ public sealed class ReceiverTypeFlowAnalysisTests
             ReceiverTypeFlowAnalysis.RequiresAnalysis(receiverBody));
     }
 
+    [Fact]
+    public void RequiresSpecializationAnalysis_SkipsCandidateFreeReceiver()
+    {
+        var body = new MethodBodyIR();
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        body.Instructions.Add(
+            new LIRCallMember0(receiver, "pop", result));
+
+        Assert.False(
+            ReceiverTypeFlowAnalysis
+                .RequiresSpecializationAnalysis(body));
+    }
+
+    [Fact]
+    public void RequiresSpecializationAnalysis_FollowsCandidateProducer()
+    {
+        var body = new MethodBodyIR();
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        body.Instructions.Add(
+            new LIRCallIntrinsicStatic(
+                nameof(JavaScriptRuntime.Array),
+                "Construct",
+                [],
+                receiver));
+        body.Instructions.Add(
+            new LIRCallMember0(receiver, "pop", result));
+
+        Assert.True(
+            ReceiverTypeFlowAnalysis
+                .RequiresSpecializationAnalysis(body));
+    }
+
     private static TempVariable AddTemp(
         MethodBodyIR body,
         ValueStorage storage,

--- a/tests/Jroc.Tests/String/JavaScript/String_PrototypeMethodOverrides.js
+++ b/tests/Jroc.Tests/String/JavaScript/String_PrototypeMethodOverrides.js
@@ -4,6 +4,33 @@ function callTrim(value) {
     return value.trim();
 }
 
+var boxed = new String("  boxed  ");
+console.log(boxed.trim());
+console.log(typeof boxed);
+
+var own = new String("own-source");
+own.trim = function () {
+    return "own";
+};
+console.log(own.trim());
+
+var defined = new String("defined-source");
+Object.defineProperty(defined, "trim", {
+    value: function () {
+        return "defined";
+    }
+});
+console.log(defined.trim());
+
+var customPrototype = {
+    trim: function () {
+        return "custom-prototype";
+    }
+};
+var custom = new String("custom-source");
+Object.setPrototypeOf(custom, customPrototype);
+console.log(custom.trim());
+
 console.log(callTrim("  uncertain  "));
 console.log(callTrim({
     trim: function () {

--- a/tests/Jroc.Tests/String/Snapshots/ExecutionTests.String_PrototypeMethodOverrides.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/ExecutionTests.String_PrototypeMethodOverrides.verified.txt
@@ -1,4 +1,9 @@
-﻿uncertain
+﻿boxed
+object
+own
+defined
+custom-prototype
+uncertain
 object-fallback
 replaced-1
 trim-getter

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharAt_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_CharAt_Basic.verified.txt
@@ -78,7 +78,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 911 (0x38f)
+		// Code size: 949 (0x3b5)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_CharAt_Basic/Scope,
@@ -340,68 +340,82 @@
 		IL_02c7: stloc.s 8
 		IL_02c9: ldc.i4.0
 		IL_02ca: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_02cf: brfalse IL_02fc
+		IL_02cf: brfalse IL_030f
 
 		IL_02d4: ldloc.s 8
 		IL_02d6: isinst [System.Runtime]System.String
 		IL_02db: dup
-		IL_02dc: brfalse IL_02fb
+		IL_02dc: brtrue IL_02f4
 
-		IL_02e1: ldc.r8 0.0
-		IL_02ea: box [System.Runtime]System.Double
-		IL_02ef: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-		IL_02f4: stloc.s 8
-		IL_02f6: br IL_0318
+		IL_02e1: pop
+		IL_02e2: ldloc.s 8
+		IL_02e4: ldstr "charAt"
+		IL_02e9: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_02ee: dup
+		IL_02ef: brfalse IL_030e
 
-		IL_02fb: pop
+		IL_02f4: ldc.r8 0.0
+		IL_02fd: box [System.Runtime]System.Double
+		IL_0302: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_0307: stloc.s 8
+		IL_0309: br IL_032b
 
-		IL_02fc: ldloc.s 8
-		IL_02fe: ldstr "charAt"
-		IL_0303: ldc.r8 0.0
-		IL_030c: box [System.Runtime]System.Double
-		IL_0311: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0316: stloc.s 8
+		IL_030e: pop
 
-		IL_0318: ldloc.s 7
-		IL_031a: ldloc.s 8
-		IL_031c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0321: pop
-		IL_0322: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0327: stloc.s 7
-		IL_0329: ldloc.s 5
-		IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0330: stloc.s 8
-		IL_0332: ldc.i4.0
-		IL_0333: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0338: brfalse IL_0365
+		IL_030f: ldloc.s 8
+		IL_0311: ldstr "charAt"
+		IL_0316: ldc.r8 0.0
+		IL_031f: box [System.Runtime]System.Double
+		IL_0324: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0329: stloc.s 8
 
-		IL_033d: ldloc.s 8
-		IL_033f: isinst [System.Runtime]System.String
-		IL_0344: dup
-		IL_0345: brfalse IL_0364
+		IL_032b: ldloc.s 7
+		IL_032d: ldloc.s 8
+		IL_032f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0334: pop
+		IL_0335: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_033a: stloc.s 7
+		IL_033c: ldloc.s 5
+		IL_033e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0343: stloc.s 8
+		IL_0345: ldc.i4.0
+		IL_0346: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_034b: brfalse IL_038b
 
-		IL_034a: ldc.r8 2
-		IL_0353: box [System.Runtime]System.Double
-		IL_0358: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-		IL_035d: stloc.s 8
-		IL_035f: br IL_0381
+		IL_0350: ldloc.s 8
+		IL_0352: isinst [System.Runtime]System.String
+		IL_0357: dup
+		IL_0358: brtrue IL_0370
 
-		IL_0364: pop
+		IL_035d: pop
+		IL_035e: ldloc.s 8
+		IL_0360: ldstr "charAt"
+		IL_0365: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_036a: dup
+		IL_036b: brfalse IL_038a
 
-		IL_0365: ldloc.s 8
-		IL_0367: ldstr "charAt"
-		IL_036c: ldc.r8 2
-		IL_0375: box [System.Runtime]System.Double
-		IL_037a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_037f: stloc.s 8
+		IL_0370: ldc.r8 2
+		IL_0379: box [System.Runtime]System.Double
+		IL_037e: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_0383: stloc.s 8
+		IL_0385: br IL_03a7
 
-		IL_0381: ldloc.s 7
-		IL_0383: ldloc.s 8
-		IL_0385: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_038a: pop
-		IL_038b: ldnull
-		IL_038c: stloc.s 6
-		IL_038e: ret
+
+		IL_038b: ldloc.s 8
+		IL_038d: ldstr "charAt"
+		IL_0392: ldc.r8 2
+		IL_039b: box [System.Runtime]System.Double
+		IL_03a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03a5: stloc.s 8
+
+		IL_03a7: ldloc.s 7
+		IL_03a9: ldloc.s 8
+		IL_03ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03b0: pop
+		IL_03b1: ldnull
+		IL_03b2: stloc.s 6
+		IL_03b4: ret
 	} // end of method String_CharAt_Basic::__js_module_init__
 
 } // end of class Modules.String_CharAt_Basic

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_NewApis_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_NewApis_Basic.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 939 (0x3ab)
+		// Code size: 958 (0x3be)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_NewApis_Basic/Scope,
@@ -288,34 +288,41 @@
 		IL_034b: stloc.s 4
 		IL_034d: ldc.i4.0
 		IL_034e: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0353: brfalse IL_0385
+		IL_0353: brfalse IL_0398
 
 		IL_0358: ldloc.s 4
 		IL_035a: isinst [System.Runtime]System.String
 		IL_035f: dup
-		IL_0360: brfalse IL_0384
+		IL_0360: brtrue IL_0378
 
-		IL_0365: ldc.r8 1
-		IL_036e: box [System.Runtime]System.Double
-		IL_0373: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
-		IL_0378: box [System.Runtime]System.Double
-		IL_037d: stloc.s 4
-		IL_037f: br IL_03a1
+		IL_0365: pop
+		IL_0366: ldloc.s 4
+		IL_0368: ldstr "charCodeAt"
+		IL_036d: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_0372: dup
+		IL_0373: brfalse IL_0397
 
-		IL_0384: pop
+		IL_0378: ldc.r8 1
+		IL_0381: box [System.Runtime]System.Double
+		IL_0386: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_038b: box [System.Runtime]System.Double
+		IL_0390: stloc.s 4
+		IL_0392: br IL_03b4
 
-		IL_0385: ldloc.s 4
-		IL_0387: ldstr "charCodeAt"
-		IL_038c: ldc.r8 1
-		IL_0395: box [System.Runtime]System.Double
-		IL_039a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_039f: stloc.s 4
+		IL_0397: pop
 
-		IL_03a1: ldloc.1
-		IL_03a2: ldloc.s 4
-		IL_03a4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03a9: pop
-		IL_03aa: ret
+		IL_0398: ldloc.s 4
+		IL_039a: ldstr "charCodeAt"
+		IL_039f: ldc.r8 1
+		IL_03a8: box [System.Runtime]System.Double
+		IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03b2: stloc.s 4
+
+		IL_03b4: ldloc.1
+		IL_03b5: ldloc.s 4
+		IL_03b7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03bc: pop
+		IL_03bd: ret
 	} // end of method String_NewApis_Basic::__js_module_init__
 
 } // end of class Modules.String_NewApis_Basic

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_PrototypeMethodOverrides.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_PrototypeMethodOverrides.verified.txt
@@ -137,7 +137,7 @@
 				01 00 00 00 00 00 00 00
 			)
 			// Header size: 12
-			// Code size: 56 (0x38)
+			// Code size: 74 (0x4a)
 			.maxstack 8
 			.locals init (
 				[0] object
@@ -148,31 +148,38 @@
 			IL_0006: stloc.0
 			IL_0007: ldc.i4.0
 			IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_000d: brfalse IL_002a
+			IL_000d: brfalse IL_003c
 
 			IL_0012: ldloc.0
 			IL_0013: isinst [System.Runtime]System.String
 			IL_0018: dup
-			IL_0019: brfalse IL_0029
+			IL_0019: brtrue IL_0030
 
-			IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-			IL_0023: stloc.0
-			IL_0024: br IL_0036
+			IL_001e: pop
+			IL_001f: ldloc.0
+			IL_0020: ldstr "trim"
+			IL_0025: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+			IL_002a: dup
+			IL_002b: brfalse IL_003b
 
-			IL_0029: pop
-
-			IL_002a: ldloc.0
-			IL_002b: ldstr "trim"
-			IL_0030: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0030: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
 			IL_0035: stloc.0
+			IL_0036: br IL_0048
 
-			IL_0036: ldloc.0
-			IL_0037: ret
+			IL_003b: pop
+
+			IL_003c: ldloc.0
+			IL_003d: ldstr "trim"
+			IL_0042: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+			IL_0047: stloc.0
+
+			IL_0048: ldloc.0
+			IL_0049: ret
 		} // end of method callTrim::__js_call__
 
 	} // end of class callTrim
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L9C10
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L12C11
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -244,7 +251,7 @@
 				.maxstack 8
 
 				IL_0000: ldnull
-				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L9C10::__js_call__(object)
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L12C11::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::CallCore
 
@@ -260,7 +267,403 @@
 				.maxstack 8
 
 				IL_0000: ldarg.3
-				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L9C10::__js_call__(object)
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L12C11::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 6 (0x6)
+			.maxstack 8
+
+			IL_0000: ldstr "own"
+			IL_0005: ret
+		} // end of method FunctionExpression_L12C11::__js_call__
+
+	} // end of class FunctionExpression_L12C11
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L19C11
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L19C11::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L19C11::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 6 (0x6)
+			.maxstack 8
+
+			IL_0000: ldstr "defined"
+			IL_0005: ret
+		} // end of method FunctionExpression_L19C11::__js_call__
+
+	} // end of class FunctionExpression_L19C11
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_customPrototype
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_customPrototype::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_customPrototype::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 6 (0x6)
+			.maxstack 8
+
+			IL_0000: ldstr "custom-prototype"
+			IL_0005: ret
+		} // end of method FunctionExpression_customPrototype::__js_call__
+
+	} // end of class FunctionExpression_customPrototype
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L36C10
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L36C10::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L36C10::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::ConstructBodyCore
 
@@ -300,11 +703,11 @@
 
 			IL_0000: ldstr "object-fallback"
 			IL_0005: ret
-		} // end of method FunctionExpression_L9C10::__js_call__
+		} // end of method FunctionExpression_L36C10::__js_call__
 
-	} // end of class FunctionExpression_L9C10
+	} // end of class FunctionExpression_L36C10
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L15C26
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L42C26
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -379,7 +782,7 @@
 				IL_0001: ldarg.2
 				IL_0002: ldc.i4.0
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0008: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L15C26::__js_call__(object, object)
+				IL_0008: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L42C26::__js_call__(object, object)
 				IL_000d: ret
 			} // end of method FunctionObject::CallCore
 
@@ -398,7 +801,7 @@
 				IL_0001: ldarg.2
 				IL_0002: ldc.i4.0
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0008: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L15C26::__js_call__(object, object)
+				IL_0008: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L42C26::__js_call__(object, object)
 				IL_000d: ret
 			} // end of method FunctionObject::ConstructBodyCore
 
@@ -446,15 +849,15 @@
 			IL_000b: stloc.0
 			IL_000c: ldloc.0
 			IL_000d: ret
-		} // end of method FunctionExpression_L15C26::__js_call__
+		} // end of method FunctionExpression_L42C26::__js_call__
 
-	} // end of class FunctionExpression_L15C26
+	} // end of class FunctionExpression_L42C26
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L24C9
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L51C9
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L26C15
+		.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L53C15
 			extends [System.Runtime]System.Object
 		{
 			// Nested Types
@@ -526,7 +929,7 @@
 					.maxstack 8
 
 					IL_0000: ldnull
-					IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/FunctionExpression_L26C15::__js_call__(object)
+					IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9/FunctionExpression_L53C15::__js_call__(object)
 					IL_0006: ret
 				} // end of method FunctionObject::CallCore
 
@@ -542,7 +945,7 @@
 					.maxstack 8
 
 					IL_0000: ldarg.3
-					IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/FunctionExpression_L26C15::__js_call__(object)
+					IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9/FunctionExpression_L53C15::__js_call__(object)
 					IL_0006: ret
 				} // end of method FunctionObject::ConstructBodyCore
 
@@ -582,9 +985,9 @@
 
 				IL_0000: ldstr "accessor-result"
 				IL_0005: ret
-			} // end of method FunctionExpression_L26C15::__js_call__
+			} // end of method FunctionExpression_L53C15::__js_call__
 
-		} // end of class FunctionExpression_L26C15
+		} // end of class FunctionExpression_L53C15
 
 		.class nested public auto ansi beforefieldinit Scope
 			extends [System.Runtime]System.Object
@@ -654,7 +1057,7 @@
 				.maxstack 8
 
 				IL_0000: ldnull
-				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9::__js_call__(object)
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::CallCore
 
@@ -670,7 +1073,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.3
-				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9::__js_call__(object)
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::ConstructBodyCore
 
@@ -708,13 +1111,13 @@
 			// Code size: 52 (0x34)
 			.maxstack 8
 			.locals init (
-				[0] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/Scope,
+				[0] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9/Scope,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 				[2] object[],
-				[3] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/FunctionExpression_L26C15/FunctionObject
+				[3] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9/FunctionExpression_L53C15/FunctionObject
 			)
 
-			IL_0000: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/Scope::.ctor()
+			IL_0000: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9/Scope::.ctor()
 			IL_0005: stloc.0
 			IL_0006: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_000b: stloc.1
@@ -724,21 +1127,21 @@
 			IL_0017: pop
 			IL_0018: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_001d: stloc.2
-			IL_001e: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/FunctionExpression_L26C15/FunctionObject::.ctor()
+			IL_001e: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9/FunctionExpression_L53C15/FunctionObject::.ctor()
 			IL_0023: ldc.i4.0
 			IL_0024: conv.r8
 			IL_0025: ldstr ""
 			IL_002a: ldc.i4.0
 			IL_002b: ldc.i4.1
-			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/FunctionExpression_L26C15/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9/FunctionExpression_L53C15/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0031: stloc.3
 			IL_0032: ldloc.3
 			IL_0033: ret
-		} // end of method FunctionExpression_L24C9::__js_call__
+		} // end of method FunctionExpression_L51C9::__js_call__
 
-	} // end of class FunctionExpression_L24C9
+	} // end of class FunctionExpression_L51C9
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L37C31
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L64C31
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -810,7 +1213,7 @@
 				.maxstack 8
 
 				IL_0000: ldnull
-				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L37C31::__js_call__(object)
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L64C31::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::CallCore
 
@@ -826,7 +1229,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.3
-				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L37C31::__js_call__(object)
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L64C31::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::ConstructBodyCore
 
@@ -866,11 +1269,11 @@
 
 			IL_0000: ldstr "inherited"
 			IL_0005: ret
-		} // end of method FunctionExpression_L37C31::__js_call__
+		} // end of method FunctionExpression_L64C31::__js_call__
 
-	} // end of class FunctionExpression_L37C31
+	} // end of class FunctionExpression_L64C31
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L58C30
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L85C30
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -945,7 +1348,7 @@
 				IL_0001: ldarg.2
 				IL_0002: ldc.i4.0
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0008: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L58C30::__js_call__(object, object)
+				IL_0008: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L85C30::__js_call__(object, object)
 				IL_000d: ret
 			} // end of method FunctionObject::CallCore
 
@@ -964,7 +1367,7 @@
 				IL_0001: ldarg.2
 				IL_0002: ldc.i4.0
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-				IL_0008: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L58C30::__js_call__(object, object)
+				IL_0008: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L85C30::__js_call__(object, object)
 				IL_000d: ret
 			} // end of method FunctionObject::ConstructBodyCore
 
@@ -1012,11 +1415,11 @@
 			IL_000b: stloc.0
 			IL_000c: ldloc.0
 			IL_000d: ret
-		} // end of method FunctionExpression_L58C30::__js_call__
+		} // end of method FunctionExpression_L85C30::__js_call__
 
-	} // end of class FunctionExpression_L58C30
+	} // end of class FunctionExpression_L85C30
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L67C30
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L94C30
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -1088,7 +1491,7 @@
 				.maxstack 8
 
 				IL_0000: ldnull
-				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L67C30::__js_call__(object)
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L94C30::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::CallCore
 
@@ -1104,7 +1507,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.3
-				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L67C30::__js_call__(object)
+				IL_0001: call object Modules.String_PrototypeMethodOverrides/FunctionExpression_L94C30::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::ConstructBodyCore
 
@@ -1144,9 +1547,9 @@
 
 			IL_0000: ldstr "41.9"
 			IL_0005: ret
-		} // end of method FunctionExpression_L67C30::__js_call__
+		} // end of method FunctionExpression_L94C30::__js_call__
 
-	} // end of class FunctionExpression_L67C30
+	} // end of class FunctionExpression_L94C30
 
 	.class nested public auto ansi beforefieldinit Scope
 		extends [System.Runtime]System.Object
@@ -1156,7 +1559,7 @@
 			6d 3d 7b 63 61 6c 6c 54 72 69 6d 7d 00 00
 		)
 		// Nested Types
-		.class nested public auto ansi beforefieldinit Block_L42C45
+		.class nested public auto ansi beforefieldinit Block_L69C45
 			extends [System.Runtime]System.Object
 		{
 			// Methods
@@ -1171,11 +1574,11 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Block_L42C45::.ctor
+			} // end of method Block_L69C45::.ctor
 
-		} // end of class Block_L42C45
+		} // end of class Block_L69C45
 
-		.class nested public auto ansi beforefieldinit Block_L44C7
+		.class nested public auto ansi beforefieldinit Block_L71C7
 			extends [System.Runtime]System.Object
 		{
 			// Methods
@@ -1190,11 +1593,11 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Block_L44C7::.ctor
+			} // end of method Block_L71C7::.ctor
 
-		} // end of class Block_L44C7
+		} // end of class Block_L71C7
 
-		.class nested public auto ansi beforefieldinit Block_L50C4
+		.class nested public auto ansi beforefieldinit Block_L77C4
 			extends [System.Runtime]System.Object
 		{
 			// Methods
@@ -1209,11 +1612,11 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Block_L50C4::.ctor
+			} // end of method Block_L77C4::.ctor
 
-		} // end of class Block_L50C4
+		} // end of class Block_L77C4
 
-		.class nested public auto ansi beforefieldinit Block_L52C16
+		.class nested public auto ansi beforefieldinit Block_L79C16
 			extends [System.Runtime]System.Object
 		{
 			// Methods
@@ -1228,9 +1631,9 @@
 				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
 				IL_0006: nop
 				IL_0007: ret
-			} // end of method Block_L52C16::.ctor
+			} // end of method Block_L79C16::.ctor
 
-		} // end of class Block_L52C16
+		} // end of class Block_L79C16
 
 
 		// Fields
@@ -1264,7 +1667,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1902 (0x76e)
+		// Code size: 2603 (0xa2b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_PrototypeMethodOverrides/Scope,
@@ -1272,634 +1675,901 @@
 			[2] object,
 			[3] object,
 			[4] object,
-			[5] object,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[6] object,
-			[7] class [System.Runtime]System.Exception,
+			[7] object,
 			[8] object,
 			[9] object,
 			[10] object,
 			[11] object,
-			[12] object,
+			[12] class [System.Runtime]System.Exception,
 			[13] object,
-			[14] object[],
-			[15] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[14] object,
+			[15] object,
 			[16] object,
-			[17] object[],
-			[18] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L9C10/FunctionObject,
-			[19] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[20] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L15C26/FunctionObject,
-			[21] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/FunctionObject,
-			[22] bool,
-			[23] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L37C31/FunctionObject,
-			[24] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L58C30/FunctionObject,
-			[25] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[26] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L67C30/FunctionObject,
-			[27] object,
-			[28] float64
+			[17] object,
+			[18] object,
+			[19] object[],
+			[20] object,
+			[21] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[22] string,
+			[23] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L12C11/FunctionObject,
+			[24] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L19C11/FunctionObject,
+			[25] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[26] class Modules.String_PrototypeMethodOverrides/FunctionExpression_customPrototype/FunctionObject,
+			[27] object[],
+			[28] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L36C10/FunctionObject,
+			[29] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L42C26/FunctionObject,
+			[30] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9/FunctionObject,
+			[31] bool,
+			[32] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L64C31/FunctionObject,
+			[33] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L85C30/FunctionObject,
+			[34] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[35] class Modules.String_PrototypeMethodOverrides/FunctionExpression_L94C30/FunctionObject,
+			[36] object,
+			[37] float64
 		)
 
-		IL_0000: newobj instance void Modules.String_PrototypeMethodOverrides/Scope::.ctor()
-		IL_0005: stloc.0
-		IL_0006: ldc.i4.1
-		IL_0007: newarr [System.Runtime]System.Object
-		IL_000c: dup
-		IL_000d: ldc.i4.0
-		IL_000e: ldloc.0
-		IL_000f: stelem.ref
-		IL_0010: stloc.s 14
-		IL_0012: newobj instance void Modules.String_PrototypeMethodOverrides/callTrim/FunctionObject::.ctor()
-		IL_0017: ldc.i4.1
-		IL_0018: conv.r8
-		IL_0019: ldstr "callTrim"
-		IL_001e: ldc.i4.0
-		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/callTrim/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0025: stloc.1
-		IL_0026: nop
-		IL_0027: nop
-		IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_002d: stloc.s 15
-		IL_002f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_0034: stloc.s 14
-		IL_0036: ldloc.1
-		IL_0037: ldloc.s 14
-		IL_0039: ldstr "  uncertain  "
-		IL_003e: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_0043: stloc.s 16
-		IL_0045: ldloc.s 15
-		IL_0047: ldloc.s 16
-		IL_0049: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_004e: pop
-		IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0054: stloc.s 15
-		IL_0056: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
-		IL_005b: stloc.s 14
-		IL_005d: ldc.i4.1
-		IL_005e: newarr [System.Runtime]System.Object
-		IL_0063: dup
-		IL_0064: ldc.i4.0
-		IL_0065: ldloc.0
-		IL_0066: stelem.ref
-		IL_0067: stloc.s 17
-		IL_0069: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L9C10/FunctionObject::.ctor()
-		IL_006e: ldc.i4.0
-		IL_006f: conv.r8
-		IL_0070: ldstr ""
-		IL_0075: ldc.i4.0
-		IL_0076: ldc.i4.1
-		IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L9C10/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_007c: stloc.s 18
-		IL_007e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_0083: dup
-		IL_0084: ldstr "trim"
-		IL_0089: ldloc.s 18
-		IL_008b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0090: stloc.s 19
-		IL_0092: ldloc.1
-		IL_0093: ldloc.s 14
-		IL_0095: ldloc.s 19
-		IL_0097: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
-		IL_009c: stloc.s 16
-		IL_009e: ldloc.s 15
-		IL_00a0: ldloc.s 16
-		IL_00a2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00a7: pop
-		IL_00a8: ldstr "String"
-		IL_00ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00b2: ldstr "prototype"
-		IL_00b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00bc: stloc.s 16
-		IL_00be: ldloc.s 16
-		IL_00c0: ldstr "charAt"
-		IL_00c5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00ca: stloc.2
-		IL_00cb: ldstr "String"
-		IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_00d5: ldstr "prototype"
-		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_00df: stloc.s 16
-		IL_00e1: ldc.i4.1
-		IL_00e2: newarr [System.Runtime]System.Object
-		IL_00e7: dup
-		IL_00e8: ldc.i4.0
-		IL_00e9: ldloc.0
-		IL_00ea: stelem.ref
-		IL_00eb: stloc.s 14
-		IL_00ed: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L15C26/FunctionObject::.ctor()
+		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
+		IL_0005: newobj instance void Modules.String_PrototypeMethodOverrides/Scope::.ctor()
+		IL_000a: stloc.0
+		IL_000b: ldc.i4.1
+		IL_000c: newarr [System.Runtime]System.Object
+		IL_0011: dup
+		IL_0012: ldc.i4.0
+		IL_0013: ldloc.0
+		IL_0014: stelem.ref
+		IL_0015: stloc.s 19
+		IL_0017: newobj instance void Modules.String_PrototypeMethodOverrides/callTrim/FunctionObject::.ctor()
+		IL_001c: ldc.i4.1
+		IL_001d: conv.r8
+		IL_001e: ldstr "callTrim"
+		IL_0023: ldc.i4.0
+		IL_0024: ldc.i4.1
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/callTrim/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002a: stloc.1
+		IL_002b: nop
+		IL_002c: nop
+		IL_002d: ldstr "String"
+		IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0037: stloc.s 20
+		IL_0039: ldloc.s 20
+		IL_003b: dup
+		IL_003c: ldstr "  boxed  "
+		IL_0041: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_0046: stloc.2
+		IL_0047: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_004c: stloc.s 21
+		IL_004e: ldloc.2
+		IL_004f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0054: stloc.s 20
+		IL_0056: ldc.i4.0
+		IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_005c: brfalse IL_008e
+
+		IL_0061: ldloc.s 20
+		IL_0063: isinst [System.Runtime]System.String
+		IL_0068: dup
+		IL_0069: brtrue IL_0081
+
+		IL_006e: pop
+		IL_006f: ldloc.s 20
+		IL_0071: ldstr "trim"
+		IL_0076: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_007b: dup
+		IL_007c: brfalse IL_008d
+
+		IL_0081: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+		IL_0086: stloc.s 20
+		IL_0088: br IL_009c
+
+		IL_008d: pop
+
+		IL_008e: ldloc.s 20
+		IL_0090: ldstr "trim"
+		IL_0095: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_009a: stloc.s 20
+
+		IL_009c: ldloc.s 21
+		IL_009e: ldloc.s 20
+		IL_00a0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00a5: pop
+		IL_00a6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00ab: stloc.s 21
+		IL_00ad: ldloc.2
+		IL_00ae: call string [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::Typeof(object)
+		IL_00b3: stloc.s 22
+		IL_00b5: ldloc.s 21
+		IL_00b7: ldloc.s 22
+		IL_00b9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00be: pop
+		IL_00bf: ldstr "String"
+		IL_00c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00c9: stloc.s 20
+		IL_00cb: ldloc.s 20
+		IL_00cd: dup
+		IL_00ce: ldstr "own-source"
+		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_00d8: stloc.3
+		IL_00d9: ldc.i4.1
+		IL_00da: newarr [System.Runtime]System.Object
+		IL_00df: dup
+		IL_00e0: ldc.i4.0
+		IL_00e1: ldloc.0
+		IL_00e2: stelem.ref
+		IL_00e3: stloc.s 19
+		IL_00e5: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L12C11/FunctionObject::.ctor()
+		IL_00ea: ldc.i4.0
+		IL_00eb: conv.r8
+		IL_00ec: ldstr ""
+		IL_00f1: ldc.i4.0
 		IL_00f2: ldc.i4.1
-		IL_00f3: conv.r8
-		IL_00f4: ldstr ""
-		IL_00f9: ldc.i4.0
-		IL_00fa: ldc.i4.1
-		IL_00fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L15C26/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0100: stloc.s 20
-		IL_0102: ldloc.s 16
-		IL_0104: ldstr "charAt"
-		IL_0109: ldloc.s 20
-		IL_010b: ldc.i4.1
-		IL_010c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0111: pop
-		IL_0112: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0117: stloc.s 15
-		IL_0119: ldc.i4.0
-		IL_011a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_011f: brfalse IL_0143
+		IL_00f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L12C11/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00f8: stloc.s 23
+		IL_00fa: ldloc.3
+		IL_00fb: ldstr "trim"
+		IL_0100: ldloc.s 23
+		IL_0102: ldc.i4.1
+		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0108: pop
+		IL_0109: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010e: stloc.s 21
+		IL_0110: ldloc.3
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0116: stloc.s 20
+		IL_0118: ldc.i4.0
+		IL_0119: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_011e: brfalse IL_0150
 
-		IL_0124: ldstr "abc"
-		IL_0129: ldc.r8 1
-		IL_0132: box [System.Runtime]System.Double
-		IL_0137: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
-		IL_013c: stloc.s 16
-		IL_013e: br IL_0162
+		IL_0123: ldloc.s 20
+		IL_0125: isinst [System.Runtime]System.String
+		IL_012a: dup
+		IL_012b: brtrue IL_0143
 
-		IL_0143: ldstr "abc"
-		IL_0148: ldstr "charAt"
-		IL_014d: ldc.r8 1
-		IL_0156: box [System.Runtime]System.Double
-		IL_015b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0160: stloc.s 16
+		IL_0130: pop
+		IL_0131: ldloc.s 20
+		IL_0133: ldstr "trim"
+		IL_0138: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_013d: dup
+		IL_013e: brfalse IL_014f
 
-		IL_0162: ldloc.s 15
-		IL_0164: ldloc.s 16
-		IL_0166: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_016b: pop
-		IL_016c: ldstr "String"
-		IL_0171: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0176: ldstr "prototype"
-		IL_017b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0180: stloc.s 16
-		IL_0182: ldloc.s 16
-		IL_0184: ldstr "charAt"
-		IL_0189: ldloc.2
-		IL_018a: ldc.i4.1
-		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0190: pop
-		IL_0191: ldstr "String"
-		IL_0196: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_019b: ldstr "prototype"
-		IL_01a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01a5: stloc.s 16
-		IL_01a7: ldloc.s 16
-		IL_01a9: ldstr "trim"
-		IL_01ae: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
-		IL_01b3: stloc.3
-		IL_01b4: ldstr "String"
-		IL_01b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_01be: ldstr "prototype"
-		IL_01c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_01c8: stloc.s 16
-		IL_01ca: ldc.i4.1
-		IL_01cb: newarr [System.Runtime]System.Object
-		IL_01d0: dup
-		IL_01d1: ldc.i4.0
-		IL_01d2: ldloc.0
-		IL_01d3: stelem.ref
-		IL_01d4: stloc.s 14
-		IL_01d6: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/FunctionObject::.ctor()
-		IL_01db: ldc.i4.0
-		IL_01dc: conv.r8
-		IL_01dd: ldstr ""
-		IL_01e2: ldc.i4.0
-		IL_01e3: ldc.i4.1
-		IL_01e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L24C9/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01e9: stloc.s 21
-		IL_01eb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01f0: dup
-		IL_01f1: ldstr "configurable"
-		IL_01f6: ldc.i4.1
-		IL_01f7: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_0143: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+		IL_0148: stloc.s 20
+		IL_014a: br IL_015e
+
+		IL_014f: pop
+
+		IL_0150: ldloc.s 20
+		IL_0152: ldstr "trim"
+		IL_0157: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_015c: stloc.s 20
+
+		IL_015e: ldloc.s 21
+		IL_0160: ldloc.s 20
+		IL_0162: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0167: pop
+		IL_0168: ldstr "String"
+		IL_016d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0172: stloc.s 20
+		IL_0174: ldloc.s 20
+		IL_0176: dup
+		IL_0177: ldstr "defined-source"
+		IL_017c: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_0181: stloc.s 4
+		IL_0183: ldc.i4.1
+		IL_0184: newarr [System.Runtime]System.Object
+		IL_0189: dup
+		IL_018a: ldc.i4.0
+		IL_018b: ldloc.0
+		IL_018c: stelem.ref
+		IL_018d: stloc.s 19
+		IL_018f: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L19C11/FunctionObject::.ctor()
+		IL_0194: ldc.i4.0
+		IL_0195: conv.r8
+		IL_0196: ldstr ""
+		IL_019b: ldc.i4.0
+		IL_019c: ldc.i4.1
+		IL_019d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L19C11/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01a2: stloc.s 24
+		IL_01a4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01a9: dup
+		IL_01aa: ldstr "value"
+		IL_01af: ldloc.s 24
+		IL_01b1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_01b6: stloc.s 25
+		IL_01b8: ldloc.s 4
+		IL_01ba: ldstr "trim"
+		IL_01bf: ldloc.s 25
+		IL_01c1: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_01c6: pop
+		IL_01c7: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01cc: stloc.s 21
+		IL_01ce: ldloc.s 4
+		IL_01d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d5: stloc.s 20
+		IL_01d7: ldc.i4.0
+		IL_01d8: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_01dd: brfalse IL_020f
+
+		IL_01e2: ldloc.s 20
+		IL_01e4: isinst [System.Runtime]System.String
+		IL_01e9: dup
+		IL_01ea: brtrue IL_0202
+
+		IL_01ef: pop
+		IL_01f0: ldloc.s 20
+		IL_01f2: ldstr "trim"
+		IL_01f7: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
 		IL_01fc: dup
-		IL_01fd: ldstr "get"
-		IL_0202: ldloc.s 21
-		IL_0204: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
-		IL_0209: stloc.s 19
-		IL_020b: ldloc.s 16
-		IL_020d: ldstr "trim"
-		IL_0212: ldloc.s 19
-		IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_0219: pop
-		IL_021a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_021f: stloc.s 15
-		IL_0221: ldc.i4.0
-		IL_0222: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0227: brfalse IL_023d
+		IL_01fd: brfalse IL_020e
 
-		IL_022c: ldstr " abc "
-		IL_0231: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
-		IL_0236: stloc.s 16
-		IL_0238: br IL_024e
+		IL_0202: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+		IL_0207: stloc.s 20
+		IL_0209: br IL_021d
 
-		IL_023d: ldstr " abc "
-		IL_0242: ldstr "trim"
-		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_024c: stloc.s 16
+		IL_020e: pop
 
-		IL_024e: ldloc.s 15
-		IL_0250: ldloc.s 16
-		IL_0252: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0257: pop
-		IL_0258: ldstr "String"
-		IL_025d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0262: ldstr "prototype"
-		IL_0267: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_026c: stloc.s 16
-		IL_026e: ldloc.s 16
-		IL_0270: ldstr "trim"
-		IL_0275: ldloc.3
-		IL_0276: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
-		IL_027b: pop
-		IL_027c: ldstr "String"
-		IL_0281: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0286: ldstr "prototype"
-		IL_028b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0290: stloc.s 16
-		IL_0292: ldloc.s 16
-		IL_0294: ldstr "toUpperCase"
-		IL_0299: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_029e: stloc.s 4
-		IL_02a0: ldstr "Object"
-		IL_02a5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02aa: ldstr "prototype"
-		IL_02af: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b4: stloc.s 16
-		IL_02b6: ldloc.s 16
-		IL_02b8: ldstr "toUpperCase"
-		IL_02bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02c2: stloc.s 5
-		IL_02c4: ldstr "String"
-		IL_02c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02ce: ldstr "prototype"
-		IL_02d3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02d8: stloc.s 16
-		IL_02da: ldloc.s 16
-		IL_02dc: ldstr "toUpperCase"
-		IL_02e1: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_02e6: stloc.s 22
-		IL_02e8: ldstr "Object"
-		IL_02ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02f2: ldstr "prototype"
-		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02fc: stloc.s 16
-		IL_02fe: ldc.i4.1
-		IL_02ff: newarr [System.Runtime]System.Object
-		IL_0304: dup
-		IL_0305: ldc.i4.0
-		IL_0306: ldloc.0
-		IL_0307: stelem.ref
-		IL_0308: stloc.s 14
-		IL_030a: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L37C31/FunctionObject::.ctor()
-		IL_030f: ldc.i4.0
-		IL_0310: conv.r8
-		IL_0311: ldstr ""
-		IL_0316: ldc.i4.0
-		IL_0317: ldc.i4.1
-		IL_0318: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L37C31/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_031d: stloc.s 23
-		IL_031f: ldloc.s 16
-		IL_0321: ldstr "toUpperCase"
-		IL_0326: ldloc.s 23
-		IL_0328: ldc.i4.1
-		IL_0329: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_032e: pop
-		IL_032f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0334: stloc.s 15
-		IL_0336: ldc.i4.0
-		IL_0337: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_033c: brfalse IL_0352
+		IL_020f: ldloc.s 20
+		IL_0211: ldstr "trim"
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_021b: stloc.s 20
 
-		IL_0341: ldstr "abc"
-		IL_0346: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
-		IL_034b: stloc.s 16
-		IL_034d: br IL_0363
+		IL_021d: ldloc.s 21
+		IL_021f: ldloc.s 20
+		IL_0221: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0226: pop
+		IL_0227: ldc.i4.1
+		IL_0228: newarr [System.Runtime]System.Object
+		IL_022d: dup
+		IL_022e: ldc.i4.0
+		IL_022f: ldloc.0
+		IL_0230: stelem.ref
+		IL_0231: stloc.s 19
+		IL_0233: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_customPrototype/FunctionObject::.ctor()
+		IL_0238: ldc.i4.0
+		IL_0239: conv.r8
+		IL_023a: ldstr ""
+		IL_023f: ldc.i4.0
+		IL_0240: ldc.i4.1
+		IL_0241: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_customPrototype/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0246: stloc.s 26
+		IL_0248: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_024d: dup
+		IL_024e: ldstr "trim"
+		IL_0253: ldloc.s 26
+		IL_0255: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_025a: stloc.s 5
+		IL_025c: ldstr "String"
+		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0266: stloc.s 20
+		IL_0268: ldloc.s 20
+		IL_026a: dup
+		IL_026b: ldstr "custom-source"
+		IL_0270: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_0275: stloc.s 6
+		IL_0277: ldloc.s 6
+		IL_0279: ldloc.s 5
+		IL_027b: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_0280: pop
+		IL_0281: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0286: stloc.s 21
+		IL_0288: ldloc.s 6
+		IL_028a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_028f: stloc.s 20
+		IL_0291: ldc.i4.0
+		IL_0292: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0297: brfalse IL_02c9
 
-		IL_0352: ldstr "abc"
-		IL_0357: ldstr "toUpperCase"
-		IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0361: stloc.s 16
+		IL_029c: ldloc.s 20
+		IL_029e: isinst [System.Runtime]System.String
+		IL_02a3: dup
+		IL_02a4: brtrue IL_02bc
 
-		IL_0363: ldloc.s 15
-		IL_0365: ldloc.s 16
-		IL_0367: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_036c: pop
-		IL_036d: ldstr "String"
-		IL_0372: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0377: ldstr "prototype"
-		IL_037c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0381: stloc.s 16
-		IL_0383: ldloc.s 16
-		IL_0385: ldstr "toUpperCase"
-		IL_038a: ldloc.s 4
-		IL_038c: ldc.i4.1
-		IL_038d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0392: pop
-		IL_0393: ldloc.s 5
-		IL_0395: stloc.s 16
-		IL_0397: ldloc.s 16
-		IL_0399: ldnull
-		IL_039a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_039f: stloc.s 22
-		IL_03a1: ldloc.s 22
-		IL_03a3: brfalse IL_03d1
+		IL_02a9: pop
+		IL_02aa: ldloc.s 20
+		IL_02ac: ldstr "trim"
+		IL_02b1: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_02b6: dup
+		IL_02b7: brfalse IL_02c8
 
-		IL_03a8: ldstr "Object"
-		IL_03ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03b2: ldstr "prototype"
-		IL_03b7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03bc: stloc.s 16
-		IL_03be: ldloc.s 16
-		IL_03c0: ldstr "toUpperCase"
-		IL_03c5: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_03ca: stloc.s 22
-		IL_03cc: br IL_03f7
+		IL_02bc: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+		IL_02c1: stloc.s 20
+		IL_02c3: br IL_02d7
 
-		IL_03d1: ldstr "Object"
-		IL_03d6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_03db: ldstr "prototype"
-		IL_03e0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_03e5: stloc.s 16
-		IL_03e7: ldloc.s 16
-		IL_03e9: ldstr "toUpperCase"
-		IL_03ee: ldloc.s 5
-		IL_03f0: ldc.i4.1
-		IL_03f1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_03f6: pop
+		IL_02c8: pop
 
-		IL_03f7: ldstr "String"
-		IL_03fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0401: ldstr "prototype"
-		IL_0406: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_040b: stloc.s 16
-		IL_040d: ldloc.s 16
-		IL_040f: ldstr "includes"
-		IL_0414: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0419: stloc.s 6
-		IL_041b: ldstr "String"
-		IL_0420: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0425: ldstr "prototype"
-		IL_042a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_042f: stloc.s 16
-		IL_0431: ldloc.s 16
-		IL_0433: ldstr "includes"
-		IL_0438: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_043d: stloc.s 22
+		IL_02c9: ldloc.s 20
+		IL_02cb: ldstr "trim"
+		IL_02d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_02d5: stloc.s 20
+
+		IL_02d7: ldloc.s 21
+		IL_02d9: ldloc.s 20
+		IL_02db: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02e0: pop
+		IL_02e1: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02e6: stloc.s 21
+		IL_02e8: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_02ed: stloc.s 19
+		IL_02ef: ldloc.1
+		IL_02f0: ldloc.s 19
+		IL_02f2: ldstr "  uncertain  "
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_02fc: stloc.s 20
+		IL_02fe: ldloc.s 21
+		IL_0300: ldloc.s 20
+		IL_0302: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0307: pop
+		IL_0308: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_030d: stloc.s 21
+		IL_030f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
+		IL_0314: stloc.s 19
+		IL_0316: ldc.i4.1
+		IL_0317: newarr [System.Runtime]System.Object
+		IL_031c: dup
+		IL_031d: ldc.i4.0
+		IL_031e: ldloc.0
+		IL_031f: stelem.ref
+		IL_0320: stloc.s 27
+		IL_0322: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L36C10/FunctionObject::.ctor()
+		IL_0327: ldc.i4.0
+		IL_0328: conv.r8
+		IL_0329: ldstr ""
+		IL_032e: ldc.i4.0
+		IL_032f: ldc.i4.1
+		IL_0330: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L36C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0335: stloc.s 28
+		IL_0337: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_033c: dup
+		IL_033d: ldstr "trim"
+		IL_0342: ldloc.s 28
+		IL_0344: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0349: stloc.s 25
+		IL_034b: ldloc.1
+		IL_034c: ldloc.s 19
+		IL_034e: ldloc.s 25
+		IL_0350: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs1(object, object[], object)
+		IL_0355: stloc.s 20
+		IL_0357: ldloc.s 21
+		IL_0359: ldloc.s 20
+		IL_035b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0360: pop
+		IL_0361: ldstr "String"
+		IL_0366: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_036b: ldstr "prototype"
+		IL_0370: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0375: stloc.s 20
+		IL_0377: ldloc.s 20
+		IL_0379: ldstr "charAt"
+		IL_037e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0383: stloc.s 7
+		IL_0385: ldstr "String"
+		IL_038a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_038f: ldstr "prototype"
+		IL_0394: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0399: stloc.s 20
+		IL_039b: ldc.i4.1
+		IL_039c: newarr [System.Runtime]System.Object
+		IL_03a1: dup
+		IL_03a2: ldc.i4.0
+		IL_03a3: ldloc.0
+		IL_03a4: stelem.ref
+		IL_03a5: stloc.s 19
+		IL_03a7: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L42C26/FunctionObject::.ctor()
+		IL_03ac: ldc.i4.1
+		IL_03ad: conv.r8
+		IL_03ae: ldstr ""
+		IL_03b3: ldc.i4.0
+		IL_03b4: ldc.i4.1
+		IL_03b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L42C26/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03ba: stloc.s 29
+		IL_03bc: ldloc.s 20
+		IL_03be: ldstr "charAt"
+		IL_03c3: ldloc.s 29
+		IL_03c5: ldc.i4.1
+		IL_03c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_03cb: pop
+		IL_03cc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03d1: stloc.s 21
+		IL_03d3: ldc.i4.0
+		IL_03d4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_03d9: brfalse IL_03fd
+
+		IL_03de: ldstr "abc"
+		IL_03e3: ldc.r8 1
+		IL_03ec: box [System.Runtime]System.Double
+		IL_03f1: call string [JavaScriptRuntime]JavaScriptRuntime.String::CharAt(string, object)
+		IL_03f6: stloc.s 20
+		IL_03f8: br IL_041c
+
+		IL_03fd: ldstr "abc"
+		IL_0402: ldstr "charAt"
+		IL_0407: ldc.r8 1
+		IL_0410: box [System.Runtime]System.Double
+		IL_0415: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_041a: stloc.s 20
+
+		IL_041c: ldloc.s 21
+		IL_041e: ldloc.s 20
+		IL_0420: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0425: pop
+		IL_0426: ldstr "String"
+		IL_042b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0430: ldstr "prototype"
+		IL_0435: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_043a: stloc.s 20
+		IL_043c: ldloc.s 20
+		IL_043e: ldstr "charAt"
+		IL_0443: ldloc.s 7
+		IL_0445: ldc.i4.1
+		IL_0446: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_044b: pop
+		IL_044c: ldstr "String"
+		IL_0451: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0456: ldstr "prototype"
+		IL_045b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0460: stloc.s 20
+		IL_0462: ldloc.s 20
+		IL_0464: ldstr "trim"
+		IL_0469: call object [JavaScriptRuntime]JavaScriptRuntime.Object::getOwnPropertyDescriptor(object, object)
+		IL_046e: stloc.s 8
+		IL_0470: ldstr "String"
+		IL_0475: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_047a: ldstr "prototype"
+		IL_047f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0484: stloc.s 20
+		IL_0486: ldc.i4.1
+		IL_0487: newarr [System.Runtime]System.Object
+		IL_048c: dup
+		IL_048d: ldc.i4.0
+		IL_048e: ldloc.0
+		IL_048f: stelem.ref
+		IL_0490: stloc.s 19
+		IL_0492: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9/FunctionObject::.ctor()
+		IL_0497: ldc.i4.0
+		IL_0498: conv.r8
+		IL_0499: ldstr ""
+		IL_049e: ldc.i4.0
+		IL_049f: ldc.i4.1
+		IL_04a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L51C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04a5: stloc.s 30
+		IL_04a7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_04ac: dup
+		IL_04ad: ldstr "configurable"
+		IL_04b2: ldc.i4.1
+		IL_04b3: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetBoolean(string, bool)
+		IL_04b8: dup
+		IL_04b9: ldstr "get"
+		IL_04be: ldloc.s 30
+		IL_04c0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_04c5: stloc.s 25
+		IL_04c7: ldloc.s 20
+		IL_04c9: ldstr "trim"
+		IL_04ce: ldloc.s 25
+		IL_04d0: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_04d5: pop
+		IL_04d6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04db: stloc.s 21
+		IL_04dd: ldc.i4.0
+		IL_04de: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_04e3: brfalse IL_04f9
+
+		IL_04e8: ldstr " abc "
+		IL_04ed: call string [JavaScriptRuntime]JavaScriptRuntime.String::Trim(string)
+		IL_04f2: stloc.s 20
+		IL_04f4: br IL_050a
+
+		IL_04f9: ldstr " abc "
+		IL_04fe: ldstr "trim"
+		IL_0503: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0508: stloc.s 20
+
+		IL_050a: ldloc.s 21
+		IL_050c: ldloc.s 20
+		IL_050e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0513: pop
+		IL_0514: ldstr "String"
+		IL_0519: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_051e: ldstr "prototype"
+		IL_0523: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0528: stloc.s 20
+		IL_052a: ldloc.s 20
+		IL_052c: ldstr "trim"
+		IL_0531: ldloc.s 8
+		IL_0533: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_0538: pop
+		IL_0539: ldstr "String"
+		IL_053e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0543: ldstr "prototype"
+		IL_0548: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_054d: stloc.s 20
+		IL_054f: ldloc.s 20
+		IL_0551: ldstr "toUpperCase"
+		IL_0556: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_055b: stloc.s 9
+		IL_055d: ldstr "Object"
+		IL_0562: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0567: ldstr "prototype"
+		IL_056c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0571: stloc.s 20
+		IL_0573: ldloc.s 20
+		IL_0575: ldstr "toUpperCase"
+		IL_057a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_057f: stloc.s 10
+		IL_0581: ldstr "String"
+		IL_0586: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_058b: ldstr "prototype"
+		IL_0590: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0595: stloc.s 20
+		IL_0597: ldloc.s 20
+		IL_0599: ldstr "toUpperCase"
+		IL_059e: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_05a3: stloc.s 31
+		IL_05a5: ldstr "Object"
+		IL_05aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_05af: ldstr "prototype"
+		IL_05b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_05b9: stloc.s 20
+		IL_05bb: ldc.i4.1
+		IL_05bc: newarr [System.Runtime]System.Object
+		IL_05c1: dup
+		IL_05c2: ldc.i4.0
+		IL_05c3: ldloc.0
+		IL_05c4: stelem.ref
+		IL_05c5: stloc.s 19
+		IL_05c7: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L64C31/FunctionObject::.ctor()
+		IL_05cc: ldc.i4.0
+		IL_05cd: conv.r8
+		IL_05ce: ldstr ""
+		IL_05d3: ldc.i4.0
+		IL_05d4: ldc.i4.1
+		IL_05d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L64C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_05da: stloc.s 32
+		IL_05dc: ldloc.s 20
+		IL_05de: ldstr "toUpperCase"
+		IL_05e3: ldloc.s 32
+		IL_05e5: ldc.i4.1
+		IL_05e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_05eb: pop
+		IL_05ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_05f1: stloc.s 21
+		IL_05f3: ldc.i4.0
+		IL_05f4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_05f9: brfalse IL_060f
+
+		IL_05fe: ldstr "abc"
+		IL_0603: call string [JavaScriptRuntime]JavaScriptRuntime.String::ToUpperCase(string)
+		IL_0608: stloc.s 20
+		IL_060a: br IL_0620
+
+		IL_060f: ldstr "abc"
+		IL_0614: ldstr "toUpperCase"
+		IL_0619: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_061e: stloc.s 20
+
+		IL_0620: ldloc.s 21
+		IL_0622: ldloc.s 20
+		IL_0624: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0629: pop
+		IL_062a: ldstr "String"
+		IL_062f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0634: ldstr "prototype"
+		IL_0639: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_063e: stloc.s 20
+		IL_0640: ldloc.s 20
+		IL_0642: ldstr "toUpperCase"
+		IL_0647: ldloc.s 9
+		IL_0649: ldc.i4.1
+		IL_064a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_064f: pop
+		IL_0650: ldloc.s 10
+		IL_0652: stloc.s 20
+		IL_0654: ldloc.s 20
+		IL_0656: ldnull
+		IL_0657: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_065c: stloc.s 31
+		IL_065e: ldloc.s 31
+		IL_0660: brfalse IL_068e
+
+		IL_0665: ldstr "Object"
+		IL_066a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_066f: ldstr "prototype"
+		IL_0674: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0679: stloc.s 20
+		IL_067b: ldloc.s 20
+		IL_067d: ldstr "toUpperCase"
+		IL_0682: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_0687: stloc.s 31
+		IL_0689: br IL_06b4
+
+		IL_068e: ldstr "Object"
+		IL_0693: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0698: ldstr "prototype"
+		IL_069d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06a2: stloc.s 20
+		IL_06a4: ldloc.s 20
+		IL_06a6: ldstr "toUpperCase"
+		IL_06ab: ldloc.s 10
+		IL_06ad: ldc.i4.1
+		IL_06ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_06b3: pop
+
+		IL_06b4: ldstr "String"
+		IL_06b9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06be: ldstr "prototype"
+		IL_06c3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06c8: stloc.s 20
+		IL_06ca: ldloc.s 20
+		IL_06cc: ldstr "includes"
+		IL_06d1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06d6: stloc.s 11
+		IL_06d8: ldstr "String"
+		IL_06dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_06e2: ldstr "prototype"
+		IL_06e7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_06ec: stloc.s 20
+		IL_06ee: ldloc.s 20
+		IL_06f0: ldstr "includes"
+		IL_06f5: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_06fa: stloc.s 31
 		.try
 		{
-			IL_043f: nop
-			IL_0440: ldc.i4.0
-			IL_0441: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-			IL_0446: brfalse IL_0460
+			IL_06fc: nop
+			IL_06fd: ldc.i4.0
+			IL_06fe: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0703: brfalse IL_071d
 
-			IL_044b: ldstr "abc"
-			IL_0450: ldstr "a"
-			IL_0455: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
-			IL_045a: pop
-			IL_045b: br IL_0475
+			IL_0708: ldstr "abc"
+			IL_070d: ldstr "a"
+			IL_0712: call bool [JavaScriptRuntime]JavaScriptRuntime.String::Includes(string, string)
+			IL_0717: pop
+			IL_0718: br IL_0732
 
-			IL_0460: ldstr "abc"
-			IL_0465: ldstr "includes"
-			IL_046a: ldstr "a"
-			IL_046f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-			IL_0474: pop
+			IL_071d: ldstr "abc"
+			IL_0722: ldstr "includes"
+			IL_0727: ldstr "a"
+			IL_072c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0731: pop
 
-			IL_0475: leave IL_04d0
+			IL_0732: leave IL_078d
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_047a: stloc.s 7
-			IL_047c: ldloc.s 7
-			IL_047e: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0483: dup
-			IL_0484: brtrue IL_049a
+			IL_0737: stloc.s 12
+			IL_0739: ldloc.s 12
+			IL_073b: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0740: dup
+			IL_0741: brtrue IL_0757
 
-			IL_0489: pop
-			IL_048a: ldloc.s 7
-			IL_048c: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_0491: dup
-			IL_0492: brtrue IL_04a6
+			IL_0746: pop
+			IL_0747: ldloc.s 12
+			IL_0749: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_074e: dup
+			IL_074f: brtrue IL_0763
 
-			IL_0497: pop
-			IL_0498: rethrow
+			IL_0754: pop
+			IL_0755: rethrow
 
-			IL_049a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_049f: stloc.s 8
-			IL_04a1: br IL_04a8
+			IL_0757: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_075c: stloc.s 13
+			IL_075e: br IL_0765
 
-			IL_04a6: stloc.s 8
+			IL_0763: stloc.s 13
 
-			IL_04a8: ldloc.s 8
-			IL_04aa: stloc.s 9
-			IL_04ac: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04b1: stloc.s 15
-			IL_04b3: ldloc.s 9
-			IL_04b5: ldstr "name"
-			IL_04ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04bf: stloc.s 16
-			IL_04c1: ldloc.s 15
-			IL_04c3: ldloc.s 16
-			IL_04c5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04ca: pop
-			IL_04cb: leave IL_04d0
+			IL_0765: ldloc.s 13
+			IL_0767: stloc.s 14
+			IL_0769: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_076e: stloc.s 21
+			IL_0770: ldloc.s 14
+			IL_0772: ldstr "name"
+			IL_0777: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_077c: stloc.s 20
+			IL_077e: ldloc.s 21
+			IL_0780: ldloc.s 20
+			IL_0782: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0787: pop
+			IL_0788: leave IL_078d
 		} // end handler
 
-		IL_04d0: ldstr "String"
-		IL_04d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_04da: ldstr "prototype"
-		IL_04df: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_04e4: stloc.s 16
-		IL_04e6: ldloc.s 16
-		IL_04e8: ldstr "includes"
-		IL_04ed: ldloc.s 6
-		IL_04ef: ldc.i4.1
-		IL_04f0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_04f5: pop
-		IL_04f6: ldstr "String"
-		IL_04fb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0500: ldstr "prototype"
-		IL_0505: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_050a: stloc.s 16
-		IL_050c: ldloc.s 16
-		IL_050e: ldstr "startsWith"
-		IL_0513: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0518: stloc.s 10
-		IL_051a: ldstr "String"
-		IL_051f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0524: ldstr "prototype"
-		IL_0529: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_052e: stloc.s 16
-		IL_0530: ldc.i4.1
-		IL_0531: newarr [System.Runtime]System.Object
-		IL_0536: dup
-		IL_0537: ldc.i4.0
-		IL_0538: ldloc.0
-		IL_0539: stelem.ref
-		IL_053a: stloc.s 14
-		IL_053c: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L58C30/FunctionObject::.ctor()
-		IL_0541: ldc.i4.1
-		IL_0542: conv.r8
-		IL_0543: ldstr ""
-		IL_0548: ldc.i4.0
-		IL_0549: ldc.i4.1
-		IL_054a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L58C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_054f: stloc.s 24
-		IL_0551: ldloc.s 16
-		IL_0553: ldstr "startsWith"
-		IL_0558: ldloc.s 24
-		IL_055a: ldc.i4.1
-		IL_055b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0560: pop
-		IL_0561: ldstr "abc"
-		IL_0566: ldstr "startsWith"
-		IL_056b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0570: stloc.s 11
-		IL_0572: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0577: stloc.s 15
-		IL_0579: ldloc.s 11
-		IL_057b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0580: ldstr "call"
-		IL_0585: ldstr "abc"
-		IL_058a: ldstr "a"
-		IL_058f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0594: stloc.s 16
-		IL_0596: ldloc.s 15
-		IL_0598: ldloc.s 16
-		IL_059a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_059f: pop
-		IL_05a0: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_05a5: stloc.s 15
-		IL_05a7: ldloc.s 11
-		IL_05a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_05ae: ldc.i4.1
-		IL_05af: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_05b4: dup
-		IL_05b5: ldstr "b"
-		IL_05ba: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
-		IL_05bf: stloc.s 25
-		IL_05c1: ldstr "apply"
-		IL_05c6: ldstr "abc"
-		IL_05cb: ldloc.s 25
-		IL_05cd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_05d2: stloc.s 16
-		IL_05d4: ldloc.s 15
-		IL_05d6: ldloc.s 16
-		IL_05d8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_05dd: pop
-		IL_05de: ldstr "String"
-		IL_05e3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_05e8: ldstr "prototype"
-		IL_05ed: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_05f2: stloc.s 16
-		IL_05f4: ldloc.s 16
-		IL_05f6: ldstr "startsWith"
-		IL_05fb: ldloc.s 10
-		IL_05fd: ldc.i4.1
-		IL_05fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0603: pop
-		IL_0604: ldstr "String"
-		IL_0609: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_060e: ldstr "prototype"
-		IL_0613: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0618: stloc.s 16
-		IL_061a: ldloc.s 16
-		IL_061c: ldstr "charCodeAt"
-		IL_0621: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0626: stloc.s 12
-		IL_0628: ldstr "String"
-		IL_062d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_0632: ldstr "prototype"
-		IL_0637: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_063c: stloc.s 16
-		IL_063e: ldc.i4.1
-		IL_063f: newarr [System.Runtime]System.Object
-		IL_0644: dup
-		IL_0645: ldc.i4.0
-		IL_0646: ldloc.0
-		IL_0647: stelem.ref
-		IL_0648: stloc.s 14
-		IL_064a: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L67C30/FunctionObject::.ctor()
-		IL_064f: ldc.i4.0
-		IL_0650: conv.r8
-		IL_0651: ldstr ""
-		IL_0656: ldc.i4.0
-		IL_0657: ldc.i4.1
-		IL_0658: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L67C30/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_065d: stloc.s 26
-		IL_065f: ldloc.s 16
-		IL_0661: ldstr "charCodeAt"
-		IL_0666: ldloc.s 26
-		IL_0668: ldc.i4.1
-		IL_0669: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_066e: pop
-		IL_066f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0674: stloc.s 15
-		IL_0676: ldc.i4.0
-		IL_0677: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_067c: brfalse IL_06a5
+		IL_078d: ldstr "String"
+		IL_0792: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0797: ldstr "prototype"
+		IL_079c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07a1: stloc.s 20
+		IL_07a3: ldloc.s 20
+		IL_07a5: ldstr "includes"
+		IL_07aa: ldloc.s 11
+		IL_07ac: ldc.i4.1
+		IL_07ad: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_07b2: pop
+		IL_07b3: ldstr "String"
+		IL_07b8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07bd: ldstr "prototype"
+		IL_07c2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07c7: stloc.s 20
+		IL_07c9: ldloc.s 20
+		IL_07cb: ldstr "startsWith"
+		IL_07d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07d5: stloc.s 15
+		IL_07d7: ldstr "String"
+		IL_07dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_07e1: ldstr "prototype"
+		IL_07e6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_07eb: stloc.s 20
+		IL_07ed: ldc.i4.1
+		IL_07ee: newarr [System.Runtime]System.Object
+		IL_07f3: dup
+		IL_07f4: ldc.i4.0
+		IL_07f5: ldloc.0
+		IL_07f6: stelem.ref
+		IL_07f7: stloc.s 19
+		IL_07f9: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L85C30/FunctionObject::.ctor()
+		IL_07fe: ldc.i4.1
+		IL_07ff: conv.r8
+		IL_0800: ldstr ""
+		IL_0805: ldc.i4.0
+		IL_0806: ldc.i4.1
+		IL_0807: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L85C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_080c: stloc.s 33
+		IL_080e: ldloc.s 20
+		IL_0810: ldstr "startsWith"
+		IL_0815: ldloc.s 33
+		IL_0817: ldc.i4.1
+		IL_0818: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_081d: pop
+		IL_081e: ldstr "abc"
+		IL_0823: ldstr "startsWith"
+		IL_0828: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_082d: stloc.s 16
+		IL_082f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0834: stloc.s 21
+		IL_0836: ldloc.s 16
+		IL_0838: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_083d: ldstr "call"
+		IL_0842: ldstr "abc"
+		IL_0847: ldstr "a"
+		IL_084c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0851: stloc.s 20
+		IL_0853: ldloc.s 21
+		IL_0855: ldloc.s 20
+		IL_0857: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_085c: pop
+		IL_085d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0862: stloc.s 21
+		IL_0864: ldloc.s 16
+		IL_0866: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_086b: ldc.i4.1
+		IL_086c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0871: dup
+		IL_0872: ldstr "b"
+		IL_0877: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_087c: stloc.s 34
+		IL_087e: ldstr "apply"
+		IL_0883: ldstr "abc"
+		IL_0888: ldloc.s 34
+		IL_088a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_088f: stloc.s 20
+		IL_0891: ldloc.s 21
+		IL_0893: ldloc.s 20
+		IL_0895: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_089a: pop
+		IL_089b: ldstr "String"
+		IL_08a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08a5: ldstr "prototype"
+		IL_08aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08af: stloc.s 20
+		IL_08b1: ldloc.s 20
+		IL_08b3: ldstr "startsWith"
+		IL_08b8: ldloc.s 15
+		IL_08ba: ldc.i4.1
+		IL_08bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_08c0: pop
+		IL_08c1: ldstr "String"
+		IL_08c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08cb: ldstr "prototype"
+		IL_08d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08d5: stloc.s 20
+		IL_08d7: ldloc.s 20
+		IL_08d9: ldstr "charCodeAt"
+		IL_08de: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08e3: stloc.s 17
+		IL_08e5: ldstr "String"
+		IL_08ea: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_08ef: ldstr "prototype"
+		IL_08f4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_08f9: stloc.s 20
+		IL_08fb: ldc.i4.1
+		IL_08fc: newarr [System.Runtime]System.Object
+		IL_0901: dup
+		IL_0902: ldc.i4.0
+		IL_0903: ldloc.0
+		IL_0904: stelem.ref
+		IL_0905: stloc.s 19
+		IL_0907: newobj instance void Modules.String_PrototypeMethodOverrides/FunctionExpression_L94C30/FunctionObject::.ctor()
+		IL_090c: ldc.i4.0
+		IL_090d: conv.r8
+		IL_090e: ldstr ""
+		IL_0913: ldc.i4.0
+		IL_0914: ldc.i4.1
+		IL_0915: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_PrototypeMethodOverrides/FunctionExpression_L94C30/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_091a: stloc.s 35
+		IL_091c: ldloc.s 20
+		IL_091e: ldstr "charCodeAt"
+		IL_0923: ldloc.s 35
+		IL_0925: ldc.i4.1
+		IL_0926: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_092b: pop
+		IL_092c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0931: stloc.s 21
+		IL_0933: ldc.i4.0
+		IL_0934: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0939: brfalse IL_0962
 
-		IL_0681: ldstr "A"
-		IL_0686: ldc.r8 0.0
-		IL_068f: box [System.Runtime]System.Double
-		IL_0694: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
-		IL_0699: box [System.Runtime]System.Double
-		IL_069e: stloc.s 16
-		IL_06a0: br IL_06c4
+		IL_093e: ldstr "A"
+		IL_0943: ldc.r8 0.0
+		IL_094c: box [System.Runtime]System.Double
+		IL_0951: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_0956: box [System.Runtime]System.Double
+		IL_095b: stloc.s 20
+		IL_095d: br IL_0981
 
-		IL_06a5: ldstr "A"
-		IL_06aa: ldstr "charCodeAt"
-		IL_06af: ldc.r8 0.0
-		IL_06b8: box [System.Runtime]System.Double
-		IL_06bd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_06c2: stloc.s 16
+		IL_0962: ldstr "A"
+		IL_0967: ldstr "charCodeAt"
+		IL_096c: ldc.r8 0.0
+		IL_0975: box [System.Runtime]System.Double
+		IL_097a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_097f: stloc.s 20
 
-		IL_06c4: ldloc.s 16
-		IL_06c6: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
-		IL_06cb: box [System.Runtime]System.Double
-		IL_06d0: stloc.s 27
-		IL_06d2: ldloc.s 15
-		IL_06d4: ldloc.s 27
-		IL_06d6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_06db: pop
-		IL_06dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_06e1: stloc.s 15
-		IL_06e3: ldc.i4.0
-		IL_06e4: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_06e9: brfalse IL_070d
+		IL_0981: ldloc.s 20
+		IL_0983: call float64 [JavaScriptRuntime]JavaScriptRuntime.Math::floor(object)
+		IL_0988: box [System.Runtime]System.Double
+		IL_098d: stloc.s 36
+		IL_098f: ldloc.s 21
+		IL_0991: ldloc.s 36
+		IL_0993: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0998: pop
+		IL_0999: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_099e: stloc.s 21
+		IL_09a0: ldc.i4.0
+		IL_09a1: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_09a6: brfalse IL_09ca
 
-		IL_06ee: ldstr "A"
-		IL_06f3: ldc.r8 0.0
-		IL_06fc: box [System.Runtime]System.Double
-		IL_0701: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
-		IL_0706: stloc.s 28
-		IL_0708: br IL_0731
+		IL_09ab: ldstr "A"
+		IL_09b0: ldc.r8 0.0
+		IL_09b9: box [System.Runtime]System.Double
+		IL_09be: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_09c3: stloc.s 37
+		IL_09c5: br IL_09ee
 
-		IL_070d: ldstr "A"
-		IL_0712: ldstr "charCodeAt"
-		IL_0717: ldc.r8 0.0
-		IL_0720: box [System.Runtime]System.Double
-		IL_0725: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_072a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_072f: stloc.s 28
+		IL_09ca: ldstr "A"
+		IL_09cf: ldstr "charCodeAt"
+		IL_09d4: ldc.r8 0.0
+		IL_09dd: box [System.Runtime]System.Double
+		IL_09e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_09e7: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+		IL_09ec: stloc.s 37
 
-		IL_0731: ldloc.s 28
-		IL_0733: box [System.Runtime]System.Double
-		IL_0738: stloc.s 27
-		IL_073a: ldloc.s 15
-		IL_073c: ldloc.s 27
-		IL_073e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0743: pop
-		IL_0744: ldstr "String"
-		IL_0749: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_074e: ldstr "prototype"
-		IL_0753: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0758: stloc.s 16
-		IL_075a: ldloc.s 16
-		IL_075c: ldstr "charCodeAt"
-		IL_0761: ldloc.s 12
-		IL_0763: ldc.i4.1
-		IL_0764: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0769: pop
-		IL_076a: ldnull
-		IL_076b: stloc.s 13
-		IL_076d: ret
+		IL_09ee: ldloc.s 37
+		IL_09f0: box [System.Runtime]System.Double
+		IL_09f5: stloc.s 36
+		IL_09f7: ldloc.s 21
+		IL_09f9: ldloc.s 36
+		IL_09fb: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0a00: pop
+		IL_0a01: ldstr "String"
+		IL_0a06: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0a0b: ldstr "prototype"
+		IL_0a10: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0a15: stloc.s 20
+		IL_0a17: ldloc.s 20
+		IL_0a19: ldstr "charCodeAt"
+		IL_0a1e: ldloc.s 17
+		IL_0a20: ldc.i4.1
+		IL_0a21: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0a26: pop
+		IL_0a27: ldnull
+		IL_0a28: stloc.s 18
+		IL_0a2a: ret
 	} // end of method String_PrototypeMethodOverrides::__js_module_init__
 
 } // end of class Modules.String_PrototypeMethodOverrides

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Regex_Empty.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Split_Regex_Empty.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 882 (0x372)
+		// Code size: 920 (0x398)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Split_Regex_Empty/Scope,
@@ -194,121 +194,135 @@
 		IL_01e5: stloc.s 8
 		IL_01e7: ldc.i4.0
 		IL_01e8: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_01ed: brfalse IL_021f
+		IL_01ed: brfalse IL_0232
 
 		IL_01f2: ldloc.s 8
 		IL_01f4: isinst [System.Runtime]System.String
 		IL_01f9: dup
-		IL_01fa: brfalse IL_021e
+		IL_01fa: brtrue IL_0212
 
-		IL_01ff: ldc.r8 0.0
-		IL_0208: box [System.Runtime]System.Double
-		IL_020d: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
-		IL_0212: box [System.Runtime]System.Double
-		IL_0217: stloc.s 8
-		IL_0219: br IL_023b
+		IL_01ff: pop
+		IL_0200: ldloc.s 8
+		IL_0202: ldstr "charCodeAt"
+		IL_0207: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_020c: dup
+		IL_020d: brfalse IL_0231
 
-		IL_021e: pop
+		IL_0212: ldc.r8 0.0
+		IL_021b: box [System.Runtime]System.Double
+		IL_0220: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_0225: box [System.Runtime]System.Double
+		IL_022a: stloc.s 8
+		IL_022c: br IL_024e
 
-		IL_021f: ldloc.s 8
-		IL_0221: ldstr "charCodeAt"
-		IL_0226: ldc.r8 0.0
-		IL_022f: box [System.Runtime]System.Double
-		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0239: stloc.s 8
+		IL_0231: pop
 
-		IL_023b: ldloc.s 7
-		IL_023d: ldloc.s 8
-		IL_023f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0244: pop
-		IL_0245: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_024a: stloc.s 7
-		IL_024c: ldloc.s 4
-		IL_024e: ldc.r8 1
-		IL_0257: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_025c: stloc.s 8
-		IL_025e: ldloc.s 8
-		IL_0260: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0265: stloc.s 8
-		IL_0267: ldc.i4.0
-		IL_0268: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_026d: brfalse IL_029f
+		IL_0232: ldloc.s 8
+		IL_0234: ldstr "charCodeAt"
+		IL_0239: ldc.r8 0.0
+		IL_0242: box [System.Runtime]System.Double
+		IL_0247: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_024c: stloc.s 8
 
-		IL_0272: ldloc.s 8
-		IL_0274: isinst [System.Runtime]System.String
-		IL_0279: dup
-		IL_027a: brfalse IL_029e
+		IL_024e: ldloc.s 7
+		IL_0250: ldloc.s 8
+		IL_0252: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0257: pop
+		IL_0258: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_025d: stloc.s 7
+		IL_025f: ldloc.s 4
+		IL_0261: ldc.r8 1
+		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_026f: stloc.s 8
+		IL_0271: ldloc.s 8
+		IL_0273: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0278: stloc.s 8
+		IL_027a: ldc.i4.0
+		IL_027b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0280: brfalse IL_02c5
 
-		IL_027f: ldc.r8 0.0
-		IL_0288: box [System.Runtime]System.Double
-		IL_028d: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
-		IL_0292: box [System.Runtime]System.Double
-		IL_0297: stloc.s 8
-		IL_0299: br IL_02bb
+		IL_0285: ldloc.s 8
+		IL_0287: isinst [System.Runtime]System.String
+		IL_028c: dup
+		IL_028d: brtrue IL_02a5
 
-		IL_029e: pop
+		IL_0292: pop
+		IL_0293: ldloc.s 8
+		IL_0295: ldstr "charCodeAt"
+		IL_029a: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+		IL_029f: dup
+		IL_02a0: brfalse IL_02c4
 
-		IL_029f: ldloc.s 8
-		IL_02a1: ldstr "charCodeAt"
-		IL_02a6: ldc.r8 0.0
-		IL_02af: box [System.Runtime]System.Double
-		IL_02b4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b9: stloc.s 8
+		IL_02a5: ldc.r8 0.0
+		IL_02ae: box [System.Runtime]System.Double
+		IL_02b3: call float64 [JavaScriptRuntime]JavaScriptRuntime.String::CharCodeAt(string, object)
+		IL_02b8: box [System.Runtime]System.Double
+		IL_02bd: stloc.s 8
+		IL_02bf: br IL_02e1
 
-		IL_02bb: ldloc.s 7
-		IL_02bd: ldloc.s 8
-		IL_02bf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
 		IL_02c4: pop
-		IL_02c5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02ca: stloc.s 7
-		IL_02cc: ldloc.s 4
-		IL_02ce: ldc.r8 2
-		IL_02d7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_02dc: stloc.s 8
-		IL_02de: ldloc.s 7
-		IL_02e0: ldloc.s 8
-		IL_02e2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02e7: pop
-		IL_02e8: ldstr "(?:)"
-		IL_02ed: ldstr "u"
-		IL_02f2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
-		IL_02f7: stloc.s 6
-		IL_02f9: ldstr "\ud83d\ude00a"
-		IL_02fe: ldstr "split"
-		IL_0303: ldloc.s 6
-		IL_0305: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_030a: stloc.s 5
-		IL_030c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0311: stloc.s 7
-		IL_0313: ldloc.s 5
-		IL_0315: ldstr "length"
-		IL_031a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_031f: stloc.s 8
-		IL_0321: ldloc.s 7
-		IL_0323: ldloc.s 8
-		IL_0325: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_032a: pop
-		IL_032b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0330: stloc.s 7
-		IL_0332: ldloc.s 5
-		IL_0334: ldc.r8 0.0
-		IL_033d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0342: stloc.s 8
-		IL_0344: ldloc.s 7
-		IL_0346: ldloc.s 8
-		IL_0348: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_034d: pop
-		IL_034e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0353: stloc.s 7
-		IL_0355: ldloc.s 5
-		IL_0357: ldc.r8 1
-		IL_0360: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0365: stloc.s 8
-		IL_0367: ldloc.s 7
-		IL_0369: ldloc.s 8
-		IL_036b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0370: pop
-		IL_0371: ret
+
+		IL_02c5: ldloc.s 8
+		IL_02c7: ldstr "charCodeAt"
+		IL_02cc: ldc.r8 0.0
+		IL_02d5: box [System.Runtime]System.Double
+		IL_02da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02df: stloc.s 8
+
+		IL_02e1: ldloc.s 7
+		IL_02e3: ldloc.s 8
+		IL_02e5: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02ea: pop
+		IL_02eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02f0: stloc.s 7
+		IL_02f2: ldloc.s 4
+		IL_02f4: ldc.r8 2
+		IL_02fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0302: stloc.s 8
+		IL_0304: ldloc.s 7
+		IL_0306: ldloc.s 8
+		IL_0308: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_030d: pop
+		IL_030e: ldstr "(?:)"
+		IL_0313: ldstr "u"
+		IL_0318: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.RegExp::.ctor(object, object)
+		IL_031d: stloc.s 6
+		IL_031f: ldstr "\ud83d\ude00a"
+		IL_0324: ldstr "split"
+		IL_0329: ldloc.s 6
+		IL_032b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0330: stloc.s 5
+		IL_0332: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0337: stloc.s 7
+		IL_0339: ldloc.s 5
+		IL_033b: ldstr "length"
+		IL_0340: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0345: stloc.s 8
+		IL_0347: ldloc.s 7
+		IL_0349: ldloc.s 8
+		IL_034b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0350: pop
+		IL_0351: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0356: stloc.s 7
+		IL_0358: ldloc.s 5
+		IL_035a: ldc.r8 0.0
+		IL_0363: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0368: stloc.s 8
+		IL_036a: ldloc.s 7
+		IL_036c: ldloc.s 8
+		IL_036e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0373: pop
+		IL_0374: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0379: stloc.s 7
+		IL_037b: ldloc.s 5
+		IL_037d: ldc.r8 1
+		IL_0386: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_038b: stloc.s 8
+		IL_038d: ldloc.s 7
+		IL_038f: ldloc.s 8
+		IL_0391: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0396: pop
+		IL_0397: ret
 	} // end of method String_Split_Regex_Empty::__js_module_init__
 
 } // end of class Modules.String_Split_Regex_Empty

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_NestedParam.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_NestedParam.verified.txt
@@ -161,7 +161,7 @@
 					01 00 02 00 00 00 00 00
 				)
 				// Header size: 12
-				// Code size: 75 (0x4b)
+				// Code size: 93 (0x5d)
 				.maxstack 8
 				.locals init (
 					[0] object
@@ -176,29 +176,36 @@
 				IL_0012: stloc.0
 				IL_0013: ldc.i4.0
 				IL_0014: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-				IL_0019: brfalse IL_003c
+				IL_0019: brfalse IL_004e
 
 				IL_001e: ldloc.0
 				IL_001f: isinst [System.Runtime]System.String
 				IL_0024: dup
-				IL_0025: brfalse IL_003b
+				IL_0025: brtrue IL_003c
 
-				IL_002a: ldarg.2
-				IL_002b: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
-				IL_0030: box [System.Runtime]System.Boolean
-				IL_0035: stloc.0
-				IL_0036: br IL_0049
+				IL_002a: pop
+				IL_002b: ldloc.0
+				IL_002c: ldstr "startsWith"
+				IL_0031: call string [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::TryUnwrapStringObjectReceiver(object, string)
+				IL_0036: dup
+				IL_0037: brfalse IL_004d
 
-				IL_003b: pop
+				IL_003c: ldarg.2
+				IL_003d: call bool [JavaScriptRuntime]JavaScriptRuntime.String::StartsWith(string, string)
+				IL_0042: box [System.Runtime]System.Boolean
+				IL_0047: stloc.0
+				IL_0048: br IL_005b
 
-				IL_003c: ldloc.0
-				IL_003d: ldstr "startsWith"
-				IL_0042: ldarg.2
-				IL_0043: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-				IL_0048: stloc.0
+				IL_004d: pop
 
-				IL_0049: ldloc.0
-				IL_004a: ret
+				IL_004e: ldloc.0
+				IL_004f: ldstr "startsWith"
+				IL_0054: ldarg.2
+				IL_0055: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+				IL_005a: stloc.0
+
+				IL_005b: ldloc.0
+				IL_005c: ret
 			} // end of method inner::__js_call__
 
 		} // end of class inner

--- a/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
+++ b/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
@@ -116,6 +116,44 @@ public class SymbolTableTypeInferenceTests
         Assert.Null(secondBinding.ClrType);
     }
 
+    [Fact]
+    public void SymbolTable_ReceiverCandidates_PreserveCapturedStringAcrossDeferredWrites()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            var text;
+            function invoke(callback) {
+                callback();
+            }
+            invoke(function () {
+                text = new String('seed');
+            });
+            invoke(function () {
+                text += text;
+            });
+        ");
+
+        var text = symbolTable.GetBindingInfo("text");
+        Assert.NotNull(text);
+        Assert.Contains(typeof(string), text.ReceiverCandidateClrTypes);
+        Assert.NotEqual(typeof(string), text.ClrType);
+    }
+
+    [Fact]
+    public void SymbolTable_ReceiverCandidates_TrackArrayAndTypedArrayWrites()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            var values = [];
+            var typed = new Int32Array(4);
+        ");
+
+        var values = symbolTable.GetBindingInfo("values");
+        var typed = symbolTable.GetBindingInfo("typed");
+        Assert.NotNull(values);
+        Assert.NotNull(typed);
+        Assert.Contains(typeof(JavaScriptRuntime.Array), values.ReceiverCandidateClrTypes);
+        Assert.Contains(typeof(JavaScriptRuntime.Int32Array), typed.ReceiverCandidateClrTypes);
+    }
+
     [Theory]
     [InlineData(typeof(double), "42", "testVar++")]
     [InlineData(typeof(double), "42", "++testVar")]
@@ -1229,6 +1267,21 @@ public class SymbolTableTypeInferenceTests
         Assert.NotNull(tmpBinding);
         Assert.True(tmpBinding!.IsStableType);
         Assert.Equal(typeof(JavaScriptRuntime.Array), tmpBinding.ClrType);
+    }
+
+    [Fact]
+    public void SymbolTable_ReceiverCandidates_DromaeoObjectString_StrIncludesString()
+    {
+        const string resourceName = "Jroc.Tests.Integration.JavaScript.Compile_Performance_Dromaeo_Object_String.js";
+        using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName);
+        Assert.NotNull(stream);
+
+        using var reader = new StreamReader(stream!);
+        var symbolTable = BuildSymbolTable(reader.ReadToEnd());
+
+        var str = symbolTable.GetBindingInfo("str");
+        Assert.NotNull(str);
+        Assert.Contains(typeof(string), str.ReceiverCandidateClrTypes);
     }
 
     [Fact]

--- a/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
+++ b/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
@@ -139,6 +139,32 @@ public class SymbolTableTypeInferenceTests
     }
 
     [Fact]
+    public void SymbolTable_ReceiverCandidates_DoNotTreatStringObjectAsPrimitiveString()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            var text = new String('seed');
+        ");
+
+        var text = symbolTable.GetBindingInfo("text");
+        Assert.NotNull(text);
+        Assert.DoesNotContain(typeof(string), text.ReceiverCandidateClrTypes);
+    }
+
+    [Fact]
+    public void SymbolTable_ReceiverCandidates_IgnoreNonAdditionCompoundAssignmentRhs()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            var text = 'seed';
+            var value = 1;
+            value -= text;
+        ");
+
+        var value = symbolTable.GetBindingInfo("value");
+        Assert.NotNull(value);
+        Assert.DoesNotContain(typeof(string), value.ReceiverCandidateClrTypes);
+    }
+
+    [Fact]
     public void SymbolTable_ReceiverCandidates_TrackArrayAndTypedArrayWrites()
     {
         var symbolTable = BuildSymbolTable(@"

--- a/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
+++ b/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
@@ -350,6 +350,124 @@ public class SymbolTableTypeInferenceTests
         Assert.True(identityScope.ReceiverReturnTypeSummary.IsEmpty);
     }
 
+    [Fact]
+    public void SymbolTable_ReceiverCandidates_DoNotPropagateExportedCallableInputs()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            export const identity = value => value;
+            identity('text');
+        ");
+
+        var identity = symbolTable.GetBindingInfo("identity");
+        var identityScope = FindFirstScope(
+            symbolTable.Root,
+            scope => scope.Kind == ScopeKind.Function
+                && scope.Parameters.Contains("value"));
+
+        Assert.NotNull(identity);
+        Assert.NotNull(identityScope);
+        Assert.NotNull(identity!.CallableMaterialization);
+        Assert.NotEqual(
+            CallableMaterializationKind.DirectOnly,
+            identity.CallableMaterialization!.Kind);
+        Assert.True(
+            identity.CallableMaterialization.Reasons.HasFlag(
+                CallableMaterializationReason.Export));
+        Assert.Empty(identityScope!.StableParameterClrTypes);
+        Assert.Empty(identityScope.ReceiverParameterTypeSummaries);
+        Assert.True(identityScope.ReceiverReturnTypeSummary.IsEmpty);
+    }
+
+    [Fact]
+    public void SymbolTable_ReceiverCandidates_DoNotPropagateNamedExportCallableInputs()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            const identity = value => value;
+            const local = number => number;
+            identity('text');
+            local(1);
+            export { identity as local };
+        ");
+
+        var identity = symbolTable.GetBindingInfo("identity");
+        var identityScope = FindFirstScope(
+            symbolTable.Root,
+            scope => scope.Kind == ScopeKind.Function
+                && scope.Parameters.Contains("value"));
+        var localScope = FindFirstScope(
+            symbolTable.Root,
+            scope => scope.Kind == ScopeKind.Function
+                && scope.Parameters.Contains("number"));
+
+        Assert.NotNull(identity);
+        Assert.NotNull(identityScope);
+        Assert.NotNull(localScope);
+        Assert.NotNull(identity!.CallableMaterialization);
+        Assert.NotEqual(
+            CallableMaterializationKind.DirectOnly,
+            identity.CallableMaterialization!.Kind);
+        Assert.True(
+            identity.CallableMaterialization.Reasons.HasFlag(
+                CallableMaterializationReason.Export));
+        Assert.Empty(identityScope!.StableParameterClrTypes);
+        Assert.Empty(identityScope.ReceiverParameterTypeSummaries);
+        Assert.True(identityScope.ReceiverReturnTypeSummary.IsEmpty);
+        AssertStableParameterType(
+            localScope!,
+            0,
+            "number",
+            typeof(double));
+    }
+
+    [Fact]
+    public void SymbolTable_ReceiverCandidates_PreservePrivateCallableInsideExport()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            export function outer() {
+                const identity = value => value;
+                identity('text');
+            }
+        ");
+
+        var identityScope = FindFirstScope(
+            symbolTable.Root,
+            scope => scope.Kind == ScopeKind.Function
+                && scope.Parameters.Contains("value"));
+
+        Assert.NotNull(identityScope);
+        AssertStableParameterType(
+            identityScope!,
+            0,
+            "value",
+            typeof(string));
+        Assert.True(
+            identityScope.ReceiverParameterTypeSummaries.ContainsKey(0));
+    }
+
+    [Fact]
+    public void SymbolTable_ReceiverCandidates_DoNotPropagateExportedClassMethodInputs()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            export class Box {
+                identity(value) {
+                    return value;
+                }
+            }
+            const box = new Box();
+            box.identity('text');
+        ");
+
+        var identityScope = FindFirstScope(
+            symbolTable.Root,
+            scope => scope.Kind == ScopeKind.Function
+                && scope.Parameters.Contains("value"));
+
+        Assert.NotNull(identityScope);
+        Assert.Empty(identityScope!.StableParameterClrTypes);
+        Assert.Empty(identityScope.ReceiverParameterTypeSummaries);
+        Assert.True(identityScope.ReceiverReturnTypeSummary.IsEmpty);
+    }
+
     [Theory]
     [InlineData(typeof(double), "42", "testVar++")]
     [InlineData(typeof(double), "42", "++testVar")]

--- a/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
+++ b/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
@@ -180,6 +180,176 @@ public class SymbolTableTypeInferenceTests
         Assert.Contains(typeof(JavaScriptRuntime.Int32Array), typed.ReceiverCandidateClrTypes);
     }
 
+    [Fact]
+    public void SymbolTable_ReceiverCandidates_PropagateDirectClosureParametersAndReturns()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            const identity = value => value;
+            var first = identity('text');
+            var second = identity([]);
+        ");
+
+        var identityScope = FindFirstScope(
+            symbolTable.Root,
+            scope => scope.Kind == ScopeKind.Function
+                && scope.Parameters.Contains("value"));
+        Assert.NotNull(identityScope);
+
+        var parameterSummary =
+            identityScope!.ReceiverParameterTypeSummaries[0];
+        Assert.False(parameterSummary.IncludesUnknown);
+        Assert.False(parameterSummary.IncludesNonCandidate);
+        Assert.Equal(
+            [
+                typeof(JavaScriptRuntime.Array),
+                typeof(string)
+            ],
+            parameterSummary.CandidateClrTypes.OrderBy(
+                static type => type.FullName));
+
+        Assert.False(identityScope.ReceiverReturnTypeSummary.IncludesUnknown);
+        Assert.False(
+            identityScope.ReceiverReturnTypeSummary.IncludesNonCandidate);
+        Assert.Contains(
+            typeof(string),
+            identityScope.ReceiverReturnTypeSummary.CandidateClrTypes);
+        Assert.Contains(
+            typeof(JavaScriptRuntime.Array),
+            identityScope.ReceiverReturnTypeSummary.CandidateClrTypes);
+
+        var first = symbolTable.GetBindingInfo("first");
+        var second = symbolTable.GetBindingInfo("second");
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Contains(typeof(string), first.ReceiverCandidateClrTypes);
+        Assert.Contains(
+            typeof(JavaScriptRuntime.Array),
+            first.ReceiverCandidateClrTypes);
+        Assert.Contains(typeof(string), second.ReceiverCandidateClrTypes);
+        Assert.Contains(
+            typeof(JavaScriptRuntime.Array),
+            second.ReceiverCandidateClrTypes);
+    }
+
+    [Fact]
+    public void SymbolTable_ReceiverCandidates_SeedDirectClosureCaptureAfterProvenWrite()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            let value;
+            const read = () => value.trim();
+            value = 'ready';
+            read();
+        ");
+
+        var value = symbolTable.GetBindingInfo("value");
+        var readScope = FindFirstScope(
+            symbolTable.Root,
+            scope => scope.Kind == ScopeKind.Function
+                && scope.Parent?.Kind == ScopeKind.Global);
+        Assert.NotNull(value);
+        Assert.NotNull(readScope);
+
+        var capturedSummary =
+            readScope!.ReceiverCapturedEntryTypeSummaries[value!];
+        Assert.False(capturedSummary.IncludesUnknown);
+        Assert.False(capturedSummary.IncludesNonCandidate);
+        Assert.Equal(
+            [typeof(string)],
+            capturedSummary.CandidateClrTypes);
+    }
+
+    [Fact]
+    public void SymbolTable_ReceiverCandidates_PreserveUncertainDirectCallInputs()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            const identity = value => value;
+            identity('text');
+            identity(1);
+            identity(getValue());
+        ");
+
+        var identityScope = FindFirstScope(
+            symbolTable.Root,
+            scope => scope.Kind == ScopeKind.Function
+                && scope.Parameters.Contains("value"));
+        Assert.NotNull(identityScope);
+
+        var parameterSummary =
+            identityScope!.ReceiverParameterTypeSummaries[0];
+        Assert.True(parameterSummary.IncludesUnknown);
+        Assert.True(parameterSummary.IncludesNonCandidate);
+        Assert.Equal(
+            [typeof(string)],
+            parameterSummary.CandidateClrTypes);
+        Assert.Equal(
+            parameterSummary,
+            identityScope.ReceiverReturnTypeSummary);
+    }
+
+    [Fact]
+    public void SymbolTable_ReceiverCandidates_DoNotSeedUnprovenOrEscapingClosureCapture()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            let value;
+            const read = () => value.trim();
+            consume(read);
+            value = 'ready';
+            read();
+        ");
+
+        var readScope = FindFirstScope(
+            symbolTable.Root,
+            scope => scope.Kind == ScopeKind.Function
+                && scope.Parent?.Kind == ScopeKind.Global);
+        Assert.NotNull(readScope);
+        Assert.Empty(readScope!.ReceiverCapturedEntryTypeSummaries);
+    }
+
+    [Fact]
+    public void SymbolTable_ReceiverCandidates_KeepUnprovenClosureEntryUnknown()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            let value;
+            const read = () => value.trim();
+            value = [];
+            value = 'ready';
+            0;
+            read();
+        ");
+
+        var value = symbolTable.GetBindingInfo("value");
+        var readScope = FindFirstScope(
+            symbolTable.Root,
+            scope => scope.Kind == ScopeKind.Function
+                && scope.Parent?.Kind == ScopeKind.Global);
+        Assert.NotNull(value);
+        Assert.NotNull(readScope);
+
+        Assert.False(
+            readScope!.ReceiverCapturedEntryTypeSummaries.TryGetValue(
+                value!,
+                out var summary)
+            && summary.HasCandidates);
+    }
+
+    [Fact]
+    public void SymbolTable_ReceiverCandidates_DoNotPropagateEscapingCallableArguments()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            const identity = value => value;
+            consume(identity);
+            identity('text');
+        ");
+
+        var identityScope = FindFirstScope(
+            symbolTable.Root,
+            scope => scope.Kind == ScopeKind.Function
+                && scope.Parameters.Contains("value"));
+        Assert.NotNull(identityScope);
+        Assert.Empty(identityScope!.ReceiverParameterTypeSummaries);
+        Assert.True(identityScope.ReceiverReturnTypeSummary.IsEmpty);
+    }
+
     [Theory]
     [InlineData(typeof(double), "42", "testVar++")]
     [InlineData(typeof(double), "42", "++testVar")]

--- a/tests/Jroc.Tests/TypedArray/ExecutionTests.cs
+++ b/tests/Jroc.Tests/TypedArray/ExecutionTests.cs
@@ -100,6 +100,9 @@ namespace Jroc.Tests.TypedArray
         public Task Int32Array_Fill_Reverse_Join_LastIndexOf() { var testName = nameof(Int32Array_Fill_Reverse_Join_LastIndexOf); return ExecutionTest(testName); }
 
         [Fact]
+        public Task TypedArray_ReceiverCandidate_GuardedOverrides() { var testName = nameof(TypedArray_ReceiverCandidate_GuardedOverrides); return ExecutionTest(testName); }
+
+        [Fact]
         public Task TypedArray_ConstructorAndSet_Errors() { var testName = nameof(TypedArray_ConstructorAndSet_Errors); return ExecutionTest(testName); }
 
         [Fact]

--- a/tests/Jroc.Tests/TypedArray/GeneratorTests.cs
+++ b/tests/Jroc.Tests/TypedArray/GeneratorTests.cs
@@ -37,6 +37,9 @@ namespace Jroc.Tests.TypedArray
         public Task Int32Array_Construct_Length() { var testName = nameof(Int32Array_Construct_Length); return GenerateTest(testName); }
 
         [Fact]
+        public Task TypedArray_ReceiverCandidate_GuardedOverrides() { var testName = nameof(TypedArray_ReceiverCandidate_GuardedOverrides); return GenerateTest(testName); }
+
+        [Fact]
         public Task Int32Array_FromArray_CopyAndCoerce() { var testName = nameof(Int32Array_FromArray_CopyAndCoerce); return GenerateTest(testName); }
 
         [Fact]

--- a/tests/Jroc.Tests/TypedArray/JavaScript/TypedArray_ReceiverCandidate_GuardedOverrides.js
+++ b/tests/Jroc.Tests/TypedArray/JavaScript/TypedArray_ReceiverCandidate_GuardedOverrides.js
@@ -2,23 +2,27 @@
 
 let receiver;
 receiver = new Int32Array([1, 2, 3]);
-console.log(receiver.includes(2) ? "included" : "missing");
+console.log(receiver.includes(1) ? "cold included" : "cold missing");
 
-receiver.includes = function () {
-    return false;
-};
-console.log(receiver.includes(2) ? "own" : "own override");
+for (let iteration = 0; iteration < 1; iteration++) {
+    console.log(receiver.includes(2) ? "included" : "missing");
 
-delete receiver.includes;
-Object.setPrototypeOf(receiver, {
-    includes() {
+    receiver.includes = function () {
         return false;
-    }
-});
-console.log(receiver.includes(2) ? "custom" : "custom override");
+    };
+    console.log(receiver.includes(2) ? "own" : "own override");
 
-Object.setPrototypeOf(receiver, Int32Array.prototype);
-Int32Array.prototype.includes = function () {
-    return false;
-};
-console.log(receiver.includes(2) ? "prototype" : "prototype override");
+    delete receiver.includes;
+    Object.setPrototypeOf(receiver, {
+        includes() {
+            return false;
+        }
+    });
+    console.log(receiver.includes(2) ? "custom" : "custom override");
+
+    Object.setPrototypeOf(receiver, Int32Array.prototype);
+    Int32Array.prototype.includes = function () {
+        return false;
+    };
+    console.log(receiver.includes(2) ? "prototype" : "prototype override");
+}

--- a/tests/Jroc.Tests/TypedArray/JavaScript/TypedArray_ReceiverCandidate_GuardedOverrides.js
+++ b/tests/Jroc.Tests/TypedArray/JavaScript/TypedArray_ReceiverCandidate_GuardedOverrides.js
@@ -1,0 +1,24 @@
+"use strict";
+
+let receiver;
+receiver = new Int32Array([1, 2, 3]);
+console.log(receiver.includes(2) ? "included" : "missing");
+
+receiver.includes = function () {
+    return false;
+};
+console.log(receiver.includes(2) ? "own" : "own override");
+
+delete receiver.includes;
+Object.setPrototypeOf(receiver, {
+    includes() {
+        return false;
+    }
+});
+console.log(receiver.includes(2) ? "custom" : "custom override");
+
+Object.setPrototypeOf(receiver, Int32Array.prototype);
+Int32Array.prototype.includes = function () {
+    return false;
+};
+console.log(receiver.includes(2) ? "prototype" : "prototype override");

--- a/tests/Jroc.Tests/TypedArray/Snapshots/ExecutionTests.TypedArray_ReceiverCandidate_GuardedOverrides.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/ExecutionTests.TypedArray_ReceiverCandidate_GuardedOverrides.verified.txt
@@ -1,3 +1,4 @@
+cold included
 included
 own override
 custom override

--- a/tests/Jroc.Tests/TypedArray/Snapshots/ExecutionTests.TypedArray_ReceiverCandidate_GuardedOverrides.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/ExecutionTests.TypedArray_ReceiverCandidate_GuardedOverrides.verified.txt
@@ -1,0 +1,4 @@
+included
+own override
+custom override
+prototype override

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Construct_ArrayBuffer_Search.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Construct_ArrayBuffer_Search.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 667 (0x29b)
+		// Code size: 868 (0x364)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Float64Array_Construct_ArrayBuffer_Search/Scope,
@@ -162,91 +162,159 @@
 		IL_016b: pop
 		IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0171: stloc.s 5
-		IL_0173: ldloc.3
-		IL_0174: ldstr "includes"
-		IL_0179: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_0182: box [System.Runtime]System.Double
-		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_018c: stloc.s 8
-		IL_018e: ldloc.s 5
-		IL_0190: ldloc.s 8
-		IL_0192: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0197: pop
-		IL_0198: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_019d: stloc.s 5
-		IL_019f: ldloc.3
-		IL_01a0: ldstr "indexOf"
-		IL_01a5: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_01ae: box [System.Runtime]System.Double
-		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01b8: stloc.s 8
-		IL_01ba: ldloc.s 5
-		IL_01bc: ldloc.s 8
-		IL_01be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01c3: pop
-		IL_01c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01c9: stloc.s 5
-		IL_01cb: ldc.r8 1
-		IL_01d4: neg
-		IL_01d5: stloc.s 6
-		IL_01d7: ldloc.s 6
-		IL_01d9: box [System.Runtime]System.Double
-		IL_01de: stloc.s 7
-		IL_01e0: ldloc.2
-		IL_01e1: ldstr "at"
-		IL_01e6: ldloc.s 7
-		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01ed: stloc.s 8
-		IL_01ef: ldloc.s 5
-		IL_01f1: ldloc.s 8
-		IL_01f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01f8: pop
-		IL_01f9: ldloc.3
-		IL_01fa: ldstr "slice"
-		IL_01ff: ldc.r8 1
-		IL_0208: box [System.Runtime]System.Double
-		IL_020d: ldc.r8 3
-		IL_0216: box [System.Runtime]System.Double
-		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_0220: stloc.s 4
-		IL_0222: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0227: stloc.s 5
-		IL_0229: ldloc.s 4
-		IL_022b: ldstr "buffer"
-		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_0235: stloc.s 8
-		IL_0237: ldloc.s 8
-		IL_0239: ldloc.1
-		IL_023a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_023f: stloc.s 9
-		IL_0241: ldloc.s 9
-		IL_0243: box [System.Runtime]System.Boolean
-		IL_0248: stloc.s 10
-		IL_024a: ldloc.s 5
-		IL_024c: ldloc.s 10
-		IL_024e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0253: pop
-		IL_0254: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0259: stloc.s 5
-		IL_025b: ldloc.s 4
-		IL_025d: ldc.r8 0.0
-		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_026b: stloc.s 8
-		IL_026d: ldloc.s 5
-		IL_026f: ldloc.s 8
-		IL_0271: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0276: pop
-		IL_0277: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_027c: stloc.s 5
-		IL_027e: ldloc.s 4
-		IL_0280: ldc.r8 1
-		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_028e: stloc.s 8
-		IL_0290: ldloc.s 5
-		IL_0292: ldloc.s 8
-		IL_0294: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0299: pop
-		IL_029a: ret
+		IL_0173: ldc.i4.2
+		IL_0174: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0179: brfalse IL_01ba
+
+		IL_017e: ldloc.3
+		IL_017f: ldstr "includes"
+		IL_0184: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_0189: brtrue IL_01ba
+
+		IL_018e: ldloc.3
+		IL_018f: ldc.i4.2
+		IL_0190: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0195: brfalse IL_01ba
+
+		IL_019a: ldloc.3
+		IL_019b: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_01a4: box [System.Runtime]System.Double
+		IL_01a9: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Float64Array::includes(object)
+		IL_01ae: box [System.Runtime]System.Boolean
+		IL_01b3: stloc.s 8
+		IL_01b5: br IL_01d5
+
+		IL_01ba: ldloc.3
+		IL_01bb: ldstr "includes"
+		IL_01c0: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_01c9: box [System.Runtime]System.Double
+		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01d3: stloc.s 8
+
+		IL_01d5: ldloc.s 5
+		IL_01d7: ldloc.s 8
+		IL_01d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01de: pop
+		IL_01df: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01e4: stloc.s 5
+		IL_01e6: ldc.i4.2
+		IL_01e7: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_01ec: brfalse IL_022d
+
+		IL_01f1: ldloc.3
+		IL_01f2: ldstr "indexOf"
+		IL_01f7: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_01fc: brtrue IL_022d
+
+		IL_0201: ldloc.3
+		IL_0202: ldc.i4.2
+		IL_0203: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0208: brfalse IL_022d
+
+		IL_020d: ldloc.3
+		IL_020e: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_0217: box [System.Runtime]System.Double
+		IL_021c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Float64Array::indexOf(object)
+		IL_0221: box [System.Runtime]System.Double
+		IL_0226: stloc.s 8
+		IL_0228: br IL_0248
+
+		IL_022d: ldloc.3
+		IL_022e: ldstr "indexOf"
+		IL_0233: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_023c: box [System.Runtime]System.Double
+		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0246: stloc.s 8
+
+		IL_0248: ldloc.s 5
+		IL_024a: ldloc.s 8
+		IL_024c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0251: pop
+		IL_0252: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0257: stloc.s 5
+		IL_0259: ldc.r8 1
+		IL_0262: neg
+		IL_0263: stloc.s 6
+		IL_0265: ldloc.s 6
+		IL_0267: box [System.Runtime]System.Double
+		IL_026c: stloc.s 7
+		IL_026e: ldc.i4.2
+		IL_026f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0274: brfalse IL_02a9
+
+		IL_0279: ldloc.2
+		IL_027a: ldstr "at"
+		IL_027f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_0284: brtrue IL_02a9
+
+		IL_0289: ldloc.2
+		IL_028a: ldc.i4.2
+		IL_028b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0290: brfalse IL_02a9
+
+		IL_0295: ldloc.2
+		IL_0296: ldloc.s 7
+		IL_0298: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Float64Array::'at'(object)
+		IL_029d: box [System.Runtime]System.Double
+		IL_02a2: stloc.s 8
+		IL_02a4: br IL_02b8
+
+		IL_02a9: ldloc.2
+		IL_02aa: ldstr "at"
+		IL_02af: ldloc.s 7
+		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02b6: stloc.s 8
+
+		IL_02b8: ldloc.s 5
+		IL_02ba: ldloc.s 8
+		IL_02bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02c1: pop
+		IL_02c2: ldloc.3
+		IL_02c3: ldstr "slice"
+		IL_02c8: ldc.r8 1
+		IL_02d1: box [System.Runtime]System.Double
+		IL_02d6: ldc.r8 3
+		IL_02df: box [System.Runtime]System.Double
+		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_02e9: stloc.s 4
+		IL_02eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02f0: stloc.s 5
+		IL_02f2: ldloc.s 4
+		IL_02f4: ldstr "buffer"
+		IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02fe: stloc.s 8
+		IL_0300: ldloc.s 8
+		IL_0302: ldloc.1
+		IL_0303: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0308: stloc.s 9
+		IL_030a: ldloc.s 9
+		IL_030c: box [System.Runtime]System.Boolean
+		IL_0311: stloc.s 10
+		IL_0313: ldloc.s 5
+		IL_0315: ldloc.s 10
+		IL_0317: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_031c: pop
+		IL_031d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0322: stloc.s 5
+		IL_0324: ldloc.s 4
+		IL_0326: ldc.r8 0.0
+		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0334: stloc.s 8
+		IL_0336: ldloc.s 5
+		IL_0338: ldloc.s 8
+		IL_033a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_033f: pop
+		IL_0340: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0345: stloc.s 5
+		IL_0347: ldloc.s 4
+		IL_0349: ldc.r8 1
+		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_0357: stloc.s 8
+		IL_0359: ldloc.s 5
+		IL_035b: ldloc.s 8
+		IL_035d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0362: pop
+		IL_0363: ret
 	} // end of method Float64Array_Construct_ArrayBuffer_Search::__js_module_init__
 
 } // end of class Modules.Float64Array_Construct_ArrayBuffer_Search

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Construct_ArrayBuffer_Search.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Construct_ArrayBuffer_Search.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 868 (0x364)
+		// Code size: 667 (0x29b)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Float64Array_Construct_ArrayBuffer_Search/Scope,
@@ -162,159 +162,91 @@
 		IL_016b: pop
 		IL_016c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0171: stloc.s 5
-		IL_0173: ldc.i4.2
-		IL_0174: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0179: brfalse IL_01ba
-
-		IL_017e: ldloc.3
-		IL_017f: ldstr "includes"
-		IL_0184: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_0189: brtrue IL_01ba
-
-		IL_018e: ldloc.3
-		IL_018f: ldc.i4.2
-		IL_0190: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0195: brfalse IL_01ba
-
-		IL_019a: ldloc.3
-		IL_019b: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_01a4: box [System.Runtime]System.Double
-		IL_01a9: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Float64Array::includes(object)
-		IL_01ae: box [System.Runtime]System.Boolean
-		IL_01b3: stloc.s 8
-		IL_01b5: br IL_01d5
-
-		IL_01ba: ldloc.3
-		IL_01bb: ldstr "includes"
-		IL_01c0: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_01c9: box [System.Runtime]System.Double
-		IL_01ce: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01d3: stloc.s 8
-
-		IL_01d5: ldloc.s 5
-		IL_01d7: ldloc.s 8
-		IL_01d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01de: pop
-		IL_01df: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01e4: stloc.s 5
-		IL_01e6: ldc.i4.2
-		IL_01e7: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_01ec: brfalse IL_022d
-
-		IL_01f1: ldloc.3
-		IL_01f2: ldstr "indexOf"
-		IL_01f7: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_01fc: brtrue IL_022d
-
-		IL_0201: ldloc.3
-		IL_0202: ldc.i4.2
-		IL_0203: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0208: brfalse IL_022d
-
-		IL_020d: ldloc.3
-		IL_020e: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_0217: box [System.Runtime]System.Double
-		IL_021c: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Float64Array::indexOf(object)
-		IL_0221: box [System.Runtime]System.Double
-		IL_0226: stloc.s 8
-		IL_0228: br IL_0248
-
-		IL_022d: ldloc.3
-		IL_022e: ldstr "indexOf"
-		IL_0233: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_023c: box [System.Runtime]System.Double
-		IL_0241: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0246: stloc.s 8
-
-		IL_0248: ldloc.s 5
-		IL_024a: ldloc.s 8
-		IL_024c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0251: pop
-		IL_0252: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0257: stloc.s 5
-		IL_0259: ldc.r8 1
-		IL_0262: neg
-		IL_0263: stloc.s 6
-		IL_0265: ldloc.s 6
-		IL_0267: box [System.Runtime]System.Double
-		IL_026c: stloc.s 7
-		IL_026e: ldc.i4.2
-		IL_026f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0274: brfalse IL_02a9
-
-		IL_0279: ldloc.2
-		IL_027a: ldstr "at"
-		IL_027f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_0284: brtrue IL_02a9
-
-		IL_0289: ldloc.2
-		IL_028a: ldc.i4.2
-		IL_028b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0290: brfalse IL_02a9
-
-		IL_0295: ldloc.2
-		IL_0296: ldloc.s 7
-		IL_0298: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Float64Array::'at'(object)
-		IL_029d: box [System.Runtime]System.Double
-		IL_02a2: stloc.s 8
-		IL_02a4: br IL_02b8
-
-		IL_02a9: ldloc.2
-		IL_02aa: ldstr "at"
-		IL_02af: ldloc.s 7
-		IL_02b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02b6: stloc.s 8
-
-		IL_02b8: ldloc.s 5
-		IL_02ba: ldloc.s 8
-		IL_02bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02c1: pop
-		IL_02c2: ldloc.3
-		IL_02c3: ldstr "slice"
-		IL_02c8: ldc.r8 1
-		IL_02d1: box [System.Runtime]System.Double
-		IL_02d6: ldc.r8 3
-		IL_02df: box [System.Runtime]System.Double
-		IL_02e4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
-		IL_02e9: stloc.s 4
-		IL_02eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02f0: stloc.s 5
-		IL_02f2: ldloc.s 4
-		IL_02f4: ldstr "buffer"
-		IL_02f9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02fe: stloc.s 8
-		IL_0300: ldloc.s 8
-		IL_0302: ldloc.1
-		IL_0303: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
-		IL_0308: stloc.s 9
-		IL_030a: ldloc.s 9
-		IL_030c: box [System.Runtime]System.Boolean
-		IL_0311: stloc.s 10
-		IL_0313: ldloc.s 5
-		IL_0315: ldloc.s 10
-		IL_0317: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_031c: pop
-		IL_031d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0322: stloc.s 5
-		IL_0324: ldloc.s 4
-		IL_0326: ldc.r8 0.0
-		IL_032f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0334: stloc.s 8
-		IL_0336: ldloc.s 5
-		IL_0338: ldloc.s 8
-		IL_033a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_033f: pop
-		IL_0340: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0345: stloc.s 5
-		IL_0347: ldloc.s 4
-		IL_0349: ldc.r8 1
-		IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
-		IL_0357: stloc.s 8
-		IL_0359: ldloc.s 5
-		IL_035b: ldloc.s 8
-		IL_035d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0362: pop
-		IL_0363: ret
+		IL_0173: ldloc.3
+		IL_0174: ldstr "includes"
+		IL_0179: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_0182: box [System.Runtime]System.Double
+		IL_0187: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_018c: stloc.s 8
+		IL_018e: ldloc.s 5
+		IL_0190: ldloc.s 8
+		IL_0192: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0197: pop
+		IL_0198: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_019d: stloc.s 5
+		IL_019f: ldloc.3
+		IL_01a0: ldstr "indexOf"
+		IL_01a5: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_01ae: box [System.Runtime]System.Double
+		IL_01b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01b8: stloc.s 8
+		IL_01ba: ldloc.s 5
+		IL_01bc: ldloc.s 8
+		IL_01be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01c3: pop
+		IL_01c4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01c9: stloc.s 5
+		IL_01cb: ldc.r8 1
+		IL_01d4: neg
+		IL_01d5: stloc.s 6
+		IL_01d7: ldloc.s 6
+		IL_01d9: box [System.Runtime]System.Double
+		IL_01de: stloc.s 7
+		IL_01e0: ldloc.2
+		IL_01e1: ldstr "at"
+		IL_01e6: ldloc.s 7
+		IL_01e8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01ed: stloc.s 8
+		IL_01ef: ldloc.s 5
+		IL_01f1: ldloc.s 8
+		IL_01f3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01f8: pop
+		IL_01f9: ldloc.3
+		IL_01fa: ldstr "slice"
+		IL_01ff: ldc.r8 1
+		IL_0208: box [System.Runtime]System.Double
+		IL_020d: ldc.r8 3
+		IL_0216: box [System.Runtime]System.Double
+		IL_021b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0220: stloc.s 4
+		IL_0222: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0227: stloc.s 5
+		IL_0229: ldloc.s 4
+		IL_022b: ldstr "buffer"
+		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0235: stloc.s 8
+		IL_0237: ldloc.s 8
+		IL_0239: ldloc.1
+		IL_023a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_023f: stloc.s 9
+		IL_0241: ldloc.s 9
+		IL_0243: box [System.Runtime]System.Boolean
+		IL_0248: stloc.s 10
+		IL_024a: ldloc.s 5
+		IL_024c: ldloc.s 10
+		IL_024e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0253: pop
+		IL_0254: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0259: stloc.s 5
+		IL_025b: ldloc.s 4
+		IL_025d: ldc.r8 0.0
+		IL_0266: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_026b: stloc.s 8
+		IL_026d: ldloc.s 5
+		IL_026f: ldloc.s 8
+		IL_0271: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0276: pop
+		IL_0277: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_027c: stloc.s 5
+		IL_027e: ldloc.s 4
+		IL_0280: ldc.r8 1
+		IL_0289: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, float64)
+		IL_028e: stloc.s 8
+		IL_0290: ldloc.s 5
+		IL_0292: ldloc.s 8
+		IL_0294: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0299: pop
+		IL_029a: ret
 	} // end of method Float64Array_Construct_ArrayBuffer_Search::__js_module_init__
 
 } // end of class Modules.Float64Array_Construct_ArrayBuffer_Search

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Fill_Reverse_Join_LastIndexOf.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Fill_Reverse_Join_LastIndexOf.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 326 (0x146)
+		// Code size: 449 (0x1c1)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Fill_Reverse_Join_LastIndexOf/Scope,
@@ -71,75 +71,118 @@
 		IL_0050: stloc.1
 		IL_0051: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0056: stloc.3
-		IL_0057: ldloc.1
-		IL_0058: ldstr "lastIndexOf"
-		IL_005d: ldc.r8 2
-		IL_0066: box [System.Runtime]System.Double
-		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0070: stloc.s 4
-		IL_0072: ldloc.3
-		IL_0073: ldloc.s 4
-		IL_0075: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_007a: pop
-		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0080: stloc.3
-		IL_0081: ldloc.1
-		IL_0082: ldstr "fill"
-		IL_0087: ldc.r8 9
-		IL_0090: box [System.Runtime]System.Double
-		IL_0095: ldc.r8 1
-		IL_009e: box [System.Runtime]System.Double
-		IL_00a3: ldc.r8 3
-		IL_00ac: box [System.Runtime]System.Double
-		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
-		IL_00b6: stloc.s 4
-		IL_00b8: ldloc.s 4
-		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00bf: ldstr "join"
-		IL_00c4: ldstr "|"
-		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00ce: stloc.s 4
-		IL_00d0: ldloc.3
-		IL_00d1: ldloc.s 4
-		IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00d8: pop
-		IL_00d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00de: stloc.3
-		IL_00df: ldloc.1
-		IL_00e0: ldstr "reverse"
-		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_00ea: stloc.s 4
-		IL_00ec: ldloc.s 4
-		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_00f3: ldstr "toString"
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0057: ldc.i4.2
+		IL_0058: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_005d: brfalse IL_009e
+
+		IL_0062: ldloc.1
+		IL_0063: ldstr "lastIndexOf"
+		IL_0068: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_006d: brtrue IL_009e
+
+		IL_0072: ldloc.1
+		IL_0073: ldc.i4.2
+		IL_0074: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0079: brfalse IL_009e
+
+		IL_007e: ldloc.1
+		IL_007f: ldc.r8 2
+		IL_0088: box [System.Runtime]System.Double
+		IL_008d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::lastIndexOf(object)
+		IL_0092: box [System.Runtime]System.Double
+		IL_0097: stloc.s 4
+		IL_0099: br IL_00b9
+
+		IL_009e: ldloc.1
+		IL_009f: ldstr "lastIndexOf"
+		IL_00a4: ldc.r8 2
+		IL_00ad: box [System.Runtime]System.Double
+		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00b7: stloc.s 4
+
+		IL_00b9: ldloc.3
+		IL_00ba: ldloc.s 4
+		IL_00bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00c1: pop
+		IL_00c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00c7: stloc.3
+		IL_00c8: ldloc.1
+		IL_00c9: ldstr "fill"
+		IL_00ce: ldc.r8 9
+		IL_00d7: box [System.Runtime]System.Double
+		IL_00dc: ldc.r8 1
+		IL_00e5: box [System.Runtime]System.Double
+		IL_00ea: ldc.r8 3
+		IL_00f3: box [System.Runtime]System.Double
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
 		IL_00fd: stloc.s 4
-		IL_00ff: ldloc.3
-		IL_0100: ldloc.s 4
-		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0107: pop
-		IL_0108: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_010d: stloc.3
-		IL_010e: ldloc.1
-		IL_010f: ldstr "toString"
-		IL_0114: ldstr "|"
-		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_011e: stloc.s 4
-		IL_0120: ldloc.3
-		IL_0121: ldloc.s 4
-		IL_0123: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0128: pop
-		IL_0129: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_012e: stloc.3
-		IL_012f: ldloc.1
-		IL_0130: ldstr "toLocaleString"
-		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_013a: stloc.s 4
-		IL_013c: ldloc.3
-		IL_013d: ldloc.s 4
-		IL_013f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0144: pop
-		IL_0145: ret
+		IL_00ff: ldloc.s 4
+		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0106: ldstr "join"
+		IL_010b: ldstr "|"
+		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0115: stloc.s 4
+		IL_0117: ldloc.3
+		IL_0118: ldloc.s 4
+		IL_011a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_011f: pop
+		IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0125: stloc.3
+		IL_0126: ldc.i4.2
+		IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_012c: brfalse IL_015a
+
+		IL_0131: ldloc.1
+		IL_0132: ldstr "reverse"
+		IL_0137: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_013c: brtrue IL_015a
+
+		IL_0141: ldloc.1
+		IL_0142: ldc.i4.2
+		IL_0143: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0148: brfalse IL_015a
+
+		IL_014d: ldloc.1
+		IL_014e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.TypedArrayBase [JavaScriptRuntime]JavaScriptRuntime.Int32Array::reverse()
+		IL_0153: stloc.s 4
+		IL_0155: br IL_0167
+
+		IL_015a: ldloc.1
+		IL_015b: ldstr "reverse"
+		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0165: stloc.s 4
+
+		IL_0167: ldloc.s 4
+		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_016e: ldstr "toString"
+		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_0178: stloc.s 4
+		IL_017a: ldloc.3
+		IL_017b: ldloc.s 4
+		IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0182: pop
+		IL_0183: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0188: stloc.3
+		IL_0189: ldloc.1
+		IL_018a: ldstr "toString"
+		IL_018f: ldstr "|"
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0199: stloc.s 4
+		IL_019b: ldloc.3
+		IL_019c: ldloc.s 4
+		IL_019e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01a3: pop
+		IL_01a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01a9: stloc.3
+		IL_01aa: ldloc.1
+		IL_01ab: ldstr "toLocaleString"
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_01b5: stloc.s 4
+		IL_01b7: ldloc.3
+		IL_01b8: ldloc.s 4
+		IL_01ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01bf: pop
+		IL_01c0: ret
 	} // end of method Int32Array_Fill_Reverse_Join_LastIndexOf::__js_module_init__
 
 } // end of class Modules.Int32Array_Fill_Reverse_Join_LastIndexOf

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Fill_Reverse_Join_LastIndexOf.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Int32Array_Fill_Reverse_Join_LastIndexOf.verified.txt
@@ -38,7 +38,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 449 (0x1c1)
+		// Code size: 326 (0x146)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Int32Array_Fill_Reverse_Join_LastIndexOf/Scope,
@@ -71,118 +71,75 @@
 		IL_0050: stloc.1
 		IL_0051: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0056: stloc.3
-		IL_0057: ldc.i4.2
-		IL_0058: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_005d: brfalse IL_009e
-
-		IL_0062: ldloc.1
-		IL_0063: ldstr "lastIndexOf"
-		IL_0068: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_006d: brtrue IL_009e
-
-		IL_0072: ldloc.1
-		IL_0073: ldc.i4.2
-		IL_0074: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0079: brfalse IL_009e
-
-		IL_007e: ldloc.1
-		IL_007f: ldc.r8 2
-		IL_0088: box [System.Runtime]System.Double
-		IL_008d: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Int32Array::lastIndexOf(object)
-		IL_0092: box [System.Runtime]System.Double
-		IL_0097: stloc.s 4
-		IL_0099: br IL_00b9
-
-		IL_009e: ldloc.1
-		IL_009f: ldstr "lastIndexOf"
-		IL_00a4: ldc.r8 2
-		IL_00ad: box [System.Runtime]System.Double
-		IL_00b2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00b7: stloc.s 4
-
-		IL_00b9: ldloc.3
-		IL_00ba: ldloc.s 4
-		IL_00bc: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00c1: pop
-		IL_00c2: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00c7: stloc.3
-		IL_00c8: ldloc.1
-		IL_00c9: ldstr "fill"
-		IL_00ce: ldc.r8 9
-		IL_00d7: box [System.Runtime]System.Double
-		IL_00dc: ldc.r8 1
-		IL_00e5: box [System.Runtime]System.Double
-		IL_00ea: ldc.r8 3
-		IL_00f3: box [System.Runtime]System.Double
-		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0057: ldloc.1
+		IL_0058: ldstr "lastIndexOf"
+		IL_005d: ldc.r8 2
+		IL_0066: box [System.Runtime]System.Double
+		IL_006b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0070: stloc.s 4
+		IL_0072: ldloc.3
+		IL_0073: ldloc.s 4
+		IL_0075: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_007a: pop
+		IL_007b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0080: stloc.3
+		IL_0081: ldloc.1
+		IL_0082: ldstr "fill"
+		IL_0087: ldc.r8 9
+		IL_0090: box [System.Runtime]System.Double
+		IL_0095: ldc.r8 1
+		IL_009e: box [System.Runtime]System.Double
+		IL_00a3: ldc.r8 3
+		IL_00ac: box [System.Runtime]System.Double
+		IL_00b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_00b6: stloc.s 4
+		IL_00b8: ldloc.s 4
+		IL_00ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00bf: ldstr "join"
+		IL_00c4: ldstr "|"
+		IL_00c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00ce: stloc.s 4
+		IL_00d0: ldloc.3
+		IL_00d1: ldloc.s 4
+		IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d8: pop
+		IL_00d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00de: stloc.3
+		IL_00df: ldloc.1
+		IL_00e0: ldstr "reverse"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_00ea: stloc.s 4
+		IL_00ec: ldloc.s 4
+		IL_00ee: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00f3: ldstr "toString"
+		IL_00f8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
 		IL_00fd: stloc.s 4
-		IL_00ff: ldloc.s 4
-		IL_0101: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_0106: ldstr "join"
-		IL_010b: ldstr "|"
-		IL_0110: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0115: stloc.s 4
-		IL_0117: ldloc.3
-		IL_0118: ldloc.s 4
-		IL_011a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_011f: pop
-		IL_0120: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0125: stloc.3
-		IL_0126: ldc.i4.2
-		IL_0127: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_012c: brfalse IL_015a
-
-		IL_0131: ldloc.1
-		IL_0132: ldstr "reverse"
-		IL_0137: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_013c: brtrue IL_015a
-
-		IL_0141: ldloc.1
-		IL_0142: ldc.i4.2
-		IL_0143: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0148: brfalse IL_015a
-
-		IL_014d: ldloc.1
-		IL_014e: callvirt instance class [JavaScriptRuntime]JavaScriptRuntime.TypedArrayBase [JavaScriptRuntime]JavaScriptRuntime.Int32Array::reverse()
-		IL_0153: stloc.s 4
-		IL_0155: br IL_0167
-
-		IL_015a: ldloc.1
-		IL_015b: ldstr "reverse"
-		IL_0160: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0165: stloc.s 4
-
-		IL_0167: ldloc.s 4
-		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
-		IL_016e: ldstr "toString"
-		IL_0173: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_0178: stloc.s 4
-		IL_017a: ldloc.3
-		IL_017b: ldloc.s 4
-		IL_017d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0182: pop
-		IL_0183: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0188: stloc.3
-		IL_0189: ldloc.1
-		IL_018a: ldstr "toString"
-		IL_018f: ldstr "|"
-		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0199: stloc.s 4
-		IL_019b: ldloc.3
-		IL_019c: ldloc.s 4
-		IL_019e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01a3: pop
-		IL_01a4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01a9: stloc.3
-		IL_01aa: ldloc.1
-		IL_01ab: ldstr "toLocaleString"
-		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
-		IL_01b5: stloc.s 4
-		IL_01b7: ldloc.3
-		IL_01b8: ldloc.s 4
-		IL_01ba: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01bf: pop
-		IL_01c0: ret
+		IL_00ff: ldloc.3
+		IL_0100: ldloc.s 4
+		IL_0102: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0107: pop
+		IL_0108: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_010d: stloc.3
+		IL_010e: ldloc.1
+		IL_010f: ldstr "toString"
+		IL_0114: ldstr "|"
+		IL_0119: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_011e: stloc.s 4
+		IL_0120: ldloc.3
+		IL_0121: ldloc.s 4
+		IL_0123: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0128: pop
+		IL_0129: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_012e: stloc.3
+		IL_012f: ldloc.1
+		IL_0130: ldstr "toLocaleString"
+		IL_0135: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_013a: stloc.s 4
+		IL_013c: ldloc.3
+		IL_013d: ldloc.s 4
+		IL_013f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0144: pop
+		IL_0145: ret
 	} // end of method Int32Array_Fill_Reverse_Join_LastIndexOf::__js_module_init__
 
 } // end of class Modules.Int32Array_Fill_Reverse_Join_LastIndexOf

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_ReceiverCandidate_GuardedOverrides.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_ReceiverCandidate_GuardedOverrides.verified.txt
@@ -7,7 +7,7 @@
 	extends [System.Runtime]System.Object
 {
 	// Nested Types
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L7C20
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L10C24
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -79,7 +79,7 @@
 				.maxstack 8
 
 				IL_0000: ldnull
-				IL_0001: call object Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L7C20::__js_call__(object)
+				IL_0001: call object Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L10C24::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::CallCore
 
@@ -95,7 +95,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.3
-				IL_0001: call object Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L7C20::__js_call__(object)
+				IL_0001: call object Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L10C24::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::ConstructBodyCore
 
@@ -136,11 +136,11 @@
 			IL_0000: ldc.i4.0
 			IL_0001: box [System.Runtime]System.Boolean
 			IL_0006: ret
-		} // end of method FunctionExpression_L7C20::__js_call__
+		} // end of method FunctionExpression_L10C24::__js_call__
 
-	} // end of class FunctionExpression_L7C20
+	} // end of class FunctionExpression_L10C24
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L14C12
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L17C16
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -212,7 +212,7 @@
 				.maxstack 8
 
 				IL_0000: ldnull
-				IL_0001: call object Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C12::__js_call__(object)
+				IL_0001: call object Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L17C16::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::CallCore
 
@@ -235,11 +235,11 @@
 			IL_0000: ldc.i4.0
 			IL_0001: box [System.Runtime]System.Boolean
 			IL_0006: ret
-		} // end of method FunctionExpression_L14C12::__js_call__
+		} // end of method FunctionExpression_L17C16::__js_call__
 
-	} // end of class FunctionExpression_L14C12
+	} // end of class FunctionExpression_L17C16
 
-	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L21C32
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L24C36
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
@@ -311,7 +311,7 @@
 				.maxstack 8
 
 				IL_0000: ldnull
-				IL_0001: call object Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L21C32::__js_call__(object)
+				IL_0001: call object Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L24C36::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::CallCore
 
@@ -327,7 +327,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.3
-				IL_0001: call object Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L21C32::__js_call__(object)
+				IL_0001: call object Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L24C36::__js_call__(object)
 				IL_0006: ret
 			} // end of method FunctionObject::ConstructBodyCore
 
@@ -368,9 +368,9 @@
 			IL_0000: ldc.i4.0
 			IL_0001: box [System.Runtime]System.Boolean
 			IL_0006: ret
-		} // end of method FunctionExpression_L21C32::__js_call__
+		} // end of method FunctionExpression_L24C36::__js_call__
 
-	} // end of class FunctionExpression_L21C32
+	} // end of class FunctionExpression_L24C36
 
 	.class nested public auto ansi beforefieldinit Scope
 		extends [System.Runtime]System.Object
@@ -391,6 +391,46 @@
 
 	} // end of class Scope
 
+	.class nested public auto ansi beforefieldinit Scope_For_L7C5
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Block_L7C52
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L7C52::.ctor
+
+		} // end of class Block_L7C52
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope_For_L7C5::.ctor
+
+	} // end of class Scope_For_L7C5
+
 
 	// Methods
 	.method public hidebysig static 
@@ -403,25 +443,28 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 926 (0x39e)
+		// Code size: 1056 (0x420)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/Scope,
 			[1] object,
 			[2] object,
-			[3] object,
+			[3] float64,
 			[4] object,
 			[5] object,
-			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[7] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
-			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[9] object,
-			[10] bool,
-			[11] object[],
-			[12] class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L7C20/FunctionObject,
-			[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[14] class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C12/FunctionObject,
-			[15] class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L21C32/FunctionObject
+			[6] object,
+			[7] object,
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
+			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[11] object,
+			[12] bool,
+			[13] float64,
+			[14] object[],
+			[15] class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L10C24/FunctionObject,
+			[16] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[17] class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L17C16/FunctionObject,
+			[18] class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L24C36/FunctionObject
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -441,296 +484,338 @@
 		IL_0032: dup
 		IL_0033: ldc.r8 3
 		IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0041: stloc.s 6
-		IL_0043: ldloc.s 6
+		IL_0041: stloc.s 8
+		IL_0043: ldloc.s 8
 		IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
-		IL_004a: stloc.s 7
-		IL_004c: ldloc.s 7
+		IL_004a: stloc.s 9
+		IL_004c: ldloc.s 9
 		IL_004e: stloc.1
 		IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0054: stloc.s 8
-		IL_0056: ldc.i4.2
-		IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_005c: brfalse IL_00a2
+		IL_0054: stloc.s 10
+		IL_0056: ldloc.1
+		IL_0057: ldstr "includes"
+		IL_005c: ldc.r8 1
+		IL_0065: box [System.Runtime]System.Double
+		IL_006a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_006f: stloc.s 11
+		IL_0071: ldloc.s 11
+		IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_0078: stloc.s 12
+		IL_007a: ldloc.s 12
+		IL_007c: brfalse IL_008c
 
-		IL_0061: ldloc.1
-		IL_0062: ldstr "includes"
-		IL_0067: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_006c: brtrue IL_00a2
+		IL_0081: ldstr "cold included"
+		IL_0086: stloc.2
+		IL_0087: br IL_0092
 
-		IL_0071: ldloc.1
-		IL_0072: ldc.i4.2
-		IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0078: brfalse IL_00a2
+		IL_008c: ldstr "cold missing"
+		IL_0091: stloc.2
 
-		IL_007d: ldloc.1
-		IL_007e: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
-		IL_0083: ldc.r8 2
-		IL_008c: box [System.Runtime]System.Double
-		IL_0091: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
-		IL_0096: box [System.Runtime]System.Boolean
-		IL_009b: stloc.s 9
-		IL_009d: br IL_00bd
+		IL_0092: ldloc.s 10
+		IL_0094: ldloc.2
+		IL_0095: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_009a: pop
+		IL_009b: ldc.r8 0.0
+		IL_00a4: stloc.3
+		// loop start (head: IL_00a5)
+			IL_00a5: ldloc.3
+			IL_00a6: stloc.s 13
+			IL_00a8: ldloc.s 13
+			IL_00aa: ldc.r8 1
+			IL_00b3: clt
+			IL_00b5: brfalse IL_041f
 
-		IL_00a2: ldloc.1
-		IL_00a3: ldstr "includes"
-		IL_00a8: ldc.r8 2
-		IL_00b1: box [System.Runtime]System.Double
-		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00bb: stloc.s 9
+			IL_00ba: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_00bf: stloc.s 10
+			IL_00c1: ldc.i4.2
+			IL_00c2: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00c7: brfalse IL_010d
 
-		IL_00bd: ldloc.s 9
-		IL_00bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-		IL_00c4: stloc.s 10
-		IL_00c6: ldloc.s 10
-		IL_00c8: brfalse IL_00d8
+			IL_00cc: ldloc.1
+			IL_00cd: ldstr "includes"
+			IL_00d2: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_00d7: brtrue IL_010d
 
-		IL_00cd: ldstr "included"
-		IL_00d2: stloc.2
-		IL_00d3: br IL_00de
+			IL_00dc: ldloc.1
+			IL_00dd: ldc.i4.2
+			IL_00de: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_00e3: brfalse IL_010d
 
-		IL_00d8: ldstr "missing"
-		IL_00dd: stloc.2
+			IL_00e8: ldloc.1
+			IL_00e9: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
+			IL_00ee: ldc.r8 2
+			IL_00f7: box [System.Runtime]System.Double
+			IL_00fc: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
+			IL_0101: box [System.Runtime]System.Boolean
+			IL_0106: stloc.s 11
+			IL_0108: br IL_0128
 
-		IL_00de: ldloc.s 8
-		IL_00e0: ldloc.2
-		IL_00e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00e6: pop
-		IL_00e7: ldc.i4.1
-		IL_00e8: newarr [System.Runtime]System.Object
-		IL_00ed: dup
-		IL_00ee: ldc.i4.0
-		IL_00ef: ldloc.0
-		IL_00f0: stelem.ref
-		IL_00f1: stloc.s 11
-		IL_00f3: newobj instance void Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L7C20/FunctionObject::.ctor()
-		IL_00f8: ldc.i4.0
-		IL_00f9: conv.r8
-		IL_00fa: ldstr ""
-		IL_00ff: ldc.i4.0
-		IL_0100: ldc.i4.1
-		IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L7C20/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0106: stloc.s 12
-		IL_0108: ldloc.1
-		IL_0109: ldstr "includes"
-		IL_010e: ldloc.s 12
-		IL_0110: ldc.i4.1
-		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0116: pop
-		IL_0117: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_011c: stloc.s 8
-		IL_011e: ldc.i4.2
-		IL_011f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0124: brfalse IL_016a
+			IL_010d: ldloc.1
+			IL_010e: ldstr "includes"
+			IL_0113: ldc.r8 2
+			IL_011c: box [System.Runtime]System.Double
+			IL_0121: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0126: stloc.s 11
 
-		IL_0129: ldloc.1
-		IL_012a: ldstr "includes"
-		IL_012f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_0134: brtrue IL_016a
+			IL_0128: ldloc.s 11
+			IL_012a: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_012f: stloc.s 12
+			IL_0131: ldloc.s 12
+			IL_0133: brfalse IL_0144
 
-		IL_0139: ldloc.1
-		IL_013a: ldc.i4.2
-		IL_013b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0140: brfalse IL_016a
+			IL_0138: ldstr "included"
+			IL_013d: stloc.s 4
+			IL_013f: br IL_014b
 
-		IL_0145: ldloc.1
-		IL_0146: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
-		IL_014b: ldc.r8 2
-		IL_0154: box [System.Runtime]System.Double
-		IL_0159: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
-		IL_015e: box [System.Runtime]System.Boolean
-		IL_0163: stloc.s 9
-		IL_0165: br IL_0185
+			IL_0144: ldstr "missing"
+			IL_0149: stloc.s 4
 
-		IL_016a: ldloc.1
-		IL_016b: ldstr "includes"
-		IL_0170: ldc.r8 2
-		IL_0179: box [System.Runtime]System.Double
-		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0183: stloc.s 9
+			IL_014b: ldloc.s 10
+			IL_014d: ldloc.s 4
+			IL_014f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_0154: pop
+			IL_0155: ldc.i4.1
+			IL_0156: newarr [System.Runtime]System.Object
+			IL_015b: dup
+			IL_015c: ldc.i4.0
+			IL_015d: ldloc.0
+			IL_015e: stelem.ref
+			IL_015f: stloc.s 14
+			IL_0161: newobj instance void Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L10C24/FunctionObject::.ctor()
+			IL_0166: ldc.i4.0
+			IL_0167: conv.r8
+			IL_0168: ldstr ""
+			IL_016d: ldc.i4.0
+			IL_016e: ldc.i4.1
+			IL_016f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L10C24/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0174: stloc.s 15
+			IL_0176: ldloc.1
+			IL_0177: ldstr "includes"
+			IL_017c: ldloc.s 15
+			IL_017e: ldc.i4.1
+			IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0184: pop
+			IL_0185: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_018a: stloc.s 10
+			IL_018c: ldc.i4.2
+			IL_018d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0192: brfalse IL_01d8
 
-		IL_0185: ldloc.s 9
-		IL_0187: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-		IL_018c: stloc.s 10
-		IL_018e: ldloc.s 10
-		IL_0190: brfalse IL_01a0
+			IL_0197: ldloc.1
+			IL_0198: ldstr "includes"
+			IL_019d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_01a2: brtrue IL_01d8
 
-		IL_0195: ldstr "own"
-		IL_019a: stloc.3
-		IL_019b: br IL_01a6
+			IL_01a7: ldloc.1
+			IL_01a8: ldc.i4.2
+			IL_01a9: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_01ae: brfalse IL_01d8
 
-		IL_01a0: ldstr "own override"
-		IL_01a5: stloc.3
+			IL_01b3: ldloc.1
+			IL_01b4: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
+			IL_01b9: ldc.r8 2
+			IL_01c2: box [System.Runtime]System.Double
+			IL_01c7: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
+			IL_01cc: box [System.Runtime]System.Boolean
+			IL_01d1: stloc.s 11
+			IL_01d3: br IL_01f3
 
-		IL_01a6: ldloc.s 8
-		IL_01a8: ldloc.3
-		IL_01a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01ae: pop
-		IL_01af: ldloc.1
-		IL_01b0: ldstr "includes"
-		IL_01b5: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
-		IL_01ba: stloc.s 10
-		IL_01bc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_01c1: stloc.s 13
-		IL_01c3: ldc.i4.1
-		IL_01c4: newarr [System.Runtime]System.Object
-		IL_01c9: dup
-		IL_01ca: ldc.i4.0
-		IL_01cb: ldloc.0
-		IL_01cc: stelem.ref
-		IL_01cd: stloc.s 11
-		IL_01cf: newobj instance void Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C12/FunctionObject::.ctor()
-		IL_01d4: ldc.i4.0
-		IL_01d5: conv.r8
-		IL_01d6: ldstr ""
-		IL_01db: ldc.i4.0
-		IL_01dc: ldc.i4.1
-		IL_01dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C12/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C12/FunctionObject>(!!0)
-		IL_01e7: stloc.s 14
-		IL_01e9: ldloc.s 13
-		IL_01eb: ldstr "includes"
-		IL_01f0: ldloc.s 14
-		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_01f7: pop
-		IL_01f8: ldloc.1
-		IL_01f9: ldloc.s 13
-		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_0200: pop
-		IL_0201: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0206: stloc.s 8
-		IL_0208: ldc.i4.2
-		IL_0209: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_020e: brfalse IL_0254
+			IL_01d8: ldloc.1
+			IL_01d9: ldstr "includes"
+			IL_01de: ldc.r8 2
+			IL_01e7: box [System.Runtime]System.Double
+			IL_01ec: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_01f1: stloc.s 11
 
-		IL_0213: ldloc.1
-		IL_0214: ldstr "includes"
-		IL_0219: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_021e: brtrue IL_0254
+			IL_01f3: ldloc.s 11
+			IL_01f5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_01fa: stloc.s 12
+			IL_01fc: ldloc.s 12
+			IL_01fe: brfalse IL_020f
 
-		IL_0223: ldloc.1
-		IL_0224: ldc.i4.2
-		IL_0225: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_022a: brfalse IL_0254
+			IL_0203: ldstr "own"
+			IL_0208: stloc.s 5
+			IL_020a: br IL_0216
 
-		IL_022f: ldloc.1
-		IL_0230: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
-		IL_0235: ldc.r8 2
-		IL_023e: box [System.Runtime]System.Double
-		IL_0243: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
-		IL_0248: box [System.Runtime]System.Boolean
-		IL_024d: stloc.s 9
-		IL_024f: br IL_026f
+			IL_020f: ldstr "own override"
+			IL_0214: stloc.s 5
 
-		IL_0254: ldloc.1
-		IL_0255: ldstr "includes"
-		IL_025a: ldc.r8 2
-		IL_0263: box [System.Runtime]System.Double
-		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026d: stloc.s 9
+			IL_0216: ldloc.s 10
+			IL_0218: ldloc.s 5
+			IL_021a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_021f: pop
+			IL_0220: ldloc.1
+			IL_0221: ldstr "includes"
+			IL_0226: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+			IL_022b: stloc.s 12
+			IL_022d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+			IL_0232: stloc.s 16
+			IL_0234: ldc.i4.1
+			IL_0235: newarr [System.Runtime]System.Object
+			IL_023a: dup
+			IL_023b: ldc.i4.0
+			IL_023c: ldloc.0
+			IL_023d: stelem.ref
+			IL_023e: stloc.s 14
+			IL_0240: newobj instance void Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L17C16/FunctionObject::.ctor()
+			IL_0245: ldc.i4.0
+			IL_0246: conv.r8
+			IL_0247: ldstr ""
+			IL_024c: ldc.i4.0
+			IL_024d: ldc.i4.1
+			IL_024e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L17C16/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0253: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L17C16/FunctionObject>(!!0)
+			IL_0258: stloc.s 17
+			IL_025a: ldloc.s 16
+			IL_025c: ldstr "includes"
+			IL_0261: ldloc.s 17
+			IL_0263: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+			IL_0268: pop
+			IL_0269: ldloc.1
+			IL_026a: ldloc.s 16
+			IL_026c: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+			IL_0271: pop
+			IL_0272: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0277: stloc.s 10
+			IL_0279: ldc.i4.2
+			IL_027a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_027f: brfalse IL_02c5
 
-		IL_026f: ldloc.s 9
-		IL_0271: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-		IL_0276: stloc.s 10
-		IL_0278: ldloc.s 10
-		IL_027a: brfalse IL_028b
+			IL_0284: ldloc.1
+			IL_0285: ldstr "includes"
+			IL_028a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_028f: brtrue IL_02c5
 
-		IL_027f: ldstr "custom"
-		IL_0284: stloc.s 4
-		IL_0286: br IL_0292
+			IL_0294: ldloc.1
+			IL_0295: ldc.i4.2
+			IL_0296: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_029b: brfalse IL_02c5
 
-		IL_028b: ldstr "custom override"
-		IL_0290: stloc.s 4
+			IL_02a0: ldloc.1
+			IL_02a1: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
+			IL_02a6: ldc.r8 2
+			IL_02af: box [System.Runtime]System.Double
+			IL_02b4: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
+			IL_02b9: box [System.Runtime]System.Boolean
+			IL_02be: stloc.s 11
+			IL_02c0: br IL_02e0
 
-		IL_0292: ldloc.s 8
-		IL_0294: ldloc.s 4
-		IL_0296: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_029b: pop
-		IL_029c: ldstr "Int32Array"
-		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02a6: ldstr "prototype"
-		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02b0: stloc.s 9
-		IL_02b2: ldloc.1
-		IL_02b3: ldloc.s 9
-		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
-		IL_02ba: pop
-		IL_02bb: ldstr "Int32Array"
-		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
-		IL_02c5: ldstr "prototype"
-		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-		IL_02cf: stloc.s 9
-		IL_02d1: ldc.i4.1
-		IL_02d2: newarr [System.Runtime]System.Object
-		IL_02d7: dup
-		IL_02d8: ldc.i4.0
-		IL_02d9: ldloc.0
-		IL_02da: stelem.ref
-		IL_02db: stloc.s 11
-		IL_02dd: newobj instance void Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L21C32/FunctionObject::.ctor()
-		IL_02e2: ldc.i4.0
-		IL_02e3: conv.r8
-		IL_02e4: ldstr ""
-		IL_02e9: ldc.i4.0
-		IL_02ea: ldc.i4.1
-		IL_02eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L21C32/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_02f0: stloc.s 15
-		IL_02f2: ldloc.s 9
-		IL_02f4: ldstr "includes"
-		IL_02f9: ldloc.s 15
-		IL_02fb: ldc.i4.1
-		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
-		IL_0301: pop
-		IL_0302: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0307: stloc.s 8
-		IL_0309: ldc.i4.2
-		IL_030a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_030f: brfalse IL_0355
+			IL_02c5: ldloc.1
+			IL_02c6: ldstr "includes"
+			IL_02cb: ldc.r8 2
+			IL_02d4: box [System.Runtime]System.Double
+			IL_02d9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_02de: stloc.s 11
 
-		IL_0314: ldloc.1
-		IL_0315: ldstr "includes"
-		IL_031a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_031f: brtrue IL_0355
+			IL_02e0: ldloc.s 11
+			IL_02e2: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_02e7: stloc.s 12
+			IL_02e9: ldloc.s 12
+			IL_02eb: brfalse IL_02fc
 
-		IL_0324: ldloc.1
-		IL_0325: ldc.i4.2
-		IL_0326: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_032b: brfalse IL_0355
+			IL_02f0: ldstr "custom"
+			IL_02f5: stloc.s 6
+			IL_02f7: br IL_0303
 
-		IL_0330: ldloc.1
-		IL_0331: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
-		IL_0336: ldc.r8 2
-		IL_033f: box [System.Runtime]System.Double
-		IL_0344: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
-		IL_0349: box [System.Runtime]System.Boolean
-		IL_034e: stloc.s 9
-		IL_0350: br IL_0370
+			IL_02fc: ldstr "custom override"
+			IL_0301: stloc.s 6
 
-		IL_0355: ldloc.1
-		IL_0356: ldstr "includes"
-		IL_035b: ldc.r8 2
-		IL_0364: box [System.Runtime]System.Double
-		IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_036e: stloc.s 9
+			IL_0303: ldloc.s 10
+			IL_0305: ldloc.s 6
+			IL_0307: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_030c: pop
+			IL_030d: ldstr "Int32Array"
+			IL_0312: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0317: ldstr "prototype"
+			IL_031c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0321: stloc.s 11
+			IL_0323: ldloc.1
+			IL_0324: ldloc.s 11
+			IL_0326: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+			IL_032b: pop
+			IL_032c: ldstr "Int32Array"
+			IL_0331: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0336: ldstr "prototype"
+			IL_033b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0340: stloc.s 11
+			IL_0342: ldc.i4.1
+			IL_0343: newarr [System.Runtime]System.Object
+			IL_0348: dup
+			IL_0349: ldc.i4.0
+			IL_034a: ldloc.0
+			IL_034b: stelem.ref
+			IL_034c: stloc.s 14
+			IL_034e: newobj instance void Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L24C36/FunctionObject::.ctor()
+			IL_0353: ldc.i4.0
+			IL_0354: conv.r8
+			IL_0355: ldstr ""
+			IL_035a: ldc.i4.0
+			IL_035b: ldc.i4.1
+			IL_035c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L24C36/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0361: stloc.s 18
+			IL_0363: ldloc.s 11
+			IL_0365: ldstr "includes"
+			IL_036a: ldloc.s 18
+			IL_036c: ldc.i4.1
+			IL_036d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+			IL_0372: pop
+			IL_0373: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_0378: stloc.s 10
+			IL_037a: ldc.i4.2
+			IL_037b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_0380: brfalse IL_03c6
 
-		IL_0370: ldloc.s 9
-		IL_0372: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
-		IL_0377: stloc.s 10
-		IL_0379: ldloc.s 10
-		IL_037b: brfalse IL_038c
+			IL_0385: ldloc.1
+			IL_0386: ldstr "includes"
+			IL_038b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+			IL_0390: brtrue IL_03c6
 
-		IL_0380: ldstr "prototype"
-		IL_0385: stloc.s 5
-		IL_0387: br IL_0393
+			IL_0395: ldloc.1
+			IL_0396: ldc.i4.2
+			IL_0397: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+			IL_039c: brfalse IL_03c6
 
-		IL_038c: ldstr "prototype override"
-		IL_0391: stloc.s 5
+			IL_03a1: ldloc.1
+			IL_03a2: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
+			IL_03a7: ldc.r8 2
+			IL_03b0: box [System.Runtime]System.Double
+			IL_03b5: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
+			IL_03ba: box [System.Runtime]System.Boolean
+			IL_03bf: stloc.s 11
+			IL_03c1: br IL_03e1
 
-		IL_0393: ldloc.s 8
-		IL_0395: ldloc.s 5
-		IL_0397: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_039c: pop
-		IL_039d: ret
+			IL_03c6: ldloc.1
+			IL_03c7: ldstr "includes"
+			IL_03cc: ldc.r8 2
+			IL_03d5: box [System.Runtime]System.Double
+			IL_03da: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_03df: stloc.s 11
+
+			IL_03e1: ldloc.s 11
+			IL_03e3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+			IL_03e8: stloc.s 12
+			IL_03ea: ldloc.s 12
+			IL_03ec: brfalse IL_03fd
+
+			IL_03f1: ldstr "prototype"
+			IL_03f6: stloc.s 7
+			IL_03f8: br IL_0404
+
+			IL_03fd: ldstr "prototype override"
+			IL_0402: stloc.s 7
+
+			IL_0404: ldloc.s 10
+			IL_0406: ldloc.s 7
+			IL_0408: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_040d: pop
+			IL_040e: ldloc.3
+			IL_040f: ldc.r8 1
+			IL_0418: add
+			IL_0419: stloc.3
+			IL_041a: br IL_00a5
+		// end loop
+
+		IL_041f: ret
 	} // end of method TypedArray_ReceiverCandidate_GuardedOverrides::__js_module_init__
 
 } // end of class Modules.TypedArray_ReceiverCandidate_GuardedOverrides

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_ReceiverCandidate_GuardedOverrides.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_ReceiverCandidate_GuardedOverrides.verified.txt
@@ -1,0 +1,759 @@
+﻿// IL code: TypedArray_ReceiverCandidate_GuardedOverrides
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.TypedArray_ReceiverCandidate_GuardedOverrides
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L7C20
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: call object Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L7C20::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L7C20::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 7 (0x7)
+			.maxstack 8
+
+			IL_0000: ldc.i4.0
+			IL_0001: box [System.Runtime]System.Boolean
+			IL_0006: ret
+		} // end of method FunctionExpression_L7C20::__js_call__
+
+	} // end of class FunctionExpression_L7C20
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L14C12
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: call object Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C12::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::CallCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 7 (0x7)
+			.maxstack 8
+
+			IL_0000: ldc.i4.0
+			IL_0001: box [System.Runtime]System.Boolean
+			IL_0006: ret
+		} // end of method FunctionExpression_L14C12::__js_call__
+
+	} // end of class FunctionExpression_L14C12
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L21C32
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: call object Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L21C32::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L21C32::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 7 (0x7)
+			.maxstack 8
+
+			IL_0000: ldc.i4.0
+			IL_0001: box [System.Runtime]System.Boolean
+			IL_0006: ret
+		} // end of method FunctionExpression_L21C32::__js_call__
+
+	} // end of class FunctionExpression_L21C32
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Header size: 12
+		// Code size: 926 (0x39e)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/Scope,
+			[1] object,
+			[2] object,
+			[3] object,
+			[4] object,
+			[5] object,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[7] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
+			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[9] object,
+			[10] bool,
+			[11] object[],
+			[12] class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L7C20/FunctionObject,
+			[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[14] class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C12/FunctionObject,
+			[15] class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L21C32/FunctionObject
+		)
+
+		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
+		IL_0005: newobj instance void Modules.TypedArray_ReceiverCandidate_GuardedOverrides/Scope::.ctor()
+		IL_000a: stloc.0
+		IL_000b: nop
+		IL_000c: ldnull
+		IL_000d: stloc.1
+		IL_000e: ldc.i4.3
+		IL_000f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0014: dup
+		IL_0015: ldc.r8 1
+		IL_001e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0023: dup
+		IL_0024: ldc.r8 2
+		IL_002d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0032: dup
+		IL_0033: ldc.r8 3
+		IL_003c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0041: stloc.s 6
+		IL_0043: ldloc.s 6
+		IL_0045: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int32Array::.ctor(object)
+		IL_004a: stloc.s 7
+		IL_004c: ldloc.s 7
+		IL_004e: stloc.1
+		IL_004f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0054: stloc.s 8
+		IL_0056: ldc.i4.2
+		IL_0057: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_005c: brfalse IL_00a2
+
+		IL_0061: ldloc.1
+		IL_0062: ldstr "includes"
+		IL_0067: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_006c: brtrue IL_00a2
+
+		IL_0071: ldloc.1
+		IL_0072: ldc.i4.2
+		IL_0073: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0078: brfalse IL_00a2
+
+		IL_007d: ldloc.1
+		IL_007e: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
+		IL_0083: ldc.r8 2
+		IL_008c: box [System.Runtime]System.Double
+		IL_0091: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
+		IL_0096: box [System.Runtime]System.Boolean
+		IL_009b: stloc.s 9
+		IL_009d: br IL_00bd
+
+		IL_00a2: ldloc.1
+		IL_00a3: ldstr "includes"
+		IL_00a8: ldc.r8 2
+		IL_00b1: box [System.Runtime]System.Double
+		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00bb: stloc.s 9
+
+		IL_00bd: ldloc.s 9
+		IL_00bf: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_00c4: stloc.s 10
+		IL_00c6: ldloc.s 10
+		IL_00c8: brfalse IL_00d8
+
+		IL_00cd: ldstr "included"
+		IL_00d2: stloc.2
+		IL_00d3: br IL_00de
+
+		IL_00d8: ldstr "missing"
+		IL_00dd: stloc.2
+
+		IL_00de: ldloc.s 8
+		IL_00e0: ldloc.2
+		IL_00e1: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e6: pop
+		IL_00e7: ldc.i4.1
+		IL_00e8: newarr [System.Runtime]System.Object
+		IL_00ed: dup
+		IL_00ee: ldc.i4.0
+		IL_00ef: ldloc.0
+		IL_00f0: stelem.ref
+		IL_00f1: stloc.s 11
+		IL_00f3: newobj instance void Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L7C20/FunctionObject::.ctor()
+		IL_00f8: ldc.i4.0
+		IL_00f9: conv.r8
+		IL_00fa: ldstr ""
+		IL_00ff: ldc.i4.0
+		IL_0100: ldc.i4.1
+		IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L7C20/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0106: stloc.s 12
+		IL_0108: ldloc.1
+		IL_0109: ldstr "includes"
+		IL_010e: ldloc.s 12
+		IL_0110: ldc.i4.1
+		IL_0111: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0116: pop
+		IL_0117: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_011c: stloc.s 8
+		IL_011e: ldc.i4.2
+		IL_011f: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0124: brfalse IL_016a
+
+		IL_0129: ldloc.1
+		IL_012a: ldstr "includes"
+		IL_012f: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_0134: brtrue IL_016a
+
+		IL_0139: ldloc.1
+		IL_013a: ldc.i4.2
+		IL_013b: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0140: brfalse IL_016a
+
+		IL_0145: ldloc.1
+		IL_0146: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
+		IL_014b: ldc.r8 2
+		IL_0154: box [System.Runtime]System.Double
+		IL_0159: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
+		IL_015e: box [System.Runtime]System.Boolean
+		IL_0163: stloc.s 9
+		IL_0165: br IL_0185
+
+		IL_016a: ldloc.1
+		IL_016b: ldstr "includes"
+		IL_0170: ldc.r8 2
+		IL_0179: box [System.Runtime]System.Double
+		IL_017e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0183: stloc.s 9
+
+		IL_0185: ldloc.s 9
+		IL_0187: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_018c: stloc.s 10
+		IL_018e: ldloc.s 10
+		IL_0190: brfalse IL_01a0
+
+		IL_0195: ldstr "own"
+		IL_019a: stloc.3
+		IL_019b: br IL_01a6
+
+		IL_01a0: ldstr "own override"
+		IL_01a5: stloc.3
+
+		IL_01a6: ldloc.s 8
+		IL_01a8: ldloc.3
+		IL_01a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01ae: pop
+		IL_01af: ldloc.1
+		IL_01b0: ldstr "includes"
+		IL_01b5: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteProperty(object, object)
+		IL_01ba: stloc.s 10
+		IL_01bc: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_01c1: stloc.s 13
+		IL_01c3: ldc.i4.1
+		IL_01c4: newarr [System.Runtime]System.Object
+		IL_01c9: dup
+		IL_01ca: ldc.i4.0
+		IL_01cb: ldloc.0
+		IL_01cc: stelem.ref
+		IL_01cd: stloc.s 11
+		IL_01cf: newobj instance void Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C12/FunctionObject::.ctor()
+		IL_01d4: ldc.i4.0
+		IL_01d5: conv.r8
+		IL_01d6: ldstr ""
+		IL_01db: ldc.i4.0
+		IL_01dc: ldc.i4.1
+		IL_01dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C12/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L14C12/FunctionObject>(!!0)
+		IL_01e7: stloc.s 14
+		IL_01e9: ldloc.s 13
+		IL_01eb: ldstr "includes"
+		IL_01f0: ldloc.s 14
+		IL_01f2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_01f7: pop
+		IL_01f8: ldloc.1
+		IL_01f9: ldloc.s 13
+		IL_01fb: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_0200: pop
+		IL_0201: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0206: stloc.s 8
+		IL_0208: ldc.i4.2
+		IL_0209: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_020e: brfalse IL_0254
+
+		IL_0213: ldloc.1
+		IL_0214: ldstr "includes"
+		IL_0219: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_021e: brtrue IL_0254
+
+		IL_0223: ldloc.1
+		IL_0224: ldc.i4.2
+		IL_0225: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_022a: brfalse IL_0254
+
+		IL_022f: ldloc.1
+		IL_0230: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
+		IL_0235: ldc.r8 2
+		IL_023e: box [System.Runtime]System.Double
+		IL_0243: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
+		IL_0248: box [System.Runtime]System.Boolean
+		IL_024d: stloc.s 9
+		IL_024f: br IL_026f
+
+		IL_0254: ldloc.1
+		IL_0255: ldstr "includes"
+		IL_025a: ldc.r8 2
+		IL_0263: box [System.Runtime]System.Double
+		IL_0268: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_026d: stloc.s 9
+
+		IL_026f: ldloc.s 9
+		IL_0271: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_0276: stloc.s 10
+		IL_0278: ldloc.s 10
+		IL_027a: brfalse IL_028b
+
+		IL_027f: ldstr "custom"
+		IL_0284: stloc.s 4
+		IL_0286: br IL_0292
+
+		IL_028b: ldstr "custom override"
+		IL_0290: stloc.s 4
+
+		IL_0292: ldloc.s 8
+		IL_0294: ldloc.s 4
+		IL_0296: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_029b: pop
+		IL_029c: ldstr "Int32Array"
+		IL_02a1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02a6: ldstr "prototype"
+		IL_02ab: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02b0: stloc.s 9
+		IL_02b2: ldloc.1
+		IL_02b3: ldloc.s 9
+		IL_02b5: call object [JavaScriptRuntime]JavaScriptRuntime.Object::setPrototypeOf(object, object)
+		IL_02ba: pop
+		IL_02bb: ldstr "Int32Array"
+		IL_02c0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02c5: ldstr "prototype"
+		IL_02ca: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02cf: stloc.s 9
+		IL_02d1: ldc.i4.1
+		IL_02d2: newarr [System.Runtime]System.Object
+		IL_02d7: dup
+		IL_02d8: ldc.i4.0
+		IL_02d9: ldloc.0
+		IL_02da: stelem.ref
+		IL_02db: stloc.s 11
+		IL_02dd: newobj instance void Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L21C32/FunctionObject::.ctor()
+		IL_02e2: ldc.i4.0
+		IL_02e3: conv.r8
+		IL_02e4: ldstr ""
+		IL_02e9: ldc.i4.0
+		IL_02ea: ldc.i4.1
+		IL_02eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_ReceiverCandidate_GuardedOverrides/FunctionExpression_L21C32/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02f0: stloc.s 15
+		IL_02f2: ldloc.s 9
+		IL_02f4: ldstr "includes"
+		IL_02f9: ldloc.s 15
+		IL_02fb: ldc.i4.1
+		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_0301: pop
+		IL_0302: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0307: stloc.s 8
+		IL_0309: ldc.i4.2
+		IL_030a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_030f: brfalse IL_0355
+
+		IL_0314: ldloc.1
+		IL_0315: ldstr "includes"
+		IL_031a: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_031f: brtrue IL_0355
+
+		IL_0324: ldloc.1
+		IL_0325: ldc.i4.2
+		IL_0326: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_032b: brfalse IL_0355
+
+		IL_0330: ldloc.1
+		IL_0331: castclass [JavaScriptRuntime]JavaScriptRuntime.Int32Array
+		IL_0336: ldc.r8 2
+		IL_033f: box [System.Runtime]System.Double
+		IL_0344: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Int32Array::includes(object)
+		IL_0349: box [System.Runtime]System.Boolean
+		IL_034e: stloc.s 9
+		IL_0350: br IL_0370
+
+		IL_0355: ldloc.1
+		IL_0356: ldstr "includes"
+		IL_035b: ldc.r8 2
+		IL_0364: box [System.Runtime]System.Double
+		IL_0369: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_036e: stloc.s 9
+
+		IL_0370: ldloc.s 9
+		IL_0372: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+		IL_0377: stloc.s 10
+		IL_0379: ldloc.s 10
+		IL_037b: brfalse IL_038c
+
+		IL_0380: ldstr "prototype"
+		IL_0385: stloc.s 5
+		IL_0387: br IL_0393
+
+		IL_038c: ldstr "prototype override"
+		IL_0391: stloc.s 5
+
+		IL_0393: ldloc.s 8
+		IL_0395: ldloc.s 5
+		IL_0397: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_039c: pop
+		IL_039d: ret
+	} // end of method TypedArray_ReceiverCandidate_GuardedOverrides::__js_module_init__
+
+} // end of class Modules.TypedArray_ReceiverCandidate_GuardedOverrides
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.TypedArray_ReceiverCandidate_GuardedOverrides::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
@@ -213,7 +213,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1020 (0x3fc)
+		// Code size: 1251 (0x4e3)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope,
@@ -273,257 +273,341 @@
 		IL_0091: stloc.1
 		IL_0092: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0097: stloc.s 12
-		IL_0099: ldloc.1
-		IL_009a: ldstr "join"
-		IL_009f: ldstr "|"
-		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a9: stloc.s 13
-		IL_00ab: ldloc.s 12
-		IL_00ad: ldloc.s 13
-		IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b4: pop
-		IL_00b5: ldc.i4.8
-		IL_00b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_00bb: dup
-		IL_00bc: ldc.r8 32769
-		IL_00c5: neg
-		IL_00c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00cb: dup
-		IL_00cc: ldc.r8 32768
-		IL_00d5: neg
-		IL_00d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00db: dup
-		IL_00dc: ldc.r8 32767
-		IL_00e5: neg
-		IL_00e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00eb: dup
-		IL_00ec: ldc.r8 32767
-		IL_00f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_00fa: dup
-		IL_00fb: ldc.r8 32768
-		IL_0104: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0109: dup
-		IL_010a: ldc.r8 32769
-		IL_0113: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0118: dup
-		IL_0119: ldc.r8 65535
-		IL_0122: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0127: dup
-		IL_0128: ldc.r8 65536
-		IL_0131: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0136: stloc.s 11
-		IL_0138: ldloc.s 11
-		IL_013a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int16Array::.ctor(object)
-		IL_013f: stloc.2
-		IL_0140: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0145: stloc.s 12
-		IL_0147: ldloc.2
-		IL_0148: ldstr "join"
-		IL_014d: ldstr "|"
-		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0157: stloc.s 13
-		IL_0159: ldloc.s 12
-		IL_015b: ldloc.s 13
-		IL_015d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0162: pop
-		IL_0163: ldc.i4.8
-		IL_0164: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0169: dup
-		IL_016a: ldc.r8 1
-		IL_0173: neg
-		IL_0174: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0179: dup
-		IL_017a: ldc.r8 0.0
-		IL_0183: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0188: dup
-		IL_0189: ldc.r8 1
-		IL_0192: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0197: dup
-		IL_0198: ldc.r8 255
-		IL_01a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01a6: dup
-		IL_01a7: ldc.r8 256
-		IL_01b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01b5: dup
-		IL_01b6: ldc.r8 257
-		IL_01bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01c4: dup
-		IL_01c5: ldc.r8 511
-		IL_01ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01d3: dup
-		IL_01d4: ldc.r8 1.9
-		IL_01dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01e2: stloc.s 11
-		IL_01e4: ldloc.s 11
-		IL_01e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_01eb: stloc.3
-		IL_01ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01f1: stloc.s 12
-		IL_01f3: ldloc.3
-		IL_01f4: ldstr "join"
-		IL_01f9: ldstr "|"
-		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0203: stloc.s 13
-		IL_0205: ldloc.s 12
-		IL_0207: ldloc.s 13
-		IL_0209: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_020e: pop
-		IL_020f: ldc.i4.s 10
-		IL_0211: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_0216: dup
-		IL_0217: ldc.r8 20
-		IL_0220: neg
-		IL_0221: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0226: dup
-		IL_0227: ldc.r8 0.5
-		IL_0230: neg
+		IL_0099: ldc.i4.2
+		IL_009a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_009f: brfalse IL_00d2
+
+		IL_00a4: ldloc.1
+		IL_00a5: ldstr "join"
+		IL_00aa: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_00af: brtrue IL_00d2
+
+		IL_00b4: ldloc.1
+		IL_00b5: ldc.i4.2
+		IL_00b6: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_00bb: brfalse IL_00d2
+
+		IL_00c0: ldloc.1
+		IL_00c1: ldstr "|"
+		IL_00c6: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Int8Array::join(object)
+		IL_00cb: stloc.s 13
+		IL_00cd: br IL_00e4
+
+		IL_00d2: ldloc.1
+		IL_00d3: ldstr "join"
+		IL_00d8: ldstr "|"
+		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e2: stloc.s 13
+
+		IL_00e4: ldloc.s 12
+		IL_00e6: ldloc.s 13
+		IL_00e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ed: pop
+		IL_00ee: ldc.i4.8
+		IL_00ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00f4: dup
+		IL_00f5: ldc.r8 32769
+		IL_00fe: neg
+		IL_00ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0104: dup
+		IL_0105: ldc.r8 32768
+		IL_010e: neg
+		IL_010f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0114: dup
+		IL_0115: ldc.r8 32767
+		IL_011e: neg
+		IL_011f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0124: dup
+		IL_0125: ldc.r8 32767
+		IL_012e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0133: dup
+		IL_0134: ldc.r8 32768
+		IL_013d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0142: dup
+		IL_0143: ldc.r8 32769
+		IL_014c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0151: dup
+		IL_0152: ldc.r8 65535
+		IL_015b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0160: dup
+		IL_0161: ldc.r8 65536
+		IL_016a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_016f: stloc.s 11
+		IL_0171: ldloc.s 11
+		IL_0173: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int16Array::.ctor(object)
+		IL_0178: stloc.2
+		IL_0179: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_017e: stloc.s 12
+		IL_0180: ldc.i4.2
+		IL_0181: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0186: brfalse IL_01b9
+
+		IL_018b: ldloc.2
+		IL_018c: ldstr "join"
+		IL_0191: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_0196: brtrue IL_01b9
+
+		IL_019b: ldloc.2
+		IL_019c: ldc.i4.2
+		IL_019d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_01a2: brfalse IL_01b9
+
+		IL_01a7: ldloc.2
+		IL_01a8: ldstr "|"
+		IL_01ad: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Int16Array::join(object)
+		IL_01b2: stloc.s 13
+		IL_01b4: br IL_01cb
+
+		IL_01b9: ldloc.2
+		IL_01ba: ldstr "join"
+		IL_01bf: ldstr "|"
+		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_01c9: stloc.s 13
+
+		IL_01cb: ldloc.s 12
+		IL_01cd: ldloc.s 13
+		IL_01cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01d4: pop
+		IL_01d5: ldc.i4.8
+		IL_01d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_01db: dup
+		IL_01dc: ldc.r8 1
+		IL_01e5: neg
+		IL_01e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01eb: dup
+		IL_01ec: ldc.r8 0.0
+		IL_01f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01fa: dup
+		IL_01fb: ldc.r8 1
+		IL_0204: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0209: dup
+		IL_020a: ldc.r8 255
+		IL_0213: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0218: dup
+		IL_0219: ldc.r8 256
+		IL_0222: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0227: dup
+		IL_0228: ldc.r8 257
 		IL_0231: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_0236: dup
-		IL_0237: ldc.r8 0.49
+		IL_0237: ldc.r8 511
 		IL_0240: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_0245: dup
-		IL_0246: ldc.r8 0.5
+		IL_0246: ldc.r8 1.9
 		IL_024f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0254: dup
-		IL_0255: ldc.r8 1.5
-		IL_025e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0263: dup
-		IL_0264: ldc.r8 2.5
-		IL_026d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0272: dup
-		IL_0273: ldc.r8 254.6
-		IL_027c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0281: dup
-		IL_0282: ldc.r8 255.4
-		IL_028b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0290: dup
-		IL_0291: ldc.r8 300
-		IL_029a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_029f: dup
-		IL_02a0: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_02a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02ae: stloc.s 11
-		IL_02b0: ldloc.s 11
-		IL_02b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray::.ctor(object)
-		IL_02b7: stloc.s 4
-		IL_02b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02be: stloc.s 12
-		IL_02c0: ldloc.s 4
-		IL_02c2: ldstr "join"
-		IL_02c7: ldstr "|"
-		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02d1: stloc.s 13
-		IL_02d3: ldloc.s 12
-		IL_02d5: ldloc.s 13
-		IL_02d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02dc: pop
-		IL_02dd: ldloc.0
-		IL_02de: ldc.r8 0.0
-		IL_02e7: box [System.Runtime]System.Double
-		IL_02ec: stfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
-		IL_02f1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_02f6: stloc.s 14
-		IL_02f8: ldc.i4.1
-		IL_02f9: newarr [System.Runtime]System.Object
-		IL_02fe: dup
-		IL_02ff: ldc.i4.0
-		IL_0300: ldloc.0
-		IL_0301: stelem.ref
-		IL_0302: stloc.s 15
-		IL_0304: ldloc.s 15
-		IL_0306: ldc.i4.0
-		IL_0307: ldelem.ref
-		IL_0308: castclass Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope
-		IL_030d: newobj instance void Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject::.ctor(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope)
-		IL_0312: ldc.i4.0
-		IL_0313: conv.r8
-		IL_0314: ldstr ""
-		IL_0319: ldc.i4.0
-		IL_031a: ldc.i4.1
-		IL_031b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0320: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject>(!!0)
-		IL_0325: stloc.s 16
-		IL_0327: ldloc.s 14
-		IL_0329: ldstr "valueOf"
-		IL_032e: ldloc.s 16
-		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_0335: pop
-		IL_0336: ldloc.s 14
-		IL_0338: stloc.s 5
-		IL_033a: ldc.r8 0.0
-		IL_0343: box [System.Runtime]System.Double
-		IL_0348: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_034d: stloc.s 6
-		IL_034f: ldloc.s 6
-		IL_0351: ldc.r8 0.0
-		IL_035a: ldloc.s 5
-		IL_035c: ldc.i4.1
-		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_0362: pop
-		IL_0363: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0368: stloc.s 12
-		IL_036a: ldloc.0
-		IL_036b: ldfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
-		IL_0370: stloc.s 13
-		IL_0372: ldloc.s 12
-		IL_0374: ldloc.s 13
-		IL_0376: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_037b: pop
+		IL_0254: stloc.s 11
+		IL_0256: ldloc.s 11
+		IL_0258: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_025d: stloc.3
+		IL_025e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0263: stloc.s 12
+		IL_0265: ldc.i4.2
+		IL_0266: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_026b: brfalse IL_029e
+
+		IL_0270: ldloc.3
+		IL_0271: ldstr "join"
+		IL_0276: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_027b: brtrue IL_029e
+
+		IL_0280: ldloc.3
+		IL_0281: ldc.i4.2
+		IL_0282: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0287: brfalse IL_029e
+
+		IL_028c: ldloc.3
+		IL_028d: ldstr "|"
+		IL_0292: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::join(object)
+		IL_0297: stloc.s 13
+		IL_0299: br IL_02b0
+
+		IL_029e: ldloc.3
+		IL_029f: ldstr "join"
+		IL_02a4: ldstr "|"
+		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02ae: stloc.s 13
+
+		IL_02b0: ldloc.s 12
+		IL_02b2: ldloc.s 13
+		IL_02b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02b9: pop
+		IL_02ba: ldc.i4.s 10
+		IL_02bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_02c1: dup
+		IL_02c2: ldc.r8 20
+		IL_02cb: neg
+		IL_02cc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02d1: dup
+		IL_02d2: ldc.r8 0.5
+		IL_02db: neg
+		IL_02dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02e1: dup
+		IL_02e2: ldc.r8 0.49
+		IL_02eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02f0: dup
+		IL_02f1: ldc.r8 0.5
+		IL_02fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02ff: dup
+		IL_0300: ldc.r8 1.5
+		IL_0309: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_030e: dup
+		IL_030f: ldc.r8 2.5
+		IL_0318: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_031d: dup
+		IL_031e: ldc.r8 254.6
+		IL_0327: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_032c: dup
+		IL_032d: ldc.r8 255.4
+		IL_0336: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_033b: dup
+		IL_033c: ldc.r8 300
+		IL_0345: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_034a: dup
+		IL_034b: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_0354: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0359: stloc.s 11
+		IL_035b: ldloc.s 11
+		IL_035d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray::.ctor(object)
+		IL_0362: stloc.s 4
+		IL_0364: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0369: stloc.s 12
+		IL_036b: ldc.i4.2
+		IL_036c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0371: brfalse IL_03a7
+
+		IL_0376: ldloc.s 4
+		IL_0378: ldstr "join"
+		IL_037d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_0382: brtrue IL_03a7
+
+		IL_0387: ldloc.s 4
+		IL_0389: ldc.i4.2
+		IL_038a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_038f: brfalse IL_03a7
+
+		IL_0394: ldloc.s 4
+		IL_0396: ldstr "|"
+		IL_039b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray::join(object)
+		IL_03a0: stloc.s 13
+		IL_03a2: br IL_03ba
+
+		IL_03a7: ldloc.s 4
+		IL_03a9: ldstr "join"
+		IL_03ae: ldstr "|"
+		IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03b8: stloc.s 13
+
+		IL_03ba: ldloc.s 12
+		IL_03bc: ldloc.s 13
+		IL_03be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03c3: pop
+		IL_03c4: ldloc.0
+		IL_03c5: ldc.r8 0.0
+		IL_03ce: box [System.Runtime]System.Double
+		IL_03d3: stfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
+		IL_03d8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_03dd: stloc.s 14
+		IL_03df: ldc.i4.1
+		IL_03e0: newarr [System.Runtime]System.Object
+		IL_03e5: dup
+		IL_03e6: ldc.i4.0
+		IL_03e7: ldloc.0
+		IL_03e8: stelem.ref
+		IL_03e9: stloc.s 15
+		IL_03eb: ldloc.s 15
+		IL_03ed: ldc.i4.0
+		IL_03ee: ldelem.ref
+		IL_03ef: castclass Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope
+		IL_03f4: newobj instance void Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject::.ctor(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope)
+		IL_03f9: ldc.i4.0
+		IL_03fa: conv.r8
+		IL_03fb: ldstr ""
+		IL_0400: ldc.i4.0
+		IL_0401: ldc.i4.1
+		IL_0402: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0407: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject>(!!0)
+		IL_040c: stloc.s 16
+		IL_040e: ldloc.s 14
+		IL_0410: ldstr "valueOf"
+		IL_0415: ldloc.s 16
+		IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_041c: pop
+		IL_041d: ldloc.s 14
+		IL_041f: stloc.s 5
+		IL_0421: ldc.r8 0.0
+		IL_042a: box [System.Runtime]System.Double
+		IL_042f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_0434: stloc.s 6
+		IL_0436: ldloc.s 6
+		IL_0438: ldc.r8 0.0
+		IL_0441: ldloc.s 5
+		IL_0443: ldc.i4.1
+		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_0449: pop
+		IL_044a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_044f: stloc.s 12
+		IL_0451: ldloc.0
+		IL_0452: ldfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
+		IL_0457: stloc.s 13
+		IL_0459: ldloc.s 12
+		IL_045b: ldloc.s 13
+		IL_045d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0462: pop
 		.try
 		{
-			IL_037c: nop
-			IL_037d: ldstr "value"
-			IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::Call(object)
-			IL_0387: stloc.s 13
-			IL_0389: ldloc.s 6
-			IL_038b: ldc.r8 0.0
-			IL_0394: ldloc.s 13
-			IL_0396: ldc.i4.1
-			IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_039c: pop
-			IL_039d: leave IL_03f8
+			IL_0463: nop
+			IL_0464: ldstr "value"
+			IL_0469: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::Call(object)
+			IL_046e: stloc.s 13
+			IL_0470: ldloc.s 6
+			IL_0472: ldc.r8 0.0
+			IL_047b: ldloc.s 13
+			IL_047d: ldc.i4.1
+			IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_0483: pop
+			IL_0484: leave IL_04df
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_03a2: stloc.s 7
-			IL_03a4: ldloc.s 7
-			IL_03a6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_03ab: dup
-			IL_03ac: brtrue IL_03c2
+			IL_0489: stloc.s 7
+			IL_048b: ldloc.s 7
+			IL_048d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0492: dup
+			IL_0493: brtrue IL_04a9
 
-			IL_03b1: pop
-			IL_03b2: ldloc.s 7
-			IL_03b4: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_03b9: dup
-			IL_03ba: brtrue IL_03ce
+			IL_0498: pop
+			IL_0499: ldloc.s 7
+			IL_049b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_04a0: dup
+			IL_04a1: brtrue IL_04b5
 
-			IL_03bf: pop
-			IL_03c0: rethrow
+			IL_04a6: pop
+			IL_04a7: rethrow
 
-			IL_03c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_03c7: stloc.s 8
-			IL_03c9: br IL_03d0
+			IL_04a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_04ae: stloc.s 8
+			IL_04b0: br IL_04b7
 
-			IL_03ce: stloc.s 8
+			IL_04b5: stloc.s 8
 
-			IL_03d0: ldloc.s 8
-			IL_03d2: stloc.s 9
-			IL_03d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_03d9: stloc.s 12
-			IL_03db: ldloc.s 9
-			IL_03dd: ldstr "name"
-			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_03e7: stloc.s 13
-			IL_03e9: ldloc.s 12
-			IL_03eb: ldloc.s 13
-			IL_03ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_03f2: pop
-			IL_03f3: leave IL_03f8
+			IL_04b7: ldloc.s 8
+			IL_04b9: stloc.s 9
+			IL_04bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_04c0: stloc.s 12
+			IL_04c2: ldloc.s 9
+			IL_04c4: ldstr "name"
+			IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_04ce: stloc.s 13
+			IL_04d0: ldloc.s 12
+			IL_04d2: ldloc.s 13
+			IL_04d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_04d9: pop
+			IL_04da: leave IL_04df
 		} // end handler
 
-		IL_03f8: ldnull
-		IL_03f9: stloc.s 10
-		IL_03fb: ret
+		IL_04df: ldnull
+		IL_04e0: stloc.s 10
+		IL_04e2: ret
 	} // end of method TypedArray_SignedAndClamped_ConversionSemantics::__js_module_init__
 
 } // end of class Modules.TypedArray_SignedAndClamped_ConversionSemantics

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
@@ -213,7 +213,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 1251 (0x4e3)
+		// Code size: 1020 (0x3fc)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope,
@@ -273,341 +273,257 @@
 		IL_0091: stloc.1
 		IL_0092: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0097: stloc.s 12
-		IL_0099: ldc.i4.2
-		IL_009a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_009f: brfalse IL_00d2
-
-		IL_00a4: ldloc.1
-		IL_00a5: ldstr "join"
-		IL_00aa: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_00af: brtrue IL_00d2
-
-		IL_00b4: ldloc.1
-		IL_00b5: ldc.i4.2
-		IL_00b6: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_00bb: brfalse IL_00d2
-
-		IL_00c0: ldloc.1
-		IL_00c1: ldstr "|"
-		IL_00c6: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Int8Array::join(object)
-		IL_00cb: stloc.s 13
-		IL_00cd: br IL_00e4
-
-		IL_00d2: ldloc.1
-		IL_00d3: ldstr "join"
-		IL_00d8: ldstr "|"
-		IL_00dd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e2: stloc.s 13
-
-		IL_00e4: ldloc.s 12
-		IL_00e6: ldloc.s 13
-		IL_00e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ed: pop
-		IL_00ee: ldc.i4.8
-		IL_00ef: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_00f4: dup
-		IL_00f5: ldc.r8 32769
-		IL_00fe: neg
-		IL_00ff: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0104: dup
-		IL_0105: ldc.r8 32768
-		IL_010e: neg
-		IL_010f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0114: dup
-		IL_0115: ldc.r8 32767
-		IL_011e: neg
-		IL_011f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0124: dup
-		IL_0125: ldc.r8 32767
-		IL_012e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0133: dup
-		IL_0134: ldc.r8 32768
-		IL_013d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0142: dup
-		IL_0143: ldc.r8 32769
-		IL_014c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0151: dup
-		IL_0152: ldc.r8 65535
-		IL_015b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0160: dup
-		IL_0161: ldc.r8 65536
-		IL_016a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_016f: stloc.s 11
-		IL_0171: ldloc.s 11
-		IL_0173: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int16Array::.ctor(object)
-		IL_0178: stloc.2
-		IL_0179: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_017e: stloc.s 12
-		IL_0180: ldc.i4.2
-		IL_0181: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0186: brfalse IL_01b9
-
-		IL_018b: ldloc.2
-		IL_018c: ldstr "join"
-		IL_0191: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_0196: brtrue IL_01b9
-
-		IL_019b: ldloc.2
-		IL_019c: ldc.i4.2
-		IL_019d: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_01a2: brfalse IL_01b9
-
-		IL_01a7: ldloc.2
-		IL_01a8: ldstr "|"
-		IL_01ad: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Int16Array::join(object)
-		IL_01b2: stloc.s 13
-		IL_01b4: br IL_01cb
-
-		IL_01b9: ldloc.2
-		IL_01ba: ldstr "join"
-		IL_01bf: ldstr "|"
-		IL_01c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_01c9: stloc.s 13
-
-		IL_01cb: ldloc.s 12
-		IL_01cd: ldloc.s 13
-		IL_01cf: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_01d4: pop
-		IL_01d5: ldc.i4.8
-		IL_01d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_01db: dup
-		IL_01dc: ldc.r8 1
-		IL_01e5: neg
-		IL_01e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01eb: dup
-		IL_01ec: ldc.r8 0.0
-		IL_01f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_01fa: dup
-		IL_01fb: ldc.r8 1
-		IL_0204: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0209: dup
-		IL_020a: ldc.r8 255
-		IL_0213: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0218: dup
-		IL_0219: ldc.r8 256
-		IL_0222: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0227: dup
-		IL_0228: ldc.r8 257
+		IL_0099: ldloc.1
+		IL_009a: ldstr "join"
+		IL_009f: ldstr "|"
+		IL_00a4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a9: stloc.s 13
+		IL_00ab: ldloc.s 12
+		IL_00ad: ldloc.s 13
+		IL_00af: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b4: pop
+		IL_00b5: ldc.i4.8
+		IL_00b6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00bb: dup
+		IL_00bc: ldc.r8 32769
+		IL_00c5: neg
+		IL_00c6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00cb: dup
+		IL_00cc: ldc.r8 32768
+		IL_00d5: neg
+		IL_00d6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00db: dup
+		IL_00dc: ldc.r8 32767
+		IL_00e5: neg
+		IL_00e6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00eb: dup
+		IL_00ec: ldc.r8 32767
+		IL_00f5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_00fa: dup
+		IL_00fb: ldc.r8 32768
+		IL_0104: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0109: dup
+		IL_010a: ldc.r8 32769
+		IL_0113: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0118: dup
+		IL_0119: ldc.r8 65535
+		IL_0122: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0127: dup
+		IL_0128: ldc.r8 65536
+		IL_0131: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0136: stloc.s 11
+		IL_0138: ldloc.s 11
+		IL_013a: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Int16Array::.ctor(object)
+		IL_013f: stloc.2
+		IL_0140: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0145: stloc.s 12
+		IL_0147: ldloc.2
+		IL_0148: ldstr "join"
+		IL_014d: ldstr "|"
+		IL_0152: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0157: stloc.s 13
+		IL_0159: ldloc.s 12
+		IL_015b: ldloc.s 13
+		IL_015d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0162: pop
+		IL_0163: ldc.i4.8
+		IL_0164: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0169: dup
+		IL_016a: ldc.r8 1
+		IL_0173: neg
+		IL_0174: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0179: dup
+		IL_017a: ldc.r8 0.0
+		IL_0183: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0188: dup
+		IL_0189: ldc.r8 1
+		IL_0192: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0197: dup
+		IL_0198: ldc.r8 255
+		IL_01a1: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01a6: dup
+		IL_01a7: ldc.r8 256
+		IL_01b0: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01b5: dup
+		IL_01b6: ldc.r8 257
+		IL_01bf: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01c4: dup
+		IL_01c5: ldc.r8 511
+		IL_01ce: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01d3: dup
+		IL_01d4: ldc.r8 1.9
+		IL_01dd: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_01e2: stloc.s 11
+		IL_01e4: ldloc.s 11
+		IL_01e6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_01eb: stloc.3
+		IL_01ec: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01f1: stloc.s 12
+		IL_01f3: ldloc.3
+		IL_01f4: ldstr "join"
+		IL_01f9: ldstr "|"
+		IL_01fe: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0203: stloc.s 13
+		IL_0205: ldloc.s 12
+		IL_0207: ldloc.s 13
+		IL_0209: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_020e: pop
+		IL_020f: ldc.i4.s 10
+		IL_0211: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0216: dup
+		IL_0217: ldc.r8 20
+		IL_0220: neg
+		IL_0221: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0226: dup
+		IL_0227: ldc.r8 0.5
+		IL_0230: neg
 		IL_0231: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_0236: dup
-		IL_0237: ldc.r8 511
+		IL_0237: ldc.r8 0.49
 		IL_0240: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
 		IL_0245: dup
-		IL_0246: ldc.r8 1.9
+		IL_0246: ldc.r8 0.5
 		IL_024f: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0254: stloc.s 11
-		IL_0256: ldloc.s 11
-		IL_0258: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_025d: stloc.3
-		IL_025e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0263: stloc.s 12
-		IL_0265: ldc.i4.2
-		IL_0266: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_026b: brfalse IL_029e
-
-		IL_0270: ldloc.3
-		IL_0271: ldstr "join"
-		IL_0276: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_027b: brtrue IL_029e
-
-		IL_0280: ldloc.3
-		IL_0281: ldc.i4.2
-		IL_0282: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0287: brfalse IL_029e
-
-		IL_028c: ldloc.3
-		IL_028d: ldstr "|"
-		IL_0292: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::join(object)
-		IL_0297: stloc.s 13
-		IL_0299: br IL_02b0
-
-		IL_029e: ldloc.3
-		IL_029f: ldstr "join"
-		IL_02a4: ldstr "|"
-		IL_02a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02ae: stloc.s 13
-
-		IL_02b0: ldloc.s 12
-		IL_02b2: ldloc.s 13
-		IL_02b4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02b9: pop
-		IL_02ba: ldc.i4.s 10
-		IL_02bc: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
-		IL_02c1: dup
-		IL_02c2: ldc.r8 20
-		IL_02cb: neg
-		IL_02cc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02d1: dup
-		IL_02d2: ldc.r8 0.5
-		IL_02db: neg
-		IL_02dc: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02e1: dup
-		IL_02e2: ldc.r8 0.49
-		IL_02eb: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02f0: dup
-		IL_02f1: ldc.r8 0.5
-		IL_02fa: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_02ff: dup
-		IL_0300: ldc.r8 1.5
-		IL_0309: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_030e: dup
-		IL_030f: ldc.r8 2.5
-		IL_0318: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_031d: dup
-		IL_031e: ldc.r8 254.6
-		IL_0327: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_032c: dup
-		IL_032d: ldc.r8 255.4
-		IL_0336: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_033b: dup
-		IL_033c: ldc.r8 300
-		IL_0345: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_034a: dup
-		IL_034b: ldc.r8 (00 00 00 00 00 00 F8 FF)
-		IL_0354: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
-		IL_0359: stloc.s 11
-		IL_035b: ldloc.s 11
-		IL_035d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray::.ctor(object)
-		IL_0362: stloc.s 4
-		IL_0364: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0369: stloc.s 12
-		IL_036b: ldc.i4.2
-		IL_036c: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0371: brfalse IL_03a7
-
-		IL_0376: ldloc.s 4
-		IL_0378: ldstr "join"
-		IL_037d: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_0382: brtrue IL_03a7
-
-		IL_0387: ldloc.s 4
-		IL_0389: ldc.i4.2
-		IL_038a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_038f: brfalse IL_03a7
-
-		IL_0394: ldloc.s 4
-		IL_0396: ldstr "|"
-		IL_039b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray::join(object)
-		IL_03a0: stloc.s 13
-		IL_03a2: br IL_03ba
-
-		IL_03a7: ldloc.s 4
-		IL_03a9: ldstr "join"
-		IL_03ae: ldstr "|"
-		IL_03b3: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_03b8: stloc.s 13
-
-		IL_03ba: ldloc.s 12
-		IL_03bc: ldloc.s 13
-		IL_03be: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_03c3: pop
-		IL_03c4: ldloc.0
-		IL_03c5: ldc.r8 0.0
-		IL_03ce: box [System.Runtime]System.Double
-		IL_03d3: stfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
-		IL_03d8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_03dd: stloc.s 14
-		IL_03df: ldc.i4.1
-		IL_03e0: newarr [System.Runtime]System.Object
-		IL_03e5: dup
-		IL_03e6: ldc.i4.0
-		IL_03e7: ldloc.0
-		IL_03e8: stelem.ref
-		IL_03e9: stloc.s 15
-		IL_03eb: ldloc.s 15
-		IL_03ed: ldc.i4.0
-		IL_03ee: ldelem.ref
-		IL_03ef: castclass Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope
-		IL_03f4: newobj instance void Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject::.ctor(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope)
-		IL_03f9: ldc.i4.0
-		IL_03fa: conv.r8
-		IL_03fb: ldstr ""
-		IL_0400: ldc.i4.0
-		IL_0401: ldc.i4.1
-		IL_0402: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0407: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject>(!!0)
-		IL_040c: stloc.s 16
-		IL_040e: ldloc.s 14
-		IL_0410: ldstr "valueOf"
-		IL_0415: ldloc.s 16
-		IL_0417: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
-		IL_041c: pop
-		IL_041d: ldloc.s 14
-		IL_041f: stloc.s 5
-		IL_0421: ldc.r8 0.0
-		IL_042a: box [System.Runtime]System.Double
-		IL_042f: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
-		IL_0434: stloc.s 6
-		IL_0436: ldloc.s 6
-		IL_0438: ldc.r8 0.0
-		IL_0441: ldloc.s 5
-		IL_0443: ldc.i4.1
-		IL_0444: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-		IL_0449: pop
-		IL_044a: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_044f: stloc.s 12
-		IL_0451: ldloc.0
-		IL_0452: ldfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
-		IL_0457: stloc.s 13
-		IL_0459: ldloc.s 12
-		IL_045b: ldloc.s 13
-		IL_045d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0462: pop
+		IL_0254: dup
+		IL_0255: ldc.r8 1.5
+		IL_025e: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0263: dup
+		IL_0264: ldc.r8 2.5
+		IL_026d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0272: dup
+		IL_0273: ldc.r8 254.6
+		IL_027c: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0281: dup
+		IL_0282: ldc.r8 255.4
+		IL_028b: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0290: dup
+		IL_0291: ldc.r8 300
+		IL_029a: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_029f: dup
+		IL_02a0: ldc.r8 (00 00 00 00 00 00 F8 FF)
+		IL_02a9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_02ae: stloc.s 11
+		IL_02b0: ldloc.s 11
+		IL_02b2: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8ClampedArray::.ctor(object)
+		IL_02b7: stloc.s 4
+		IL_02b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02be: stloc.s 12
+		IL_02c0: ldloc.s 4
+		IL_02c2: ldstr "join"
+		IL_02c7: ldstr "|"
+		IL_02cc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02d1: stloc.s 13
+		IL_02d3: ldloc.s 12
+		IL_02d5: ldloc.s 13
+		IL_02d7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02dc: pop
+		IL_02dd: ldloc.0
+		IL_02de: ldc.r8 0.0
+		IL_02e7: box [System.Runtime]System.Double
+		IL_02ec: stfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
+		IL_02f1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_02f6: stloc.s 14
+		IL_02f8: ldc.i4.1
+		IL_02f9: newarr [System.Runtime]System.Object
+		IL_02fe: dup
+		IL_02ff: ldc.i4.0
+		IL_0300: ldloc.0
+		IL_0301: stelem.ref
+		IL_0302: stloc.s 15
+		IL_0304: ldloc.s 15
+		IL_0306: ldc.i4.0
+		IL_0307: ldelem.ref
+		IL_0308: castclass Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope
+		IL_030d: newobj instance void Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject::.ctor(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope)
+		IL_0312: ldc.i4.0
+		IL_0313: conv.r8
+		IL_0314: ldstr ""
+		IL_0319: ldc.i4.0
+		IL_031a: ldc.i4.1
+		IL_031b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0320: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject>(!!0)
+		IL_0325: stloc.s 16
+		IL_0327: ldloc.s 14
+		IL_0329: ldstr "valueOf"
+		IL_032e: ldloc.s 16
+		IL_0330: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0335: pop
+		IL_0336: ldloc.s 14
+		IL_0338: stloc.s 5
+		IL_033a: ldc.r8 0.0
+		IL_0343: box [System.Runtime]System.Double
+		IL_0348: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::.ctor(object)
+		IL_034d: stloc.s 6
+		IL_034f: ldloc.s 6
+		IL_0351: ldc.r8 0.0
+		IL_035a: ldloc.s 5
+		IL_035c: ldc.i4.1
+		IL_035d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_0362: pop
+		IL_0363: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0368: stloc.s 12
+		IL_036a: ldloc.0
+		IL_036b: ldfld object Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::coercions
+		IL_0370: stloc.s 13
+		IL_0372: ldloc.s 12
+		IL_0374: ldloc.s 13
+		IL_0376: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_037b: pop
 		.try
 		{
-			IL_0463: nop
-			IL_0464: ldstr "value"
-			IL_0469: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::Call(object)
-			IL_046e: stloc.s 13
-			IL_0470: ldloc.s 6
-			IL_0472: ldc.r8 0.0
-			IL_047b: ldloc.s 13
-			IL_047d: ldc.i4.1
-			IL_047e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
-			IL_0483: pop
-			IL_0484: leave IL_04df
+			IL_037c: nop
+			IL_037d: ldstr "value"
+			IL_0382: call object [JavaScriptRuntime]JavaScriptRuntime.Symbol::Call(object)
+			IL_0387: stloc.s 13
+			IL_0389: ldloc.s 6
+			IL_038b: ldc.r8 0.0
+			IL_0394: ldloc.s 13
+			IL_0396: ldc.i4.1
+			IL_0397: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+			IL_039c: pop
+			IL_039d: leave IL_03f8
 		} // end .try
 		catch [System.Runtime]System.Exception
 		{
-			IL_0489: stloc.s 7
-			IL_048b: ldloc.s 7
-			IL_048d: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
-			IL_0492: dup
-			IL_0493: brtrue IL_04a9
+			IL_03a2: stloc.s 7
+			IL_03a4: ldloc.s 7
+			IL_03a6: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_03ab: dup
+			IL_03ac: brtrue IL_03c2
 
-			IL_0498: pop
-			IL_0499: ldloc.s 7
-			IL_049b: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
-			IL_04a0: dup
-			IL_04a1: brtrue IL_04b5
+			IL_03b1: pop
+			IL_03b2: ldloc.s 7
+			IL_03b4: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03b9: dup
+			IL_03ba: brtrue IL_03ce
 
-			IL_04a6: pop
-			IL_04a7: rethrow
+			IL_03bf: pop
+			IL_03c0: rethrow
 
-			IL_04a9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
-			IL_04ae: stloc.s 8
-			IL_04b0: br IL_04b7
+			IL_03c2: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03c7: stloc.s 8
+			IL_03c9: br IL_03d0
 
-			IL_04b5: stloc.s 8
+			IL_03ce: stloc.s 8
 
-			IL_04b7: ldloc.s 8
-			IL_04b9: stloc.s 9
-			IL_04bb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-			IL_04c0: stloc.s 12
-			IL_04c2: ldloc.s 9
-			IL_04c4: ldstr "name"
-			IL_04c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
-			IL_04ce: stloc.s 13
-			IL_04d0: ldloc.s 12
-			IL_04d2: ldloc.s 13
-			IL_04d4: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-			IL_04d9: pop
-			IL_04da: leave IL_04df
+			IL_03d0: ldloc.s 8
+			IL_03d2: stloc.s 9
+			IL_03d4: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03d9: stloc.s 12
+			IL_03db: ldloc.s 9
+			IL_03dd: ldstr "name"
+			IL_03e2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_03e7: stloc.s 13
+			IL_03e9: ldloc.s 12
+			IL_03eb: ldloc.s 13
+			IL_03ed: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03f2: pop
+			IL_03f3: leave IL_03f8
 		} // end handler
 
-		IL_04df: ldnull
-		IL_04e0: stloc.s 10
-		IL_04e2: ret
+		IL_03f8: ldnull
+		IL_03f9: stloc.s 10
+		IL_03fb: ret
 	} // end of method TypedArray_SignedAndClamped_ConversionSemantics::__js_module_init__
 
 } // end of class Modules.TypedArray_SignedAndClamped_ConversionSemantics

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_Static_From_Of.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_Static_From_Of.verified.txt
@@ -364,7 +364,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 537 (0x219)
+		// Code size: 777 (0x309)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_Static_From_Of/Scope,
@@ -431,126 +431,210 @@
 		IL_008c: ldloc.1
 		IL_008d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
 		IL_0092: stloc.s 10
-		IL_0094: ldloc.s 10
-		IL_0096: ldstr "join"
-		IL_009b: ldstr "|"
-		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00a5: stloc.s 11
-		IL_00a7: ldloc.s 9
-		IL_00a9: ldloc.s 11
-		IL_00ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00b0: pop
-		IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00b6: dup
-		IL_00b7: ldstr "0"
-		IL_00bc: ldc.r8 7
-		IL_00c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_00ca: dup
-		IL_00cb: ldstr "1"
-		IL_00d0: ldc.r8 8
-		IL_00d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_00de: dup
-		IL_00df: ldstr "length"
-		IL_00e4: ldc.r8 2
-		IL_00ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_00f2: call class [JavaScriptRuntime]JavaScriptRuntime.Int32Array [JavaScriptRuntime]JavaScriptRuntime.Int32Array::from(object)
-		IL_00f7: stloc.2
-		IL_00f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_00fd: stloc.s 9
-		IL_00ff: ldloc.2
-		IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_0105: stloc.s 10
-		IL_0107: ldloc.s 10
-		IL_0109: ldstr "join"
-		IL_010e: ldstr "|"
-		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0118: stloc.s 11
-		IL_011a: ldloc.s 9
-		IL_011c: ldloc.s 11
-		IL_011e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0123: pop
-		IL_0124: ldc.i4.3
-		IL_0125: newarr [System.Runtime]System.Object
-		IL_012a: dup
-		IL_012b: ldc.i4.0
-		IL_012c: ldc.r8 257
-		IL_0135: box [System.Runtime]System.Double
-		IL_013a: stelem.ref
-		IL_013b: dup
-		IL_013c: ldc.i4.1
-		IL_013d: ldc.r8 1
-		IL_0146: neg
-		IL_0147: box [System.Runtime]System.Double
-		IL_014c: stelem.ref
-		IL_014d: dup
-		IL_014e: ldc.i4.2
-		IL_014f: ldc.r8 3
-		IL_0158: box [System.Runtime]System.Double
-		IL_015d: stelem.ref
-		IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::of(object[])
-		IL_0163: stloc.3
-		IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0169: stloc.s 9
-		IL_016b: ldloc.3
-		IL_016c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
-		IL_0171: stloc.s 12
-		IL_0173: ldloc.s 12
-		IL_0175: ldstr "join"
-		IL_017a: ldstr "|"
-		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0184: stloc.s 11
-		IL_0186: ldloc.s 9
-		IL_0188: ldloc.s 11
-		IL_018a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_018f: pop
-		IL_0190: ldc.i4.2
-		IL_0191: newarr [System.Runtime]System.Object
-		IL_0196: dup
-		IL_0197: ldc.i4.0
-		IL_0198: ldc.r8 4
-		IL_01a1: box [System.Runtime]System.Double
-		IL_01a6: stelem.ref
-		IL_01a7: dup
-		IL_01a8: ldc.i4.1
-		IL_01a9: ldc.r8 5
-		IL_01b2: box [System.Runtime]System.Double
-		IL_01b7: stelem.ref
-		IL_01b8: call class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::of(object[])
-		IL_01bd: stloc.s 12
-		IL_01bf: ldc.i4.1
-		IL_01c0: newarr [System.Runtime]System.Object
+		IL_0094: ldc.i4.2
+		IL_0095: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_009a: brfalse IL_00d0
+
+		IL_009f: ldloc.s 10
+		IL_00a1: ldstr "join"
+		IL_00a6: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_00ab: brtrue IL_00d0
+
+		IL_00b0: ldloc.s 10
+		IL_00b2: ldc.i4.2
+		IL_00b3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_00b8: brfalse IL_00d0
+
+		IL_00bd: ldloc.s 10
+		IL_00bf: ldstr "|"
+		IL_00c4: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Int32Array::join(object)
+		IL_00c9: stloc.s 11
+		IL_00cb: br IL_00e3
+
+		IL_00d0: ldloc.s 10
+		IL_00d2: ldstr "join"
+		IL_00d7: ldstr "|"
+		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00e1: stloc.s 11
+
+		IL_00e3: ldloc.s 9
+		IL_00e5: ldloc.s 11
+		IL_00e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00ec: pop
+		IL_00ed: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00f2: dup
+		IL_00f3: ldstr "0"
+		IL_00f8: ldc.r8 7
+		IL_0101: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_0106: dup
+		IL_0107: ldstr "1"
+		IL_010c: ldc.r8 8
+		IL_0115: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_011a: dup
+		IL_011b: ldstr "length"
+		IL_0120: ldc.r8 2
+		IL_0129: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_012e: call class [JavaScriptRuntime]JavaScriptRuntime.Int32Array [JavaScriptRuntime]JavaScriptRuntime.Int32Array::from(object)
+		IL_0133: stloc.2
+		IL_0134: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0139: stloc.s 9
+		IL_013b: ldloc.2
+		IL_013c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_0141: stloc.s 10
+		IL_0143: ldc.i4.2
+		IL_0144: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0149: brfalse IL_017f
+
+		IL_014e: ldloc.s 10
+		IL_0150: ldstr "join"
+		IL_0155: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_015a: brtrue IL_017f
+
+		IL_015f: ldloc.s 10
+		IL_0161: ldc.i4.2
+		IL_0162: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0167: brfalse IL_017f
+
+		IL_016c: ldloc.s 10
+		IL_016e: ldstr "|"
+		IL_0173: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Int32Array::join(object)
+		IL_0178: stloc.s 11
+		IL_017a: br IL_0192
+
+		IL_017f: ldloc.s 10
+		IL_0181: ldstr "join"
+		IL_0186: ldstr "|"
+		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0190: stloc.s 11
+
+		IL_0192: ldloc.s 9
+		IL_0194: ldloc.s 11
+		IL_0196: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_019b: pop
+		IL_019c: ldc.i4.3
+		IL_019d: newarr [System.Runtime]System.Object
+		IL_01a2: dup
+		IL_01a3: ldc.i4.0
+		IL_01a4: ldc.r8 257
+		IL_01ad: box [System.Runtime]System.Double
+		IL_01b2: stelem.ref
+		IL_01b3: dup
+		IL_01b4: ldc.i4.1
+		IL_01b5: ldc.r8 1
+		IL_01be: neg
+		IL_01bf: box [System.Runtime]System.Double
+		IL_01c4: stelem.ref
 		IL_01c5: dup
-		IL_01c6: ldc.i4.0
-		IL_01c7: ldloc.0
-		IL_01c8: stelem.ref
-		IL_01c9: stloc.s 6
-		IL_01cb: newobj instance void Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject::.ctor()
-		IL_01d0: ldc.i4.1
-		IL_01d1: conv.r8
-		IL_01d2: ldstr ""
-		IL_01d7: ldc.i4.0
-		IL_01d8: ldc.i4.1
-		IL_01d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_01de: stloc.s 13
-		IL_01e0: ldloc.s 12
-		IL_01e2: ldloc.s 13
-		IL_01e4: call class [JavaScriptRuntime]JavaScriptRuntime.Float64Array [JavaScriptRuntime]JavaScriptRuntime.Float64Array::from(object, object)
-		IL_01e9: stloc.s 4
-		IL_01eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01f0: stloc.s 9
-		IL_01f2: ldloc.s 4
-		IL_01f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
-		IL_01f9: stloc.s 14
-		IL_01fb: ldloc.s 14
-		IL_01fd: ldstr "join"
-		IL_0202: ldstr "|"
-		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_020c: stloc.s 11
-		IL_020e: ldloc.s 9
-		IL_0210: ldloc.s 11
-		IL_0212: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0217: pop
-		IL_0218: ret
+		IL_01c6: ldc.i4.2
+		IL_01c7: ldc.r8 3
+		IL_01d0: box [System.Runtime]System.Double
+		IL_01d5: stelem.ref
+		IL_01d6: call class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::of(object[])
+		IL_01db: stloc.3
+		IL_01dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01e1: stloc.s 9
+		IL_01e3: ldloc.3
+		IL_01e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
+		IL_01e9: stloc.s 12
+		IL_01eb: ldc.i4.2
+		IL_01ec: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_01f1: brfalse IL_0227
+
+		IL_01f6: ldloc.s 12
+		IL_01f8: ldstr "join"
+		IL_01fd: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_0202: brtrue IL_0227
+
+		IL_0207: ldloc.s 12
+		IL_0209: ldc.i4.2
+		IL_020a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_020f: brfalse IL_0227
+
+		IL_0214: ldloc.s 12
+		IL_0216: ldstr "|"
+		IL_021b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::join(object)
+		IL_0220: stloc.s 11
+		IL_0222: br IL_023a
+
+		IL_0227: ldloc.s 12
+		IL_0229: ldstr "join"
+		IL_022e: ldstr "|"
+		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0238: stloc.s 11
+
+		IL_023a: ldloc.s 9
+		IL_023c: ldloc.s 11
+		IL_023e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0243: pop
+		IL_0244: ldc.i4.2
+		IL_0245: newarr [System.Runtime]System.Object
+		IL_024a: dup
+		IL_024b: ldc.i4.0
+		IL_024c: ldc.r8 4
+		IL_0255: box [System.Runtime]System.Double
+		IL_025a: stelem.ref
+		IL_025b: dup
+		IL_025c: ldc.i4.1
+		IL_025d: ldc.r8 5
+		IL_0266: box [System.Runtime]System.Double
+		IL_026b: stelem.ref
+		IL_026c: call class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::of(object[])
+		IL_0271: stloc.s 12
+		IL_0273: ldc.i4.1
+		IL_0274: newarr [System.Runtime]System.Object
+		IL_0279: dup
+		IL_027a: ldc.i4.0
+		IL_027b: ldloc.0
+		IL_027c: stelem.ref
+		IL_027d: stloc.s 6
+		IL_027f: newobj instance void Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject::.ctor()
+		IL_0284: ldc.i4.1
+		IL_0285: conv.r8
+		IL_0286: ldstr ""
+		IL_028b: ldc.i4.0
+		IL_028c: ldc.i4.1
+		IL_028d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0292: stloc.s 13
+		IL_0294: ldloc.s 12
+		IL_0296: ldloc.s 13
+		IL_0298: call class [JavaScriptRuntime]JavaScriptRuntime.Float64Array [JavaScriptRuntime]JavaScriptRuntime.Float64Array::from(object, object)
+		IL_029d: stloc.s 4
+		IL_029f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02a4: stloc.s 9
+		IL_02a6: ldloc.s 4
+		IL_02a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
+		IL_02ad: stloc.s 14
+		IL_02af: ldc.i4.2
+		IL_02b0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_02b5: brfalse IL_02eb
+
+		IL_02ba: ldloc.s 14
+		IL_02bc: ldstr "join"
+		IL_02c1: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_02c6: brtrue IL_02eb
+
+		IL_02cb: ldloc.s 14
+		IL_02cd: ldc.i4.2
+		IL_02ce: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_02d3: brfalse IL_02eb
+
+		IL_02d8: ldloc.s 14
+		IL_02da: ldstr "|"
+		IL_02df: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Float64Array::join(object)
+		IL_02e4: stloc.s 11
+		IL_02e6: br IL_02fe
+
+		IL_02eb: ldloc.s 14
+		IL_02ed: ldstr "join"
+		IL_02f2: ldstr "|"
+		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02fc: stloc.s 11
+
+		IL_02fe: ldloc.s 9
+		IL_0300: ldloc.s 11
+		IL_0302: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0307: pop
+		IL_0308: ret
 	} // end of method TypedArray_Static_From_Of::__js_module_init__
 
 } // end of class Modules.TypedArray_Static_From_Of

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_Static_From_Of.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_Static_From_Of.verified.txt
@@ -364,7 +364,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 777 (0x309)
+		// Code size: 537 (0x219)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TypedArray_Static_From_Of/Scope,
@@ -431,210 +431,126 @@
 		IL_008c: ldloc.1
 		IL_008d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
 		IL_0092: stloc.s 10
-		IL_0094: ldc.i4.2
-		IL_0095: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_009a: brfalse IL_00d0
-
-		IL_009f: ldloc.s 10
-		IL_00a1: ldstr "join"
-		IL_00a6: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_00ab: brtrue IL_00d0
-
-		IL_00b0: ldloc.s 10
-		IL_00b2: ldc.i4.2
-		IL_00b3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_00b8: brfalse IL_00d0
-
-		IL_00bd: ldloc.s 10
-		IL_00bf: ldstr "|"
-		IL_00c4: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Int32Array::join(object)
-		IL_00c9: stloc.s 11
-		IL_00cb: br IL_00e3
-
-		IL_00d0: ldloc.s 10
-		IL_00d2: ldstr "join"
-		IL_00d7: ldstr "|"
-		IL_00dc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_00e1: stloc.s 11
-
-		IL_00e3: ldloc.s 9
-		IL_00e5: ldloc.s 11
-		IL_00e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_00ec: pop
-		IL_00ed: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
-		IL_00f2: dup
-		IL_00f3: ldstr "0"
-		IL_00f8: ldc.r8 7
-		IL_0101: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_0106: dup
-		IL_0107: ldstr "1"
-		IL_010c: ldc.r8 8
-		IL_0115: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_011a: dup
-		IL_011b: ldstr "length"
-		IL_0120: ldc.r8 2
-		IL_0129: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
-		IL_012e: call class [JavaScriptRuntime]JavaScriptRuntime.Int32Array [JavaScriptRuntime]JavaScriptRuntime.Int32Array::from(object)
-		IL_0133: stloc.2
-		IL_0134: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0139: stloc.s 9
-		IL_013b: ldloc.2
-		IL_013c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
-		IL_0141: stloc.s 10
-		IL_0143: ldc.i4.2
-		IL_0144: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0149: brfalse IL_017f
-
-		IL_014e: ldloc.s 10
-		IL_0150: ldstr "join"
-		IL_0155: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_015a: brtrue IL_017f
-
-		IL_015f: ldloc.s 10
-		IL_0161: ldc.i4.2
-		IL_0162: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0167: brfalse IL_017f
-
-		IL_016c: ldloc.s 10
-		IL_016e: ldstr "|"
-		IL_0173: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Int32Array::join(object)
-		IL_0178: stloc.s 11
-		IL_017a: br IL_0192
-
-		IL_017f: ldloc.s 10
-		IL_0181: ldstr "join"
-		IL_0186: ldstr "|"
-		IL_018b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0190: stloc.s 11
-
-		IL_0192: ldloc.s 9
-		IL_0194: ldloc.s 11
-		IL_0196: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_019b: pop
-		IL_019c: ldc.i4.3
-		IL_019d: newarr [System.Runtime]System.Object
-		IL_01a2: dup
-		IL_01a3: ldc.i4.0
-		IL_01a4: ldc.r8 257
-		IL_01ad: box [System.Runtime]System.Double
-		IL_01b2: stelem.ref
-		IL_01b3: dup
-		IL_01b4: ldc.i4.1
-		IL_01b5: ldc.r8 1
-		IL_01be: neg
-		IL_01bf: box [System.Runtime]System.Double
-		IL_01c4: stelem.ref
+		IL_0094: ldloc.s 10
+		IL_0096: ldstr "join"
+		IL_009b: ldstr "|"
+		IL_00a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00a5: stloc.s 11
+		IL_00a7: ldloc.s 9
+		IL_00a9: ldloc.s 11
+		IL_00ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00b0: pop
+		IL_00b1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00b6: dup
+		IL_00b7: ldstr "0"
+		IL_00bc: ldc.r8 7
+		IL_00c5: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_00ca: dup
+		IL_00cb: ldstr "1"
+		IL_00d0: ldc.r8 8
+		IL_00d9: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_00de: dup
+		IL_00df: ldstr "length"
+		IL_00e4: ldc.r8 2
+		IL_00ed: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_00f2: call class [JavaScriptRuntime]JavaScriptRuntime.Int32Array [JavaScriptRuntime]JavaScriptRuntime.Int32Array::from(object)
+		IL_00f7: stloc.2
+		IL_00f8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00fd: stloc.s 9
+		IL_00ff: ldloc.2
+		IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Int32Array>(!!0)
+		IL_0105: stloc.s 10
+		IL_0107: ldloc.s 10
+		IL_0109: ldstr "join"
+		IL_010e: ldstr "|"
+		IL_0113: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0118: stloc.s 11
+		IL_011a: ldloc.s 9
+		IL_011c: ldloc.s 11
+		IL_011e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0123: pop
+		IL_0124: ldc.i4.3
+		IL_0125: newarr [System.Runtime]System.Object
+		IL_012a: dup
+		IL_012b: ldc.i4.0
+		IL_012c: ldc.r8 257
+		IL_0135: box [System.Runtime]System.Double
+		IL_013a: stelem.ref
+		IL_013b: dup
+		IL_013c: ldc.i4.1
+		IL_013d: ldc.r8 1
+		IL_0146: neg
+		IL_0147: box [System.Runtime]System.Double
+		IL_014c: stelem.ref
+		IL_014d: dup
+		IL_014e: ldc.i4.2
+		IL_014f: ldc.r8 3
+		IL_0158: box [System.Runtime]System.Double
+		IL_015d: stelem.ref
+		IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::of(object[])
+		IL_0163: stloc.3
+		IL_0164: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0169: stloc.s 9
+		IL_016b: ldloc.3
+		IL_016c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
+		IL_0171: stloc.s 12
+		IL_0173: ldloc.s 12
+		IL_0175: ldstr "join"
+		IL_017a: ldstr "|"
+		IL_017f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0184: stloc.s 11
+		IL_0186: ldloc.s 9
+		IL_0188: ldloc.s 11
+		IL_018a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_018f: pop
+		IL_0190: ldc.i4.2
+		IL_0191: newarr [System.Runtime]System.Object
+		IL_0196: dup
+		IL_0197: ldc.i4.0
+		IL_0198: ldc.r8 4
+		IL_01a1: box [System.Runtime]System.Double
+		IL_01a6: stelem.ref
+		IL_01a7: dup
+		IL_01a8: ldc.i4.1
+		IL_01a9: ldc.r8 5
+		IL_01b2: box [System.Runtime]System.Double
+		IL_01b7: stelem.ref
+		IL_01b8: call class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::of(object[])
+		IL_01bd: stloc.s 12
+		IL_01bf: ldc.i4.1
+		IL_01c0: newarr [System.Runtime]System.Object
 		IL_01c5: dup
-		IL_01c6: ldc.i4.2
-		IL_01c7: ldc.r8 3
-		IL_01d0: box [System.Runtime]System.Double
-		IL_01d5: stelem.ref
-		IL_01d6: call class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::of(object[])
-		IL_01db: stloc.3
-		IL_01dc: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_01e1: stloc.s 9
-		IL_01e3: ldloc.3
-		IL_01e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array>(!!0)
-		IL_01e9: stloc.s 12
-		IL_01eb: ldc.i4.2
-		IL_01ec: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_01f1: brfalse IL_0227
-
-		IL_01f6: ldloc.s 12
-		IL_01f8: ldstr "join"
-		IL_01fd: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_0202: brtrue IL_0227
-
-		IL_0207: ldloc.s 12
-		IL_0209: ldc.i4.2
-		IL_020a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_020f: brfalse IL_0227
-
-		IL_0214: ldloc.s 12
-		IL_0216: ldstr "|"
-		IL_021b: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::join(object)
-		IL_0220: stloc.s 11
-		IL_0222: br IL_023a
-
-		IL_0227: ldloc.s 12
-		IL_0229: ldstr "join"
-		IL_022e: ldstr "|"
-		IL_0233: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0238: stloc.s 11
-
-		IL_023a: ldloc.s 9
-		IL_023c: ldloc.s 11
-		IL_023e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0243: pop
-		IL_0244: ldc.i4.2
-		IL_0245: newarr [System.Runtime]System.Object
-		IL_024a: dup
-		IL_024b: ldc.i4.0
-		IL_024c: ldc.r8 4
-		IL_0255: box [System.Runtime]System.Double
-		IL_025a: stelem.ref
-		IL_025b: dup
-		IL_025c: ldc.i4.1
-		IL_025d: ldc.r8 5
-		IL_0266: box [System.Runtime]System.Double
-		IL_026b: stelem.ref
-		IL_026c: call class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::of(object[])
-		IL_0271: stloc.s 12
-		IL_0273: ldc.i4.1
-		IL_0274: newarr [System.Runtime]System.Object
-		IL_0279: dup
-		IL_027a: ldc.i4.0
-		IL_027b: ldloc.0
-		IL_027c: stelem.ref
-		IL_027d: stloc.s 6
-		IL_027f: newobj instance void Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject::.ctor()
-		IL_0284: ldc.i4.1
-		IL_0285: conv.r8
-		IL_0286: ldstr ""
-		IL_028b: ldc.i4.0
-		IL_028c: ldc.i4.1
-		IL_028d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject>(!!0, float64, string, bool, bool)
-		IL_0292: stloc.s 13
-		IL_0294: ldloc.s 12
-		IL_0296: ldloc.s 13
-		IL_0298: call class [JavaScriptRuntime]JavaScriptRuntime.Float64Array [JavaScriptRuntime]JavaScriptRuntime.Float64Array::from(object, object)
-		IL_029d: stloc.s 4
-		IL_029f: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02a4: stloc.s 9
-		IL_02a6: ldloc.s 4
-		IL_02a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
-		IL_02ad: stloc.s 14
-		IL_02af: ldc.i4.2
-		IL_02b0: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_02b5: brfalse IL_02eb
-
-		IL_02ba: ldloc.s 14
-		IL_02bc: ldstr "join"
-		IL_02c1: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_02c6: brtrue IL_02eb
-
-		IL_02cb: ldloc.s 14
-		IL_02cd: ldc.i4.2
-		IL_02ce: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_02d3: brfalse IL_02eb
-
-		IL_02d8: ldloc.s 14
-		IL_02da: ldstr "|"
-		IL_02df: callvirt instance string [JavaScriptRuntime]JavaScriptRuntime.Float64Array::join(object)
-		IL_02e4: stloc.s 11
-		IL_02e6: br IL_02fe
-
-		IL_02eb: ldloc.s 14
-		IL_02ed: ldstr "join"
-		IL_02f2: ldstr "|"
-		IL_02f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02fc: stloc.s 11
-
-		IL_02fe: ldloc.s 9
-		IL_0300: ldloc.s 11
-		IL_0302: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0307: pop
-		IL_0308: ret
+		IL_01c6: ldc.i4.0
+		IL_01c7: ldloc.0
+		IL_01c8: stelem.ref
+		IL_01c9: stloc.s 6
+		IL_01cb: newobj instance void Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject::.ctor()
+		IL_01d0: ldc.i4.1
+		IL_01d1: conv.r8
+		IL_01d2: ldstr ""
+		IL_01d7: ldc.i4.0
+		IL_01d8: ldc.i4.1
+		IL_01d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01de: stloc.s 13
+		IL_01e0: ldloc.s 12
+		IL_01e2: ldloc.s 13
+		IL_01e4: call class [JavaScriptRuntime]JavaScriptRuntime.Float64Array [JavaScriptRuntime]JavaScriptRuntime.Float64Array::from(object, object)
+		IL_01e9: stloc.s 4
+		IL_01eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01f0: stloc.s 9
+		IL_01f2: ldloc.s 4
+		IL_01f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible<class [JavaScriptRuntime]JavaScriptRuntime.Float64Array>(!!0)
+		IL_01f9: stloc.s 14
+		IL_01fb: ldloc.s 14
+		IL_01fd: ldstr "join"
+		IL_0202: ldstr "|"
+		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_020c: stloc.s 11
+		IL_020e: ldloc.s 9
+		IL_0210: ldloc.s 11
+		IL_0212: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0217: pop
+		IL_0218: ret
 	} // end of method TypedArray_Static_From_Of::__js_module_init__
 
 } // end of class Modules.TypedArray_Static_From_Of

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Construct_ArrayLike_Buffer_Search.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Construct_ArrayLike_Buffer_Search.verified.txt
@@ -78,7 +78,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 636 (0x27c)
+		// Code size: 846 (0x34e)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Uint8Array_Construct_ArrayLike_Buffer_Search/Scope,
@@ -244,46 +244,114 @@
 		IL_01ea: pop
 		IL_01eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_01f0: stloc.s 7
-		IL_01f2: ldloc.s 4
-		IL_01f4: ldstr "includes"
-		IL_01f9: ldc.r8 43
-		IL_0202: box [System.Runtime]System.Double
-		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_020c: stloc.s 11
-		IL_020e: ldloc.s 7
-		IL_0210: ldloc.s 11
-		IL_0212: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0217: pop
-		IL_0218: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_021d: stloc.s 7
-		IL_021f: ldloc.s 4
-		IL_0221: ldstr "indexOf"
-		IL_0226: ldc.r8 42
-		IL_022f: box [System.Runtime]System.Double
-		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0239: stloc.s 11
-		IL_023b: ldloc.s 7
-		IL_023d: ldloc.s 11
-		IL_023f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0244: pop
-		IL_0245: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_024a: stloc.s 7
-		IL_024c: ldc.r8 1
-		IL_0255: neg
-		IL_0256: stloc.s 10
-		IL_0258: ldloc.s 10
-		IL_025a: box [System.Runtime]System.Double
-		IL_025f: stloc.s 9
-		IL_0261: ldloc.s 4
-		IL_0263: ldstr "at"
-		IL_0268: ldloc.s 9
-		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_026f: stloc.s 11
-		IL_0271: ldloc.s 7
-		IL_0273: ldloc.s 11
-		IL_0275: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_027a: pop
-		IL_027b: ret
+		IL_01f2: ldc.i4.2
+		IL_01f3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_01f8: brfalse IL_023c
+
+		IL_01fd: ldloc.s 4
+		IL_01ff: ldstr "includes"
+		IL_0204: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_0209: brtrue IL_023c
+
+		IL_020e: ldloc.s 4
+		IL_0210: ldc.i4.2
+		IL_0211: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0216: brfalse IL_023c
+
+		IL_021b: ldloc.s 4
+		IL_021d: ldc.r8 43
+		IL_0226: box [System.Runtime]System.Double
+		IL_022b: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::includes(object)
+		IL_0230: box [System.Runtime]System.Boolean
+		IL_0235: stloc.s 11
+		IL_0237: br IL_0258
+
+		IL_023c: ldloc.s 4
+		IL_023e: ldstr "includes"
+		IL_0243: ldc.r8 43
+		IL_024c: box [System.Runtime]System.Double
+		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0256: stloc.s 11
+
+		IL_0258: ldloc.s 7
+		IL_025a: ldloc.s 11
+		IL_025c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0261: pop
+		IL_0262: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0267: stloc.s 7
+		IL_0269: ldc.i4.2
+		IL_026a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_026f: brfalse IL_02b3
+
+		IL_0274: ldloc.s 4
+		IL_0276: ldstr "indexOf"
+		IL_027b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_0280: brtrue IL_02b3
+
+		IL_0285: ldloc.s 4
+		IL_0287: ldc.i4.2
+		IL_0288: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_028d: brfalse IL_02b3
+
+		IL_0292: ldloc.s 4
+		IL_0294: ldc.r8 42
+		IL_029d: box [System.Runtime]System.Double
+		IL_02a2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::indexOf(object)
+		IL_02a7: box [System.Runtime]System.Double
+		IL_02ac: stloc.s 11
+		IL_02ae: br IL_02cf
+
+		IL_02b3: ldloc.s 4
+		IL_02b5: ldstr "indexOf"
+		IL_02ba: ldc.r8 42
+		IL_02c3: box [System.Runtime]System.Double
+		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_02cd: stloc.s 11
+
+		IL_02cf: ldloc.s 7
+		IL_02d1: ldloc.s 11
+		IL_02d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02d8: pop
+		IL_02d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02de: stloc.s 7
+		IL_02e0: ldc.r8 1
+		IL_02e9: neg
+		IL_02ea: stloc.s 10
+		IL_02ec: ldloc.s 10
+		IL_02ee: box [System.Runtime]System.Double
+		IL_02f3: stloc.s 9
+		IL_02f5: ldc.i4.2
+		IL_02f6: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_02fb: brfalse IL_0333
+
+		IL_0300: ldloc.s 4
+		IL_0302: ldstr "at"
+		IL_0307: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
+		IL_030c: brtrue IL_0333
+
+		IL_0311: ldloc.s 4
+		IL_0313: ldc.i4.2
+		IL_0314: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
+		IL_0319: brfalse IL_0333
+
+		IL_031e: ldloc.s 4
+		IL_0320: ldloc.s 9
+		IL_0322: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::'at'(object)
+		IL_0327: box [System.Runtime]System.Double
+		IL_032c: stloc.s 11
+		IL_032e: br IL_0343
+
+		IL_0333: ldloc.s 4
+		IL_0335: ldstr "at"
+		IL_033a: ldloc.s 9
+		IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0341: stloc.s 11
+
+		IL_0343: ldloc.s 7
+		IL_0345: ldloc.s 11
+		IL_0347: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_034c: pop
+		IL_034d: ret
 	} // end of method Uint8Array_Construct_ArrayLike_Buffer_Search::__js_module_init__
 
 } // end of class Modules.Uint8Array_Construct_ArrayLike_Buffer_Search

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Construct_ArrayLike_Buffer_Search.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Uint8Array_Construct_ArrayLike_Buffer_Search.verified.txt
@@ -78,7 +78,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 846 (0x34e)
+		// Code size: 636 (0x27c)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Uint8Array_Construct_ArrayLike_Buffer_Search/Scope,
@@ -244,114 +244,46 @@
 		IL_01ea: pop
 		IL_01eb: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_01f0: stloc.s 7
-		IL_01f2: ldc.i4.2
-		IL_01f3: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_01f8: brfalse IL_023c
-
-		IL_01fd: ldloc.s 4
-		IL_01ff: ldstr "includes"
-		IL_0204: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_0209: brtrue IL_023c
-
-		IL_020e: ldloc.s 4
-		IL_0210: ldc.i4.2
-		IL_0211: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0216: brfalse IL_023c
-
-		IL_021b: ldloc.s 4
-		IL_021d: ldc.r8 43
-		IL_0226: box [System.Runtime]System.Double
-		IL_022b: callvirt instance bool [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::includes(object)
-		IL_0230: box [System.Runtime]System.Boolean
-		IL_0235: stloc.s 11
-		IL_0237: br IL_0258
-
-		IL_023c: ldloc.s 4
-		IL_023e: ldstr "includes"
-		IL_0243: ldc.r8 43
-		IL_024c: box [System.Runtime]System.Double
-		IL_0251: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0256: stloc.s 11
-
-		IL_0258: ldloc.s 7
-		IL_025a: ldloc.s 11
-		IL_025c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0261: pop
-		IL_0262: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_0267: stloc.s 7
-		IL_0269: ldc.i4.2
-		IL_026a: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_026f: brfalse IL_02b3
-
-		IL_0274: ldloc.s 4
-		IL_0276: ldstr "indexOf"
-		IL_027b: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_0280: brtrue IL_02b3
-
-		IL_0285: ldloc.s 4
-		IL_0287: ldc.i4.2
-		IL_0288: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_028d: brfalse IL_02b3
-
-		IL_0292: ldloc.s 4
-		IL_0294: ldc.r8 42
-		IL_029d: box [System.Runtime]System.Double
-		IL_02a2: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::indexOf(object)
-		IL_02a7: box [System.Runtime]System.Double
-		IL_02ac: stloc.s 11
-		IL_02ae: br IL_02cf
-
-		IL_02b3: ldloc.s 4
-		IL_02b5: ldstr "indexOf"
-		IL_02ba: ldc.r8 42
-		IL_02c3: box [System.Runtime]System.Double
-		IL_02c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_02cd: stloc.s 11
-
-		IL_02cf: ldloc.s 7
-		IL_02d1: ldloc.s 11
-		IL_02d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_02d8: pop
-		IL_02d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
-		IL_02de: stloc.s 7
-		IL_02e0: ldc.r8 1
-		IL_02e9: neg
-		IL_02ea: stloc.s 10
-		IL_02ec: ldloc.s 10
-		IL_02ee: box [System.Runtime]System.Double
-		IL_02f3: stloc.s 9
-		IL_02f5: ldc.i4.2
-		IL_02f6: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::IsPristine(valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_02fb: brfalse IL_0333
-
-		IL_0300: ldloc.s 4
-		IL_0302: ldstr "at"
-		IL_0307: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::HasOwnIntrinsicMemberOverride(object, string)
-		IL_030c: brtrue IL_0333
-
-		IL_0311: ldloc.s 4
-		IL_0313: ldc.i4.2
-		IL_0314: call bool [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeEpochs::HasDefaultPrototype(object, valuetype [JavaScriptRuntime]JavaScriptRuntime.IntrinsicPrototypeFamily)
-		IL_0319: brfalse IL_0333
-
-		IL_031e: ldloc.s 4
-		IL_0320: ldloc.s 9
-		IL_0322: callvirt instance float64 [JavaScriptRuntime]JavaScriptRuntime.Uint8Array::'at'(object)
-		IL_0327: box [System.Runtime]System.Double
-		IL_032c: stloc.s 11
-		IL_032e: br IL_0343
-
-		IL_0333: ldloc.s 4
-		IL_0335: ldstr "at"
-		IL_033a: ldloc.s 9
-		IL_033c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
-		IL_0341: stloc.s 11
-
-		IL_0343: ldloc.s 7
-		IL_0345: ldloc.s 11
-		IL_0347: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_034c: pop
-		IL_034d: ret
+		IL_01f2: ldloc.s 4
+		IL_01f4: ldstr "includes"
+		IL_01f9: ldc.r8 43
+		IL_0202: box [System.Runtime]System.Double
+		IL_0207: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_020c: stloc.s 11
+		IL_020e: ldloc.s 7
+		IL_0210: ldloc.s 11
+		IL_0212: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0217: pop
+		IL_0218: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_021d: stloc.s 7
+		IL_021f: ldloc.s 4
+		IL_0221: ldstr "indexOf"
+		IL_0226: ldc.r8 42
+		IL_022f: box [System.Runtime]System.Double
+		IL_0234: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0239: stloc.s 11
+		IL_023b: ldloc.s 7
+		IL_023d: ldloc.s 11
+		IL_023f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0244: pop
+		IL_0245: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_024a: stloc.s 7
+		IL_024c: ldc.r8 1
+		IL_0255: neg
+		IL_0256: stloc.s 10
+		IL_0258: ldloc.s 10
+		IL_025a: box [System.Runtime]System.Double
+		IL_025f: stloc.s 9
+		IL_0261: ldloc.s 4
+		IL_0263: ldstr "at"
+		IL_0268: ldloc.s 9
+		IL_026a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_026f: stloc.s 11
+		IL_0271: ldloc.s 7
+		IL_0273: ldloc.s 11
+		IL_0275: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_027a: pop
+		IL_027b: ret
 	} // end of method Uint8Array_Construct_ArrayLike_Buffer_Search::__js_module_init__
 
 } // end of class Modules.Uint8Array_Construct_ArrayLike_Buffer_Search

--- a/tests/performance/Benchmarks/GuardedStringIntrinsicBenchmarks.cs
+++ b/tests/performance/Benchmarks/GuardedStringIntrinsicBenchmarks.cs
@@ -16,6 +16,7 @@ public class GuardedStringIntrinsicBenchmarks
     private const string Receiver = "value";
     private const string MethodName = "trim";
     private readonly object _uncertainReceiver = Receiver;
+    private object _stringObjectReceiver = null!;
     private RuntimeAgentCluster? _cluster;
     private IDisposable? _scope;
 
@@ -27,6 +28,10 @@ public class GuardedStringIntrinsicBenchmarks
         var context = RuntimeExecutionContext.GetOrCreate(services);
         _scope = context.EnterAsRoot();
         _ = GlobalThis.globalThis;
+        _stringObjectReceiver =
+            JavaScriptRuntime.String.Construct(
+                [Receiver],
+                newTarget: null);
     }
 
     [GlobalCleanup]
@@ -66,6 +71,38 @@ public class GuardedStringIntrinsicBenchmarks
 
         return ObjectRuntime.CallMember0(
             _uncertainReceiver,
+            MethodName);
+    }
+
+    [Benchmark(Description = "CallMember0 String-object.trim")]
+    public object? GenericStringObjectCallMember()
+        => ObjectRuntime.CallMember0(
+            _stringObjectReceiver,
+            MethodName);
+
+    [Benchmark(Description = "Guarded String-object.trim")]
+    public object? GuardedStringObjectReceiver()
+    {
+        if (IntrinsicPrototypeEpochs.IsPristine(
+                IntrinsicPrototypeFamily.String))
+        {
+            if (_stringObjectReceiver is string input)
+            {
+                return JavaScriptRuntime.String.Trim(input);
+            }
+
+            var unwrapped = IntrinsicPrototypeEpochs
+                .TryUnwrapStringObjectReceiver(
+                    _stringObjectReceiver,
+                    MethodName);
+            if (unwrapped != null)
+            {
+                return JavaScriptRuntime.String.Trim(unwrapped);
+            }
+        }
+
+        return ObjectRuntime.CallMember0(
+            _stringObjectReceiver,
             MethodName);
     }
 }


### PR DESCRIPTION
Closes #1898

## Summary

- Track observed reference receiver types independently of representation-safe CLR storage.
- Preserve candidates across aliases, captured/deferred writes, primitive String conversion, boxed-String `+=`, Array values, and typed-array values.
- Compute sparse per-program-point receiver facts over final LIR assignments, copies, branches, loop back edges, mutable slots, parameters, and captured fields.
- Propagate receiver summaries through direct-only callable parameters, returns, and ordering-proven captured closure entries.
- Invalidate facts conservatively across unknown calls, dynamic accessors, unsupported LIR barriers, escaping closures, and module/host exposure.
- Consume eligible Array and typed-array facts through guarded fixed-arity calls with exact generic fallback.
- Consume String candidates for loop-hot numeric element reads with exact generic fallback.
- Extend guarded String method calls to semantically safe same-realm boxed String receivers.
- Restrict post-flow guarded specialization to natural-loop sites so cold calls do not duplicate guard and fallback IL.
- Run normal receiver-flow solving only when an eligible specialization has a backward-reachable candidate source.
- Explain receiver fact merges, invalidations, retained candidates, and specialization decisions through opt-in diagnostics.
- Cover Dromaeo's `dromaeo-object-string` fixture with execution and generated-IL snapshots.

## Correctness invariants

- Candidate facts never change CLR storage or callable ABI. Only the explicit post-flow specialization pass may consume them.
- `new String(...)` is tracked as a boxed String object, not as a primitive `string` candidate.
- A candidate cannot override a known receiver type or bypass storage compatibility checks.
- Only plain assignment and JavaScript addition assignment propagate receiver candidates; other compound operators do not inherit their RHS type.
- Each flow fact separately represents candidate CLR types, unconstrained paths, and known non-candidate paths.
- Plain assignments are strong updates. Branch and loop joins retain all candidate, non-candidate, and unknown alternatives.
- Calls, suspension, and dynamic property access invalidate captured facts because arbitrary JavaScript can run and mutate escaping closures.
- Unsupported LIR instructions invalidate all mutable facts; `leave` in a method containing `finally` does the same.
- Interprocedural summaries require a statically proven direct-only, non-escaping callable. Captured entry facts additionally require a stable binding or an immediately preceding assignment at every call.
- Direct and named ESM exports, exported class methods, CommonJS exports, aliases, and unknown callback arguments cannot contribute direct-only summaries. Private nested callables inside an exported function remain eligible.
- Guarded String methods accept a boxed receiver only when the realm epoch is pristine, its prototype is exactly the current realm's `String.prototype`, it has no own member override, and its `[[StringData]]` is intact.
- Every failed primitive or boxed String method guard executes the original `ObjectRuntime.CallMemberN`.
- Numeric String indexing handles only canonical in-range primitive String indices directly; every other receiver/index executes the original `ObjectRuntime.GetItem`.
- Array and typed-array fast paths require a pristine prototype-family epoch, the expected runtime type when uncertain, no own member override, and the receiver's default intrinsic prototype.
- Every failed guard executes the original `ObjectRuntime.CallMemberN`; object literals and user classes retain their separate shape/metadata specialization paths.
- Post-flow Array and typed-array guards require natural-loop depth ≥1. Eligible cold sites stay generic.
- Normal compilation narrows flow roots to operations consumed by specialization; opt-in diagnostics retain the broader dynamic-receiver analysis.
- Receiver diagnostics are created and formatted only for `-v` or `--diagnostic-file`; normal compilation pays no trace allocation or formatting cost.

## Implementation

The flow pass runs after all LIR normalization and variable-slot coalescing.
It first builds a receiver-rooted backward slice through copies, coercions,
parameter loads/stores, mutable slots, and captured field loads/stores, then
solves the resulting CFG to a fixed point. Facts are available before used
operands and after definitions, including phi-like temps represented by
branch-local copies to one mutable slot.

Receiver candidate inference runs once after the core type-inference fixed
point converges because no core type pass consumes candidate facts. In normal
compilation, a conservative backward reachability gate checks eligible
Array/typed-array calls and numeric String reads for candidate-producing
definitions, bindings, parameters, or callable summaries before constructing
the CFG and solving full flow. Diagnostic mode retains all dynamic-receiver
roots.

Direct-only calls use a separate receiver summary domain so conflicting call
sites can retain candidate unions without changing the callable ABI. Parameter
summaries seed callee entry flow, return summaries seed direct-call result
temps, and closure capture summaries are accepted only with explicit
ordering/escape proof.

The invalidation layer recognizes generic property operations and normalized
`LIRGetJsArrayElement` reads, whose accessors or prototype getters may execute
user code. Export traversal covers wrapped ESM declarations and local export
specifiers without treating export aliases or re-export names as local
references.

The post-flow specialization pass consumes eligible Array, concrete
typed-array, and String facts. Array and typed-array methods preserve
own-property, custom-prototype, realm epoch, runtime-type, and arbitrary
fallback-result semantics. Numeric String reads use a small checked helper
only at loop-hot candidate sites. Existing proven Array calls remain on their
prior direct path.

Guarded String method IL now checks primitive `string` first, then safely
unwraps an ordinary boxed String with the exact current-realm prototype and no
own override. Cross-realm wrappers, custom prototypes, assignment/descriptor
overrides, and every prototype-epoch mutation retain exact generic dispatch.

The final-LIR CFG is shared by receiver-flow and loop-nesting analysis.
Dominators identify natural-loop back edges, multiple latches are merged by
header, and nested headers increment instruction depth independently. The
analysis is lazy and exits before dominator construction when the CFG has no
possible back edge.

When verbose or diagnostic-file logging is enabled, a deterministic
`[ReceiverFlow]` trace reports CFG joins with predecessor/result facts,
candidate-bearing mutable facts invalidated by calls and other barriers,
facts retained at dynamic receiver sites, and guarded versus
`retained-generic(cold)` specialization decisions. Normal compilation does not
allocate the trace, clone diagnostic-only block outputs, or format messages.

## Validation

- Release solution build: zero warnings and errors
- Item-7 receiver-flow, specialization, and CLI diagnostic tests: 52 passed
- Latest receiver flow/loop focused tests: 49 passed
- Latest affected Array, typed-array, integration, and receiver suites: 330 passed
- Full generator snapshot suite: 1,051 passed
- Latest Array/typed-array test262 selection: 459 passed
- Item-5 targeted test262 selections: 623 passed, 1 pre-existing String skip
- Item-8 focused runtime/compiler/hosting suite: 90 passed
- Item-8 `built_ins.String` test262 selection: 611 passed, 1 skipped
- Item-9 affected semantic/compiler suite: 584 passed
- Item-9 String/Array/TypedArray test262 selection: 1,090 passed, 1 skipped
- Item-9 independent correctness/performance review: no blocking findings
- New Array and typed-array execution fixtures match Node.js output

## Current performance result

Item 8 adds a boxed-String arm to guarded String method calls and a loop-gated
numeric String-index helper. A focused .NET 10 ShortRun measured boxed
`String.trim` at 34.894 ns / 0 B through the guard versus 183.714 ns / 32 B
through generic `CallMember0` (N=3).

For the exact `dromaeo-object-string` fixture, the pre-change DefaultJob run
measured 20.426 ms mean / 20.359 ms median (N=19). Three post-change runs
measured 20.190, 20.273, and 20.165 ms means (N=18, 15, and 17), averaging
20.210 ms; their medians averaged 20.255 ms. This is approximately a 1.1%
mean and 0.5% median improvement, but the single baseline and small effect
make the end-to-end result noise-sensitive.

Generated IL provides the causal evidence: five hot numeric String reads now
call `GetStringElementWithFallback` instead of generic `GetItem`. The fixture
assembly grows from 22,528 to 23,040 bytes because 37 uncertain guarded String
method sites now contain the safe boxed-receiver arm. Per-load allocation is
effectively unchanged.

For Array candidates, the final item-5 design preserves the existing proven
Array hot path: `dromaeo-object-array` measured 3.626 ms / 4.42 MB versus the
item-4 baseline's 3.589 ms / 4.43 MB. A controlled object-stored Array
candidate ran materially faster with the guard than generic dispatch.

The item-6 hotness control changes a controlled cold+loop fixture from two
guards to one while retaining the loop guard. Total method IL falls from 498
to 413 bytes. Across five existing cold typed-array fixtures, 16 guards are
removed and total method IL falls from 4,704 to 3,699 bytes. The
At the item-6 checkpoint, the `dromaeo-object-regexp` hot-path artifact remained
byte-for-byte equivalent between items 5 and 6 (47,616 assembly bytes, 16,761
method IL bytes, three total prototype guards).

The acyclic fast exit prevents dominator cost at large cold methods. A
1,000-branch cold-candidate stress fixture measured 1.959 s current versus
1.974 s item-5 baseline median across three interleaved Release compilations.

### Final master-relative validation

The repository branch-comparison workflow checked out `master` and candidate
commit `3d07da395` on the same .NET 10.0.11 runner:

| Run | Scenario | Master mean / median | PR mean / median | Mean | Allocation |
| --- | --- | ---: | ---: | ---: | ---: |
| [32458452258](https://github.com/tomacox74/js2il/actions/runs/32458452258) | `dromaeo-object-string` | 24.282 / 24.380 ms (N=15) | 23.807 / 23.773 ms (N=14) | -1.96% | -0.04% |
| [32458452751](https://github.com/tomacox74/js2il/actions/runs/32458452751) | `dromaeo-object-regexp` | 148.011 / 148.465 ms (N=39) | 145.743 / 145.870 ms (N=25) | -1.53% | -0.98% |

These are single sequential baseline/candidate runs, so the percentages remain
noise-sensitive. The causal/code-size checks are deterministic:

- String: five hot reads use `GetStringElementWithFallback`; assembly
  22,528→23,040 bytes, total method IL 9,119→9,797 bytes.
- RegExp: one loop-hot Array `push` guard; assembly remains 47,616 bytes,
  total method IL 16,680→16,798 bytes.
- Array: byte-identical at 10,752 assembly bytes and 2,593 method IL bytes.

The first final compile comparison found the PR approximately 11% slower than
master on the 466 KB `ai-astar-data.js` control (4.063 s versus 3.662 s across
three interleaved runs). Item 9 moved candidate inference after core type
convergence and added the specialization/candidate-path gate described above.
Two subsequent interleaved five-run batches averaged 3.855 s for the PR and
3.834 s for master (+0.5%); medians were 3.884 and 3.816 s (+1.8%), within
observed same-host variation. The compile-time gate leaves optimized String
and RegExp IL byte-for-byte unchanged.
