### PR TITLE
feat(hosting): establish Phase 0 generated facade contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- compiler/sdk/hosting: establish the Phase 0 generated-host-API contracts for
+  #1917. Explicit assembly identities now drive PE and artifact names, compiled
+  manifests identify one canonical entry module separately from aliases,
+  hosting APIs expose that identity, and deterministic future facade naming
+  rejects ordinal and case-insensitive CLR path collisions. Add an external
+  C# consumer harness for compile, reflection, execution, diagnostics, runtime
+  reference policing, and cleanup.
 - runtime/test262/docs: port 200 test262 fixtures across Date, DataView, and
   JSON.parse. DataView index coercion now truncates negative fractional
   offsets before range validation, and `Date.prototype[@@toPrimitive]` now

--- a/docs/sdk/api/InMemoryCompiler.md
+++ b/docs/sdk/api/InMemoryCompiler.md
@@ -9,6 +9,7 @@ The in-memory compiler APIs compile JavaScript without requiring the normal on-d
 ```csharp
 public sealed record JrocInMemoryCompileRequest(string EntryFilePath)
 {
+    public string? AssemblyName { get; init; }
     public string? SourceText { get; init; }
     public IFileSystem? FileSystem { get; init; }
     public string? RootModuleIdOverride { get; init; }
@@ -20,7 +21,7 @@ public sealed record JrocInMemoryCompileRequest(string EntryFilePath)
 }
 ```
 
-`EntryFilePath` is still required because module ids, diagnostics, and PDB sequence points need a stable source identity. When `SourceText` is set, the compiler overlays that text at `EntryFilePath` and uses the supplied `FileSystem` only for any additional imports or requires.
+`EntryFilePath` is still required because module ids, diagnostics, and PDB sequence points need a stable source identity. `AssemblyName` is the authoritative PE identity and basename for the DLL, PDB, and runtime config; when omitted, it defaults to the entry filename without its extension. When `SourceText` is set, the compiler overlays that text at `EntryFilePath` and uses the supplied `FileSystem` only for any additional imports or requires.
 
 ## Compile to an artifact
 
@@ -42,6 +43,9 @@ JrocCompiledAssemblyArtifact artifact =
 | `PeBytes` | The compiled assembly PE image. |
 | `PdbBytes` | Optional Portable PDB bytes when `EmitPdb` is enabled. |
 | `ModuleIds` | Module ids embedded in the compiled assembly manifest. |
+| `EntryModuleId` | Canonical id of the one compiler-selected entry module. |
+| `EntryModuleAliases` | Host-facing aliases for the entry module, kept separate from its canonical id. |
+| `FacadeNames` | Validated, deterministic CLR naming plan reserved for the generated host facade. Phase 0 records the plan but does not emit facade types. |
 
 This API does not write the generated DLL, PDB, runtime config, or runtime assembly to disk.
 

--- a/docs/sdk/api/JrocCompile.md
+++ b/docs/sdk/api/JrocCompile.md
@@ -24,6 +24,7 @@ The target runs before `ResolveAssemblyReferences`, writes generated files under
 | `OutputDirectory` | `JrocOutputRoot` | `$(IntermediateOutputPath)\jroc` | Output root for generated DLL, PDB, runtime config, and runtime assembly files. |
 | `ModuleResolutionBaseDirectory` | `JrocModuleResolutionBaseDirectory` | `$(MSBuildProjectDirectory)` | Base directory for resolving package/module-id entrypoints. |
 | `RootModuleId` | `JrocRootModuleId` | empty | Overrides the root module id embedded in the compiled assembly. |
+| `AssemblyName` | `JrocAssemblyName` | source filename, or a package-derived name | Sets the authoritative PE identity and DLL/PDB/runtime-config basename. |
 | `ReferenceOutputAssembly` | `JrocReferenceOutputAssembly` | `true` | Adds the generated module assembly as a normal project reference. |
 | `CopyToOutputDirectory` | `JrocCopyToOutputDirectory` | `false` | Copies generated outputs to `$(TargetDir)` after build. |
 | `EmitPdb` | `JrocEmitPdb` | `true` in Debug, otherwise `false` | Emits a Portable PDB for the compiled module. |
@@ -45,6 +46,14 @@ Per-item metadata wins over the matching project property.
 ```
 
 When `RootModuleId` is not set for a package-style entrypoint, the SDK preserves the item specifier as the root module id.
+
+The SDK derives a portable assembly identity for package ids (for example,
+`@mixmark-io/domino` becomes `mixmark-io.domino`). Set `AssemblyName` when the
+consumer-facing assembly identity must differ. The SDK passes this identity
+into compilation; it does not rename artifacts after the PE is generated.
+Two items in one build cannot share an assembly identity, even when their
+output directories differ, because both would become references in the same
+consumer compilation.
 
 ## Outputs
 

--- a/docs/sdk/api/JsEngine.md
+++ b/docs/sdk/api/JsEngine.md
@@ -58,6 +58,16 @@ public static IReadOnlyList<string> GetModuleIds(Assembly compiledAssembly)
 - Prefer this over scanning types directly; compiled assemblies emitted by JROC include an assembly-level manifest via `[JsCompiledModule]`.
 - Includes a back-compat fallback for older compiled assemblies.
 
+## GetEntryModuleId(Assembly compiledAssembly)
+
+```csharp
+public static string GetEntryModuleId(Assembly compiledAssembly)
+```
+
+- Returns the canonical entry-module id from `[JsCompiledEntryModule]`.
+- Does not infer the entry from filenames, aliases, or generated type names.
+- Throws when the metadata is missing or does not identify exactly one entry.
+
 ## Threading model (high level)
 
 Each load call creates a runtime instance with a dedicated script thread.

--- a/docs/sdk/tutorials/InMemoryCompileAndRun.md
+++ b/docs/sdk/tutorials/InMemoryCompileAndRun.md
@@ -50,16 +50,20 @@ When `SourceText` is not set, JROC reads the entry file and any imported modules
 var artifact = JrocInMemoryCompiler.Compile(
     new JrocInMemoryCompileRequest(@"C:\virtual\math.js")
     {
+        AssemblyName = "HostedMath",
         SourceText = "exports.answer = 42;",
         EmitPdb = true
     });
 
 Console.WriteLine(artifact.AssemblyName);
+Console.WriteLine(artifact.EntryModuleId);
 Console.WriteLine(artifact.PeBytes.Length);
 Console.WriteLine(artifact.PdbBytes?.Length ?? 0);
 ```
 
 Use artifact-only compilation when the host wants to cache, inspect, or persist PE/PDB bytes itself.
+The configured assembly name is also used for materialized DLL, PDB, and
+runtime-config filenames. If it is omitted, JROC uses `math` in this example.
 
 ## 5) Dispose the module
 

--- a/docs/sdk/tutorials/ModuleIdsAndDiscovery.md
+++ b/docs/sdk/tutorials/ModuleIdsAndDiscovery.md
@@ -21,6 +21,7 @@ using System.Reflection;
 
 var asm = Assembly.LoadFrom("compiled.dll");
 var ids = JsEngine.GetModuleIds(asm);
+var entryId = JsEngine.GetEntryModuleId(asm);
 
 foreach (var id in ids)
 {
@@ -29,6 +30,9 @@ foreach (var id in ids)
 ```
 
 `GetModuleIds` uses the assembly-level manifest (`[JsCompiledModule]` attributes) when present, and falls back to scanning well-known namespaces for older assemblies.
+
+`GetEntryModuleId` reads the separate entry-module declaration. It returns the
+canonical id even when the entry also has package or root aliases.
 
 ## Bare vs path-like ids
 

--- a/src/Cli/Program.cs
+++ b/src/Cli/Program.cs
@@ -17,6 +17,10 @@ public class JrocArgs
     [ArgShortcut("--moduleid")]
     public string? ModuleId { get; set; }
 
+    [ArgDescription("Set the generated assembly identity and artifact basename")]
+    [ArgShortcut("--assemblyname")]
+    public string? AssemblyName { get; set; }
+
     [ArgPosition(1)]
     [ArgDescription("The output directory for the generated IL")]
     [ArgShortcut("--output")]
@@ -78,6 +82,7 @@ class Program
 
             using var servicesProvider = CompilerServices.BuildServiceProvider(new CompilerOptions
             {
+                AssemblyName = parsed.AssemblyName,
                 OutputDirectory = parsed.OutputPath,
                 Verbose = parsed.Verbose,
                 DiagnosticFilePath = diagnosticFilePath,
@@ -158,6 +163,7 @@ class Program
         logger.WriteLineError("Option                 Description");
         logger.WriteLineError("-i, --input            The JavaScript file to convert (positional supported)");
         logger.WriteLineError("--moduleid             Compile an npm/CommonJS module id instead of a file path");
+        logger.WriteLineError("--assemblyname <name>   Set the assembly identity and artifact basename");
         logger.WriteLineError("-o, --output           The output directory for the generated IL (created if missing)");
         logger.WriteLineError("-v, --verbose          Enable diagnostics output to console");
         logger.WriteLineError("--diagnostic-file <path> Write diagnostics output to a text file");

--- a/src/Compiler/Compiler.cs
+++ b/src/Compiler/Compiler.cs
@@ -8,6 +8,7 @@ public class Compiler
 {
     private readonly bool analyzeUnused;
     private readonly string? outputDirectory;
+    private readonly string? configuredAssemblyName;
     private readonly bool diagnosticsEnabled;
 
     private readonly SymbolTableBuilder _symbolTableBuilder;
@@ -27,6 +28,7 @@ public class Compiler
         Microsoft.Extensions.Logging.ILogger<Compiler> diagnosticLogger)
     {
         this.outputDirectory = options.OutputDirectory;
+        this.configuredAssemblyName = options.AssemblyName;
         this.diagnosticsEnabled = options.DiagnosticsEnabled;
         this.analyzeUnused = options.AnalyzeUnused;
         this._moduleLoader = moduleLoader;
@@ -60,6 +62,17 @@ public class Compiler
 
     internal JrocCompiledAssemblyArtifact? CompileToArtifact(string inputFile, string? rootModuleIdOverride = null)
     {
+        string assemblyName;
+        try
+        {
+            assemblyName = JrocAssemblyIdentity.Resolve(inputFile, this.configuredAssemblyName);
+        }
+        catch (ArgumentException ex)
+        {
+            _ux.WriteLineError($"Error: {ex.Message}");
+            return null;
+        }
+
         // When diagnostics are enabled, capture IR pipeline failure reasons to aid debugging.
         if (this.diagnosticsEnabled)
         {
@@ -118,8 +131,15 @@ public class Compiler
             _diagnosticLogger.LogInformation("Generating dotnet assembly...");
         }
         var assemblyGenerator = _serviceProvider.GetRequiredService<AssemblyGenerator>();
-        var assemblyName = Path.GetFileNameWithoutExtension(inputFile);
-        return assemblyGenerator.GenerateArtifact(modules, assemblyName);
+        try
+        {
+            return assemblyGenerator.GenerateArtifact(modules, assemblyName);
+        }
+        catch (JrocFacadeNameCollisionException ex)
+        {
+            _ux.WriteLineError($"Error: {ex.Message}");
+            return null;
+        }
     }
 
     private bool EnsureOutputPathExists(string inputFile, string? outputDirectory, out string outputPath)

--- a/src/Compiler/CompilerOptions.cs
+++ b/src/Compiler/CompilerOptions.cs
@@ -1,5 +1,11 @@
 public class CompilerOptions
 {
+    /// <summary>
+    /// Authoritative assembly identity and artifact basename. When omitted, the entry source
+    /// filename without its extension is used for backward compatibility.
+    /// </summary>
+    public string? AssemblyName { get; set; }
+
     public string? OutputDirectory { get; set; } = null;
     public bool Verbose { get; set; } = false;
     public string? DiagnosticFilePath { get; set; } = null;

--- a/src/Compiler/JrocAssemblyIdentity.cs
+++ b/src/Compiler/JrocAssemblyIdentity.cs
@@ -1,0 +1,53 @@
+namespace Jroc;
+
+public static class JrocAssemblyIdentity
+{
+    public static string Resolve(string entryFilePath, string? configuredAssemblyName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryFilePath);
+
+        var assemblyName = configuredAssemblyName is null
+            ? Path.GetFileNameWithoutExtension(entryFilePath)
+            : configuredAssemblyName;
+
+        Validate(assemblyName);
+        return assemblyName;
+    }
+
+    public static void Validate(string assemblyName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(assemblyName);
+
+        var invalidPortableFileNameCharacters = new[] { '<', '>', ':', '"', '/', '\\', '|', '?', '*' };
+        if (assemblyName is "." or ".."
+            || assemblyName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
+            || assemblyName.IndexOfAny(invalidPortableFileNameCharacters) >= 0
+            || assemblyName.Any(char.IsControl)
+            || assemblyName.StartsWith(' ')
+            || assemblyName.EndsWith(' ')
+            || assemblyName.EndsWith('.'))
+        {
+            throw new ArgumentException(
+                $"Assembly name '{assemblyName}' is not a valid portable assembly and artifact name.",
+                nameof(assemblyName));
+        }
+
+        try
+        {
+            var parsedName = new System.Reflection.AssemblyName(assemblyName).Name;
+            if (!string.Equals(parsedName, assemblyName, StringComparison.Ordinal))
+            {
+                throw new ArgumentException(
+                    $"Assembly name '{assemblyName}' must be a simple assembly name without version, culture, or public-key components.",
+                    nameof(assemblyName));
+            }
+        }
+        catch (FileLoadException ex)
+        {
+            throw new ArgumentException(
+                $"Assembly name '{assemblyName}' is not a valid CLR assembly identity.",
+                nameof(assemblyName),
+                ex);
+        }
+    }
+}

--- a/src/Compiler/JrocCompiledAssemblyArtifact.cs
+++ b/src/Compiler/JrocCompiledAssemblyArtifact.cs
@@ -4,7 +4,10 @@ public sealed record JrocCompiledAssemblyArtifact(
     string AssemblyName,
     byte[] PeBytes,
     byte[]? PdbBytes,
-    IReadOnlyList<string> ModuleIds)
+    IReadOnlyList<string> ModuleIds,
+    string EntryModuleId = "",
+    IReadOnlyList<string>? EntryModuleAliases = null,
+    JrocFacadeNamePlan? FacadeNames = null)
 {
     /// <summary>
     /// Writes this artifact and its runtime dependencies to <paramref name="outputDirectory"/>.

--- a/src/Compiler/JrocFacadeNamePlanner.cs
+++ b/src/Compiler/JrocFacadeNamePlanner.cs
@@ -1,0 +1,238 @@
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace Jroc;
+
+public sealed record JrocFacadeModuleName(string ModuleId, IReadOnlyList<string> TypePath)
+{
+    public string ClrPath(string rootTypeName) =>
+        string.Join(".", new[] { rootTypeName, "Scripts" }.Concat(TypePath));
+}
+
+public sealed record JrocFacadeNamePlan(
+    string RootTypeName,
+    string EntryModuleId,
+    IReadOnlyList<JrocFacadeModuleName> Modules);
+
+public sealed class JrocFacadeNameCollisionException : InvalidOperationException
+{
+    internal JrocFacadeNameCollisionException(
+        string firstModuleId,
+        string secondModuleId,
+        string proposedClrPath)
+        : base(
+            $"Module ids '{firstModuleId}' and '{secondModuleId}' collide at generated CLR path " +
+            $"'{proposedClrPath}'. Rename one module or choose module ids that remain distinct after C# identifier normalization.")
+    {
+        FirstModuleId = firstModuleId;
+        SecondModuleId = secondModuleId;
+        ProposedClrPath = proposedClrPath;
+    }
+
+    public string FirstModuleId { get; }
+
+    public string SecondModuleId { get; }
+
+    public string ProposedClrPath { get; }
+}
+
+public static class JrocFacadeNamePlanner
+{
+    private static readonly HashSet<string> CSharpKeywords =
+    [
+        "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked",
+        "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else",
+        "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for",
+        "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock",
+        "long", "namespace", "new", "null", "object", "operator", "out", "override", "params",
+        "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short",
+        "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true",
+        "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual",
+        "void", "volatile", "while"
+    ];
+
+    public static JrocFacadeNamePlan Create(
+        string assemblyName,
+        string entryModuleId,
+        IEnumerable<string> canonicalModuleIds,
+        string? moduleIdPrefix = null)
+    {
+        JrocAssemblyIdentity.Validate(assemblyName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entryModuleId);
+        ArgumentNullException.ThrowIfNull(canonicalModuleIds);
+
+        var rootTypeName = NormalizeIdentifier(assemblyName, stripLeadingAtSign: true);
+        var modules = new List<JrocFacadeModuleName>();
+        var root = new NameNode(sourceSegment: null, sourceModuleId: null);
+
+        foreach (var moduleId in canonicalModuleIds
+                     .Distinct(StringComparer.Ordinal)
+                     .Order(StringComparer.Ordinal))
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(moduleId);
+            var relativeModuleId = RemovePrefix(moduleId, moduleIdPrefix);
+            var sourceSegments = NormalizeModuleId(relativeModuleId);
+            var typePath = sourceSegments.Select(segment => NormalizeIdentifier(segment)).ToArray();
+
+            Insert(root, sourceSegments, typePath, moduleId, rootTypeName);
+            modules.Add(new JrocFacadeModuleName(moduleId, new ReadOnlyCollection<string>(typePath)));
+        }
+
+        if (!modules.Any(module => string.Equals(module.ModuleId, entryModuleId, StringComparison.Ordinal)))
+        {
+            throw new InvalidOperationException(
+                $"Entry module '{entryModuleId}' is not present in the facade naming plan.");
+        }
+
+        return new JrocFacadeNamePlan(
+            rootTypeName,
+            entryModuleId,
+            new ReadOnlyCollection<JrocFacadeModuleName>(
+                modules.OrderBy(module => module.ModuleId, StringComparer.Ordinal).ToArray()));
+    }
+
+    public static string NormalizeIdentifier(string value, bool stripLeadingAtSign = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+
+        var trimmed = value.Trim();
+        if (stripLeadingAtSign)
+        {
+            trimmed = trimmed.TrimStart('@');
+        }
+
+        var builder = new StringBuilder(trimmed.Length);
+        var previousWasReplacement = false;
+        foreach (var character in trimmed)
+        {
+            if (character == '_' || char.IsLetterOrDigit(character))
+            {
+                builder.Append(character);
+                previousWasReplacement = false;
+            }
+            else if (!previousWasReplacement)
+            {
+                builder.Append('_');
+                previousWasReplacement = true;
+            }
+        }
+
+        var identifier = builder.ToString().Trim('_');
+        if (identifier.Length == 0)
+        {
+            identifier = "_";
+        }
+
+        if (char.IsDigit(identifier[0]) || CSharpKeywords.Contains(identifier))
+        {
+            identifier = "_" + identifier;
+        }
+
+        return identifier;
+    }
+
+    private static string RemovePrefix(string moduleId, string? moduleIdPrefix)
+    {
+        var normalized = moduleId.Trim().Replace('\\', '/').TrimStart('/');
+        var normalizedPrefix = moduleIdPrefix?.Trim().Replace('\\', '/').Trim('/');
+
+        if (!string.IsNullOrWhiteSpace(normalizedPrefix)
+            && normalized.StartsWith(normalizedPrefix + "/", StringComparison.Ordinal))
+        {
+            return normalized[(normalizedPrefix.Length + 1)..];
+        }
+
+        return normalized;
+    }
+
+    private static string[] NormalizeModuleId(string moduleId)
+    {
+        var normalized = moduleId.Trim().Replace('\\', '/').Trim('/');
+        if (normalized.StartsWith("./", StringComparison.Ordinal))
+        {
+            normalized = normalized[2..];
+        }
+
+        if (normalized.EndsWith(".js", StringComparison.OrdinalIgnoreCase)
+            || normalized.EndsWith(".mjs", StringComparison.OrdinalIgnoreCase)
+            || normalized.EndsWith(".cjs", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = normalized[..normalized.LastIndexOf('.')];
+        }
+
+        var segments = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return segments.Length == 0 ? ["index"] : segments;
+    }
+
+    private static void Insert(
+        NameNode root,
+        IReadOnlyList<string> sourceSegments,
+        IReadOnlyList<string> typePath,
+        string moduleId,
+        string rootTypeName)
+    {
+        var current = root;
+        for (var index = 0; index < typePath.Count; index++)
+        {
+            var typeSegment = typePath[index];
+            var sourceSegment = sourceSegments[index];
+            if (current.Children.TryGetValue(typeSegment, out var existing))
+            {
+                if (!string.Equals(existing.SourceSegment, sourceSegment, StringComparison.Ordinal))
+                {
+                    var proposedPath = string.Join(
+                        ".",
+                        new[] { rootTypeName, "Scripts" }.Concat(typePath.Take(index + 1)));
+                    throw new JrocFacadeNameCollisionException(
+                        existing.SourceModuleId ?? moduleId,
+                        moduleId,
+                        proposedPath);
+                }
+
+                current = existing;
+                continue;
+            }
+
+            var caseInsensitiveMatch = current.Children.Values.FirstOrDefault(
+                child => string.Equals(child.TypeSegment, typeSegment, StringComparison.OrdinalIgnoreCase));
+            if (caseInsensitiveMatch is not null)
+            {
+                var proposedPath = string.Join(
+                    ".",
+                    new[] { rootTypeName, "Scripts" }.Concat(typePath.Take(index + 1)));
+                throw new JrocFacadeNameCollisionException(
+                    caseInsensitiveMatch.SourceModuleId ?? moduleId,
+                    moduleId,
+                    proposedPath);
+            }
+
+            var child = new NameNode(sourceSegment, moduleId) { TypeSegment = typeSegment };
+            current.Children.Add(typeSegment, child);
+            current = child;
+        }
+
+        if (current.ModuleId is not null
+            && !string.Equals(current.ModuleId, moduleId, StringComparison.Ordinal))
+        {
+            throw new JrocFacadeNameCollisionException(
+                current.ModuleId,
+                moduleId,
+                string.Join(".", new[] { rootTypeName, "Scripts" }.Concat(typePath)));
+        }
+
+        current.ModuleId = moduleId;
+    }
+
+    private sealed class NameNode(string? sourceSegment, string? sourceModuleId)
+    {
+        public string? SourceSegment { get; } = sourceSegment;
+
+        public string? SourceModuleId { get; } = sourceModuleId;
+
+        public string TypeSegment { get; init; } = string.Empty;
+
+        public Dictionary<string, NameNode> Children { get; } = new(StringComparer.Ordinal);
+
+        public string? ModuleId { get; set; }
+    }
+}

--- a/src/Compiler/JrocInMemoryAssemblyLoader.cs
+++ b/src/Compiler/JrocInMemoryAssemblyLoader.cs
@@ -32,7 +32,12 @@ public static class JrocInMemoryAssemblyLoader
             // dependencies fail deterministically here instead of later at first use.
             _ = assembly.GetTypes();
 
-            return new JrocLoadedAssembly(loadContext, assembly, artifact.ModuleIds);
+            return new JrocLoadedAssembly(
+                loadContext,
+                assembly,
+                artifact.ModuleIds,
+                artifact.EntryModuleId,
+                artifact.EntryModuleAliases ?? []);
         }
         catch
         {

--- a/src/Compiler/JrocInMemoryCompileRequest.cs
+++ b/src/Compiler/JrocInMemoryCompileRequest.cs
@@ -2,6 +2,8 @@ namespace Jroc;
 
 public sealed record JrocInMemoryCompileRequest(string EntryFilePath)
 {
+    public string? AssemblyName { get; init; }
+
     public string? SourceText { get; init; }
 
     public IFileSystem? FileSystem { get; init; }

--- a/src/Compiler/JrocInMemoryCompiler.cs
+++ b/src/Compiler/JrocInMemoryCompiler.cs
@@ -83,6 +83,7 @@ public static class JrocInMemoryCompiler
 
         var options = new CompilerOptions
         {
+            AssemblyName = request.AssemblyName,
             EmitPdb = request.EmitPdb,
             Verbose = request.Verbose,
             DiagnosticFilePath = request.DiagnosticFilePath,
@@ -185,21 +186,14 @@ public static class JrocInMemoryCompiler
             return matchedExplicitModuleId;
         }
 
-        if (artifact.ModuleIds.Count == 1)
+        if (!string.IsNullOrWhiteSpace(artifact.EntryModuleId))
         {
-            return artifact.ModuleIds[0];
-        }
-
-        var matchedRootOverrideModuleId = MatchPublishedModuleId(artifact, request.RootModuleIdOverride);
-        if (!string.IsNullOrWhiteSpace(matchedRootOverrideModuleId))
-        {
-            return matchedRootOverrideModuleId;
+            return artifact.EntryModuleId;
         }
 
         throw new InvalidOperationException(
-            "Unable to infer the module id for compile-and-load. " +
-            "Pass moduleId explicitly, set RootModuleIdOverride on the compile request, " +
-            $"or compile an artifact with a single module id. Available module ids: {string.Join(", ", artifact.ModuleIds)}");
+            "The compiled artifact does not identify an entry module. " +
+            "Pass moduleId explicitly when loading an artifact emitted by an older compiler.");
     }
 
     private static string? MatchPublishedModuleId(JrocCompiledAssemblyArtifact artifact, string? candidate)

--- a/src/Compiler/JrocInMemoryModule.cs
+++ b/src/Compiler/JrocInMemoryModule.cs
@@ -28,6 +28,10 @@ public class JrocInMemoryModule : IDisposable
 
     public IReadOnlyList<string> ModuleIds => LoadedAssembly.ModuleIds;
 
+    public string EntryModuleId => LoadedAssembly.EntryModuleId;
+
+    public IReadOnlyList<string> EntryModuleAliases => LoadedAssembly.EntryModuleAliases;
+
     public WeakReference LoadContextWeakReference => LoadedAssembly.LoadContextWeakReference;
 
     protected JrocLoadedAssembly LoadedAssembly => _loadedAssembly ?? throw new ObjectDisposedException(nameof(JrocInMemoryModule));

--- a/src/Compiler/JrocLoadedAssembly.cs
+++ b/src/Compiler/JrocLoadedAssembly.cs
@@ -13,17 +13,25 @@ public sealed class JrocLoadedAssembly : IDisposable
     internal JrocLoadedAssembly(
         AssemblyLoadContext loadContext,
         Assembly assembly,
-        IReadOnlyList<string> moduleIds)
+        IReadOnlyList<string> moduleIds,
+        string entryModuleId,
+        IReadOnlyList<string> entryModuleAliases)
     {
         _loadContext = loadContext;
         _assembly = assembly;
         ModuleIds = moduleIds.ToArray();
+        EntryModuleId = entryModuleId;
+        EntryModuleAliases = entryModuleAliases.ToArray();
         LoadContextWeakReference = new WeakReference(loadContext);
     }
 
     public Assembly Assembly => _assembly ?? throw new ObjectDisposedException(nameof(JrocLoadedAssembly));
 
     public IReadOnlyList<string> ModuleIds { get; }
+
+    public string EntryModuleId { get; }
+
+    public IReadOnlyList<string> EntryModuleAliases { get; }
 
     public WeakReference LoadContextWeakReference { get; }
 

--- a/src/Compiler/Services/AssemblyGenerator.cs
+++ b/src/Compiler/Services/AssemblyGenerator.cs
@@ -69,6 +69,8 @@ namespace Jroc.Services
 
         public JrocCompiledAssemblyArtifact GenerateArtifact(Modules modules, string assemblyName)
         {
+            var facadeNames = CreateFacadeNamePlan(modules, assemblyName);
+
             createAssemblyMetadata(assemblyName);
 
             EmitDebuggableAttributeIfEnabled();
@@ -288,7 +290,12 @@ namespace Jroc.Services
             // This must happen after all TypeDefs have been created.
             _serviceProvider.GetRequiredService<NestedTypeRelationshipRegistry>().EmitAllSorted(_metadataBuilder);
 
-            return CreateCompiledAssemblyArtifact(assemblyName, CollectPublishedModuleIds(modules));
+            return CreateCompiledAssemblyArtifact(
+                assemblyName,
+                CollectPublishedModuleIds(modules),
+                modules.rootModule.ModuleId,
+                modules.rootModule.AliasModuleIds,
+                facadeNames);
         }
 
         private void EmitDebuggableAttributeIfEnabled()
@@ -570,9 +577,18 @@ namespace Jroc.Services
 
             var ctorRef = _bclReferences.JsCompiledModuleAttribute_Ctor_Ref;
             var typeMapCtorRef = _bclReferences.JsCompiledModuleTypeAttribute_Ctor_Ref;
+            var entryModuleCtorRef = _bclReferences.JsCompiledEntryModuleAttribute_Ctor_Ref;
 
-            // Root module path is used as the base for stable relative module ids.
-            var rootModulePath = modules.rootModule.Path;
+            if (!modules._modules.Values.Contains(modules.rootModule))
+            {
+                throw new InvalidOperationException(
+                    "The compiled module graph must contain exactly one selected entry module.");
+            }
+
+            _metadataBuilder.AddCustomAttribute(
+                parent: _assemblyDefinition,
+                constructor: entryModuleCtorRef,
+                value: CreateSingleStringCustomAttributeValue(modules.rootModule.ModuleId));
 
             foreach (var module in modules._modules.Values)
             {
@@ -682,7 +698,12 @@ namespace Jroc.Services
             artifact.Materialize(outputPath);
         }
 
-        private JrocCompiledAssemblyArtifact CreateCompiledAssemblyArtifact(string name, IReadOnlyList<string> moduleIds)
+        private JrocCompiledAssemblyArtifact CreateCompiledAssemblyArtifact(
+            string name,
+            IReadOnlyList<string> moduleIds,
+            string entryModuleId,
+            IReadOnlyList<string> entryModuleAliases,
+            JrocFacadeNamePlan facadeNames)
         {
             var options = _serviceProvider.GetRequiredService<CompilerOptions>();
 
@@ -716,7 +737,44 @@ namespace Jroc.Services
             // BadImageFormatException during Assembly.Load.
             ClrMetadataConsistencyValidator.ValidateOrThrow(peBytes, label: name);
 
-            return new JrocCompiledAssemblyArtifact(name, peBytes, pdbBytes, moduleIds);
+            return new JrocCompiledAssemblyArtifact(
+                name,
+                peBytes,
+                pdbBytes,
+                moduleIds,
+                entryModuleId,
+                entryModuleAliases.ToArray(),
+                facadeNames);
+        }
+
+        private static JrocFacadeNamePlan CreateFacadeNamePlan(Modules modules, string assemblyName)
+        {
+            var entryModule = modules.rootModule;
+            var prefix = entryModule.IsPackageModule
+                ? GetPackagePrefix(entryModule.ModuleId)
+                : null;
+
+            return JrocFacadeNamePlanner.Create(
+                assemblyName,
+                entryModule.ModuleId,
+                modules._modules.Values.Select(module => module.ModuleId),
+                prefix);
+        }
+
+        private static string? GetPackagePrefix(string moduleId)
+        {
+            var segments = moduleId.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length == 0)
+            {
+                return null;
+            }
+
+            if (segments[0].StartsWith('@') && segments.Length >= 2)
+            {
+                return $"{segments[0]}/{segments[1]}";
+            }
+
+            return segments[0];
         }
 
         private static IReadOnlyList<string> CollectPublishedModuleIds(Modules modules)

--- a/src/Compiler/Services/BaseClassLibraryReferences.cs
+++ b/src/Compiler/Services/BaseClassLibraryReferences.cs
@@ -270,6 +270,9 @@ namespace Jroc.Services
         public MemberReferenceHandle JsCompiledModuleTypeAttribute_Ctor_Ref =>
             _memberRefRegistry.GetOrAddConstructor(typeof(Jroc.Runtime.JsCompiledModuleTypeAttribute), new[] { typeof(string), typeof(string), typeof(string) });
 
+        public MemberReferenceHandle JsCompiledEntryModuleAttribute_Ctor_Ref =>
+            _memberRefRegistry.GetOrAddConstructor(typeof(Jroc.Runtime.JsCompiledEntryModuleAttribute), new[] { typeof(string) });
+
         public MemberReferenceHandle JsModuleAttribute_Ctor_Ref =>
             _memberRefRegistry.GetOrAddConstructor(typeof(Jroc.Runtime.JsModuleAttribute), new[] { typeof(string) });
 

--- a/src/JavaScriptRuntime/Hosting/JsCompiledEntryModuleAttribute.cs
+++ b/src/JavaScriptRuntime/Hosting/JsCompiledEntryModuleAttribute.cs
@@ -1,0 +1,16 @@
+namespace Jroc.Runtime;
+
+/// <summary>
+/// Identifies the single canonical entry module in a compiled JROC assembly.
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+public sealed class JsCompiledEntryModuleAttribute : Attribute
+{
+    public JsCompiledEntryModuleAttribute(string moduleId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(moduleId);
+        ModuleId = moduleId;
+    }
+
+    public string ModuleId { get; }
+}

--- a/src/JavaScriptRuntime/Hosting/JsEngine.cs
+++ b/src/JavaScriptRuntime/Hosting/JsEngine.cs
@@ -6,6 +6,29 @@ namespace Jroc.Runtime;
 public static class JsEngine
 {
     /// <summary>
+    /// Returns the canonical entry module id recorded in a compiled JROC assembly.
+    /// </summary>
+    public static string GetEntryModuleId(Assembly compiledAssembly)
+    {
+        ArgumentNullException.ThrowIfNull(compiledAssembly);
+
+        var entryModules = compiledAssembly
+            .GetCustomAttributes<JsCompiledEntryModuleAttribute>()
+            .Select(attribute => attribute.ModuleId)
+            .Where(moduleId => !string.IsNullOrWhiteSpace(moduleId))
+            .ToArray();
+
+        return entryModules.Length switch
+        {
+            1 => entryModules[0],
+            0 => throw new InvalidOperationException(
+                "The assembly does not contain JROC entry-module metadata."),
+            _ => throw new InvalidOperationException(
+                $"The assembly contains {entryModules.Length} entry-module declarations; exactly one is required.")
+        };
+    }
+
+    /// <summary>
     /// Returns module ids present in a compiled JROC assembly.
     /// Prefer this over scanning types directly; compiled assemblies emitted by JROC include
     /// an assembly-level manifest via <see cref="JsCompiledModuleAttribute"/>.

--- a/src/Jroc.SDK/JrocCompileTask.cs
+++ b/src/Jroc.SDK/JrocCompileTask.cs
@@ -23,10 +23,11 @@ public sealed class JrocCompileTask : Microsoft.Build.Utilities.Task
     {
         var generatedAssemblies = new List<ITaskItem>();
         var generatedOutputs = new List<ITaskItem>();
+        var claimedAssemblyNames = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var source in Sources)
         {
-            if (!TryCompileSource(source, generatedAssemblies, generatedOutputs))
+            if (!TryCompileSource(source, generatedAssemblies, generatedOutputs, claimedAssemblyNames))
             {
                 continue;
             }
@@ -40,7 +41,8 @@ public sealed class JrocCompileTask : Microsoft.Build.Utilities.Task
     private bool TryCompileSource(
         ITaskItem source,
         List<ITaskItem> generatedAssemblies,
-        List<ITaskItem> generatedOutputs)
+        List<ITaskItem> generatedOutputs,
+        Dictionary<string, string> claimedAssemblyNames)
     {
         var sourceSpecifier = source.ItemSpec;
         var sourcePath = GetMetadataOrFallback(source, "ResolvedSourcePath", () => Path.GetFullPath(source.ItemSpec));
@@ -76,6 +78,36 @@ public sealed class JrocCompileTask : Microsoft.Build.Utilities.Task
             return false;
         }
 
+        var configuredAssemblyName = source.GetMetadata("AssemblyName");
+        var defaultAssemblyName = resolvedFromModuleId
+            ? DeriveAssemblyNameFromModuleId(sourceSpecifier)
+            : Path.GetFileNameWithoutExtension(sourcePath);
+        string assemblyName;
+        try
+        {
+            assemblyName = JrocAssemblyIdentity.Resolve(
+                sourcePath,
+                string.IsNullOrWhiteSpace(configuredAssemblyName)
+                    ? defaultAssemblyName
+                    : configuredAssemblyName);
+        }
+        catch (ArgumentException ex)
+        {
+            Log.LogError($"Invalid assembly identity for Jroc source '{sourceSpecifier}': {ex.Message}");
+            return false;
+        }
+
+        var assemblyPath = Path.Combine(outputDirectory, assemblyName + ".dll");
+        if (claimedAssemblyNames.TryGetValue(assemblyName, out var conflictingSource))
+        {
+            Log.LogError(
+                $"Jroc sources '{conflictingSource}' and '{sourceSpecifier}' both produce assembly " +
+                $"identity '{assemblyName}'. Configure distinct AssemblyName metadata.");
+            return false;
+        }
+
+        claimedAssemblyNames.Add(assemblyName, sourceSpecifier);
+
         if (!TryGetBooleanMetadata(source, "Verbose", out var verbose)
             || !TryGetBooleanMetadata(source, "AnalyzeUnused", out var analyzeUnused)
             || !TryGetBooleanMetadata(source, "EmitPdb", out var emitPdb)
@@ -93,6 +125,7 @@ public sealed class JrocCompileTask : Microsoft.Build.Utilities.Task
 
         var compilerOptions = new CompilerOptions
         {
+            AssemblyName = assemblyName,
             OutputDirectory = outputDirectory,
             Verbose = verbose,
             DiagnosticFilePath = string.IsNullOrWhiteSpace(diagnosticFilePath) ? null : diagnosticFilePath,
@@ -113,10 +146,8 @@ public sealed class JrocCompileTask : Microsoft.Build.Utilities.Task
             return false;
         }
 
-        var emittedAssemblyName = Path.GetFileNameWithoutExtension(sourcePath);
-        var assemblyPath = Path.Combine(outputDirectory, emittedAssemblyName + ".dll");
-        var assemblyPdbPath = Path.Combine(outputDirectory, emittedAssemblyName + ".pdb");
-        var runtimeConfigPath = Path.Combine(outputDirectory, emittedAssemblyName + ".runtimeconfig.json");
+        var assemblyPdbPath = Path.Combine(outputDirectory, assemblyName + ".pdb");
+        var runtimeConfigPath = Path.Combine(outputDirectory, assemblyName + ".runtimeconfig.json");
         var runtimeAssemblyPath = Path.Combine(outputDirectory, "JavaScriptRuntime.dll");
         var runtimePdbPath = Path.Combine(outputDirectory, "JavaScriptRuntime.pdb");
 
@@ -136,55 +167,6 @@ public sealed class JrocCompileTask : Microsoft.Build.Utilities.Task
         {
             Log.LogError($"Jroc did not produce the expected runtime support assembly '{runtimeAssemblyPath}' for source '{sourcePath}'.");
             return false;
-        }
-
-        var assemblyName = resolvedFromModuleId
-            ? DeriveAssemblyNameFromModuleId(sourceSpecifier)
-            : emittedAssemblyName;
-        if (!string.Equals(assemblyName, emittedAssemblyName, StringComparison.Ordinal))
-        {
-            var desiredAssemblyPath = Path.Combine(outputDirectory, assemblyName + ".dll");
-            var desiredAssemblyPdbPath = Path.Combine(outputDirectory, assemblyName + ".pdb");
-            var desiredRuntimeConfigPath = Path.Combine(outputDirectory, assemblyName + ".runtimeconfig.json");
-
-            try
-            {
-                if (File.Exists(desiredAssemblyPath))
-                {
-                    File.Delete(desiredAssemblyPath);
-                }
-
-                File.Move(assemblyPath, desiredAssemblyPath);
-                assemblyPath = desiredAssemblyPath;
-
-                if (File.Exists(assemblyPdbPath))
-                {
-                    if (File.Exists(desiredAssemblyPdbPath))
-                    {
-                        File.Delete(desiredAssemblyPdbPath);
-                    }
-
-                    File.Move(assemblyPdbPath, desiredAssemblyPdbPath);
-                    assemblyPdbPath = desiredAssemblyPdbPath;
-                }
-                else
-                {
-                    assemblyPdbPath = desiredAssemblyPdbPath;
-                }
-
-                if (File.Exists(desiredRuntimeConfigPath))
-                {
-                    File.Delete(desiredRuntimeConfigPath);
-                }
-
-                File.Move(runtimeConfigPath, desiredRuntimeConfigPath);
-                runtimeConfigPath = desiredRuntimeConfigPath;
-            }
-            catch (Exception ex)
-            {
-                Log.LogError($"Jroc failed to rename generated module artifacts from '{emittedAssemblyName}' to '{assemblyName}': {ex.Message}");
-                return false;
-            }
         }
 
         var assemblyItem = new TaskItem(assemblyPath);

--- a/src/Jroc.SDK/build/Jroc.SDK.props
+++ b/src/Jroc.SDK/build/Jroc.SDK.props
@@ -4,6 +4,7 @@
     <JrocCompileOnBuild Condition="'$(JrocCompileOnBuild)' == ''">true</JrocCompileOnBuild>
     <JrocOutputRoot Condition="'$(JrocOutputRoot)' == ''">$([System.IO.Path]::Combine('$(IntermediateOutputPath)', 'jroc'))</JrocOutputRoot>
     <JrocRootModuleId Condition="'$(JrocRootModuleId)' == ''"></JrocRootModuleId>
+    <JrocAssemblyName Condition="'$(JrocAssemblyName)' == ''"></JrocAssemblyName>
     <JrocModuleResolutionBaseDirectory Condition="'$(JrocModuleResolutionBaseDirectory)' == ''">$(MSBuildProjectDirectory)</JrocModuleResolutionBaseDirectory>
     <JrocReferenceOutputAssembly Condition="'$(JrocReferenceOutputAssembly)' == ''">true</JrocReferenceOutputAssembly>
     <JrocCopyToOutputDirectory Condition="'$(JrocCopyToOutputDirectory)' == ''">false</JrocCopyToOutputDirectory>

--- a/src/Jroc.SDK/build/Jroc.SDK.targets
+++ b/src/Jroc.SDK/build/Jroc.SDK.targets
@@ -16,6 +16,8 @@
         <ResolvedDiagnosticFilePath Condition="'%(JrocCompile.DiagnosticFilePath)' != ''">$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '%(JrocCompile.DiagnosticFilePath)'))))</ResolvedDiagnosticFilePath>
         <RootModuleId Condition="'%(JrocCompile.RootModuleId)' == '' and '$(JrocRootModuleId)' != ''">$(JrocRootModuleId)</RootModuleId>
         <RootModuleId Condition="'%(JrocCompile.RootModuleId)' != ''">%(JrocCompile.RootModuleId)</RootModuleId>
+        <AssemblyName Condition="'%(JrocCompile.AssemblyName)' == '' and '$(JrocAssemblyName)' != ''">$(JrocAssemblyName)</AssemblyName>
+        <AssemblyName Condition="'%(JrocCompile.AssemblyName)' != ''">%(JrocCompile.AssemblyName)</AssemblyName>
         <ReferenceOutputAssembly Condition="'%(JrocCompile.ReferenceOutputAssembly)' == ''">$(JrocReferenceOutputAssembly)</ReferenceOutputAssembly>
         <ReferenceOutputAssembly Condition="'%(JrocCompile.ReferenceOutputAssembly)' != ''">%(JrocCompile.ReferenceOutputAssembly)</ReferenceOutputAssembly>
         <CopyToOutputDirectory Condition="'%(JrocCompile.CopyToOutputDirectory)' == ''">$(JrocCopyToOutputDirectory)</CopyToOutputDirectory>

--- a/tests/Jroc.Testing/GeneratedAssemblyConsumerHarness.cs
+++ b/tests/Jroc.Testing/GeneratedAssemblyConsumerHarness.cs
@@ -1,0 +1,229 @@
+using System.Diagnostics;
+using System.Security;
+
+namespace Jroc.Tests;
+
+public sealed record GeneratedAssemblyConsumerResult(
+    int BuildExitCode,
+    string BuildStandardOutput,
+    string BuildStandardError,
+    int? RunExitCode,
+    string RunStandardOutput,
+    string RunStandardError)
+{
+    public string BuildDiagnostics => BuildStandardOutput + Environment.NewLine + BuildStandardError;
+}
+
+public sealed class GeneratedAssemblyConsumerHarness : IDisposable
+{
+    private readonly JrocMaterializedAssembly _materializedAssembly;
+    private int _disposed;
+
+    public GeneratedAssemblyConsumerHarness(
+        string javaScript,
+        string assemblyName = "ConsumerFixture",
+        IReadOnlyDictionary<string, string>? additionalScripts = null)
+    {
+        ArgumentNullException.ThrowIfNull(javaScript);
+
+        WorkingDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "Jroc.Tests",
+            "GeneratedAssemblyConsumer",
+            Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var sourceDirectory = Path.Combine(WorkingDirectory, "javascript");
+            var entryPath = Path.Combine(sourceDirectory, "entry.js");
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(entryPath, javaScript);
+            foreach (var (relativePath, source) in additionalScripts ?? new Dictionary<string, string>())
+            {
+                fileSystem.AddFile(Path.Combine(sourceDirectory, relativePath), source);
+            }
+
+            Artifact = JrocInMemoryCompiler.Compile(
+                new JrocInMemoryCompileRequest(entryPath)
+                {
+                    AssemblyName = assemblyName,
+                    FileSystem = fileSystem,
+                    EmitPdb = true
+                });
+            _materializedAssembly = Artifact.Materialize(Path.Combine(WorkingDirectory, "generated"));
+        }
+        catch
+        {
+            DeleteWorkingDirectory();
+            throw;
+        }
+    }
+
+    public string WorkingDirectory { get; }
+
+    public JrocCompiledAssemblyArtifact Artifact { get; }
+
+    public GeneratedAssemblyConsumerResult Build(string consumerSource, bool run = false)
+    {
+        ObjectDisposedException.ThrowIf(_disposed != 0, this);
+        ArgumentException.ThrowIfNullOrWhiteSpace(consumerSource);
+
+        var projectDirectory = Path.Combine(WorkingDirectory, "consumer");
+        Directory.CreateDirectory(projectDirectory);
+        var projectText = CreateProjectText(_materializedAssembly.AssemblyPath);
+        AssertNoDirectRuntimeReference(consumerSource, projectText);
+
+        File.WriteAllText(Path.Combine(projectDirectory, "Program.cs"), consumerSource);
+        File.WriteAllText(Path.Combine(projectDirectory, "Consumer.csproj"), projectText);
+
+        var build = RunProcess(
+            "dotnet",
+            ["build", "Consumer.csproj", "--nologo", "--verbosity:minimal"],
+            projectDirectory);
+
+        if (!run || build.ExitCode != 0)
+        {
+            return new GeneratedAssemblyConsumerResult(
+                build.ExitCode,
+                build.StandardOutput,
+                build.StandardError,
+                null,
+                string.Empty,
+                string.Empty);
+        }
+
+        var outputDirectory = Path.Combine(projectDirectory, "bin", "Debug", "net10.0");
+        CopyRuntimeImplementation(outputDirectory);
+        var runResult = RunProcess(
+            "dotnet",
+            [Path.Combine(outputDirectory, "Consumer.dll")],
+            projectDirectory);
+
+        return new GeneratedAssemblyConsumerResult(
+            build.ExitCode,
+            build.StandardOutput,
+            build.StandardError,
+            runResult.ExitCode,
+            runResult.StandardOutput,
+            runResult.StandardError);
+    }
+
+    public static void AssertNoDirectRuntimeReference(string consumerSource, string projectText)
+    {
+        ArgumentNullException.ThrowIfNull(consumerSource);
+        ArgumentNullException.ThrowIfNull(projectText);
+
+        foreach (var forbiddenReference in new[] { "Jroc.Runtime", "JavaScriptRuntime" })
+        {
+            if (consumerSource.Contains(forbiddenReference, StringComparison.Ordinal)
+                || projectText.Contains(forbiddenReference, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Consumer source and project files must not directly reference '{forbiddenReference}'.");
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        DeleteWorkingDirectory();
+    }
+
+    private static string CreateProjectText(string assemblyPath)
+    {
+        var escapedAssemblyPath = SecurityElement.Escape(assemblyPath)
+            ?? throw new InvalidOperationException("Could not encode the generated assembly path.");
+
+        return $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net10.0</TargetFramework>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+                <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+              </PropertyGroup>
+              <ItemGroup>
+                <Reference Include="GeneratedJavaScript">
+                  <HintPath>{{escapedAssemblyPath}}</HintPath>
+                  <Private>true</Private>
+                </Reference>
+              </ItemGroup>
+            </Project>
+            """;
+    }
+
+    private static void CopyRuntimeImplementation(string outputDirectory)
+    {
+        var runtimePath = typeof(JavaScriptRuntime.ObjectRuntime).Assembly.Location;
+        if (string.IsNullOrWhiteSpace(runtimePath) || !File.Exists(runtimePath))
+        {
+            throw new FileNotFoundException("Could not locate JavaScriptRuntime.dll.", runtimePath);
+        }
+
+        File.Copy(
+            runtimePath,
+            Path.Combine(outputDirectory, Path.GetFileName(runtimePath)),
+            overwrite: true);
+    }
+
+    private static ProcessResult RunProcess(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        string workingDirectory)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Could not start '{fileName}'.");
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(120_000))
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException($"Process '{fileName}' timed out.");
+        }
+
+        return new ProcessResult(
+            process.ExitCode,
+            standardOutput.GetAwaiter().GetResult(),
+            standardError.GetAwaiter().GetResult());
+    }
+
+    private void DeleteWorkingDirectory()
+    {
+        if (!Directory.Exists(WorkingDirectory))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.Delete(WorkingDirectory, recursive: true);
+        }
+        catch (IOException)
+        {
+            Thread.Sleep(100);
+            Directory.Delete(WorkingDirectory, recursive: true);
+        }
+    }
+
+    private sealed record ProcessResult(int ExitCode, string StandardOutput, string StandardError);
+}

--- a/tests/Jroc.Tests/CliTests.cs
+++ b/tests/Jroc.Tests/CliTests.cs
@@ -215,6 +215,37 @@ namespace Jroc.Tests
         }
 
         [Fact]
+        public void Convert_WithAssemblyName_UsesIdentityForAllArtifacts()
+        {
+            var tempRoot = Path.Combine(Path.GetTempPath(), "jroc_cli_identity_" + Guid.NewGuid().ToString("n"));
+            Directory.CreateDirectory(tempRoot);
+            var jsFile = Path.Combine(tempRoot, "source.js");
+            var outDir = Path.Combine(tempRoot, "out");
+            File.WriteAllText(jsFile, "console.log('identity');");
+
+            try
+            {
+                var (code, stdout, stderr) = RunOutOfProc(
+                    jsFile,
+                    "-o",
+                    outDir,
+                    "--assemblyname",
+                    "Configured.Identity");
+
+                Assert.Equal(0, code);
+                Assert.True(string.IsNullOrWhiteSpace(stderr), $"Unexpected stderr: {stderr}");
+                var assemblyPath = Path.Combine(outDir, "Configured.Identity.dll");
+                Assert.True(File.Exists(assemblyPath));
+                Assert.True(File.Exists(Path.Combine(outDir, "Configured.Identity.runtimeconfig.json")));
+                Assert.Equal("Configured.Identity", AssemblyName.GetAssemblyName(assemblyPath).Name);
+            }
+            finally
+            {
+                try { Directory.Delete(tempRoot, recursive: true); } catch { }
+            }
+        }
+
+        [Fact]
         public void Convert_WithDiagnosticFile_WritesDiagnosticsToFile()
         {
             var tempRoot = Path.Combine(Path.GetTempPath(), "jroc_cli_test_" + Guid.NewGuid().ToString("n"));

--- a/tests/Jroc.Tests/GeneratedFacadePhaseZeroTests.cs
+++ b/tests/Jroc.Tests/GeneratedFacadePhaseZeroTests.cs
@@ -1,0 +1,275 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Jroc.Runtime;
+
+namespace Jroc.Tests;
+
+public sealed class GeneratedFacadePhaseZeroTests
+{
+    [Fact]
+    public void ExplicitAssemblyIdentity_DrivesMetadataArtifactsPdbAndFacadeRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "Jroc.Tests", "PhaseZero", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var artifact = JrocInMemoryCompiler.Compile(
+                new JrocInMemoryCompileRequest(Path.Combine(root, "source-file.js"))
+                {
+                    AssemblyName = "Host-Friendly.Package",
+                    SourceText = "console.log('hello');",
+                    EmitPdb = true
+                });
+
+            Assert.Equal("Host-Friendly.Package", artifact.AssemblyName);
+            Assert.Equal("Host_Friendly_Package", artifact.FacadeNames!.RootTypeName);
+
+            using (var peReader = new PEReader(new MemoryStream(artifact.PeBytes)))
+            {
+                var metadata = peReader.GetMetadataReader();
+                Assert.Equal(
+                    "Host-Friendly.Package",
+                    metadata.GetString(metadata.GetAssemblyDefinition().Name));
+                var codeViewEntry = Assert.Single(
+                    peReader.ReadDebugDirectory(),
+                    entry => entry.Type == DebugDirectoryEntryType.CodeView);
+                Assert.Equal(
+                    "Host-Friendly.Package.pdb",
+                    peReader.ReadCodeViewDebugDirectoryData(codeViewEntry).Path);
+            }
+
+            var materialized = artifact.Materialize(root);
+            Assert.Equal("Host-Friendly.Package.dll", Path.GetFileName(materialized.AssemblyPath));
+            Assert.Equal("Host-Friendly.Package.pdb", Path.GetFileName(materialized.PdbPath));
+            Assert.Equal(
+                "Host-Friendly.Package.runtimeconfig.json",
+                Path.GetFileName(materialized.RuntimeConfigPath));
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void OmittedAssemblyIdentity_PreservesSourceFilenameDefault()
+    {
+        var artifact = JrocInMemoryCompiler.Compile(
+            new JrocInMemoryCompileRequest("/virtual/legacy-name.js")
+            {
+                SourceText = "console.log('hello');"
+            });
+
+        Assert.Equal("legacy-name", artifact.AssemblyName);
+        Assert.Equal("legacy_name", artifact.FacadeNames!.RootTypeName);
+    }
+
+    [Theory]
+    [InlineData("../escape")]
+    [InlineData("trailing.")]
+    [InlineData("trailing ")]
+    [InlineData("line\nbreak")]
+    public void InvalidAssemblyIdentity_IsRejected(string assemblyName)
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => JrocInMemoryCompiler.Compile(
+                new JrocInMemoryCompileRequest("/virtual/entry.js")
+                {
+                    AssemblyName = assemblyName,
+                    SourceText = "console.log('hello');"
+                }));
+
+        Assert.Contains("not a valid portable assembly", exception.Message);
+    }
+
+    [Fact]
+    public void EntryModuleMetadata_UsesCanonicalIdentityAndPreservesAliases()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "Jroc.Tests", "PhaseZero", Guid.NewGuid().ToString("N"));
+        var entryPath = Path.Combine(root, "entry.js");
+        var fileSystem = new MockFileSystem();
+        fileSystem.AddFile(entryPath, "require('./dependency.js'); module.exports = 42;");
+        fileSystem.AddFile(Path.Combine(root, "dependency.js"), "module.exports = 'dependency';");
+
+        var artifact = JrocInMemoryCompiler.Compile(
+            new JrocInMemoryCompileRequest(entryPath)
+            {
+                FileSystem = fileSystem,
+                RootModuleIdOverride = "sample-package"
+            });
+
+        Assert.Equal("entry", artifact.EntryModuleId);
+        Assert.Contains("sample-package", artifact.EntryModuleAliases!);
+        Assert.Contains("dependency", artifact.ModuleIds);
+
+        using var loaded = JrocInMemoryAssemblyLoader.Load(artifact);
+        Assert.Equal("entry", loaded.EntryModuleId);
+        Assert.Equal("entry", JsEngine.GetEntryModuleId(loaded.Assembly));
+        Assert.Single(loaded.Assembly.GetCustomAttributes<JsCompiledEntryModuleAttribute>());
+        var alias = Assert.Single(
+            loaded.Assembly.GetCustomAttributes<JsCompiledModuleTypeAttribute>(),
+            attribute => attribute.ModuleId == "sample-package");
+        Assert.Equal("entry", alias.CanonicalModuleId);
+    }
+
+    [Fact]
+    public void CompileAndLoad_WithMultipleModules_DefaultsToRecordedEntryModule()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "Jroc.Tests", "PhaseZero", Guid.NewGuid().ToString("N"));
+        var entryPath = Path.Combine(root, "entry.js");
+        var fileSystem = new MockFileSystem();
+        fileSystem.AddFile(
+            entryPath,
+            "const dependency = require('./dependency.js'); exports.value = dependency + 1;");
+        fileSystem.AddFile(Path.Combine(root, "dependency.js"), "module.exports = 41;");
+
+        using var module = JrocInMemoryCompiler.CompileAndLoadModule(
+            new JrocInMemoryCompileRequest(entryPath) { FileSystem = fileSystem });
+
+        dynamic exports = module.Exports;
+        Assert.Equal(42d, (double)exports.value);
+        Assert.Equal("entry", module.EntryModuleId);
+    }
+
+    [Fact]
+    public void HostingDiscovery_RejectsMissingOrAmbiguousEntryModuleMetadata()
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => JsEngine.GetEntryModuleId(typeof(GeneratedFacadePhaseZeroTests).Assembly));
+
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("AmbiguousEntryModules"),
+            AssemblyBuilderAccess.Run);
+        var constructor = typeof(JsCompiledEntryModuleAttribute).GetConstructor([typeof(string)])!;
+        assembly.SetCustomAttribute(new CustomAttributeBuilder(constructor, ["first"]));
+        assembly.SetCustomAttribute(new CustomAttributeBuilder(constructor, ["second"]));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => JsEngine.GetEntryModuleId(assembly));
+        Assert.Contains("exactly one", exception.Message);
+    }
+
+    [Fact]
+    public void FacadeNaming_MapsScopedPackagesKeywordsExtensionsAndDeepPaths()
+    {
+        var plan = JrocFacadeNamePlanner.Create(
+            "mixmark-io.domino",
+            "@mixmark-io/domino/index.js",
+            [
+                "@mixmark-io/domino/index.js",
+                "@mixmark-io/domino/api.js",
+                "@mixmark-io/domino/api/css.mjs",
+                "@mixmark-io/domino/class.cjs",
+                "@mixmark-io/domino/123 tools.js"
+            ],
+            "@mixmark-io/domino");
+
+        Assert.Equal("mixmark_io_domino", plan.RootTypeName);
+        Assert.Equal(
+            "mixmark_io_domino",
+            JrocFacadeNamePlanner.NormalizeIdentifier("@mixmark-io/domino", stripLeadingAtSign: true));
+        Assert.Equal(["index"], FindPath(plan, "@mixmark-io/domino/index.js"));
+        Assert.Equal(["api"], FindPath(plan, "@mixmark-io/domino/api.js"));
+        Assert.Equal(["api", "css"], FindPath(plan, "@mixmark-io/domino/api/css.mjs"));
+        Assert.Equal(["_class"], FindPath(plan, "@mixmark-io/domino/class.cjs"));
+        Assert.Equal(["_123_tools"], FindPath(plan, "@mixmark-io/domino/123 tools.js"));
+    }
+
+    [Fact]
+    public void FacadeNaming_AllowsModuleAndDirectoryDuality()
+    {
+        var plan = JrocFacadeNamePlanner.Create(
+            "DualityAssembly",
+            "api.js",
+            ["api.js", "api/css.js"]);
+
+        Assert.Equal(["api"], FindPath(plan, "api.js"));
+        Assert.Equal(["api", "css"], FindPath(plan, "api/css.js"));
+    }
+
+    [Theory]
+    [InlineData("api-one.js", "api_one.js")]
+    [InlineData("api.js", "API.js")]
+    [InlineData("some path/a.js", "some-path/b.js")]
+    public void FacadeNaming_RejectsOrdinalAndCaseInsensitiveCollisions(
+        string firstModuleId,
+        string secondModuleId)
+    {
+        var exception = Assert.Throws<JrocFacadeNameCollisionException>(
+            () => JrocFacadeNamePlanner.Create(
+                "CollisionAssembly",
+                firstModuleId,
+                [firstModuleId, secondModuleId]));
+
+        Assert.Contains(exception.FirstModuleId, new[] { firstModuleId, secondModuleId });
+        Assert.Contains(exception.SecondModuleId, new[] { firstModuleId, secondModuleId });
+        Assert.NotEqual(exception.FirstModuleId, exception.SecondModuleId);
+        Assert.Contains("CollisionAssembly.Scripts", exception.ProposedClrPath);
+    }
+
+    [Fact]
+    public void ConsumerHarness_BuildsReferencesReflectsAndRunsGeneratedAssembly()
+    {
+        string workingDirectory;
+        using (var harness = new GeneratedAssemblyConsumerHarness(
+                   "console.log('hello from generated assembly');",
+                   "ConsumerFixture"))
+        {
+            workingDirectory = harness.WorkingDirectory;
+            Assert.Equal("entry", harness.Artifact.EntryModuleId);
+
+            var result = harness.Build(
+                """
+                using System.Reflection;
+
+                var assembly = Assembly.Load("ConsumerFixture");
+                Console.WriteLine($"assembly={assembly.GetName().Name}");
+                assembly.EntryPoint!.Invoke(null, null);
+                """,
+                run: true);
+
+            Assert.Equal(0, result.BuildExitCode);
+            Assert.True(
+                result.RunExitCode == 0,
+                $"Consumer failed.{Environment.NewLine}{result.RunStandardOutput}{Environment.NewLine}{result.RunStandardError}");
+            Assert.Contains("assembly=ConsumerFixture", result.RunStandardOutput);
+            Assert.Contains("hello from generated assembly", result.RunStandardOutput);
+        }
+
+        Assert.False(Directory.Exists(workingDirectory));
+    }
+
+    [Fact]
+    public void ConsumerHarness_CapturesCompilerRejectionsAndCleansFailureArtifacts()
+    {
+        string workingDirectory;
+        using (var harness = new GeneratedAssemblyConsumerHarness(
+                   "console.log('fixture');"))
+        {
+            workingDirectory = harness.WorkingDirectory;
+            var result = harness.Build("MissingGeneratedFacade.Run();");
+
+            Assert.NotEqual(0, result.BuildExitCode);
+            Assert.Contains("CS0103", result.BuildDiagnostics);
+        }
+
+        Assert.False(Directory.Exists(workingDirectory));
+    }
+
+    [Theory]
+    [InlineData("using Jroc.Runtime;")]
+    [InlineData("var runtime = typeof(JavaScriptRuntime.ObjectRuntime);")]
+    public void ConsumerHarness_RejectsDirectRuntimeReferences(string consumerSource)
+    {
+        using var harness = new GeneratedAssemblyConsumerHarness("console.log('fixture');");
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => harness.Build(consumerSource));
+
+        Assert.Contains("must not directly reference", exception.Message);
+    }
+
+    private static IReadOnlyList<string> FindPath(JrocFacadeNamePlan plan, string moduleId) =>
+        Assert.Single(plan.Modules, module => module.ModuleId == moduleId).TypePath;
+}

--- a/tests/Jroc.Tests/JrocSdkPackageTests.cs
+++ b/tests/Jroc.Tests/JrocSdkPackageTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.IO.Compression;
+using System.Reflection;
 using System.Xml.Linq;
 
 namespace Jroc.Tests;
@@ -252,12 +253,14 @@ public class JrocSdkPackageTests
                 $"dotnet build failed.{Environment.NewLine}STDOUT:{Environment.NewLine}{build.StdOut}{Environment.NewLine}STDERR:{Environment.NewLine}{build.StdErr}");
 
             var generatedDir = Path.Combine(projectDir, "obj", "jroc-custom", "HostedMathModule");
-            Assert.True(File.Exists(Path.Combine(generatedDir, "HostedMathModule.dll")), $"Missing generated module dll in '{generatedDir}'.");
-            Assert.True(File.Exists(Path.Combine(generatedDir, "HostedMathModule.runtimeconfig.json")), $"Missing generated runtimeconfig in '{generatedDir}'.");
+            var generatedAssemblyPath = Path.Combine(generatedDir, "HostedMathAssembly.dll");
+            Assert.True(File.Exists(generatedAssemblyPath), $"Missing generated module dll in '{generatedDir}'.");
+            Assert.True(File.Exists(Path.Combine(generatedDir, "HostedMathAssembly.runtimeconfig.json")), $"Missing generated runtimeconfig in '{generatedDir}'.");
+            Assert.Equal("HostedMathAssembly", AssemblyName.GetAssemblyName(generatedAssemblyPath).Name);
 
             var targetDir = Path.Combine(projectDir, "bin", "Debug", "net10.0");
-            Assert.True(File.Exists(Path.Combine(targetDir, "HostedMathModule.dll")), $"Missing referenced module dll in '{targetDir}'.");
-            Assert.True(File.Exists(Path.Combine(targetDir, "HostedMathModule.runtimeconfig.json")), $"Missing copied runtimeconfig in '{targetDir}'.");
+            Assert.True(File.Exists(Path.Combine(targetDir, "HostedMathAssembly.dll")), $"Missing referenced module dll in '{targetDir}'.");
+            Assert.True(File.Exists(Path.Combine(targetDir, "HostedMathAssembly.runtimeconfig.json")), $"Missing copied runtimeconfig in '{targetDir}'.");
 
             var run = RunProcess(
                 fileName: "dotnet",
@@ -308,8 +311,10 @@ public class JrocSdkPackageTests
                 $"dotnet build failed.{Environment.NewLine}STDOUT:{Environment.NewLine}{build.StdOut}{Environment.NewLine}STDERR:{Environment.NewLine}{build.StdErr}");
 
             var generatedDir = Path.Combine(projectDir, "obj", "jroc-custom", "pkg");
-            Assert.True(File.Exists(Path.Combine(generatedDir, "scope.pkg.dll")), $"Missing generated package module dll in '{generatedDir}'.");
+            var generatedAssemblyPath = Path.Combine(generatedDir, "scope.pkg.dll");
+            Assert.True(File.Exists(generatedAssemblyPath), $"Missing generated package module dll in '{generatedDir}'.");
             Assert.True(File.Exists(Path.Combine(generatedDir, "scope.pkg.runtimeconfig.json")), $"Missing generated package runtimeconfig in '{generatedDir}'.");
+            Assert.Equal("scope.pkg", AssemblyName.GetAssemblyName(generatedAssemblyPath).Name);
 
             var targetDir = Path.Combine(projectDir, "bin", "Debug", "net10.0");
             Assert.True(File.Exists(Path.Combine(targetDir, "scope.pkg.dll")), $"Missing copied package module dll in '{targetDir}'.");
@@ -468,6 +473,7 @@ public class JrocSdkPackageTests
 
                 <JrocCompile Include="JavaScript\HostedMathModule.js"
                               OutputDirectory="$(BaseIntermediateOutputPath)\jroc-custom\HostedMathModule"
+                              AssemblyName="HostedMathAssembly"
                               RootModuleId="sample.math"
                               CopyToOutputDirectory="true" />
               </ItemGroup>
@@ -493,12 +499,12 @@ public class JrocSdkPackageTests
             """
             using System.Linq;
             using Jroc.Runtime;
-            using Jroc.HostedMathModule;
+            using Jroc.HostedMathAssembly;
 
-            var moduleIds = JsEngine.GetModuleIds(typeof(IHostedMathModuleExports).Assembly);
+            var moduleIds = JsEngine.GetModuleIds(typeof(IHostedMathAssemblyExports).Assembly);
             Console.WriteLine($"hasModuleId={moduleIds.Contains("sample.math", StringComparer.Ordinal)}");
 
-            using var exports = JsEngine.LoadModule<IHostedMathModuleExports>();
+            using var exports = JsEngine.LoadModule<IHostedMathAssemblyExports>();
             Console.WriteLine($"version={exports.Version}");
             Console.WriteLine($"sum={exports.Add(1, 2)}");
             """);


### PR DESCRIPTION
## Summary

Implements Phase 0 of #1917 and establishes the contracts required before generated `Run()` and `Import()` facades are emitted.

- adds a reusable external C# consumer harness with compile, rejection, reflection, execution, diagnostics, runtime-reference policing, and cleanup coverage
- makes configured assembly identity authoritative across PE metadata, DLL/PDB/runtime-config basenames, in-memory compilation, CLI, and `JrocCompile`
- records exactly one canonical entry module separately from aliases and exposes it through artifacts, loaded modules, and `JsEngine.GetEntryModuleId`
- adds a deterministic future-facade naming plan for assembly roots and nested script paths, including scoped packages, keywords, extensions, module/directory duality, and ordinal/case-insensitive collision rejection
- documents the new compiler, SDK, artifact, and hosting contracts

Facade TypeDefs and `Run()`/`Import()` methods remain intentionally out of scope for Phase 0.

## Validation

- `dotnet build jroc.sln --no-restore --nologo --verbosity:minimal`
- focused Phase 0/compiler/CLI tests: 31 passed
- `MSBUILDDISABLENODEREUSE=1 dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-build --no-restore --nologo --filter "FullyQualifiedName!~JrocSdkPackageTests" --verbosity:minimal`: 3,595 passed, 1 skipped
- direct `JrocCompileTask` validation confirmed configured PE/PDB/runtime-config identity and duplicate-identity rejection

Closes #1926
Closes #1927
Closes #1928
Closes #1929

Part of #1917
