### PR TITLE
perf: specialize inferred Array hot loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- perf(compiler/runtime): implement issue #1958 Phase 2 by propagating an
+  uncertain Array receiver candidate into ordinary functions assigned to the
+  intrinsic `Array.prototype`. Loop-hot numeric `length` and indexed reads now
+  use guarded helpers with generic fallback, keep `length` unboxed through
+  comparisons, and preserve the original per-iteration evaluation point.
 - perf(compiler/runtime): recover the identity-cache megamorphic regression
   from issue #1958 Phase 1. Generated property-read and zero-argument member
   call sites now publish a bounded terminal deoptimization flag and branch

--- a/docs/compiler/GuardedStringIntrinsicCalls.md
+++ b/docs/compiler/GuardedStringIntrinsicCalls.md
@@ -70,6 +70,34 @@ and generated user-class metadata remain separate identity domains and
 continue through their existing specialized lowering rather than being
 collapsed into CLR receiver candidates.
 
+An ordinary function expression assigned directly to a property of the
+unshadowed intrinsic `Array.prototype` also receives an Array candidate for
+its dynamic `this` value. The summary deliberately includes unknown and
+non-candidate inputs: the function can be extracted, invoked with `call`, or
+used as a constructor. It therefore authorizes only guarded specialization,
+never an Array-typed callable ABI or an unconditional cast.
+
+### Array length and indexed reads
+
+Loop-hot numeric consumption of `.length` on an Array candidate lowers to
+`ObjectRuntime.GetArrayLengthWithFallback`. The helper returns `double`
+directly for an actual `JavaScriptRuntime.Array`, avoiding the generic
+property result box and preserving an unboxed value through the loop
+comparison. A non-Array receiver executes `GetItem(receiver, "length")`
+followed by ordinary numeric conversion.
+
+Loop-hot numeric index reads use
+`ObjectRuntime.GetArrayElementWithFallback`. An actual Array enters the
+existing exotic Array indexer; every other receiver uses the generic numeric
+`GetItem` algorithm. The Array indexer itself still handles descriptor-backed
+indices, holes, sparse and out-of-range reads, and prototype-visible misses.
+Proxies do not satisfy the Array type check and therefore remain on the
+generic path.
+
+These rewrites do not hoist either operation. A source-level `this.length`
+inside a loop is still evaluated at its original point on every iteration, so
+length changes made by the loop body remain observable.
+
 ### Per-program-point facts
 
 After final LIR normalization and variable-slot coalescing, the compiler runs a
@@ -125,8 +153,8 @@ typed-array call.
 
 This gate does not change existing proven-Array direct calls or guarded String
 method calls. It controls the code-size expansion introduced when post-flow
-receiver specialization selects a guarded method or numeric String-index fast
-path.
+receiver specialization selects a guarded method, candidate Array
+length/index helper, or numeric String-index fast path.
 
 ### Guard hoisting
 

--- a/docs/compiler/JavaScriptToDotNetTypeMapping.md
+++ b/docs/compiler/JavaScriptToDotNetTypeMapping.md
@@ -186,6 +186,13 @@ Examples of the kinds of rewrites this enables:
 - `GetItem(obj, index)` → `GetInt32ArrayElement(arr, index)` when `obj` is proven to be `JavaScriptRuntime.Int32Array` and `index` is a numeric index
 - `GetItem(arr, index)` → `GetJsArrayElement(arr, index)` when `arr` is `JavaScriptRuntime.Array`
 - `GetLength(obj)` → `GetJsArrayLength(arr)` / `GetInt32ArrayLength(arr)` when receiver type is known
+- loop-hot candidate `this.length` numeric reads →
+  `ObjectRuntime.GetArrayLengthWithFallback(object)`, preserving an unboxed
+  `double` for Arrays and generic property semantics otherwise
+- loop-hot candidate Array numeric index reads →
+  `ObjectRuntime.GetArrayElementWithFallback(object, double)`, preserving
+  holes, descriptors, prototype-visible misses, proxies, and non-Array
+  fallback
 
 This typically also updates temp storage so downstream codegen can treat results as unboxed `double` where appropriate.
 
@@ -451,4 +458,3 @@ A typical shape of emitted artifacts:
 - Class emission + `_scopes`: [src/Compiler/Services/ILGenerators/ClassesGenerator.cs](../../src/Compiler/Services/ILGenerators/ClassesGenerator.cs)
 - Value sentinels (`undefined` vs `null`): [src/JavaScriptRuntime/TypeUtilities.cs](../../src/JavaScriptRuntime/TypeUtilities.cs), [src/JavaScriptRuntime/JsNull.cs](../../src/JavaScriptRuntime/JsNull.cs)
 - Scope naming behavior: [tests/Jroc.Tests/ScopeNamingTests.cs](../../tests/Jroc.Tests/ScopeNamingTests.cs)
-

--- a/scripts/runKrackenAStarGuardrails.js
+++ b/scripts/runKrackenAStarGuardrails.js
@@ -494,6 +494,7 @@ function runMicrobenchmarks(repoRoot, args, reportPath) {
     "*MegamorphicFallback*",
     "*ArrayLengthBoxedThenConsumed*",
     "*ArrayLengthDirectNumber*",
+    "*ArrayLengthGuardedCandidate*",
   ];
   appendDryJobArgs(dotnetArgs, args.dry);
   runChecked("dotnet", dotnetArgs, { cwd: path.dirname(benchmarkProject) });
@@ -511,6 +512,7 @@ function parseMicrobenchmarkReport(reportPath) {
     "MegamorphicFallback",
     "ArrayLengthBoxedThenConsumed",
     "ArrayLengthDirectNumber",
+    "ArrayLengthGuardedCandidate",
   ];
   const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
   const rows = (report?.Benchmarks || [])
@@ -560,12 +562,15 @@ function printMicrobenchmarks(result) {
   const direct = result.rows.find(
     (row) => row.method === "ArrayLengthDirectNumber"
   );
+  const guarded = result.rows.find(
+    (row) => row.method === "ArrayLengthGuardedCandidate"
+  );
   console.log(
     `Megamorphic vs generic: ${format(megamorphic.meanNs / generic.meanNs, 2)}x`
   );
   console.log(
-    `Array length allocation, boxed/direct: ${boxed.allocatedBytes}/` +
-      `${direct.allocatedBytes} B/op`
+    `Array length allocation, boxed/guarded/direct: ${boxed.allocatedBytes}/` +
+      `${guarded.allocatedBytes}/${direct.allocatedBytes} B/op`
   );
 }
 

--- a/src/Compiler/IR/LIR/HIRToLIRLower.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLower.cs
@@ -177,6 +177,9 @@ public sealed partial class HIRToLIRLowerer
             return;
         }
 
+        _methodBodyIR.ReceiverThisTypeSummary =
+            _scope.ReceiverThisTypeSummary;
+
         foreach (var (index, summary) in
                  _scope.ReceiverParameterTypeSummaries)
         {

--- a/src/Compiler/IR/LIR/LIRReceiverSpecialization.cs
+++ b/src/Compiler/IR/LIR/LIRReceiverSpecialization.cs
@@ -14,6 +14,15 @@ internal static class LIRReceiverSpecialization
 
         for (var index = 0; index < methodBody.Instructions.Count; index++)
         {
+            if (TryNormalizeArrayPropertyAccess(
+                    methodBody,
+                    index,
+                    ref staticCandidates,
+                    diagnostics))
+            {
+                continue;
+            }
+
             if (TryNormalizeStringPropertyAccess(
                     methodBody,
                     index,
@@ -78,6 +87,217 @@ internal static class LIRReceiverSpecialization
                     result);
             SetObjectResultStorage(methodBody, result);
         }
+    }
+
+    private static bool TryNormalizeArrayPropertyAccess(
+        MethodBodyIR methodBody,
+        int instructionIndex,
+        ref Dictionary<int, HashSet<Type>>? staticCandidates,
+        ReceiverTypeFlowDiagnosticTrace? diagnostics)
+    {
+        TempVariable receiver;
+        TempVariable result;
+        IReadOnlyList<TempVariable> arguments;
+        string memberName;
+        string helperName;
+
+        switch (methodBody.Instructions[instructionIndex])
+        {
+            case LIRGetItem getItem
+                when IsUnboxedDouble(
+                    methodBody,
+                    getItem.Index):
+                receiver = getItem.Object;
+                result = getItem.Result;
+                arguments = [receiver, getItem.Index];
+                memberName = "[index]";
+                helperName = nameof(
+                    JavaScriptRuntime.ObjectRuntime
+                        .GetArrayElementWithFallback);
+                break;
+            case LIRGetItemAsNumber getItemAsNumber
+                when TryGetConstantString(
+                        methodBody,
+                        instructionIndex,
+                        getItemAsNumber.Index,
+                        out var objectKey)
+                    && string.Equals(
+                        objectKey,
+                        "length",
+                        StringComparison.Ordinal):
+                receiver = getItemAsNumber.Object;
+                result = getItemAsNumber.Result;
+                arguments = [receiver];
+                memberName = "length";
+                helperName = nameof(
+                    JavaScriptRuntime.ObjectRuntime
+                        .GetArrayLengthWithFallback);
+                break;
+            case LIRGetItemAsNumberString getItemAsNumber
+                when TryGetConstantString(
+                        methodBody,
+                        instructionIndex,
+                        getItemAsNumber.Index,
+                        out var stringKey)
+                    && string.Equals(
+                        stringKey,
+                        "length",
+                        StringComparison.Ordinal):
+                receiver = getItemAsNumber.Object;
+                result = getItemAsNumber.Result;
+                arguments = [receiver];
+                memberName = "length";
+                helperName = nameof(
+                    JavaScriptRuntime.ObjectRuntime
+                        .GetArrayLengthWithFallback);
+                break;
+            default:
+                return false;
+        }
+
+        if (!TryClassifyArrayReceiver(
+                methodBody,
+                instructionIndex,
+                receiver,
+                ref staticCandidates,
+                out var receiverIsProvenArray))
+        {
+            return false;
+        }
+
+        methodBody.LoopNestingFacts ??=
+            LIRLoopNestingAnalysis.Analyze(methodBody);
+        var loopDepth =
+            methodBody.LoopNestingFacts.GetDepth(instructionIndex);
+        if (loopDepth < MinimumLoopDepth)
+        {
+            diagnostics?.RecordSpecialization(
+                instructionIndex,
+                memberName,
+                receiver,
+                typeof(JavaScriptRuntime.Array),
+                loopDepth,
+                receiverIsProvenArray,
+                "retained-generic(cold)");
+            return false;
+        }
+
+        diagnostics?.RecordSpecialization(
+            instructionIndex,
+            memberName,
+            receiver,
+            typeof(JavaScriptRuntime.Array),
+            loopDepth,
+            receiverIsProvenArray,
+            "guarded");
+        methodBody.Instructions[instructionIndex] =
+            new LIRCallIntrinsicStatic(
+                nameof(JavaScriptRuntime.ObjectRuntime),
+                helperName,
+                arguments,
+                result);
+        if (string.Equals(
+                helperName,
+                nameof(JavaScriptRuntime.ObjectRuntime
+                    .GetArrayLengthWithFallback),
+                StringComparison.Ordinal))
+        {
+            methodBody.TempStorages[result.Index] =
+                new ValueStorage(
+                    ValueStorageKind.UnboxedValue,
+                    typeof(double));
+        }
+        else
+        {
+            SetObjectResultStorage(methodBody, result);
+        }
+        return true;
+    }
+
+    private static bool TryClassifyArrayReceiver(
+        MethodBodyIR methodBody,
+        int instructionIndex,
+        TempVariable receiver,
+        ref Dictionary<int, HashSet<Type>>? staticCandidates,
+        out bool receiverIsProvenArray)
+    {
+        receiverIsProvenArray = false;
+        if (TryGetStorageReceiverType(
+                methodBody,
+                receiver,
+                out var storageType))
+        {
+            if (storageType == typeof(JavaScriptRuntime.Array))
+            {
+                receiverIsProvenArray = true;
+                return true;
+            }
+
+            if (storageType != typeof(object))
+            {
+                return false;
+            }
+        }
+
+        var fact = methodBody.ReceiverTypeFlowFacts?
+            .GetTempBefore(instructionIndex, receiver);
+        if (fact?.Contains(
+                typeof(JavaScriptRuntime.Array)) == true)
+        {
+            receiverIsProvenArray =
+                !fact.IncludesUnknown
+                && !fact.IncludesNonCandidate
+                && fact.CandidateClrTypes.Count == 1;
+            return true;
+        }
+
+        staticCandidates ??=
+            BuildStaticReceiverCandidates(methodBody);
+        return staticCandidates.TryGetValue(
+                receiver.Index,
+                out var candidates)
+            && candidates.Contains(
+                typeof(JavaScriptRuntime.Array));
+    }
+
+    private static bool TryGetConstantString(
+        MethodBodyIR methodBody,
+        int instructionIndex,
+        TempVariable temp,
+        out string value)
+    {
+        value = string.Empty;
+        var current = temp;
+        for (var index = instructionIndex - 1;
+             index >= 0;
+             index--)
+        {
+            var instruction = methodBody.Instructions[index];
+            if (!LIRInstructionInfo.TryGetDefinedTemp(
+                    instruction,
+                    out var defined)
+                || defined.Index != current.Index)
+            {
+                continue;
+            }
+
+            switch (instruction)
+            {
+                case LIRConstString constant:
+                    value = constant.Value;
+                    return true;
+                case LIRCopyTemp copy:
+                    current = copy.Source;
+                    continue;
+                case LIRConvertToObject convert:
+                    current = convert.Source;
+                    continue;
+                default:
+                    return false;
+            }
+        }
+
+        return false;
     }
 
     private static bool TryNormalizeStringPropertyAccess(
@@ -234,6 +454,12 @@ internal static class LIRReceiverSpecialization
 
                 switch (instruction)
                 {
+                    case LIRLoadThis:
+                        changed |= Add(
+                            result,
+                            methodBody.ReceiverThisTypeSummary
+                                .CandidateClrTypes);
+                        break;
                     case LIRLoadScopeField load:
                         changed |= Add(
                             result,
@@ -326,6 +552,20 @@ internal static class LIRReceiverSpecialization
             && IsUnboxedDouble(methodBody, getItem.Index))
         {
             receiver = getItem.Object;
+            return true;
+        }
+
+        if (instruction is LIRGetItemAsNumber
+                or LIRGetItemAsNumberString)
+        {
+            receiver = instruction switch
+            {
+                LIRGetItemAsNumber numericGetItem =>
+                    numericGetItem.Object,
+                LIRGetItemAsNumberString stringGetItem =>
+                    stringGetItem.Object,
+                _ => default
+            };
             return true;
         }
 

--- a/src/Compiler/IR/LIR/ReceiverTypeFlowAnalysis.cs
+++ b/src/Compiler/IR/LIR/ReceiverTypeFlowAnalysis.cs
@@ -421,6 +421,9 @@ internal static class ReceiverTypeFlowAnalysis
                 IntrinsicName: nameof(JavaScriptRuntime.Array),
                 MethodName: "Construct"
             } => FlowValue.ForCandidate(typeof(JavaScriptRuntime.Array)),
+            LIRLoadThis when methodBody.ReceiverThisTypeSummary.HasCandidates
+                => FlowValue.FromSummary(
+                    methodBody.ReceiverThisTypeSummary),
             LIRConstString => FlowValue.ForCandidate(typeof(string)),
             LIRConvertToString => FlowValue.ForCandidate(typeof(string)),
             LIRConcatStrings => FlowValue.ForCandidate(typeof(string)),
@@ -911,7 +914,9 @@ internal static class ReceiverTypeFlowAnalysis
                     IntrinsicName:
                         nameof(JavaScriptRuntime.Array),
                     MethodName: "Construct"
-                })
+                }
+                || instruction is LIRLoadThis
+                    && methodBody.ReceiverThisTypeSummary.HasCandidates)
             {
                 return true;
             }
@@ -1070,6 +1075,8 @@ internal static class ReceiverTypeFlowAnalysis
                     nameof(JavaScriptRuntime.Array),
                 MethodName: "Construct"
             }
+            || instruction is LIRLoadThis
+                && methodBody.ReceiverThisTypeSummary.HasCandidates
             || defined.Index >= 0
             && defined.Index < methodBody.TempStorages.Count
             && IsReceiverCandidateType(

--- a/src/Compiler/IR/MethodBodyIR.cs
+++ b/src/Compiler/IR/MethodBodyIR.cs
@@ -131,6 +131,9 @@ public sealed class MethodBodyIR
     internal Dictionary<int, ReceiverTypeSummary>
         ReceiverParameterTypeSummaries { get; } = new();
 
+    internal ReceiverTypeSummary ReceiverThisTypeSummary { get; set; } =
+        ReceiverTypeSummary.Empty;
+
     internal Dictionary<BindingInfo, ReceiverTypeSummary>
         ReceiverCapturedEntryTypeSummaries { get; } = new();
 

--- a/src/Compiler/SymbolTable/Scope.cs
+++ b/src/Compiler/SymbolTable/Scope.cs
@@ -134,6 +134,14 @@ public class Scope
         ReceiverTypeSummary.Empty;
 
     /// <summary>
+    /// Candidate receiver facts for the callable's dynamic <c>this</c> value.
+    /// These facts never change the callable ABI and always require a runtime
+    /// guard when ordinary JavaScript invocation can supply another receiver.
+    /// </summary>
+    internal ReceiverTypeSummary ReceiverThisTypeSummary { get; set; } =
+        ReceiverTypeSummary.Empty;
+
+    /// <summary>
     /// Captured receiver facts proven at entry to a non-escaping direct-only
     /// closure.
     /// </summary>

--- a/src/Compiler/SymbolTable/SymbolTableBuilder.ReceiverTypeCandidates.cs
+++ b/src/Compiler/SymbolTable/SymbolTableBuilder.ReceiverTypeCandidates.cs
@@ -21,6 +21,7 @@ public partial class SymbolTableBuilder
             scope.ReceiverParameterTypeSummaries.Clear();
             scope.ReceiverCapturedEntryTypeSummaries.Clear();
             scope.ReceiverReturnTypeSummary = ReceiverTypeSummary.Empty;
+            scope.ReceiverThisTypeSummary = ReceiverTypeSummary.Empty;
 
             foreach (var (index, type) in scope.StableParameterClrTypes)
             {
@@ -120,6 +121,41 @@ public partial class SymbolTableBuilder
                         RecordParameterInputs(call, scope, targetScope);
                         RecordCapturedInputs(call, scope, targetScope);
                         break;
+
+                    case AssignmentExpression
+                    {
+                        Operator: Operator.Assignment,
+                        Left: MemberExpression member,
+                        Right: FunctionExpression function
+                    }
+                    when TryGetIntrinsicPrototypeReceiverType(
+                        member,
+                        scope,
+                        out var receiverType):
+                    {
+                        var functionScope =
+                            FindScopeByAstNode(root, function);
+                        if (functionScope != null)
+                        {
+                            var candidate =
+                                new ReceiverTypeSummary(
+                                    includesUnknown: true,
+                                    includesNonCandidate: true,
+                                    [receiverType]);
+                            var merged =
+                                functionScope.ReceiverThisTypeSummary
+                                    .Union(candidate);
+                            if (!merged.Equals(
+                                    functionScope
+                                        .ReceiverThisTypeSummary))
+                            {
+                                functionScope
+                                    .ReceiverThisTypeSummary = merged;
+                                changed = true;
+                            }
+                        }
+                        break;
+                    }
                 }
 
                 foreach (var child in node.ChildNodes)
@@ -813,6 +849,36 @@ public partial class SymbolTableBuilder
 
         Dictionary<Node, Node> GetParentMap()
             => parentMap ??= BuildParentMap(root.AstNode);
+
+        bool TryGetIntrinsicPrototypeReceiverType(
+            MemberExpression assignedMember,
+            Scope assignmentScope,
+            out Type receiverType)
+        {
+            receiverType = null!;
+            if (assignedMember.Object is not MemberExpression
+                {
+                    Computed: false,
+                    Object: Identifier constructor,
+                    Property: Identifier
+                    {
+                        Name: "prototype"
+                    }
+                }
+                || IsIdentifierShadowed(
+                    assignmentScope,
+                    constructor.Name))
+            {
+                return false;
+            }
+
+            receiverType = constructor.Name switch
+            {
+                "Array" => typeof(JavaScriptRuntime.Array),
+                _ => null!
+            };
+            return receiverType != null;
+        }
 
         static bool UnionSummary<TKey>(
             Dictionary<TKey, ReceiverTypeSummary> summaries,

--- a/src/JavaScriptRuntime/ObjectRuntime.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.cs
@@ -910,6 +910,34 @@ namespace JavaScriptRuntime
             return GetItem(receiver, index);
         }
 
+        [System.Runtime.CompilerServices.MethodImpl(
+            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static double GetArrayLengthWithFallback(
+            object receiver)
+        {
+            if (receiver is Array array)
+            {
+                return array.length;
+            }
+
+            return TypeUtilities.ToNumber(
+                GetItem(receiver, "length"));
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(
+            System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static object GetArrayElementWithFallback(
+            object receiver,
+            double index)
+        {
+            if (receiver is Array array)
+            {
+                return array[index]!;
+            }
+
+            return GetItem(receiver, index);
+        }
+
         /// <summary>
         /// Fast-path overload for string key reads.
         /// Avoids boxing at the call site when the compiler has proven the key is a string.

--- a/tests/Jroc.Tests/Array/ExecutionTests.cs
+++ b/tests/Jroc.Tests/Array/ExecutionTests.cs
@@ -44,6 +44,13 @@ namespace Jroc.Tests.Array
         public Task Array_ReceiverCandidate_GuardedOverrides() { var testName = nameof(Array_ReceiverCandidate_GuardedOverrides); return ExecutionTest(testName); }
 
         [Fact]
+        public Task Array_PrototypeMethod_InferredThisLengthAndIndex()
+        {
+            return ExecutionTest(
+                nameof(Array_PrototypeMethod_InferredThisLengthAndIndex));
+        }
+
+        [Fact]
         public Task Array_IntrinsicGuard_HoistedLoop()
         {
             return ExecutionTest(

--- a/tests/Jroc.Tests/Array/GeneratorTests.cs
+++ b/tests/Jroc.Tests/Array/GeneratorTests.cs
@@ -49,6 +49,13 @@ namespace Jroc.Tests.Array
         public Task Array_ReceiverCandidate_GuardedOverrides() { var testName = nameof(Array_ReceiverCandidate_GuardedOverrides); return GenerateTest(testName); }
 
         [Fact]
+        public Task Array_PrototypeMethod_InferredThisLengthAndIndex()
+        {
+            return GenerateTest(
+                nameof(Array_PrototypeMethod_InferredThisLengthAndIndex));
+        }
+
+        [Fact]
         public Task Array_IntrinsicGuard_HoistedLoop()
         {
             return GenerateTest(

--- a/tests/Jroc.Tests/Array/JavaScript/Array_PrototypeMethod_InferredThisLengthAndIndex.js
+++ b/tests/Jroc.Tests/Array/JavaScript/Array_PrototypeMethod_InferredThisLengthAndIndex.js
@@ -1,0 +1,56 @@
+"use strict";
+
+Array.prototype.scanPhaseTwo = function (onVisit) {
+    let result = "";
+    for (let index = 0; index < this.length; index++) {
+        result += this[index];
+        if (onVisit) {
+            onVisit(this, index);
+        }
+    }
+    return result;
+};
+
+const values = ["a", "b"];
+console.log(values.scanPhaseTwo(function (array, index) {
+    if (index === 0) {
+        array.push("c");
+    }
+}));
+
+const descriptorArray = ["unused"];
+Object.defineProperty(descriptorArray, "0", {
+    configurable: true,
+    get() {
+        return "getter";
+    }
+});
+console.log(descriptorArray.scanPhaseTwo());
+
+const sparse = [];
+sparse.length = 2;
+Array.prototype[1] = "prototype";
+console.log(sparse.scanPhaseTwo());
+delete Array.prototype[1];
+
+const scanPhaseTwo = Array.prototype.scanPhaseTwo;
+console.log(scanPhaseTwo.call({
+    0: "ordinary",
+    length: 1
+}));
+
+const proxy = new Proxy({
+    0: "proxy",
+    length: 1
+}, {
+    get(target, key) {
+        return target[key];
+    }
+});
+console.log(scanPhaseTwo.call(proxy));
+
+class DerivedArray extends Array {
+}
+const derived = new DerivedArray();
+derived.push("subclass");
+console.log(derived.scanPhaseTwo());

--- a/tests/Jroc.Tests/Array/Snapshots/ExecutionTests.Array_PrototypeMethod_InferredThisLengthAndIndex.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/ExecutionTests.Array_PrototypeMethod_InferredThisLengthAndIndex.verified.txt
@@ -1,0 +1,6 @@
+abc
+getter
+undefinedprototype
+ordinary
+proxy
+subclass

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethod_InferredThisLengthAndIndex.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethod_InferredThisLengthAndIndex.verified.txt
@@ -1,0 +1,1307 @@
+﻿// IL code: Array_PrototypeMethod_InferredThisLengthAndIndex
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.Array_PrototypeMethod_InferredThisLengthAndIndex
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L3C31
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi beforefieldinit Scope_For_L5C9
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L5C54
+				extends [System.Runtime]System.Object
+			{
+				// Nested Types
+				.class nested public auto ansi beforefieldinit Block_L7C21
+					extends [System.Runtime]System.Object
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Header size: 1
+						// Code size: 8 (0x8)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+						IL_0006: nop
+						IL_0007: ret
+					} // end of method Block_L7C21::.ctor
+
+				} // end of class Block_L7C21
+
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L5C54::.ctor
+
+			} // end of class Block_L5C54
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope_For_L5C9::.ctor
+
+		} // end of class Scope_For_L5C9
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/Scope _environment0_Array_PrototypeMethod_InferredThisLengthAndIndex
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/Scope capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 22 (0x16)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldc.i4.1
+				IL_0008: ldc.i4.1
+				IL_0009: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::InitializeInvocationContext(int32, bool)
+				IL_000e: ldarg.0
+				IL_000f: ldarg.1
+				IL_0010: stfld class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/Scope Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L3C31/FunctionObject::_environment0_Array_PrototypeMethod_InferredThisLengthAndIndex
+				IL_0015: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/Scope Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L3C31/FunctionObject::_environment0_Array_PrototypeMethod_InferredThisLengthAndIndex
+				IL_0006: ldnull
+				IL_0007: ldc.i4.1
+				IL_0008: ldarg.1
+				IL_0009: ldarg.2
+				IL_000a: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_000f: ldarg.0
+				IL_0010: ldnull
+				IL_0011: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0016: ldarg.2
+				IL_0017: ldc.i4.0
+				IL_0018: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001d: call object Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L3C31::__js_call__(class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/Scope, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, object)
+				IL_0022: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/Scope Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L3C31/FunctionObject::_environment0_Array_PrototypeMethod_InferredThisLengthAndIndex
+				IL_0006: ldarg.3
+				IL_0007: ldc.i4.1
+				IL_0008: ldarg.1
+				IL_0009: ldarg.2
+				IL_000a: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_000f: ldarg.0
+				IL_0010: ldarg.3
+				IL_0011: call valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::Create(int32, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object, object)
+				IL_0016: ldarg.2
+				IL_0017: ldc.i4.0
+				IL_0018: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001d: call object Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L3C31::__js_call__(class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/Scope, object, valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext, object)
+				IL_0022: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/Scope scope,
+				object newTarget,
+				valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext invocationContext,
+				object onVisit
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 01 00 00 00 01 00 54 08 1c 53 69 6e 67 6c
+				65 53 63 6f 70 65 54 79 70 65 4d 65 74 61 64 61
+				74 61 54 6f 6b 65 6e 08 00 00 02
+			)
+			// Header size: 12
+			// Code size: 166 (0xa6)
+			.maxstack 8
+			.locals init (
+				[0] class [System.Runtime]System.Text.StringBuilder,
+				[1] float64,
+				[2] float64,
+				[3] float64,
+				[4] object,
+				[5] string,
+				[6] bool,
+				[7] object[],
+				[8] object
+			)
+
+			IL_0000: ldstr ""
+			IL_0005: call class [System.Runtime]System.Text.StringBuilder [JavaScriptRuntime]JavaScriptRuntime.String::CreateConcatBuilder(string)
+			IL_000a: stloc.0
+			IL_000b: ldc.r8 0.0
+			IL_0014: stloc.1
+			// loop start (head: IL_0015)
+				IL_0015: ldloc.1
+				IL_0016: stloc.2
+				IL_0017: ldarg.2
+				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+				IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+				IL_0022: call float64 [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetArrayLengthWithFallback(object)
+				IL_0027: stloc.3
+				IL_0028: ldloc.2
+				IL_0029: ldloc.3
+				IL_002a: clt
+				IL_002c: brfalse IL_009f
+
+				IL_0031: ldarg.2
+				IL_0032: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+				IL_0037: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+				IL_003c: ldloc.1
+				IL_003d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetArrayElementWithFallback(object, float64)
+				IL_0042: stloc.s 4
+				IL_0044: ldloc.s 4
+				IL_0046: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_004b: stloc.s 5
+				IL_004d: ldloc.0
+				IL_004e: ldloc.s 5
+				IL_0050: call void [JavaScriptRuntime]JavaScriptRuntime.String::AppendConcatBuilder(class [System.Runtime]System.Text.StringBuilder, string)
+				IL_0055: ldarg.3
+				IL_0056: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::IsTruthy(object)
+				IL_005b: stloc.s 6
+				IL_005d: ldloc.s 6
+				IL_005f: brfalse IL_008e
+
+				IL_0064: ldc.i4.1
+				IL_0065: newarr [System.Runtime]System.Object
+				IL_006a: dup
+				IL_006b: ldc.i4.0
+				IL_006c: ldarg.0
+				IL_006d: stelem.ref
+				IL_006e: stloc.s 7
+				IL_0070: ldloc.1
+				IL_0071: box [System.Runtime]System.Double
+				IL_0076: stloc.s 8
+				IL_0078: ldarg.3
+				IL_0079: ldloc.s 7
+				IL_007b: ldarg.2
+				IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext::GetThis(valuetype [JavaScriptRuntime]JavaScriptRuntime.GeneratedInvocationContext)
+				IL_0081: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+				IL_0086: ldloc.s 8
+				IL_0088: call object [JavaScriptRuntime]JavaScriptRuntime.Closure::InvokeFunctionCallWithArgs2(object, object[], object, object)
+				IL_008d: pop
+
+				IL_008e: ldloc.1
+				IL_008f: ldc.r8 1
+				IL_0098: add
+				IL_0099: stloc.1
+				IL_009a: br IL_0015
+			// end loop
+
+			IL_009f: ldloc.0
+			IL_00a0: call string [JavaScriptRuntime]JavaScriptRuntime.String::MaterializeConcatBuilder(class [System.Runtime]System.Text.StringBuilder)
+			IL_00a5: ret
+		} // end of method FunctionExpression_L3C31::__js_call__
+
+	} // end of class FunctionExpression_L3C31
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L15C32
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Nested Types
+			.class nested public auto ansi beforefieldinit Block_L16C21
+				extends [System.Runtime]System.Object
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Header size: 1
+					// Code size: 8 (0x8)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+					IL_0006: nop
+					IL_0007: ret
+				} // end of method Block_L16C21::.ctor
+
+			} // end of class Block_L16C21
+
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L15C32::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L15C32::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object 'array',
+				object index
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 51 (0x33)
+			.maxstack 8
+			.locals init (
+				[0] bool
+			)
+
+			IL_0000: ldarg.2
+			IL_0001: ldc.r8 0.0
+			IL_000a: box [System.Runtime]System.Double
+			IL_000f: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+			IL_0014: stloc.0
+			IL_0015: ldloc.0
+			IL_0016: brfalse IL_0031
+
+			IL_001b: ldarg.1
+			IL_001c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0021: ldstr "push"
+			IL_0026: ldstr "c"
+			IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0030: pop
+
+			IL_0031: ldnull
+			IL_0032: ret
+		} // end of method FunctionExpression_L15C32::__js_call__
+
+	} // end of class FunctionExpression_L15C32
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L24C7
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: call object Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L24C7::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::CallCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 6 (0x6)
+			.maxstack 8
+
+			IL_0000: ldstr "getter"
+			IL_0005: ret
+		} // end of method FunctionExpression_L24C7::__js_call__
+
+	} // end of class FunctionExpression_L24C7
+
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_proxy
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldnull
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_proxy::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject::CallCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget,
+				object target,
+				object key
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 12
+			// Code size: 10 (0xa)
+			.maxstack 8
+			.locals init (
+				[0] object
+			)
+
+			IL_0000: ldarg.1
+			IL_0001: ldarg.2
+			IL_0002: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, object)
+			IL_0007: stloc.0
+			IL_0008: ldloc.0
+			IL_0009: ret
+		} // end of method FunctionExpression_proxy::__js_call__
+
+	} // end of class FunctionExpression_proxy
+
+	.class nested public auto ansi beforefieldinit DerivedArray
+		extends [JavaScriptRuntime]JavaScriptRuntime.Array
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray/FunctionObject::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 25 (0x19)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor()
+			IL_0006: ldarg.0
+			IL_0007: ldc.i4.0
+			IL_0008: newarr [System.Runtime]System.Object
+			IL_000d: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::ConstructInto(object[])
+			IL_0012: ldarg.0
+			IL_0013: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeDerivedConstructorThisBinding(object)
+			IL_0018: ret
+		} // end of method DerivedArray::.ctor
+
+	} // end of class DerivedArray
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Header size: 12
+		// Code size: 1263 (0x4ef)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/Scope,
+			[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[4] object,
+			[5] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
+			[6] object,
+			[7] object,
+			[8] object,
+			[9] object[],
+			[10] class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L3C31/FunctionObject,
+			[11] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[12] class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L15C32/FunctionObject,
+			[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[14] class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L24C7/FunctionObject,
+			[15] bool,
+			[16] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
+			[17] class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_proxy/FunctionObject,
+			[18] class [System.Runtime]System.Type,
+			[19] class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray/FunctionObject
+		)
+
+		IL_0000: newobj instance void Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: nop
+		IL_0007: ldstr "Array"
+		IL_000c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0011: volatile.
+		IL_0013: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_0018: brfalse IL_002c
+
+		IL_001d: ldstr "prototype"
+		IL_0022: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0027: br IL_0040
+
+		IL_002c: ldstr "prototype"
+		IL_0031: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:7"
+		IL_0036: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_3
+		IL_003b: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0040: stloc.s 8
+		IL_0042: ldc.i4.1
+		IL_0043: newarr [System.Runtime]System.Object
+		IL_0048: dup
+		IL_0049: ldc.i4.0
+		IL_004a: ldloc.0
+		IL_004b: stelem.ref
+		IL_004c: stloc.s 9
+		IL_004e: ldloc.s 9
+		IL_0050: ldc.i4.0
+		IL_0051: ldelem.ref
+		IL_0052: castclass Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/Scope
+		IL_0057: newobj instance void Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L3C31/FunctionObject::.ctor(class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/Scope)
+		IL_005c: ldc.i4.1
+		IL_005d: conv.r8
+		IL_005e: ldstr ""
+		IL_0063: ldc.i4.0
+		IL_0064: ldc.i4.1
+		IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L3C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_006a: stloc.s 10
+		IL_006c: ldloc.s 8
+		IL_006e: ldstr "scanPhaseTwo"
+		IL_0073: ldloc.s 10
+		IL_0075: ldc.i4.1
+		IL_0076: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_007b: pop
+		IL_007c: ldc.i4.2
+		IL_007d: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_0082: dup
+		IL_0083: ldstr "a"
+		IL_0088: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_008d: dup
+		IL_008e: ldstr "b"
+		IL_0093: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0098: stloc.1
+		IL_0099: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_009e: stloc.s 11
+		IL_00a0: ldc.i4.1
+		IL_00a1: newarr [System.Runtime]System.Object
+		IL_00a6: dup
+		IL_00a7: ldc.i4.0
+		IL_00a8: ldloc.0
+		IL_00a9: stelem.ref
+		IL_00aa: stloc.s 9
+		IL_00ac: ldc.i4.1
+		IL_00ad: newarr [System.Runtime]System.Object
+		IL_00b2: dup
+		IL_00b3: ldc.i4.0
+		IL_00b4: ldloc.0
+		IL_00b5: stelem.ref
+		IL_00b6: stloc.s 9
+		IL_00b8: newobj instance void Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L15C32/FunctionObject::.ctor()
+		IL_00bd: ldc.i4.2
+		IL_00be: conv.r8
+		IL_00bf: ldstr ""
+		IL_00c4: ldc.i4.0
+		IL_00c5: ldc.i4.1
+		IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L15C32/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00cb: stloc.s 12
+		IL_00cd: ldloc.1
+		IL_00ce: ldstr "scanPhaseTwo"
+		IL_00d3: ldloc.s 12
+		IL_00d5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00da: stloc.s 8
+		IL_00dc: ldloc.s 11
+		IL_00de: ldloc.s 8
+		IL_00e0: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00e5: pop
+		IL_00e6: ldc.i4.1
+		IL_00e7: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_00ec: dup
+		IL_00ed: ldstr "unused"
+		IL_00f2: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_00f7: stloc.2
+		IL_00f8: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_00fd: stloc.s 13
+		IL_00ff: ldloc.s 13
+		IL_0101: ldstr "configurable"
+		IL_0106: ldc.i4.1
+		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, bool)
+		IL_010c: pop
+		IL_010d: ldc.i4.1
+		IL_010e: newarr [System.Runtime]System.Object
+		IL_0113: dup
+		IL_0114: ldc.i4.0
+		IL_0115: ldloc.0
+		IL_0116: stelem.ref
+		IL_0117: stloc.s 9
+		IL_0119: newobj instance void Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L24C7/FunctionObject::.ctor()
+		IL_011e: ldc.i4.0
+		IL_011f: conv.r8
+		IL_0120: ldstr ""
+		IL_0125: ldc.i4.0
+		IL_0126: ldc.i4.1
+		IL_0127: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L24C7/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_012c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_L24C7/FunctionObject>(!!0)
+		IL_0131: stloc.s 14
+		IL_0133: ldloc.s 13
+		IL_0135: ldstr "get"
+		IL_013a: ldloc.s 14
+		IL_013c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_0141: pop
+		IL_0142: ldloc.2
+		IL_0143: ldstr "0"
+		IL_0148: ldloc.s 13
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.Object::defineProperty(object, object, object)
+		IL_014f: pop
+		IL_0150: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0155: stloc.s 11
+		IL_0157: volatile.
+		IL_0159: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_015e: brfalse IL_0173
+
+		IL_0163: ldloc.2
+		IL_0164: ldstr "scanPhaseTwo"
+		IL_0169: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_016e: br IL_0188
+
+		IL_0173: ldloc.2
+		IL_0174: ldstr "scanPhaseTwo"
+		IL_0179: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:42"
+		IL_017e: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_4
+		IL_0183: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0188: stloc.s 8
+		IL_018a: ldloc.s 11
+		IL_018c: ldloc.s 8
+		IL_018e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0193: pop
+		IL_0194: ldc.i4.0
+		IL_0195: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_019a: stloc.3
+		IL_019b: ldloc.3
+		IL_019c: ldc.r8 2
+		IL_01a5: ldc.i4.1
+		IL_01a6: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::SetLength(float64, bool)
+		IL_01ab: ldstr "Array"
+		IL_01b0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01b5: volatile.
+		IL_01b7: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01bc: brfalse IL_01d0
+
+		IL_01c1: ldstr "prototype"
+		IL_01c6: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01cb: br IL_01e4
+
+		IL_01d0: ldstr "prototype"
+		IL_01d5: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:55"
+		IL_01da: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_5
+		IL_01df: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_01e4: stloc.s 8
+		IL_01e6: ldloc.s 8
+		IL_01e8: ldc.r8 1
+		IL_01f1: ldstr "prototype"
+		IL_01f6: ldc.i4.1
+		IL_01f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, float64, object, bool)
+		IL_01fc: pop
+		IL_01fd: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0202: stloc.s 11
+		IL_0204: volatile.
+		IL_0206: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_020b: brfalse IL_0220
+
+		IL_0210: ldloc.3
+		IL_0211: ldstr "scanPhaseTwo"
+		IL_0216: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_021b: br IL_0235
+
+		IL_0220: ldloc.3
+		IL_0221: ldstr "scanPhaseTwo"
+		IL_0226: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:61"
+		IL_022b: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_6
+		IL_0230: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_0235: stloc.s 8
+		IL_0237: ldloc.s 11
+		IL_0239: ldloc.s 8
+		IL_023b: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0240: pop
+		IL_0241: ldstr "Array"
+		IL_0246: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_024b: volatile.
+		IL_024d: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0252: brfalse IL_0266
+
+		IL_0257: ldstr "prototype"
+		IL_025c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0261: br IL_027a
+
+		IL_0266: ldstr "prototype"
+		IL_026b: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:67"
+		IL_0270: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_7
+		IL_0275: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_027a: stloc.s 8
+		IL_027c: ldloc.s 8
+		IL_027e: ldc.r8 1
+		IL_0287: box [System.Runtime]System.Double
+		IL_028c: call bool [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DeleteItem(object, object)
+		IL_0291: stloc.s 15
+		IL_0293: ldstr "Array"
+		IL_0298: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_029d: volatile.
+		IL_029f: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02a4: brfalse IL_02b8
+
+		IL_02a9: ldstr "prototype"
+		IL_02ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02b3: br IL_02cc
+
+		IL_02b8: ldstr "prototype"
+		IL_02bd: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:76"
+		IL_02c2: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_8
+		IL_02c7: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_02cc: stloc.s 8
+		IL_02ce: volatile.
+		IL_02d0: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02d5: brfalse IL_02eb
+
+		IL_02da: ldloc.s 8
+		IL_02dc: ldstr "scanPhaseTwo"
+		IL_02e1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02e6: br IL_0301
+
+		IL_02eb: ldloc.s 8
+		IL_02ed: ldstr "scanPhaseTwo"
+		IL_02f2: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:78"
+		IL_02f7: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_9
+		IL_02fc: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::GetItem(object, string, string, int32&)
+
+		IL_0301: stloc.s 4
+		IL_0303: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0308: stloc.s 11
+		IL_030a: ldloc.s 4
+		IL_030c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0311: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0316: dup
+		IL_0317: ldstr "0"
+		IL_031c: ldstr "ordinary"
+		IL_0321: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0326: dup
+		IL_0327: ldstr "length"
+		IL_032c: ldc.r8 1
+		IL_0335: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_033a: stloc.s 13
+		IL_033c: ldstr "call"
+		IL_0341: ldloc.s 13
+		IL_0343: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_0348: stloc.s 8
+		IL_034a: ldloc.s 11
+		IL_034c: ldloc.s 8
+		IL_034e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0353: pop
+		IL_0354: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0359: dup
+		IL_035a: ldstr "0"
+		IL_035f: ldstr "proxy"
+		IL_0364: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetObject(string, object)
+		IL_0369: dup
+		IL_036a: ldstr "length"
+		IL_036f: ldc.r8 1
+		IL_0378: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.JsObject::SetNumber(string, float64)
+		IL_037d: stloc.s 13
+		IL_037f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
+		IL_0384: stloc.s 16
+		IL_0386: ldc.i4.1
+		IL_0387: newarr [System.Runtime]System.Object
+		IL_038c: dup
+		IL_038d: ldc.i4.0
+		IL_038e: ldloc.0
+		IL_038f: stelem.ref
+		IL_0390: stloc.s 9
+		IL_0392: newobj instance void Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_proxy/FunctionObject::.ctor()
+		IL_0397: ldc.i4.2
+		IL_0398: conv.r8
+		IL_0399: ldstr ""
+		IL_039e: ldc.i4.0
+		IL_039f: ldc.i4.1
+		IL_03a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_proxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_03a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/FunctionExpression_proxy/FunctionObject>(!!0)
+		IL_03aa: stloc.s 17
+		IL_03ac: ldloc.s 16
+		IL_03ae: ldstr "get"
+		IL_03b3: ldloc.s 17
+		IL_03b5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
+		IL_03ba: pop
+		IL_03bb: ldloc.s 13
+		IL_03bd: ldloc.s 16
+		IL_03bf: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Proxy::.ctor(object, object)
+		IL_03c4: stloc.s 5
+		IL_03c6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_03cb: stloc.s 11
+		IL_03cd: ldloc.s 4
+		IL_03cf: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_03d4: ldstr "call"
+		IL_03d9: ldloc.s 5
+		IL_03db: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_03e0: stloc.s 8
+		IL_03e2: ldloc.s 11
+		IL_03e4: ldloc.s 8
+		IL_03e6: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_03eb: pop
+		IL_03ec: ldc.i4.1
+		IL_03ed: newarr [System.Runtime]System.Object
+		IL_03f2: dup
+		IL_03f3: ldc.i4.0
+		IL_03f4: ldloc.0
+		IL_03f5: stelem.ref
+		IL_03f6: stloc.s 9
+		IL_03f8: ldtoken Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray
+		IL_03fd: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_0402: ldtoken Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray
+		IL_0407: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+		IL_040c: stloc.s 18
+		IL_040e: ldloc.s 9
+		IL_0410: newobj instance void Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray/FunctionObject::.ctor(object[])
+		IL_0415: ldloc.s 18
+		IL_0417: ldloc.s 9
+		IL_0419: ldc.i4.0
+		IL_041a: conv.r8
+		IL_041b: ldc.i4.0
+		IL_041c: call class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::InitializeClassConstructorObject(class [JavaScriptRuntime]JavaScriptRuntime.JsClassConstructorObject, class [System.Runtime]System.Type, object[], float64, bool)
+		IL_0421: castclass Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray/FunctionObject
+		IL_0426: stloc.s 19
+		IL_0428: ldstr "Array"
+		IL_042d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0432: stloc.s 8
+		IL_0434: ldloc.s 19
+		IL_0436: ldloc.s 8
+		IL_0438: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::SetClassConstructorPrototype(object, object)
+		IL_043d: stloc.s 8
+		IL_043f: ldloc.s 8
+		IL_0441: stloc.s 6
+		IL_0443: ldc.i4.0
+		IL_0444: newarr [System.Runtime]System.Object
+		IL_0449: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentArguments(object[])
+		IL_044e: ldloc.s 6
+		IL_0450: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushCurrentNewTarget(object)
+		IL_0455: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PushDerivedConstructorThisBinding()
+		IL_045a: newobj instance void Modules.Array_PrototypeMethod_InferredThisLengthAndIndex/DerivedArray::.ctor()
+		IL_045f: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentNewTarget()
+		IL_0464: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopCurrentArguments()
+		IL_0469: dup
+		IL_046a: ldloc.s 6
+		IL_046c: ldstr "prototype"
+		IL_0471: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetProperty(object, string)
+		IL_0476: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::SetPrototype(object, object)
+		IL_047b: stloc.s 7
+		IL_047d: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentThis()
+		IL_0482: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::ResolveLexicalThis(object)
+		IL_0487: stloc.s 7
+		IL_0489: call void [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::PopDerivedConstructorThisBinding()
+		IL_048e: ldloc.s 7
+		IL_0490: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0495: ldstr "push"
+		IL_049a: ldstr "subclass"
+		IL_049f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_04a4: pop
+		IL_04a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_04aa: stloc.s 11
+		IL_04ac: ldloc.s 7
+		IL_04ae: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_04b3: volatile.
+		IL_04b5: ldsfld int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_04ba: brfalse IL_04ce
+
+		IL_04bf: ldstr "scanPhaseTwo"
+		IL_04c4: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember0(object, string)
+		IL_04c9: br IL_04e2
+
+		IL_04ce: ldstr "scanPhaseTwo"
+		IL_04d3: ldstr "Array_PrototypeMethod_InferredThisLengthAndIndex:Modules.Array_PrototypeMethod_InferredThisLengthAndIndex:__js_module_init__:123"
+		IL_04d8: ldsflda int32 Jroc.Generated.DynamicLookupSites::__jroc_dynamicLookup_10
+		IL_04dd: call object [JavaScriptRuntime]JavaScriptRuntime.DynamicLookupInlineCache::CallMember0(object, string, string, int32&)
+
+		IL_04e2: stloc.s 8
+		IL_04e4: ldloc.s 11
+		IL_04e6: ldloc.s 8
+		IL_04e8: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_04ed: pop
+		IL_04ee: ret
+	} // end of method Array_PrototypeMethod_InferredThisLengthAndIndex::__js_module_init__
+
+} // end of class Modules.Array_PrototypeMethod_InferredThisLengthAndIndex
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.Array_PrototypeMethod_InferredThisLengthAndIndex::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+
+.class private auto ansi abstract sealed beforefieldinit Jroc.Generated.DynamicLookupSites
+	extends [System.Runtime]System.Object
+{
+	// Fields
+	.field assembly static int32 __jroc_dynamicLookup_3
+	.field assembly static int32 __jroc_dynamicLookup_4
+	.field assembly static int32 __jroc_dynamicLookup_5
+	.field assembly static int32 __jroc_dynamicLookup_6
+	.field assembly static int32 __jroc_dynamicLookup_7
+	.field assembly static int32 __jroc_dynamicLookup_8
+	.field assembly static int32 __jroc_dynamicLookup_9
+	.field assembly static int32 __jroc_dynamicLookup_10
+
+} // end of class Jroc.Generated.DynamicLookupSites
+

--- a/tests/Jroc.Tests/ArrayReceiverSpecializationRuntimeTests.cs
+++ b/tests/Jroc.Tests/ArrayReceiverSpecializationRuntimeTests.cs
@@ -1,0 +1,106 @@
+using JavaScriptRuntime;
+using Xunit;
+
+namespace Jroc.Tests;
+
+public sealed class ArrayReceiverSpecializationRuntimeTests
+{
+    [Fact]
+    public void HelpersPreserveArrayAndFallbackSemantics()
+    {
+        WithRealm(
+            () =>
+            {
+                var array = new JavaScriptRuntime.Array(
+                    new object?[] { "dense" });
+                array.length = 2d;
+                ObjectRuntime.SetProperty(
+                    JavaScriptRuntime.Array.Prototype,
+                    "1",
+                    "prototype");
+
+                Assert.Equal(
+                    2d,
+                    ObjectRuntime.GetArrayLengthWithFallback(
+                        array));
+                Assert.Equal(
+                    "dense",
+                    ObjectRuntime.GetArrayElementWithFallback(
+                        array,
+                        0d));
+                Assert.Equal(
+                    "prototype",
+                    ObjectRuntime.GetArrayElementWithFallback(
+                        array,
+                        1d));
+
+                var ordinary = new JsObject();
+                ObjectRuntime.SetProperty(
+                    ordinary,
+                    "length",
+                    1d);
+                ObjectRuntime.SetProperty(
+                    ordinary,
+                    "0",
+                    "ordinary");
+
+                Assert.Equal(
+                    1d,
+                    ObjectRuntime.GetArrayLengthWithFallback(
+                        ordinary));
+                Assert.Equal(
+                    "ordinary",
+                    ObjectRuntime.GetArrayElementWithFallback(
+                        ordinary,
+                        0d));
+            });
+    }
+
+    [Fact]
+    public void ArrayLengthFastPathAllocatesNothing()
+    {
+        WithRealm(
+            () =>
+            {
+                var array = new JavaScriptRuntime.Array(
+                    new object?[] { 1d, 2d, 3d });
+                var result = 0d;
+                for (var index = 0; index < 32; index++)
+                {
+                    result +=
+                        ObjectRuntime
+                            .GetArrayLengthWithFallback(array);
+                }
+
+                var before =
+                    GC.GetAllocatedBytesForCurrentThread();
+                for (var index = 0; index < 10_000; index++)
+                {
+                    result +=
+                        ObjectRuntime
+                            .GetArrayLengthWithFallback(array);
+                }
+                var allocated =
+                    GC.GetAllocatedBytesForCurrentThread() - before;
+
+                GC.KeepAlive(result);
+                Assert.Equal(0, allocated);
+            });
+    }
+
+    private static void WithRealm(Action body)
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        var context =
+            RuntimeExecutionContext.GetOrCreate(services);
+        try
+        {
+            using var scope = context.EnterAsRoot();
+            body();
+        }
+        finally
+        {
+            services.OwningRealm!.Agent.Cluster.Dispose();
+        }
+    }
+}

--- a/tests/Jroc.Tests/LIRIntrinsicNormalizationTests.cs
+++ b/tests/Jroc.Tests/LIRIntrinsicNormalizationTests.cs
@@ -364,6 +364,113 @@ public sealed class LIRIntrinsicNormalizationTests
     }
 
     [Fact]
+    public void ReceiverSpecialization_RewritesHotArrayLengthCandidate()
+    {
+        var body = new MethodBodyIR();
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        var key = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(string)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.UnboxedValue,
+                typeof(double)));
+        body.ReceiverTempTypeSummaries[receiver.Index] =
+            new ReceiverTypeSummary(
+                includesUnknown: true,
+                includesNonCandidate: true,
+                [typeof(JavaScriptRuntime.Array)]);
+        body.Instructions.Add(new LIRCallIntrinsicStatic(
+            "Unknown",
+            "Call",
+            [],
+            receiver));
+        body.Instructions.Add(new LIRLabel(100));
+        body.Instructions.Add(new LIRConstString("length", key));
+        body.Instructions.Add(
+            new LIRGetItemAsNumberString(receiver, key, result));
+        body.Instructions.Add(new LIRBranch(100));
+        body.ReceiverTypeFlowFacts =
+            ReceiverTypeFlowAnalysis.Analyze(body);
+
+        LIRReceiverSpecialization.Normalize(body);
+
+        var guarded =
+            Assert.IsType<LIRCallIntrinsicStatic>(
+                body.Instructions[3]);
+        Assert.Equal(
+            nameof(JavaScriptRuntime.ObjectRuntime),
+            guarded.IntrinsicName);
+        Assert.Equal(
+            "GetArrayLengthWithFallback",
+            guarded.MethodName);
+        Assert.Equal([receiver], guarded.Arguments);
+        Assert.Equal(
+            new ValueStorage(
+                ValueStorageKind.UnboxedValue,
+                typeof(double)),
+            body.TempStorages[result.Index]);
+    }
+
+    [Fact]
+    public void ReceiverSpecialization_RewritesHotArrayIndexedReadCandidate()
+    {
+        var body = new MethodBodyIR();
+        var receiver = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        var index = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.UnboxedValue,
+                typeof(double)));
+        var result = AddTemp(
+            body,
+            new ValueStorage(
+                ValueStorageKind.Reference,
+                typeof(object)));
+        body.ReceiverTempTypeSummaries[receiver.Index] =
+            new ReceiverTypeSummary(
+                includesUnknown: true,
+                includesNonCandidate: true,
+                [typeof(JavaScriptRuntime.Array)]);
+        body.Instructions.Add(new LIRCallIntrinsicStatic(
+            "Unknown",
+            "Call",
+            [],
+            receiver));
+        body.Instructions.Add(new LIRLabel(100));
+        body.Instructions.Add(new LIRConstNumber(0d, index));
+        body.Instructions.Add(
+            new LIRGetItem(receiver, index, result));
+        body.Instructions.Add(new LIRBranch(100));
+        body.ReceiverTypeFlowFacts =
+            ReceiverTypeFlowAnalysis.Analyze(body);
+
+        LIRReceiverSpecialization.Normalize(body);
+
+        var guarded =
+            Assert.IsType<LIRCallIntrinsicStatic>(
+                body.Instructions[3]);
+        Assert.Equal(
+            nameof(JavaScriptRuntime.ObjectRuntime),
+            guarded.IntrinsicName);
+        Assert.Equal(
+            "GetArrayElementWithFallback",
+            guarded.MethodName);
+        Assert.Equal([receiver, index], guarded.Arguments);
+    }
+
+    [Fact]
     public void ReceiverSpecialization_KeepsColdCandidateCallGeneric()
     {
         var body = new MethodBodyIR();

--- a/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
+++ b/tests/Jroc.Tests/SymbolTableTypeInferenceTests.cs
@@ -181,6 +181,49 @@ public class SymbolTableTypeInferenceTests
     }
 
     [Fact]
+    public void SymbolTable_ReceiverCandidates_TrackArrayPrototypeMethodThis()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            Array.prototype.scan = function () {
+                return this.length;
+            };
+        ");
+
+        var functionScope = FindFirstScope(
+            symbolTable.Root,
+            scope => scope.AstNode is FunctionExpression);
+        Assert.NotNull(functionScope);
+        Assert.True(
+            functionScope!.ReceiverThisTypeSummary.IncludesUnknown);
+        Assert.True(
+            functionScope.ReceiverThisTypeSummary
+                .IncludesNonCandidate);
+        Assert.Contains(
+            typeof(JavaScriptRuntime.Array),
+            functionScope.ReceiverThisTypeSummary
+                .CandidateClrTypes);
+    }
+
+    [Fact]
+    public void SymbolTable_ReceiverCandidates_IgnoreShadowedArrayPrototype()
+    {
+        var symbolTable = BuildSymbolTable(@"
+            function configure(Array) {
+                Array.prototype.scan = function () {
+                    return this.length;
+                };
+            }
+        ");
+
+        var functionScope = FindFirstScope(
+            symbolTable.Root,
+            scope => scope.AstNode is FunctionExpression);
+        Assert.NotNull(functionScope);
+        Assert.True(
+            functionScope!.ReceiverThisTypeSummary.IsEmpty);
+    }
+
+    [Fact]
     public void SymbolTable_ReceiverCandidates_PropagateDirectClosureParametersAndReturns()
     {
         var symbolTable = BuildSymbolTable(@"

--- a/tests/performance/Benchmarks/DynamicLookupInlineCacheBenchmarks.cs
+++ b/tests/performance/Benchmarks/DynamicLookupInlineCacheBenchmarks.cs
@@ -231,6 +231,11 @@ public class DynamicLookupInlineCacheBenchmarks
         => _array.length;
 
     [Benchmark]
+    public double ArrayLengthGuardedCandidate()
+        => ObjectRuntime.GetArrayLengthWithFallback(
+            _array);
+
+    [Benchmark]
     public object ArrayCacheStubFallback()
         => DynamicLookupInlineCache.GetItem(
             _array,

--- a/tests/performance/Benchmarks/README.md
+++ b/tests/performance/Benchmarks/README.md
@@ -165,7 +165,8 @@ This command:
 - preserves the benchmark boundary by compiling, loading, and initializing the
   fixture in `GlobalSetup`, then measuring only the registered A* workload;
 - runs focused monomorphic, polymorphic, post-megamorphic, generic-property,
-  boxed Array-length, and direct numeric Array-length controls;
+  boxed Array-length, guarded candidate Array-length, and direct numeric
+  Array-length controls;
 - compiles the exact composed fixture and reports counters from the generated
   `Array.prototype.findGraphNode` method.
 
@@ -269,6 +270,30 @@ Phase 1 candidate recorded on the same Intel host on 2026-08-21:
 These are separate non-Dry runs on the same host, not simultaneous paired
 measurements. Preserve and compare the raw reports with the guardrail helper
 when making a regression decision.
+
+Phase 2 Array specialization candidate recorded on the same Intel host on
+2026-08-21:
+
+- source: Phase 1 merge `13a74806cc9aad7aad5ae2b774e6dcd85969d9a4`
+  plus the Phase 2 working-tree changes;
+- exact non-Dry `kracken-ai-astar` JROC result: 4.984 s mean, 4.954 s
+  median, N=19, 57,534,240 B/op;
+- compared with the same-host Phase 1 result, the mean is 33.0% lower and
+  managed allocation is 97.5% lower;
+- this was a JROC-only rerun. Competitors were intentionally not repeated;
+  their same-host Phase 1 measurements remain above;
+- the guarded candidate Array-length allocation control reports 0 B/op,
+  matching direct Array length and avoiding the boxed path's 24 B/op;
+- generated `findGraphNode`: 217 IL bytes, 2 dynamic-cache property reads,
+  3 generic item/property reads, 0 generic numeric `Array.length` reads,
+  and 1 explicit `box`. The loop-hot index read uses the guarded Array helper;
+  the return-only index read remains generic because it is outside the natural
+  loop and executes at most once.
+
+The Phase 2 comparison uses separate non-Dry runs with matching host, OS,
+runtime, benchmark version, scenario, and benchmark boundary. The raw reports,
+sample counts, and allocation values are the comparison evidence; the focused
+Dry control is used only to verify allocation shape, not timing.
 
 #### Cube-focused guardrail workflow
 Runs only the Dromaeo cube phased scenarios and prints the execution counters we track for issue #1327:


### PR DESCRIPTION
## Summary

- infer a conservative Array candidate for dynamic `this` in ordinary
  functions assigned directly to the unshadowed intrinsic `Array.prototype`
- specialize loop-hot candidate `length` and numeric index reads through
  guarded runtime helpers with exact generic fallback
- keep Array length unboxed through numeric loop comparisons without hoisting
  or changing its source evaluation point
- add execution, generator, runtime allocation, LIR, inference, benchmark, and
  documentation coverage

## Correctness

The inferred `this` summary always includes unknown and non-candidate inputs,
so it never changes the callable ABI or treats an Array candidate as proof.
Actual Arrays use the existing Array exotic implementation; ordinary objects
and Proxies use the existing generic lookup path. Coverage includes loop-body
length mutation, descriptor-backed indices, sparse holes, prototype-visible
values, extracted calls with ordinary receivers, Proxies, and Array subclasses.

## Performance evidence

Same-host non-Dry BenchmarkDotNet comparison for the unmodified
`kracken-ai-astar` workload:

| Revision | Mean | Median | N | Allocated/op |
| --- | ---: | ---: | ---: | ---: |
| Phase 1 `13a74806c` | 7.434 s | 7.452 s | 16 | 2,314,930,320 B |
| Phase 2 candidate | 4.984 s | 4.954 s | 19 | 57,534,240 B |

That is a 33.0% lower mean and 97.5% less managed allocation. Both runs used
the Intel Xeon 6975P-C host, Ubuntu 24.04.4, .NET 10.0.11, and BenchmarkDotNet
0.15.8. The candidate benchmark was run from the implementation worktree later
committed unchanged as `46bf67179`.

Generated `findGraphNode` decreased from 225 to 217 IL bytes, eliminated the
generic numeric Array-length read, and replaced the loop-hot indexed read with
the guarded Array helper. The allocation control reports 0 B/op for guarded
candidate Array length versus 24 B/op for the boxed generic path.

## Validation

- `Jroc.Tests`: 3,616 passed, 1 skipped with collection parallelism disabled
  to isolate allocation assertions
- targeted Array, Proxy, and Array-subclass test262 selection: 370 passed
- Release solution build with warnings as errors: 0 warnings, 0 errors

Closes #1962
Part of #1958
Related to #1923
